### PR TITLE
fix: set gateway to unmanaged

### DIFF
--- a/deployment/base/networking/gateway-api.yaml
+++ b/deployment/base/networking/gateway-api.yaml
@@ -28,6 +28,8 @@ kind: Gateway
 metadata:
   name: maas-default-gateway
   namespace: openshift-ingress
+  annotations:
+    opendatahub.io/managed: "false"
   labels:
     app.kubernetes.io/name: maas
     app.kubernetes.io/instance: maas-default-gateway

--- a/deployment/base/policies/gateway-auth-policy.yaml
+++ b/deployment/base/policies/gateway-auth-policy.yaml
@@ -2,8 +2,6 @@
 apiVersion: kuadrant.io/v1
 kind: AuthPolicy
 metadata:
-  annotations:
-    opendatahub.io/managed: "false"
   name: gateway-auth-policy
   namespace: openshift-ingress
 spec:


### PR DESCRIPTION
Fixing unmanaged gateway, put the annotation on the wrong object.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated gateway resource management configuration with strategic annotation adjustments to enhance resource control, operational visibility, and infrastructure management for network resources.
  * Revised authentication policy resource annotations to ensure consistency across network resources, align operational practices with current management standards, and improve overall resource governance and control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->