### PR TITLE
feat(config): debug mode

### DIFF
--- a/maas-api/cmd/main.go
+++ b/maas-api/cmd/main.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
-
 	"github.com/opendatahub-io/maas-billing/maas-api/internal/auth"
 	"github.com/opendatahub-io/maas-billing/maas-api/internal/config"
 	"github.com/opendatahub-io/maas-billing/maas-api/internal/handlers"
@@ -26,7 +25,13 @@ func main() {
 	cfg := config.Load()
 	flag.Parse()
 
-	router := registerHandlers(cfg)
+	gin.SetMode(gin.ReleaseMode) // Explicitly set release mode
+	if cfg.DebugMode {
+		gin.SetMode(gin.DebugMode)
+	}
+
+	router := gin.Default()
+	registerHandlers(cfg, router)
 
 	srv := &http.Server{
 		Addr:              ":" + cfg.Port,
@@ -60,9 +65,7 @@ func main() {
 	log.Println("Server exited gracefully")
 }
 
-func registerHandlers(cfg *config.Config) *gin.Engine {
-	router := gin.Default()
-
+func registerHandlers(cfg *config.Config, router *gin.Engine) *gin.Engine {
 	// Health check endpoint (no auth required)
 	router.GET("/health", handlers.NewHealthHandler().HealthCheck)
 

--- a/maas-api/deploy/overlays/dev/kustomization.yaml
+++ b/maas-api/deploy/overlays/dev/kustomization.yaml
@@ -14,6 +14,9 @@ namespace: maas-api
 transformers:
   - transformers/namespace.yaml
 
+patches:
+- path: patches/debug-mode-patch.yaml
+
 # Overwrite the image to use the local image set through kustomize edit set image
 # This is needed because the image is set to ghcr.io/redhat-et/maas-key-manager in the base/deployment.yaml using params.env "injection"
 images:

--- a/maas-api/deploy/overlays/dev/patches/debug-mode-patch.yaml
+++ b/maas-api/deploy/overlays/dev/patches/debug-mode-patch.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: key-manager
+spec:
+  template:
+    spec:
+      containers:
+      - name: key-manager
+        env:
+        - name: DEBUG_MODE
+          value: "true"

--- a/maas-api/internal/auth/middleware.go
+++ b/maas-api/internal/auth/middleware.go
@@ -1,17 +1,18 @@
 package auth
 
 import (
-	"os"
 	"strings"
 
 	"github.com/gin-gonic/gin"
+	"k8s.io/utils/env"
+
 	"net/http"
 )
 
 // AdminAuthMiddleware creates a middleware for admin authentication
 func AdminAuthMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
-		adminKey := getEnvOrDefault("ADMIN_API_KEY", "")
+		adminKey := env.GetString("ADMIN_API_KEY", "")
 
 		// If no admin key is set, allow access (backward compatibility)
 		if adminKey == "" {
@@ -48,12 +49,4 @@ func AdminAuthMiddleware() gin.HandlerFunc {
 
 		c.Next()
 	}
-}
-
-// getEnvOrDefault gets environment variable or returns default value
-func getEnvOrDefault(key, defaultValue string) string {
-	if value := os.Getenv(key); value != "" {
-		return value
-	}
-	return defaultValue
 }


### PR DESCRIPTION
Introduces `--debug` flag (and `cfg.DebugMode`) to enable debugging features for development purposes.

`dev` overlay has `DEBUG_MODE` environment variable injected to enable it for local development.

With this change Gin framework runs in `production` mode, rather than `debug` (which is the default and is shown as `WARNING` in the logs). 

```
[GIN-debug] [WARNING] Creating an Engine instance with the Logger and Recovery middleware already attached.

[GIN-debug] [WARNING] Running in "debug" mode. Switch to "release" mode in production. 
- using env:    export GIN_MODE=release
- using code:    gin.SetMode(gin.ReleaseMode)
```

**Bonus**: removed duplicated "getEnvOrDefault" and swapped to k8s utils.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added application Debug Mode for easier troubleshooting, configurable via environment variable (DEBUG_MODE) or CLI flag (--debug).

- Chores
  - Dev environment now enables Debug Mode by default via overlay patch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->