### PR TITLE
fix: brings back managed route

### DIFF
--- a/docs/samples/models/facebook-opt-125m-cpu/model.yaml
+++ b/docs/samples/models/facebook-opt-125m-cpu/model.yaml
@@ -10,7 +10,7 @@ spec:
     name: facebook/opt-125m
   replicas: 1
   router:
-    # route: { }
+    route: { }
     # Connect to MaaS-enabled gateway
     gateway:
       refs:


### PR DESCRIPTION
Commenting out `spec.router.route` leads to no http route attached to the gateway.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated sample LLM inference service configuration to enable routing functionality, allowing traffic to be directed through the routing layer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->