### PR TITLE
chore: move to kuadrant v1.3 final

### DIFF
--- a/deployment/base/maas-api/kustomization.yaml
+++ b/deployment/base/maas-api/kustomization.yaml
@@ -4,7 +4,6 @@ kind: Kustomization
 namespace: maas-api
 
 resources:
-  - namespace.yaml
   - deployment.yaml
   - service.yaml
   - rbac

--- a/deployment/base/maas-api/namespace.yaml
+++ b/deployment/base/maas-api/namespace.yaml
@@ -1,5 +1,0 @@
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: maas-api

--- a/deployment/scripts/install-dependencies.sh
+++ b/deployment/scripts/install-dependencies.sh
@@ -129,7 +129,7 @@ spec:
   displayName: Kuadrant Operators
   grpcPodConfig:
     securityContextConfig: restricted
-  image: 'quay.io/kuadrant/kuadrant-operator-catalog:v1.3.0-rc2'
+  image: 'quay.io/kuadrant/kuadrant-operator-catalog:v1.3.0'
   publisher: grpc
   sourceType: grpc
 EOF
@@ -178,7 +178,7 @@ EOF
         # Patch Kuadrant for OpenShift Gateway Controller
         echo "   Patching Kuadrant operator..."
         if ! kubectl -n kuadrant-system get deployment kuadrant-operator-controller-manager -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="ISTIO_GATEWAY_CONTROLLER_NAMES")]}' | grep -q "ISTIO_GATEWAY_CONTROLLER_NAMES"; then
-          kubectl patch csv kuadrant-operator.v1.3.0-rc2 -n kuadrant-system --type='json' -p='[
+          kubectl patch csv kuadrant-operator.v1.3.0 -n kuadrant-system --type='json' -p='[
             {
               "op": "add",
               "path": "/spec/install/spec/deployments/0/spec/template/spec/containers/0/env/-",

--- a/docs/content/installation.md
+++ b/docs/content/installation.md
@@ -67,9 +67,6 @@ kubectl get pods -n opendatahub
 
 #### Deploy Sample Models (Optional)
 
-!!! note
-    These models use KServe's `LLMInferenceService` custom resource, which requires ODH/RHOAI with KServe enabled.
-
 **Simulator Model (CPU)**
 ```bash
 PROJECT_DIR=$(git rev-parse --show-toplevel)
@@ -148,14 +145,13 @@ If you prefer to test manually or troubleshoot specific components, follow these
 
 #### 1. Get Gateway Endpoint
 
-For OpenShift:
 ```bash
-HOST="$(kubectl get gateway maas-default-gateway -n openshift-ingress -o jsonpath='{.status.addresses[0].value}')"
+CLUSTER_DOMAIN=$(kubectl get ingresses.config.openshift.io cluster -o jsonpath='{.spec.domain}')
+HOST="maas.${CLUSTER_DOMAIN}"
 ```
 
 #### 2. Get Authentication Token
 
-For OpenShift:
 ```bash
 TOKEN_RESPONSE=$(curl -sSk \
   -H "Authorization: Bearer $(oc whoami -t)" \


### PR DESCRIPTION
This updates install script to setup Kuadrant v1.3 final version.

Also, the namespace manifest is removed, because it is pre-created by `deploy-openshift.sh`. This is inline with other ODH components where manifests won't create namespaces, but the odh-operator will create.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Kuadrant operator/catalog to v1.3.0 and aligned install/wait steps
  * Removed explicit namespace manifest from deployment set (namespace no longer created by manifests)
  * Removed OpenShift-specific Kuadrant patch step from the deployment flow

* **Documentation**
  * Simplified gateway endpoint retrieval to derive cluster domain and construct host
  * Consolidated token retrieval instructions and removed an outdated note from sample models section
<!-- end of auto-generated comment: release notes by coderabbit.ai -->