### PR TITLE
feat(config): provider flag to swap token/key implementation

### DIFF
--- a/maas-api/internal/config/config.go
+++ b/maas-api/internal/config/config.go
@@ -17,6 +17,9 @@ type Config struct {
 	// Server configuration
 	Port string
 
+	// Provider config
+	Provider ProviderType
+
 	// Kubernetes configuration
 	KeyNamespace        string
 	SecretSelectorLabel string
@@ -40,6 +43,7 @@ func Load() *Config {
 		Name:      env.GetString("INSTANCE_NAME", "openshift-ai-inference"),
 		Namespace: env.GetString("NAMESPACE", "maas-api"),
 		Port:      env.GetString("PORT", "8080"),
+		Provider:  ProviderType(env.GetString("PROVIDER", string(Secrets))),
 		DebugMode: debugMode,
 		// Secrets provider configuration
 		KeyNamespace:             env.GetString("KEY_NAMESPACE", "llm"),
@@ -62,4 +66,5 @@ func (c *Config) bindFlags(fs *flag.FlagSet) {
 	fs.StringVar(&c.Namespace, "namespace", c.Namespace, "Namespace")
 	fs.StringVar(&c.Port, "port", c.Port, "Port to listen on")
 	fs.BoolVar(&c.DebugMode, "debug", c.DebugMode, "Enable debug mode")
+	fs.Var(&c.Provider, "provider", "Provider type to use for API keys")
 }

--- a/maas-api/internal/config/provider_type.go
+++ b/maas-api/internal/config/provider_type.go
@@ -1,0 +1,36 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+)
+
+var (
+	Secrets  ProviderType = "secrets"
+	SATokens ProviderType = "sa-tokens"
+)
+
+type ProviderType string
+
+func (p *ProviderType) Set(s string) error {
+	switch strings.ToLower(s) {
+	case string(Secrets):
+		*p = Secrets
+	case string(SATokens):
+		*p = SATokens
+	default:
+		return fmt.Errorf("unknown provider type %q (valid: %s, %s)", s, Secrets, SATokens)
+	}
+	return nil
+}
+
+func (p *ProviderType) String() string {
+	switch *p {
+	case Secrets:
+		return string(Secrets)
+	case SATokens:
+		return string(SATokens)
+	default:
+		return "unknown"
+	}
+}


### PR DESCRIPTION
To keep evolution of the `apps` suite both Service Account token and custom Secret implementation for key management are going to be kept for the time being.

This PR enables swapping implementation through configuration, either by using `--provider` flag or `PROVIDER` environment variable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added provider selection via environment variable or CLI flag (supports “secrets” and “sa-tokens”).
  * Introduced /tiers/lookup endpoint.
  * Expanded API with grouped endpoints for teams, users, and keys, with appropriate authentication.
  * Retained health and model endpoints (/health, /models, /v1/models).
  * Improved startup logging around default team creation.

* Chores
  * Internal routing and context handling streamlined for cleaner setup and shutdown behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->