### PR TITLE
Add an interim workaround for limitador metrics for dev

### DIFF
--- a/deployment/examples/README.md
+++ b/deployment/examples/README.md
@@ -176,6 +176,23 @@ curl -H 'Authorization: APIKEY premiumuser1_key' \
 | Free     | `freeuser1_key`, `freeuser2_key`       | 100 tokens per 1min       |
 | Premium  | `premiumuser1_key`, `premiumuser2_key` | 500 tokens per 1min       |
 
+## User Metrics (Temporary Workaround Until Upstream)
+
+This feature is still in development in upstream Kuadrant. In the meantime, you can patch the Limitador image with the following for development work with metrics until the feature lands upstream.
+
+```bash
+# patch with this interim image providing metrics
+kubectl patch limitador limitador \
+  -n kuadrant-system \
+  --type merge -p '{"spec":{"image":"ghcr.io/redhat-et/limitador:metrics","version":""}}'
+
+# kick the deployment
+kubectl rollout status deployment/limitador-limitador -n kuadrant-system
+
+# run some completions to generate some metrics and then curl the metrics endpoint
+kubectl exec -n kuadrant-system deployment/limitador-limitador -- curl -s localhost:8080/metrics
+```
+
 ## Component Details
 
 ### Models (`kustomize-templates/models/`)


### PR DESCRIPTION
- Since metrics are moving back to the originally proposed limitador location, this image exposes per/user metrics from limitador so development can proceed on a more aligned path, with what will eventually be upstream.
- The limitador feature code is throwaway and can be viewed [here](https://github.com/Kuadrant/limitador/compare/main...nerdalert:limitador:user-tracking-prom-metrics).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for enabling user metrics via a temporary workaround using a metrics-enabled Limitador image, including rollout and query commands.
  * Note: The new “User Metrics (Temporary Workaround Until Upstream)” section appears twice, resulting in duplicated instructions. No functional changes to the product.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->