### PR TITLE
fix: increase Kuadrant operator deployment wait time by ~2.5m

### DIFF
--- a/deployment/scripts/install-dependencies.sh
+++ b/deployment/scripts/install-dependencies.sh
@@ -152,7 +152,7 @@ EOF
 EOF
         # Wait for kuadrant-operator-controller-manager deployment to exist before waiting for Available condition
         ATTEMPTS=0
-        MAX_ATTEMPTS=5
+        MAX_ATTEMPTS=7
         while true; do
 
             if kubectl get deployment/kuadrant-operator-controller-manager -n kuadrant-system &>/dev/null; then


### PR DESCRIPTION
Increases MAX_ATTEMPTS from 5 to 7, adding ~2.5 minutes to the deployment wait time

I hit a timeout on a ROSA deployment. Extends wait time from 200s to 350s to give OLM more time to create the deployment.

Deployment timeout output:

```
🚀 Installing kuadrant (via OLM Subscription)...
subscription.operators.coreos.com/kuadrant-operator created
⏳ Waiting for kuadrant-operator-controller-manager deployment to be created... (attempt 1/5)
⏳ Waiting for kuadrant-operator-controller-manager deployment to be created... (attempt 2/5)
⏳ Waiting for kuadrant-operator-controller-manager deployment to be created... (attempt 3/5)
⏳ Waiting for kuadrant-operator-controller-manager deployment to be created... (attempt 4/5)
❌ kuadrant-operator-controller-manager deployment not found after 5 attempts.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved installation reliability by extending the grace period for deployment initialization during setup, allowing more time for the system to reach a ready state before reporting issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->