### PR TITLE
chore: setup ODH with operator

### DIFF
--- a/deployment/scripts/installers/install-odh.sh
+++ b/deployment/scripts/installers/install-odh.sh
@@ -5,20 +5,62 @@
 
 set -e
 
+
+# TODO: For now, default to DEV_INSTALL, because no suitable ODH version for MaaS has
+# TODO: been released yet. Switch to false once ODH releases.
+DEV_INSTALL=true
+if [[ $# -eq 1 ]] && [[ "$1" == "--dev" ]]; then
+    DEV_INSTALL=true
+elif [[ $# -ne 0 ]]; then
+    echo "This script only supports a single argument: --dev"
+    exit 1
+fi
+
 echo "========================================="
 echo "🚀 OpenDataHub (ODH) Installation"
 echo "========================================="
 echo ""
 
 # Step 1: Install ODH Operator
-echo "1️⃣ Installing ODH Operator..."
-
-# Check if operator is already installed
-if kubectl get csv -n openshift-operators 2>/dev/null | grep -q opendatahub-operator; then
-    echo "   ✅ ODH operator already installed"
-else
-    echo "   Creating OperatorGroup..."
+if [[ "$DEV_INSTALL" == true ]]; then
+    ODH_OPERATOR_NS="opendatahub-operator-system"
+    echo "1️⃣ Installing ODH Operator from repository manifests..."
     cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: $ODH_OPERATOR_NS
+EOF
+
+    TMP_DIR=$(mktemp -d)
+    trap 'rm -fr -- "$TMP_DIR"' EXIT
+
+    pushd $TMP_DIR
+    git clone -q --depth 1 "https://github.com/opendatahub-io/opendatahub-operator.git"
+    if [[ $? -ne 0 ]]; then
+        echo "   Failed cloning repository https://github.com/opendatahub-io/opendatahub-operator.git"
+        popd
+        exit 1
+    fi
+
+    pushd ./opendatahub-operator
+    cp config/manager/kustomization.yaml.in config/manager/kustomization.yaml
+    sed -i 's#REPLACE_IMAGE#quay.io/opendatahub/opendatahub-operator#' config/manager/kustomization.yaml
+    kustomize build --load-restrictor LoadRestrictionsNone config/default | kubectl apply --namespace $ODH_OPERATOR_NS -f -
+    popd
+    popd
+
+    echo "   Waiting for operator to be ready (this may take a few minutes)..."
+    kubectl wait deployment/opendatahub-operator-controller-manager -n $ODH_OPERATOR_NS --for condition=Available=True --timeout=300s
+else
+    echo "1️⃣ Installing ODH Operator..."
+
+    # Check if operator is already installed
+    if kubectl get csv -n openshift-operators 2>/dev/null | grep -q opendatahub-operator; then
+        echo "   ✅ ODH operator already installed"
+    else
+        echo "   Creating OperatorGroup..."
+        cat <<EOF | kubectl apply -f -
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
@@ -26,8 +68,8 @@ metadata:
   namespace: openshift-operators
 EOF
 
-    echo "   Creating Subscription..."
-    cat <<EOF | kubectl apply -f -
+        echo "   Creating Subscription..."
+        cat <<EOF | kubectl apply -f -
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
@@ -40,67 +82,36 @@ spec:
   sourceNamespace: openshift-marketplace
 EOF
 
-    echo "   Waiting for operator to be ready (this may take a few minutes)..."
-    sleep 30
-    
-    # Wait for operator to be ready
-    for i in {1..30}; do
-        if kubectl get deployment -n openshift-operators | grep -q opendatahub-operator; then
-            echo "   Operator deployment found, waiting for ready state..."
-            kubectl wait --for=condition=Available deployment -l app.kubernetes.io/name=opendatahub-operator -n openshift-operators --timeout=300s || true
-            break
-        fi
-        echo "   Waiting for operator deployment to appear... ($i/30)"
-        sleep 10
-    done
-fi
+        echo "   Waiting for operator to be ready (this may take a few minutes)..."
+        sleep 30
 
-# Step 2: Create ODH namespace if it doesn't exist
-echo ""
-echo "2️⃣ Creating opendatahub namespace..."
-kubectl create namespace opendatahub 2>/dev/null || echo "   Namespace already exists"
-
-# Step 3: Wait for CRDs to be registered
-echo ""
-echo "3️⃣ Waiting for ODH CRDs to be registered..."
-for i in {1..30}; do
-    if kubectl get crd dscinitializations.dscinitialization.opendatahub.io &>/dev/null 2>&1; then
-        echo "   ✅ DSCInitialization CRD found"
-        break
+      # Wait for operator to be ready
+      for i in {1..30}; do
+          if kubectl get deployment -n openshift-operators | grep -q opendatahub-operator; then
+              echo "   Operator deployment found, waiting for ready state..."
+              kubectl wait --for=condition=Available deployment -l app.kubernetes.io/name=opendatahub-operator -n openshift-operators --timeout=300s || true
+              break
+          fi
+          echo "   Waiting for operator deployment to appear... ($i/30)"
+          sleep 10
+      done
     fi
-    echo "   Waiting for DSCInitialization CRD... ($i/30)"
-    sleep 10
-done
-
-if ! kubectl get crd dscinitializations.dscinitialization.opendatahub.io &>/dev/null 2>&1; then
-    echo "   ❌ DSCInitialization CRD not found after waiting"
-    echo "   Please check the operator logs:"
-    echo "   kubectl logs -n openshift-operators deployment/opendatahub-operator-controller-manager"
-    exit 1
 fi
 
-# Step 4: Create DSCInitialization (REQUIRED before DataScienceCluster)
+# Step 2: Create DSCInitialization (REQUIRED before DataScienceCluster)
 echo ""
-echo "4️⃣ Creating DSCInitialization resource..."
+echo "2️⃣ Creating DSCInitialization resource..."
 cat <<EOF | kubectl apply -f -
-apiVersion: dscinitialization.opendatahub.io/v1
+apiVersion: dscinitialization.opendatahub.io/v2
 kind: DSCInitialization
 metadata:
   name: default-dsci
-  namespace: opendatahub
 spec:
   applicationsNamespace: opendatahub
   monitoring:
     managementState: Managed
     namespace: opendatahub
-  serviceMesh:
-    managementState: Managed
-    auth:
-      audiences:
-        - "https://kubernetes.default.svc"
-    controlPlane:
-      name: data-science-smcp
-      namespace: istio-system
+    metrics: {}
   trustedCABundle:
     managementState: Managed
 EOF
@@ -115,66 +126,43 @@ for i in {1..30}; do
     sleep 10
 done
 
-# Step 5: Create DataScienceCluster
+# Step 3: Create DataScienceCluster
 echo ""
-echo "5️⃣ Creating DataScienceCluster..."
+echo "3️⃣ Creating DataScienceCluster..."
 cat <<EOF | kubectl apply -f -
-apiVersion: datasciencecluster.opendatahub.io/v1
+apiVersion: datasciencecluster.opendatahub.io/v2
 kind: DataScienceCluster
 metadata:
   name: default-dsc
-  namespace: opendatahub
 spec:
   components:
-    # Core component for notebooks
-    dashboard:
-      managementState: Managed
-    
-    # Notebook controller
-    workbenches:
-      managementState: Managed
-    
-    # Model serving with KServe in RawDeployment mode (no Knative)
     kserve:
       managementState: Managed
-      defaultDeploymentMode: RawDeployment
       nim:
-        managementState: Managed  # Enable NVIDIA NIM support
-      rawDeploymentServiceConfig: Headless
-      serving:
-        ingressGateway:
-          certificate:
-            type: OpenshiftDefaultIngress
-        managementState: Removed  # Disable Knative serving (using RawDeployment)
-        name: knative-serving
-    
-    # Model serving platform
-    modelmeshserving:
-      managementState: Removed  # Use KServe instead
-    
-    # Data science pipelines
-    datasciencepipelines:
-      managementState: Removed  # Not needed for MaaS
-    
-    # Ray for distributed computing
+        managementState: Managed
+      rawDeploymentServiceConfig: Headed
+
+    # Components not needed for MaaS:
+    dashboard:
+      managementState: Removed
+    workbenches:
+      managementState: Removed
+    aipipelines:
+      managementState: Removed
     ray:
-      managementState: Removed  # Not needed for MaaS
-    
-    # Kueue for job queueing
+      managementState: Removed
     kueue:
-      managementState: Removed  # Not needed for MaaS
-    
-    # Model registry
+      managementState: Removed
     modelregistry:
-      managementState: Removed  # Not needed for MaaS
-    
-    # TrustyAI for model explainability
+      managementState: Removed
     trustyai:
-      managementState: Removed  # Not needed for MaaS
-    
-    # Training operator
+      managementState: Removed
     trainingoperator:
-      managementState: Removed  # Not needed for MaaS
+      managementState: Removed
+    feastoperator:
+      managementState: Removed
+    llamastackoperator:
+      managementState: Removed
 EOF
 
 echo "   Waiting for DataScienceCluster to be ready..."
@@ -190,7 +178,7 @@ for i in {1..60}; do
     sleep 10
 done
 
-# Step 6: Verify installation
+# Step 4: Verify installation
 echo ""
 echo "========================================="
 echo "📊 Verification"
@@ -205,24 +193,14 @@ echo "DataScienceCluster Status:"
 kubectl get datasciencecluster -n opendatahub
 
 echo ""
-echo "KServe Components:"
-kubectl get pods -n kserve 2>/dev/null || echo "KServe namespace not yet created"
-
-echo ""
-echo "Istio Components:"
-kubectl get pods -n istio-system 2>/dev/null || echo "Istio namespace not yet created"
-
-echo ""
 echo "========================================="
 echo "✅ ODH Installation Complete!"
 echo "========================================="
 echo ""
 echo "Next steps:"
-echo "1. Verify KServe is running: kubectl get pods -n kserve"
-echo "2. Check Service Mesh: kubectl get smcp -n istio-system"
-echo "3. Deploy your models using KServe InferenceService"
+echo "1. Deploy your models using KServe InferenceService"
 echo ""
 echo "If you encounter issues, check the logs:"
 echo "- ODH Operator: kubectl logs -n openshift-operators deployment/opendatahub-operator-controller-manager"
-echo "- DSCInitialization: kubectl describe dscinitializations -n opendatahub default-dsci"
-echo "- DataScienceCluster: kubectl describe datasciencecluster -n opendatahub default-dsc" 
+echo "- DSCInitialization: kubectl describe dscinitializations default-dsci"
+echo "- DataScienceCluster: kubectl describe datasciencecluster default-dsc"


### PR DESCRIPTION
Rather than using Kustomize manifests to install `kserve` and `odh-model-controller`, these changes will install ODH operator and let the operator to do the setup of these components.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Consolidated dependency installation to simplify the OpenShift deployment flow and reduce redundant waits.
  * Updated OpenData Hub API versions and adjusted deployment component defaults.
  * Reworked readiness checks to use iterative polling and clearer status messaging.

* **New Features**
  * Added a development-mode install option for flexible local/operator installation paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->