### PR TITLE
fix: add all prerequisites for the deployment scripts

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -4,6 +4,13 @@ This guide provides instructions for deploying the MaaS Platform infrastructure 
 
 ## Prerequisites
 
+- **OpenShift cluster (4.19.9+)** with **kubectl** or **oc** access
+
+- **Required CLI Tools**:
+  - **jq**: Command-line JSON processor
+  - **kustomize**: Kubernetes manifests customization tool (v5.7.0+)
+  - **git**: Version control system
+
 - **ODH/RHOAI requirements**:
   - KServe enabled in DataScienceCluster
   - Service Mesh installed (automatically installed with ODH/RHOAI)


### PR DESCRIPTION
Add missing prerequisites and the required kustomize version


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated deployment prerequisites to include OpenShift cluster (version 4.19.9+) with kubectl or oc access
  * Added required CLI tools: jq, kustomize (v5.7.0+), and git

<!-- end of auto-generated comment: release notes by coderabbit.ai -->