### PR TITLE
fix: label gatewayapi with managed false

### DIFF
--- a/deployment/base/networking/gateway-api.yaml
+++ b/deployment/base/networking/gateway-api.yaml
@@ -34,6 +34,7 @@ metadata:
     app.kubernetes.io/name: maas
     app.kubernetes.io/instance: maas-default-gateway
     app.kubernetes.io/component: gateway
+    opendatahub.io/managed: "false"
 spec:
   gatewayClassName: openshift-default
   listeners:


### PR DESCRIPTION
Recent change to the odh-model-controller required that change the annotation `opendatahub.io/managed: "false"` to a label.

For now I am keeping both to prevent further issues and will remove the annotation code changes settle down.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default gateway configuration metadata labels for improved resource management and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->