### PR TITLE
fix: scope Kuadrant OperatorGroup to kuadrant-system namespace

### DIFF
--- a/deployment/scripts/install-dependencies.sh
+++ b/deployment/scripts/install-dependencies.sh
@@ -111,7 +111,9 @@ kind: OperatorGroup
 metadata:
   name: kuadrant-operator-group
   namespace: kuadrant-system
-spec: {}
+spec:
+  targetNamespaces:
+  - kuadrant-system
 EOF
         
         # Check if the CatalogSource already exists before applying


### PR DESCRIPTION
  The OperatorGroup spec was empty, causing it to watch all namespaces
  and replicate CSVs cluster-wide. This prevented CRDs from being created
  and kept all Kuadrant operators in a pending state.

Example:

```
$ kubectl get csv -A | grep -c kuadrant-operator
80

Truncated output (replicated on all namespace):
🐈 ip-172-31-45-224:~$ kubectl get csv -A
NAMESPACE                                          NAME                           DISPLAY                            VERSION          REPLACES                      PHASE
cert-manager                                       authorino-operator.v0.22.0     Authorino Operator                 0.22.0                                         Pending
cert-manager                                       dns-operator.v0.15.0           DNS Operator                       0.15.0                                         Pending
cert-manager                                       kuadrant-operator.v1.3.0-rc2   Kuadrant Operator                  1.3.0-rc2                                      Pending
cert-manager                                       limitador-operator.v0.16.0     Limitador                          0.16.0                                         Pending
cert-manager                                       servicemeshoperator3.v3.1.0    Red Hat OpenShift Service Mesh 3   3.1.0            servicemeshoperator3.v3.0.5   Succeeded
default                                            authorino-operator.v0.22.0     Authorino Operator                 0.22.0                                         Pending
default                                            dns-operator.v0.15.0           DNS Operator                       0.15.0                                         Pending
default                                            kuadrant-operator.v1.3.0-rc2   Kuadrant Operator                  1.3.0-rc2                                      Pending
default                                            limitador-operator.v0.16.0     Limitador                          0.16.0                                         Pending
default                                            servicemeshoperator3.v3.1.0    Red Hat OpenShift Service Mesh 3   3.1.0            servicemeshoperator3.v3.0.5   Succeeded
kserve                                             authorino-operator.v0.22.0     Authorino Operator                 0.22.0                                         Pending
kserve                                             dns-operator.v0.15.0           DNS Operator                       0.15.0                                         Pending
kserve                                             kuadrant-operator.v1.3.0-rc2   Kuadrant Operator                  1.3.0-rc2                                      Pending
kserve                                             limitador-operator.v0.16.0     Limitador                          0.16.0                                         Pending


```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Scoped the OperatorGroup to the kuadrant-system namespace, ensuring the operator manages only resources within that namespace during OpenShift installation and preventing unintended cluster-wide impact.

* **Chores**
  * Updated installation configuration to include targetNamespaces for a more predictable, namespace-scoped deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->