### PR TITLE
fix: adding https to our listeners

### DIFF
--- a/deployment/base/networking/gateway-api.yaml
+++ b/deployment/base/networking/gateway-api.yaml
@@ -44,3 +44,16 @@ spec:
      allowedRoutes:
        namespaces:
          from: All
+   - name: https
+     hostname: maas.${CLUSTER_DOMAIN}
+     port: 443
+     protocol: HTTPS
+     allowedRoutes:
+       namespaces:
+         from: All
+     tls:
+       certificateRefs:
+       - group: ''
+         kind: Secret
+         name: default-gateway-tls
+       mode: Terminate


### PR DESCRIPTION
Adding a listener for https

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled HTTPS support on the gateway with TLS termination, providing secure encrypted connections on port 443 while maintaining existing HTTP functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->