### PR TITLE
docs: add maas prerequisited and ODH manual install

### DIFF
--- a/docs/content/install/odh-setup.md
+++ b/docs/content/install/odh-setup.md
@@ -1,0 +1,257 @@
+# Install Open Data Hub project
+
+This guide covers the installation of the Open Data Hub project, with the required
+configuration to deploy the Model-as-a-Service capability (MaaS).
+
+You need a Red Hat OpenShift cluster version 4.19.9 or later. Older OpenShift
+versions are not suitable.
+
+MaaS requires ODH's Model Serving component configured for deploying models with
+`LLMInferenceService` resources. The prerequisites for this ODH setup are Kuadrant and the
+LeaderWorkerSet API (LWS). Kuadrant, in turn, requires cert-manager.
+
+Tools you will need:
+
+* kubectl or oc client (this guide uses kubectl)
+* curl
+* jq
+
+!!! warning
+    You should choose either to install the ODH project, or Red Hat OpenShift AI (RHOAI). 
+    Follow this guide only if your cluster does not have RHOAI installed.  
+
+## Install cert-manager
+
+Install the latest version of cert-manager by using the _kubectl_ method from
+[cert-manager's official documentation](https://cert-manager.io/docs/installation/kubectl/).
+The following script will do so:
+
+```shell
+GH_LATEST_CM_ENTRY_URL="https://api.github.com/repos/cert-manager/cert-manager/releases/latest"
+LATEST_CM_VERSION=$(curl -sSf ${GH_LATEST_CM_ENTRY_URL} | jq -r '.tag_name')
+
+kubectl apply --server-side -f https://github.com/cert-manager/cert-manager/releases/download/${LATEST_CM_VERSION}/cert-manager.yaml
+```
+
+### Verification
+
+Check that cert-manager deployments are ready:
+
+```shell
+kubectl get deployments --namespace cert-manager
+
+NAME                      READY   UP-TO-DATE   AVAILABLE   AGE
+cert-manager              1/1     1            1           16s
+cert-manager-cainjector   1/1     1            1           16s
+cert-manager-webhook      1/1     1            1           15s
+```
+
+## Install LeaderWorkerSet API
+
+Install the latest version of LWS by using the _kubectl_ method from
+[LWS official documentation](https://lws.sigs.k8s.io/docs/installation/#install-by-kubectl).
+The following script will do so:
+
+```shell
+GH_LATEST_LWS_ENTRY_URL="https://api.github.com/repos/kubernetes-sigs/lws/releases"
+LATEST_LWS_VERSION=$(curl -sSf ${GH_LATEST_LWS_ENTRY_URL} | jq -r 'sort_by(.tag_name|ltrimstr("v")|split(".")|map(tonumber)) | last | .tag_name')
+
+kubectl apply --server-side -f https://github.com/kubernetes-sigs/lws/releases/download/${LATEST_LWS_VERSION}/manifests.yaml
+```
+
+### Verification
+
+Check that LWS deployments are ready:
+
+```shell
+kubectl get deployments --namespace lws-system
+
+NAME                     READY   UP-TO-DATE   AVAILABLE   AGE
+lws-controller-manager   2/2     2            2           35s
+```
+
+## Install Kuadrant
+
+[Kuadrant official documentation](https://docs.kuadrant.io/latest/install-olm/)
+is used as a base to install Kuadrant's latest version (v1.3.0+ is required) using the
+OLM method.
+
+Start by creating the `kuadrant-system` namespace:
+
+```shell
+kubectl create namespace kuadrant-system
+```
+
+Create an OperatorGroup in the `kuadrant-system` namespace.
+
+```shell
+kubectl apply -f - <<EOF
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: kuadrant-operator-group
+  namespace: kuadrant-system
+spec: {}
+EOF
+```
+
+!!! note
+    A single OperatorGroup should exist in any given namespace. Check for the
+    existence of multiple OperatorGroups if Kuadrant operator is not deployed 
+    successfully.
+
+Configure Kuadrant's CatalogSource:
+
+```shell
+# Find latest Kuadrant operator version:
+GH_LATEST_KUADRANT_ENTRY_URL="https://api.github.com/repos/Kuadrant/kuadrant-operator/releases/latest"
+LATEST_KUADRANT_VERSION=$(curl -sSf ${GH_LATEST_KUADRANT_ENTRY_URL} | jq -r '.tag_name')
+
+# Install the CatalogSource
+kubectl apply -f - <<EOF
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: kuadrant-operator-catalog
+  namespace: kuadrant-system
+spec:
+  displayName: Kuadrant Operators
+  image: quay.io/kuadrant/kuadrant-operator-catalog:${LATEST_KUADRANT_VERSION}
+  sourceType: grpc
+EOF
+```
+
+Deploy the Kuadrant operator, configuring it to work with OpenShift's provided Gateway API
+implementation:
+
+```shell
+kubectl apply -f - <<EOF
+  apiVersion: operators.coreos.com/v1alpha1
+  kind: Subscription
+  metadata:
+    name: kuadrant-operator
+    namespace: kuadrant-system
+  spec:
+    channel: stable
+    installPlanApproval: Automatic
+    name: kuadrant-operator
+    source: kuadrant-operator-catalog
+    sourceNamespace: kuadrant-system
+    config:
+      env:
+      - name: "ISTIO_GATEWAY_CONTROLLER_NAMES"
+        value: "openshift.io/gateway-controller/v1"
+EOF
+```
+
+### Verification
+
+Check that Kuadrant deployments are ready:
+
+```shell
+kubectl get deployments -n kuadrant-system
+
+NAME                                    READY   UP-TO-DATE   AVAILABLE   AGE
+authorino-operator                      1/1     1            1           80s
+dns-operator-controller-manager         1/1     1            1           77s
+kuadrant-console-plugin                 1/1     1            1           58s
+kuadrant-operator-controller-manager    1/1     1            1           69s
+limitador-operator-controller-manager   1/1     1            1           73s
+```
+
+## Install Open Data Hub with Model Serving
+
+The Open Data Hub Project (ODH) is installed via its operator, which is available in
+OpenShift's preconfigured CatalogSource of community operators. Create the following
+Subscription to install the latest version of ODH Operator (version 3.0 or later is 
+required for MaaS):
+
+```shell
+kubectl apply -f - <<EOF
+  apiVersion: operators.coreos.com/v1alpha1
+  kind: Subscription
+  metadata:
+    name: opendatahub-operator
+    namespace: openshift-operators
+  spec:
+    channel: fast-3.x
+    name: opendatahub-operator
+    source: community-operators
+    sourceNamespace: openshift-marketplace
+EOF
+```
+
+!!! note
+    As of Oct 24th, 2025, ODH v3 is not released yet.
+
+Set up the inference Gateway, required by ODH's Model Serving, by creating the 
+following resources:
+
+```shell
+kubectl apply -f - <<EOF
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: openshift-default
+spec:
+  controllerName: "openshift.io/gateway-controller/v1"
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: openshift-ai-inference
+  namespace: openshift-ingress
+spec:
+  gatewayClassName: openshift-default
+  listeners:
+   - name: http
+     port: 80
+     protocol: HTTP
+     allowedRoutes:
+       namespaces:
+         from: All
+  infrastructure:
+    labels:
+      serving.kserve.io/gateway: kserve-ingress-gateway
+EOF
+```
+
+Install the ODH Model Serving component by creating two resources:
+1. A `DSCInitialization` resource to initialize the ODH platform
+2. A `DataScienceCluster` resource to install ODH components
+
+```shell
+kubectl apply -f - <<EOF
+apiVersion: dscinitialization.opendatahub.io/v2
+kind: DSCInitialization
+metadata:
+  name: default-dsci
+spec:
+  applicationsNamespace: opendatahub
+  monitoring:
+    managementState: Managed
+    namespace: opendatahub
+    metrics: {}
+  trustedCABundle:
+    managementState: Managed
+---
+apiVersion: datasciencecluster.opendatahub.io/v2
+kind: DataScienceCluster
+metadata:
+  name: default-dsc
+spec:
+  components:
+    # Components required for MaaS:
+    kserve:
+      managementState: Managed
+      rawDeploymentServiceConfig: Headed
+
+    # Components recommended for MaaS:
+    dashboard:
+      managementState: Managed
+EOF
+```
+
+### Verification
+
+TODO: _Work in progress_

--- a/docs/content/install/prerequisites.md
+++ b/docs/content/install/prerequisites.md
@@ -1,0 +1,26 @@
+# MaaS Installation Prerequisites
+
+Currently, ODH's _Model-as-a-Service_ is provided as a standalone capability that is
+compatible with the Open Data Hub project (ODH), and with Red Hat OpenShift AI (RHOAI). To
+install MaaS, you should choose one of these platforms.
+
+MaaS inherits the platform requirement for a Red Hat OpenShift cluster version 4.19.9 or
+later.
+
+## Requirements for Open Data Hub project
+
+MaaS requires Open Data Hub version 3.0 or later, with the Model Serving component
+enabled (KServe) and properly configured for deploying models with `LLMInferenceService`
+resources.
+
+A specific requirement for MaaS is to set up ODH's Model Serving with Kuadrant v1.3+, even
+though ODH can work with earlier Kuadrant versions.
+
+## Requirements for Red Hat OpenShift AI
+
+MaaS requires Red Hat OpenShift AI (RHOAI) version 3.0 or later, with the Model
+Serving component enabled (KServe) and properly configured for deploying models with
+`LLMInferenceService` resources.
+
+A specific requirement for MaaS is to set up RHOAI Model Serving with Red Hat Connectivity
+Link (RHCL) v1.2+, even though RHOAI can work with earlier RHCL versions.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -46,18 +46,20 @@ plugins:
 
 nav:
   - Home: index.md
-  - Getting Started:
-    - Installation: installation.md
+  - Quick Start: installation.md
   - User Guide:
+    - Installation:
+      - Prerequisites: install/prerequisites.md
+      - install/odh-setup.md
     - User Guide: user-guide.md
     - Model Access: model-access.md
-  - Configuration & Management:
-    - Tier Management: tier-management.md
-    - Token Management: token-management.md
-    - Gateway Setup: gateway-setup.md
+    - Configuration & Management:
+      - Tier Management: tier-management.md
+      - Token Management: token-management.md
+      - Gateway Setup: gateway-setup.md
+    - Advanced Administration:
+      - Observability: observability.md
   - Architecture: architecture.md
-  - Advanced Administration:
-    - Observability: observability.md
 
 markdown_extensions:
   - pymdownx.highlight:


### PR DESCRIPTION
This adds two new pages to the _User Guide_ section of the documentation:
* prerequisites.md, which briefly comments MaaS requirements to be installed in an OpenShift cluster.
* odh-setup.md, which guides users to set up ODH platform with the needed configuration to install MaaS in an OpenShift cluster.

Additionally, the structure of the docs is changed to unify under the `User Guide` top level section.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Open Data Hub (ODH) installation guide for Model-as-a-Service on Red Hat OpenShift with step-by-step procedures and verification checks.
  * Added prerequisites documentation clarifying platform requirements and component dependencies.
  * Reorganized documentation navigation structure for improved discoverability and clearer installation workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->