### PR TITLE
Remove some remaining hardcodes

### DIFF
--- a/deployment/core-infrastructure/kustomize-templates/maas-api/07-maas-api-routing.yaml
+++ b/deployment/core-infrastructure/kustomize-templates/maas-api/07-maas-api-routing.yaml
@@ -13,7 +13,7 @@ spec:
     - name: inference-gateway
       namespace: llm
   hostnames:
-    - "maas-api.apps.summit-gpu.octo-emerging.redhataicoe.com"
+    - "maas-api.${CLUSTER_DOMAIN}"
   rules:
     - matches:
         - path:

--- a/deployment/core-infrastructure/kustomize-templates/maas-api/09-maas-api-route.yaml
+++ b/deployment/core-infrastructure/kustomize-templates/maas-api/09-maas-api-route.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
     app: maas-gateway
 spec:
-  host: maas-api.apps.summit-gpu.octo-emerging.redhataicoe.com
+  host: "maas-api.${CLUSTER_DOMAIN}"
   port:
     targetPort: 80
   to:


### PR DESCRIPTION
A couple of hardcodes leftover replaced with `${CLUSTER_DOMAIN}`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * MaaS API routing now uses an environment-based domain, automatically aligning hostnames with the active cluster’s domain.
* **Chores**
  * Standardized host configuration across routing resources to reduce manual updates and improve consistency across environments.
  * Improves reliability during deployments by eliminating hard-coded domains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->