### PR TITLE
feat: infer service account groups for tenant tiers dynamically

### DIFF
--- a/maas-api/deploy/overlays/dev/resources/tier-mapping-configmap.yaml
+++ b/maas-api/deploy/overlays/dev/resources/tier-mapping-configmap.yaml
@@ -9,17 +9,14 @@ data:
       level: 1
       groups:
       - system:authenticated
-      - system:serviceaccount:openshift-ai-inference-tier-free
     - name: premium
       description: Premium tier for paying customers
       level: 10
       groups:
-      - system:serviceaccount:openshift-ai-inference-tier-premium
       - premium-users
     - name: enterprise
       description: Enterprise tier for corporate customers
       level: 20
       groups:
-      - system:serviceaccount:openshift-ai-inference-tier-enterprise
       - enterprise-users
       - admin-users

--- a/maas-api/internal/tier/mapper.go
+++ b/maas-api/internal/tier/mapper.go
@@ -51,8 +51,9 @@ func (m *Mapper) Namespaces(ctx context.Context) map[string]string {
 
 	namespaces := make(map[string]string, len(tiers))
 
-	for _, tier := range tiers {
-		namespaces[tier.Name] = fmt.Sprintf("%s-tier-%s", m.tenantName, tier.Name)
+	for i := range tiers {
+		tier := &tiers[i]
+		namespaces[tier.Name] = m.projectedNsName(tier)
 	}
 
 	return namespaces
@@ -109,5 +110,14 @@ func (m *Mapper) loadTierConfig(ctx context.Context) ([]Tier, error) {
 		return nil, fmt.Errorf("failed to parse tier configuration: %w", err)
 	}
 
+	for i := range tiers {
+		tier := &tiers[i]
+		tier.Groups = append(tier.Groups, fmt.Sprintf("system:serviceaccount:%s", m.projectedNsName(tier)))
+	}
+
 	return tiers, nil
+}
+
+func (m *Mapper) projectedNsName(tier *Tier) string {
+	return fmt.Sprintf("%s-tier-%s", m.tenantName, tier.Name)
 }

--- a/maas-api/internal/tier/mapper_test.go
+++ b/maas-api/internal/tier/mapper_test.go
@@ -39,6 +39,12 @@ func TestMapper_GetTierForGroups(t *testing.T) {
 			description:  "User belongs to only free tier group",
 		},
 		{
+			name:         "inferred SA group - free tier",
+			groups:       []string{"system:serviceaccount:test-tenant-tier-free"},
+			expectedTier: "free",
+			description:  "User belongs to only free tier group",
+		},
+		{
 			name:         "single group - premium tier",
 			groups:       []string{"premium-users"},
 			expectedTier: "premium",


### PR DESCRIPTION
Service account groups were expected to be defined in the config, making tenant-specific namespace projections less flexible. This change ensures that tier-related service accounts are inferred automatically per tenant, reducing manual config and potential drift.

- Removed hardcoded service account group mappings from the dev overlay configmap
- Added dynamic projection of service account groups in the tier mapper
- Extended test coverage to validate group inference for free tier service accounts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Service accounts are now inferred and automatically mapped to the appropriate tier (free, premium, enterprise) via namespace-derived group entries, so they no longer need explicit listing in configuration.

* Bug Fixes
  * More consistent namespace handling for tier resolution, reducing mismatches for service-account groups.

* Tests
  * Added test coverage confirming inferred service-account group maps to the free tier.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->