### PR TITLE
Fix incorrectly formatted code block.

### DIFF
--- a/deployment/examples/README.md
+++ b/deployment/examples/README.md
@@ -15,13 +15,12 @@ deployment/scripts/install.sh
 
 # Deploy specific deployment type
 deployment/scripts/install.sh gpu
-deployment/scripts/install.sh basic
-
+```
 # Add a new deployment type
 
-Any subdirectory under deployment/examples/ named as {name}-deployment will be picked up as a deployment type by deployment/scripts/insall.sh
+Any subdirectory under `deployment/examples/` named as {name}-deployment will be picked up as a deployment type by `deployment/scripts/insall.sh`
 
-e.g. deployment/examples/gpu-deployment will display as the deployment option --gpu in the installer.
+e.g. `deployment/examples/gpu-deployment` will display as the `deployment option --gpu` in the installer.
 
 ## Installation Sequence
 
@@ -30,7 +29,7 @@ The install script enforces this critical sequence for reliable deployment:
 1. **Install Dependencies** - Install all required operators and tools
    ```bash
    scripts/install-dependencies.sh --all
-   ```
+
 
 2. **Set Cluster Domain** - Configure domain for external access
    ```bash


### PR DESCRIPTION
The examples README file has a code block that eats non-code sections.

## Description
Moves the code black up.

## How Has This Been Tested?
Github's Markdown preview

## Merge criteria:

- [ x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated deployment guide to remove the “basic” deployment option from examples and clarify GPU deployment usage.
  * Standardized inline code formatting for paths, scripts, and CLI flags to improve readability.
  * Refined installation instructions by adjusting code block boundaries and formatting for clearer step-by-step execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->