### PR TITLE
Updated Dockerfile to run build as root and updated default builder as Podman

### DIFF
--- a/maas-api/Dockerfile
+++ b/maas-api/Dockerfile
@@ -8,6 +8,7 @@ RUN go mod download
 
 COPY . .
 
+USER root
 RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w" -o maas-api ./cmd/
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest

--- a/maas-api/Makefile
+++ b/maas-api/Makefile
@@ -1,10 +1,7 @@
 # MaaS Billing Makefile
 
 # Container Engine to be used for building image and with kind
-CONTAINER_ENGINE ?= docker
-ifeq (podman,$(CONTAINER_ENGINE))
-    CONTAINER_ENGINE_EXTRA_FLAGS ?= --load
-endif
+CONTAINER_ENGINE ?= podman
 
 # Image settings
 REPO ?= ghcr.io/your-org/maas-api


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Updated the Dockerfile permissions to run `go build` as root user.
Updated Makefile to configure default build engine as `podman` instead of docker.
 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Testing in the dev environment using `make build-image` command. 
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Default container engine switched to Podman for image builds, improving compatibility in Podman-based environments.
  - Build stage now runs as root during compilation while runtime containers remain non-root, keeping runtime security posture.
  - Image loading behavior adjusted for the new default engine; deployments and runtime operation remain unaffected.
  - Improves local and CI build reliability across diverse developer environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->