### PR TITLE
fix: remove hardcoded hostname in gateway-route

### DIFF
--- a/deployment/overlays/openshift/gateway-route.yaml
+++ b/deployment/overlays/openshift/gateway-route.yaml
@@ -16,7 +16,7 @@ metadata:
     app: maas
     gateway: maas-default-gateway
 spec:
-  host: gateway.apps.test-maas-v1.eh5f.s1.devshift.org
+  host: gateway.${CLUSTER_DOMAIN} 
   port:
     targetPort: 80
   tls:
@@ -26,4 +26,5 @@ spec:
     kind: Service
     name: maas-default-gateway-openshift-default
     weight: 100
-  wildcardPolicy: None 
+  wildcardPolicy: None
+


### PR DESCRIPTION
Removes the hardcoded route.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved deployment flexibility by templating the route host to use the cluster’s domain, reducing manual configuration and easing multi-cluster deployments.
* **Style**
  * Cleaned up formatting by removing trailing whitespace in configuration with no functional impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->