### PR TITLE
Hermetic builds compatibility and remove healthcheck

### DIFF
--- a/maas-api/Dockerfile
+++ b/maas-api/Dockerfile
@@ -14,7 +14,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w" -o maas-api ./c
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 # Install CA certificates for HTTPS requests
-RUN microdnf update -y && microdnf install -y ca-certificates curl-minimal && microdnf clean all
+RUN microdnf install -y ca-certificates && microdnf clean all
 
 WORKDIR /app
 
@@ -29,8 +29,5 @@ RUN chmod +x maas-api && \
 USER 1001
 
 EXPOSE 8080
-
-HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-  CMD curl -f http://localhost:8080/health || exit 1
 
 CMD ["./maas-api"]


### PR DESCRIPTION
* Remove `microdnf update`, since network is not available in a hermetic build.
* No longer install `curl-minimal`. This is not needed by the application.
  * In consequence, remove `HEALTHCHECK` which is docker-specific. There are probes already configured in the k8s Deployment.

Related to https://issues.redhat.com/browse/RHOAIENG-33988

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined container image to reduce size and improve build efficiency by simplifying package installation and cleanup.
  * No changes to runtime command; existing behavior remains intact.

* **Refactor**
  * Removed container healthcheck configuration, affecting how health status is reported in deployments.

* **Documentation**
  * None.

* **Tests**
  * None.

* **Bug Fixes**
  * None.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->