### PR TITLE
fix: Install/Deploy Fixes

### DIFF
--- a/deployment/scripts/install-dependencies.sh
+++ b/deployment/scripts/install-dependencies.sh
@@ -98,11 +98,11 @@ install_component() {
         return 0
     fi
     
-    # Inline handler for Kuadrant (installed via Helm)
+    # Inline handler for Kuadrant (installed via OLM)
     if [[ "$component" == "kuadrant" ]]; then
         # Ensure kuadrant-system namespace exists
         kubectl create namespace kuadrant-system 2>/dev/null || echo "✅ Namespace kuadrant-system already exists"
-        
+
 
         echo "🚀 Creating Kuadrant OperatorGroup..."
         kubectl apply -f - <<EOF
@@ -113,7 +113,7 @@ metadata:
   namespace: kuadrant-system
 spec: {}
 EOF
-        
+
         # Check if the CatalogSource already exists before applying
         if kubectl get catalogsource kuadrant-operator-catalog -n kuadrant-system &>/dev/null; then
             echo "✅ Kuadrant CatalogSource already exists in namespace kuadrant-system, skipping creation."
@@ -154,7 +154,7 @@ EOF
         ATTEMPTS=0
         MAX_ATTEMPTS=5
         while true; do
-        
+
             if kubectl get deployment/kuadrant-operator-controller-manager -n kuadrant-system &>/dev/null; then
                 break
             else
@@ -360,3 +360,4 @@ if [[ "$COMPONENT_SELECTED" == true ]]; then
         echo "🎉 Selected components installed successfully!"
     fi
 fi
+


### PR DESCRIPTION
- Add helper functions for CSV and CRD waiting with proper timeouts instead of sleep commands
- Fix Kuadrant installation timing: split gateway and kuadrant deployment, wait for OLM operators before applying Kuadrant config (fixes circular dependencies)
- Add OpenShift routes deployment step
- Only cleanup leftover CRDs if Kuadrant is not already installed
- Make install and deployment scripts idempotent

** Note ** the llmisvc kserve webhook issue is still present once everything is installed and a model is attempted to deploy but everything gets installed and you can retrieve a token. See the end of the deploy video below for the exact error.

Depends on #153

https://github.com/user-attachments/assets/c28e44ec-5565-4c91-912d-ad013e617960



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Robust, time-bounded waits with progress for CRDs and operator installations.
  - Pre-install cleanup of leftover CRDs and OpenShift-specific deployment steps (routes, gateway routes).
  - Expanded status reporting and readiness checks for Service Mesh and Kuadrant CRDs.
- Refactor
  - Reworked deployment sequencing and wording; centralized CRD cleanup.
  - Switched network deployment approach and moved Kuadrant install to OLM-only path with patching when needed.
- Documentation
  - Enhanced end-user guidance: obtaining endpoints, token generation, testing model endpoints, and troubleshooting steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->