### PR TITLE
refactor: fail early when no tier mapping configmap is found

### DIFF
--- a/maas-api/internal/tier/handler_test.go
+++ b/maas-api/internal/tier/handler_test.go
@@ -170,7 +170,7 @@ func TestHandler_PostTierLookup_BadRequest(t *testing.T) {
 	}
 }
 
-func TestHandler_PostTierLookup_ConfigMapMissing_ShouldDefaultEveryUserToFreeTier(t *testing.T) {
+func TestHandler_PostTierLookup_ConfigMapMissing_ShouldError(t *testing.T) {
 	mapper := createTestMapper(false) // No ConfigMap
 	router := fixtures.SetupTierTestRouter(mapper)
 
@@ -182,16 +182,7 @@ func TestHandler_PostTierLookup_ConfigMapMissing_ShouldDefaultEveryUserToFreeTie
 	req.Header.Set("Content-Type", "application/json")
 	router.ServeHTTP(w, req)
 
-	if w.Code != http.StatusOK {
-		t.Errorf("expected status %d, got %d", http.StatusOK, w.Code)
-	}
-
-	var response tier.LookupResponse
-	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
-		t.Fatalf("failed to unmarshal response: %v", err)
-	}
-
-	if response.Tier != "free" {
-		t.Errorf("expected tier 'free', got %s", response.Tier)
+	if w.Code == http.StatusOK {
+		t.Errorf("expected status %d, got %d", http.StatusServiceUnavailable, w.Code)
 	}
 }

--- a/maas-api/internal/tier/mapper_test.go
+++ b/maas-api/internal/tier/mapper_test.go
@@ -155,17 +155,12 @@ func TestMapper_GetTierForGroups(t *testing.T) {
 func TestMapper_GetTierForGroups_MissingConfigMap(t *testing.T) {
 	ctx := t.Context()
 
-	clientset := fake.NewSimpleClientset()
+	clientset := fake.NewClientset()
 	mapper := tier.NewMapper(clientset, testTenant, testNamespace)
 
-	// Should default to free mappedTier when ConfigMap is missing
-	mappedTier, err := mapper.GetTierForGroups(ctx, "any-group", "another-group")
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-
-	if mappedTier != "free" {
-		t.Errorf("expected default mappedTier 'free', got %s", mappedTier)
+	_, err := mapper.GetTierForGroups(ctx, "any-group", "another-group")
+	if err == nil {
+		t.Errorf("expected error")
 	}
 }
 


### PR DESCRIPTION
Previously, when tier mapping configmap was missing, every used got defaulted to `free`, which could mislead users and hide configuration issues. 

By failing fast, cluster operators are immediately informed of the problem and can correct it, avoiding confusion and unintended behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Clearer, user-facing error messages when a tier’s namespace cannot be resolved.

* **Bug Fixes**
  * Token revocation and tier operations now fail with explicit errors when tier configuration is missing instead of silently defaulting.

* **Refactor**
  * Namespace resolution streamlined and legacy defaults removed to reduce unexpected behavior.

* **Tests**
  * Updated tests to expect failure paths when tier configuration is absent (no longer defaulting to a fallback tier).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->