### PR TITLE
fix: deployment script improvements and workarounds for webhook issues

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -213,7 +213,7 @@ kubectl patch authpolicy maas-api-auth-policy -n maas-api \
 
 ```bash
 CLUSTER_DOMAIN=$(kubectl get ingresses.config.openshift.io cluster -o jsonpath='{.spec.domain}')
-HOST="maas-api.${CLUSTER_DOMAIN}"
+HOST="maas.${CLUSTER_DOMAIN}"
 ```
 
 ### 2. Get Authentication Token

--- a/deployment/base/networking/gateway-api.yaml
+++ b/deployment/base/networking/gateway-api.yaml
@@ -36,7 +36,7 @@ spec:
   gatewayClassName: openshift-default
   listeners:
    - name: http
-     hostname: maas-api.${CLUSTER_DOMAIN}
+     hostname: maas.${CLUSTER_DOMAIN}
      port: 80
      protocol: HTTP
      allowedRoutes:

--- a/deployment/scripts/install-dependencies.sh
+++ b/deployment/scripts/install-dependencies.sh
@@ -111,9 +111,7 @@ kind: OperatorGroup
 metadata:
   name: kuadrant-operator-group
   namespace: kuadrant-system
-spec:
-  targetNamespaces:
-  - kuadrant-system
+spec: {}
 EOF
 
         # Check if the CatalogSource already exists before applying

--- a/docs/samples/models/simulator/model.yaml
+++ b/docs/samples/models/simulator/model.yaml
@@ -24,7 +24,7 @@ spec:
         - --port
         - "8000" 
         - --model
-        - facebook-opt-125m-simulated
+        - facebook/opt-125m
         - --mode
         - random
         - --ssl-certfile


### PR DESCRIPTION
This PR includes critical fixes and workarounds for the OpenShift deployment script to address webhook connectivity issues and improve the user experience.

## Changes

### 🔧 Temporary Workarounds (To Be Removed)
- **Remove overly restrictive NetworkPolicy** for ODH model controller that was blocking webhook traffic
- **Restart Kuadrant, Authorino, and Limitador operators** to refresh webhook configurations after NetworkPolicy removal
- Added proper wait/status checks for operator readiness

### 🌐 URL/Hostname Fixes
- Changed gateway hostname from `maas-api.${CLUSTER_DOMAIN}` to `maas.${CLUSTER_DOMAIN}` for consistency
- Updated all documentation and script examples to use correct hostname

### 🐛 Bug Fixes
- **Fixed variable expansion in curl commands** - Changed from single quotes to double quotes with proper escaping so `${MODEL_NAME}` is correctly resolved
- Added `-sSk` flags to curl commands for silent, show-errors, and insecure (self-signed certs)
- Fixed simulator model name from `facebook-opt-125m-simulated` to `facebook/opt-125m`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated instructions and examples to use the new endpoint host (maas.${CLUSTER_DOMAIN}).
  * Revised testing flow with clearer model URL guidance and escaped JSON payload examples.

* **Chores**
  * Updated gateway configuration to serve on maas.${CLUSTER_DOMAIN}.
  * Improved deployment scripts with operator readiness checks, temporary workarounds, and more resilient curl options.
  * Adjusted operator installation scope by simplifying OperatorGroup configuration.

* **Tests**
  * Sample model configuration now targets “facebook/opt-125m” for simulator scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->