### PR TITLE
feat(make): run target with injectable flags

### DIFF
--- a/maas-api/Makefile
+++ b/maas-api/Makefile
@@ -128,10 +128,11 @@ deploy-dev: ## Deploy to development
 		kustomize edit set image maas-api=$(FULL_IMAGE) && \
 		kustomize build . | kubectl apply -f -
 
+default_run_flags := --debug
+RUN_FLAGS ?= 
 .PHONY: run
 run: build ## Run the maas-api locally
-	@echo "Running $(BINARY_NAME)..."
-	@$(BUILD_DIR)/$(BINARY_NAME)
+	$(BUILD_DIR)/$(BINARY_NAME) $(default_run_flags) $(RUN_FLAGS) 
 
 .PHONY: version
 version: ## Show version information


### PR DESCRIPTION
When running `maas-api` locally using `make run` target it is now possible to configure it dynamically by using `RUN_FLAGS`, e.g.:

```shell
make run -e RUN_FLAGS="--port 9090"
```

> [!NOTE]
> `--debug` flag is always enabled


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved local run workflow: running the app in development now defaults to debug mode, shows the actual command being executed, and supports passing custom runtime flags when starting the app.
  * Enhances local debugging and flexibility without requiring code changes.
  * No impact to production behavior or user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->