### PR TITLE
Fixing sample model

### DIFF
--- a/docs/samples/models/simulator/model.yaml
+++ b/docs/samples/models/simulator/model.yaml
@@ -7,7 +7,8 @@ spec:
     uri: hf://facebook/opt-125m
     name: facebook/opt-125m
   replicas: 1
-  router:
+  router: 
+    route: {}
     # Connect to MaaS-enabled gateway
     gateway:
       refs:


### PR DESCRIPTION
The gateway did infact need the `route: {}` in order to actually create the HTTPRoute

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the simulator model sample YAML to reflect the current router structure, introducing an explicit route field under router for clarity and alignment with the latest schema.
  - Improves accuracy of examples and helps users configure simulator models correctly using the updated configuration format.
  - No runtime or API changes; impact is limited to sample documentation and configuration guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->