### PR TITLE
fix: setting gateway to unmanaged

### DIFF
--- a/deployment/base/policies/gateway-auth-policy.yaml
+++ b/deployment/base/policies/gateway-auth-policy.yaml
@@ -2,6 +2,8 @@
 apiVersion: kuadrant.io/v1
 kind: AuthPolicy
 metadata:
+  annotations:
+    opendatahub.io/managed: "false"
   name: gateway-auth-policy
   namespace: openshift-ingress
 spec:


### PR DESCRIPTION
Recent update in the controller has allowed for us to add an annotation that prevents the ODH controller from creating an AuthPolicy so that we can apply our own.

Related to this PR:
https://github.com/opendatahub-io/odh-model-controller/pulls?q=is%3Apr+is%3Aclosed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal authentication policy configuration metadata to reflect management status. No user-facing changes or impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->