### PR TITLE
feat(build): uses ubi go-toolset as builder image

### DIFF
--- a/maas-api/.dockerignore
+++ b/maas-api/.dockerignore
@@ -1,0 +1,2 @@
+deploy
+*.md

--- a/maas-api/Dockerfile
+++ b/maas-api/Dockerfile
@@ -1,31 +1,22 @@
-# Build stage
-FROM golang:1.24.2-alpine AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.24 AS builder
 
-# Set working directory
 WORKDIR /app
 
-# Copy go mod files
 COPY go.mod go.sum ./
 
-# Download dependencies
 RUN go mod download
 
-# Copy source code
 COPY . .
 
-# Build the application
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o maas-api ./cmd/
+RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w" -o maas-api ./cmd/
 
-# Runtime stage
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 # Install CA certificates for HTTPS requests
-RUN microdnf update -y && microdnf install -y ca-certificates && microdnf clean all
+RUN microdnf update -y && microdnf install -y ca-certificates curl-minimal && microdnf clean all
 
-# Set working directory
 WORKDIR /app
 
-# Copy the binary from builder stage
 COPY --from=builder /app/maas-api .
 
 # Make binary executable and fix permissions for OpenShift
@@ -36,12 +27,9 @@ RUN chmod +x maas-api && \
 # Use a non-root user (OpenShift will assign random UID)
 USER 1001
 
-# Expose port
 EXPOSE 8080
 
-# Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
   CMD curl -f http://localhost:8080/health || exit 1
 
-# Run the application
 CMD ["./maas-api"]


### PR DESCRIPTION
To align with other repos lets use ubi9 go-toolset as the builder.

Additionally, `.dockerignore` is added to limit the context for the build and avoid unnecessary layers rebuild when irrelevant files are changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated container base image for improved compatibility and maintenance.
  - Reduced Docker build context by excluding deployment assets and Markdown files, improving build efficiency.
  - Hardened container permissions and aligned runtime to a non-root user for better security.
  - Health checks and runtime behavior remain unchanged.
  - No user-facing functionality changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->