### PR TITLE
fix(kustomize): proper names in patch

### DIFF
--- a/maas-api/deploy/overlays/dev/patches/debug-mode-patch.yaml
+++ b/maas-api/deploy/overlays/dev/patches/debug-mode-patch.yaml
@@ -1,12 +1,12 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: key-manager
+  name: maas-api
 spec:
   template:
     spec:
       containers:
-      - name: key-manager
+      - name: maas-api
         env:
         - name: DEBUG_MODE
           value: "true"


### PR DESCRIPTION
Dev overlay patch for enabling debug mode was targeting old deployment `key-manager`. Lost in merge/rebase frenzy :)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development deployment identifiers to align with the maas-api service naming.
  * Ensured container naming is consistent across the development environment.
  * Confirmed debug mode remains enabled in development for troubleshooting.

No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->