### PR TITLE
fix: revert Kuadrant OperatorGroup targetNamespaces #153

### DIFF
--- a/deployment/scripts/install-dependencies.sh
+++ b/deployment/scripts/install-dependencies.sh
@@ -111,9 +111,7 @@ kind: OperatorGroup
 metadata:
   name: kuadrant-operator-group
   namespace: kuadrant-system
-spec:
-  targetNamespaces:
-  - kuadrant-system
+spec: {}
 EOF
 
         # Check if the CatalogSource already exists before applying


### PR DESCRIPTION
- This will hopefully be reconciled with the Kuadrant release


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted OperatorGroup configuration to remove explicit namespace targeting, preventing validation/scope issues during installation.
* **Chores**
  * Simplified deployment setup for operator installation while keeping CatalogSource and Subscription creation behavior unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->