### PR TITLE
chore: ns/gw/cfgmap constants

### DIFF
--- a/maas-api/internal/config/config.go
+++ b/maas-api/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"flag"
 
+	"github.com/opendatahub-io/maas-billing/maas-api/internal/constant"
 	"k8s.io/utils/env"
 )
 
@@ -40,8 +41,8 @@ func Load() *Config {
 	defaultTeam, _ := env.GetBool("CREATE_DEFAULT_TEAM", true)
 
 	c := &Config{
-		Name:      env.GetString("INSTANCE_NAME", "openshift-ai-inference"),
-		Namespace: env.GetString("NAMESPACE", "maas-api"),
+		Name:      env.GetString("INSTANCE_NAME", constant.DefaultGatewayName),
+		Namespace: env.GetString("NAMESPACE", constant.DefaultNamespace),
 		Port:      env.GetString("PORT", "8080"),
 		Provider:  ProviderType(env.GetString("PROVIDER", string(SATokens))),
 		DebugMode: debugMode,
@@ -54,7 +55,6 @@ func Load() *Config {
 		CreateDefaultTeam:        defaultTeam,
 		AdminAPIKey:              env.GetString("ADMIN_API_KEY", ""),
 	}
-
 	c.bindFlags(flag.CommandLine)
 
 	return c

--- a/maas-api/internal/constant/const.go
+++ b/maas-api/internal/constant/const.go
@@ -1,0 +1,7 @@
+package constant
+
+const (
+	TierMappingConfigMap = "tier-to-group-mapping"
+	DefaultNamespace     = "maas-api"
+	DefaultGatewayName   = "openshift-ai-inference"
+)

--- a/maas-api/internal/tier/mapper.go
+++ b/maas-api/internal/tier/mapper.go
@@ -8,16 +8,13 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/opendatahub-io/maas-billing/maas-api/internal/constant"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	corev1typed "k8s.io/client-go/kubernetes/typed/core/v1"
 
 	"gopkg.in/yaml.v3"
 	"k8s.io/apimachinery/pkg/api/errors"
-)
-
-const (
-	MappingConfigMap = "tier-to-group-mapping"
 )
 
 var defaultTier = Tier{
@@ -71,10 +68,10 @@ func (m *Mapper) GetTierForGroups(ctx context.Context, groups ...string) (string
 	tiers, err := m.loadTierConfig(ctx)
 	if err != nil {
 		if errors.IsNotFound(err) {
-			log.Printf("tier mapping %s not found, defaulting to 'free' tier", MappingConfigMap)
+			log.Printf("tier mapping %s not found, defaulting to 'free' tier", constant.TierMappingConfigMap)
 			return "free", nil
 		}
-		log.Printf("Failed to load tier configuration from ConfigMap %s: %v", MappingConfigMap, err)
+		log.Printf("Failed to load tier configuration from ConfigMap %s: %v", constant.TierMappingConfigMap, err)
 		return "", fmt.Errorf("failed to load tier configuration: %w", err)
 	}
 
@@ -94,14 +91,14 @@ func (m *Mapper) GetTierForGroups(ctx context.Context, groups ...string) (string
 }
 
 func (m *Mapper) loadTierConfig(ctx context.Context) ([]Tier, error) {
-	cm, err := m.configMapClient.Get(ctx, MappingConfigMap, metav1.GetOptions{})
+	cm, err := m.configMapClient.Get(ctx, constant.TierMappingConfigMap, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}
 
 	configData, exists := cm.Data["tiers"]
 	if !exists {
-		log.Printf("tiers key not found in ConfigMap %s", MappingConfigMap)
+		log.Printf("tiers key not found in ConfigMap %s", constant.TierMappingConfigMap)
 		return nil, fmt.Errorf("tier to group mapping configuration not found")
 	}
 

--- a/maas-api/internal/tier/mapper_test.go
+++ b/maas-api/internal/tier/mapper_test.go
@@ -3,6 +3,7 @@ package tier_test
 import (
 	"testing"
 
+	"github.com/opendatahub-io/maas-billing/maas-api/internal/constant"
 	"github.com/opendatahub-io/maas-billing/maas-api/internal/tier"
 	"github.com/opendatahub-io/maas-billing/maas-api/test/fixtures"
 	corev1 "k8s.io/api/core/v1"
@@ -162,7 +163,7 @@ func TestMapper_GetTierForGroups_SameLevels(t *testing.T) {
 	// Test case where two tiers have the same level
 	configMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      tier.MappingConfigMap,
+			Name:      constant.TierMappingConfigMap,
 			Namespace: testNamespace,
 		},
 		Data: map[string]string{

--- a/maas-api/test/fixtures/configmaps.go
+++ b/maas-api/test/fixtures/configmaps.go
@@ -1,7 +1,7 @@
 package fixtures
 
 import (
-	"github.com/opendatahub-io/maas-billing/maas-api/internal/tier"
+	"github.com/opendatahub-io/maas-billing/maas-api/internal/constant"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -37,7 +37,7 @@ const TierConfigYAML = `
 func CreateTierConfigMap(namespace string) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      tier.MappingConfigMap,
+			Name:      constant.TierMappingConfigMap,
 			Namespace: namespace,
 		},
 		Data: map[string]string{


### PR DESCRIPTION
For easier code reuse common defaults for namespace, gateway name and tier configmap has been extracted as constants.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Centralized default namespace and gateway name, and unified the tier-mapping ConfigMap name to ensure consistent configuration across the app.
- Tests
  - Updated tests and fixtures to use the centralized constants for configuration names, improving reliability and maintainability.
- Chores
  - Introduced shared constants for configuration values to reduce duplication and potential mismatches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->