### PR TITLE
Small fix to default REPO name

### DIFF
--- a/maas-api/Makefile
+++ b/maas-api/Makefile
@@ -7,7 +7,7 @@ ifeq (podman,$(CONTAINER_ENGINE))
 endif
 
 # Image settings
-REPO ?= ghcr.io/your-org/maas-maas-api
+REPO ?= ghcr.io/your-org/maas-api
 TAG ?= latest
 FULL_IMAGE ?= $(REPO):$(TAG)
 


### PR DESCRIPTION
To remove duplication in the name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default container image repository to ghcr.io/your-org/maas-api.
  * Image tags and build behavior remain the same; no functional changes to the application.
  * Operators may need to update deployment configurations to pull from the new image path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->