### PR TITLE
docs: add Limitador metric persistence documentation and Redis setup script

### DIFF
--- a/deployment/scripts/setup-redis.sh
+++ b/deployment/scripts/setup-redis.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+#
+# This script deploys a basic Redis instance (Deployment + Service) 
+# for testing Limitador persistence.
+#
+# Namespace selection:
+#   - Use NAMESPACE environment variable if set
+#   - Default: redis-limitador (created if it doesn't exist)
+#
+# WARNING: This is a basic, non-production Redis instance intended
+# for local development and validation only.
+#
+
+set -e
+
+# Determine target namespace:
+# Use NAMESPACE env var if set, otherwise default to redis-limitador
+: "${NAMESPACE:=redis-limitador}"
+
+# Ensure namespace exists
+if ! kubectl get namespace "$NAMESPACE" >/dev/null 2>&1; then
+  echo "📦 Creating namespace '$NAMESPACE'..."
+  kubectl create namespace "$NAMESPACE"
+fi
+
+echo "🔧 Deploying Redis Deployment and Service to namespace '$NAMESPACE'..."
+
+# Create the Redis Deployment
+kubectl apply -n "$NAMESPACE" -f - <<EOF
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+  namespace: $NAMESPACE
+  labels:
+    app: redis
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      containers:
+      - name: redis
+        image: redis:7-alpine
+        ports:
+        - containerPort: 6379
+        resources:
+          requests:
+            memory: "128Mi"
+            cpu: "100m"
+          limits:
+            memory: "256Mi"
+            cpu: "200m"
+EOF
+
+# Create the Redis Service
+kubectl apply -n "$NAMESPACE" -f - <<EOF
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-service
+  namespace: $NAMESPACE
+  labels:
+    app: redis
+spec:
+  selector:
+    app: redis
+  ports:
+  - protocol: TCP
+    port: 6379
+    targetPort: 6379
+EOF
+
+echo "⏳ Waiting for Redis to be ready..."
+kubectl wait --for=condition=available deployment/redis -n "$NAMESPACE" --timeout=120s
+
+if [ $? -eq 0 ]; then
+  echo ""
+  echo "✅ Redis deployment successful."
+  echo ""
+  echo "📝 Use this URL in your Limitador CR 'spec.storage.redis.config.url':"
+  echo ""
+  echo "   redis://redis-service.$NAMESPACE.svc:6379"
+  echo ""
+  echo "💡 To edit your Limitador CR:"
+  echo "   kubectl edit limitador <your-limitador-instance-name>"
+  echo ""
+  echo "📚 For more information, see: docs/content/advanced-administration/limitador-persistence.md"
+else
+  echo "❌ Redis deployment failed or timed out."
+  echo "Check the deployment status: kubectl describe deployment/redis -n $NAMESPACE"
+  exit 1
+fi
+

--- a/docs/content/advanced-administration/limitador-persistence.md
+++ b/docs/content/advanced-administration/limitador-persistence.md
@@ -1,0 +1,151 @@
+# Persisting Limitador Metric Counts
+
+By default, Limitador stores its rate-limiting counters in memory. This provides high performance but has a significant drawback: if a Limitador pod restarts, scales down, or is rescheduled, all hit counts are lost.
+
+For persistent, production-ready rate limiting where counts are maintained across pod lifecycles, you must configure Limitador to use an external Redis backend.
+
+!!! warning
+    **Production Considerations**: The basic Redis setup script provided in this document is intended for local development and validation only. For production deployments, follow the official Red Hat documentation for proper Redis configuration and high availability.
+
+---
+
+## Table of Contents
+
+1. [Requirements for Persistent Counts](#requirements-for-persistent-counts)
+2. [Example Limitador CR Configuration](#example-limitador-cr-configuration)
+3. [Local Validation Script](#local-validation-script-basic-redis)
+4. [How to Validate Persistence](#how-to-validate-persistence)
+5. [Related Documentation](#related-documentation)
+
+---
+
+## Requirements for Persistent Counts
+
+To enable persistence, two conditions must be met:
+
+1. **A Running Redis Instance**: A Redis instance must be deployed and network-accessible from within the Kubernetes cluster.
+
+2. **Limitador Custom Resource (CR) Configuration**: The Limitador CR that manages your deployment must be updated to point to the running Redis instance by specifying the storage configuration in its spec.
+
+---
+
+## Example Limitador CR Configuration
+
+You must edit your Limitador CR (`kubectl edit limitador <your-instance-name>`) to include the storage block. The URL should point to the internal Kubernetes service for your Redis deployment.
+
+```yaml
+apiVersion: limitador.kuadrant.io/v1alpha1
+kind: Limitador
+metadata:
+  name: my-limitador-instance
+spec:
+  # ... other spec fields
+  storage:
+    redis:
+      config:
+        # This URL must point to your internal Redis service
+        url: "redis://<redis-service-name>.<namespace>.svc:6379"
+```
+
+!!! tip
+    **Internal Service URL Format**: The Redis URL must use the Kubernetes service DNS format: `redis://<service-name>.<namespace>.svc:<port>`. For example, with the default `redis-limitador` namespace: `redis://redis-service.redis-limitador.svc:6379`
+
+For detailed, official instructions, refer to the Red Hat documentation:
+
+- [Red Hat Connectivity Link - Configure Redis](https://docs.redhat.com/en/documentation/red_hat_connectivity_link/1.1/html/installing_connectivity_link_on_openshift/configure-redis_connectivity-link)
+
+---
+
+## Local Validation Script (Basic Redis)
+
+A basic Redis setup script is provided for local development and validation. This script deploys a non-production Redis instance.
+
+**Script Location:** [`deployment/scripts/setup-redis.sh`](https://github.com/opendatahub-io/maas-billing/blob/main/deployment/scripts/setup-redis.sh)
+
+### Namespace Selection
+
+The script uses a simple namespace selection logic:
+
+- **`NAMESPACE` environment variable** (if set)
+- **Default: `redis-limitador`** (created automatically if it doesn't exist)
+
+This opinionated default simplifies troubleshooting and ensures consistent deployments.
+
+### Usage
+
+```bash
+# Make the script executable
+chmod +x deployment/scripts/setup-redis.sh
+
+# Run with default namespace (redis-limitador)
+./deployment/scripts/setup-redis.sh
+
+# Or override with environment variable
+NAMESPACE=my-namespace ./deployment/scripts/setup-redis.sh
+```
+
+The script will:
+
+- Create the namespace if it doesn't exist (for default `redis-limitador` namespace)
+- Deploy a Redis Deployment and Service
+- Wait for Redis to be ready
+- Output the Redis URL for use in your Limitador CR configuration
+
+!!! note
+    **Single Source of Truth**: The script content is maintained only in `deployment/scripts/setup-redis.sh`. Any updates to the script are automatically reflected when users download and run it.
+
+---
+
+## How to Validate Persistence
+
+1. **Run the script**: `./deployment/scripts/setup-redis.sh`
+
+   This will deploy Redis to the `redis-limitador` namespace by default (or use your `NAMESPACE` env var).
+
+2. **Copy the output URL** (e.g., `redis://redis-service.redis-limitador.svc:6379`).
+
+3. **Edit your Limitador CR** and add the storage block pointing to that URL:
+
+   ```bash
+   kubectl edit limitador <your-limitador-instance-name>
+   ```
+
+4. **Send traffic** against a rate-limited route until you have a non-zero hit count.
+
+   You can verify metrics in Prometheus:
+
+   ```bash
+   # Port-forward to Prometheus (adjust namespace as needed)
+   kubectl port-forward -n monitoring svc/prometheus-k8s 9090:9091
+
+   # Query for authorized_hits metric
+   # Open http://localhost:9090 and search for: authorized_hits
+   ```
+
+5. **Find your Limitador pod**:
+
+   ```bash
+   kubectl get pods -l app=limitador
+   ```
+
+6. **Delete the pod** to force a restart:
+
+   ```bash
+   kubectl delete pod <limitador-pod-name>
+   ```
+
+7. **Wait for the new pod** to become Running:
+
+   ```bash
+   kubectl get pods -l app=limitador -w
+   ```
+
+8. **Send another request** to the same route. You will see that the metric count continues from its previous value instead of resetting to 1.
+
+---
+
+## Related Documentation
+
+- [Tier Overview](../configuration-and-management/tier-overview.md) - Overview of tier management for access control, rate limits, and quotas
+- [Tier Configuration](../configuration-and-management/tier-configuration.md) - Step-by-step guide for configuring subscription tiers
+- [Red Hat Connectivity Link - Configure Redis](https://docs.redhat.com/en/documentation/red_hat_connectivity_link/1.1/html/installing_connectivity_link_on_openshift/configure-redis_connectivity-link) - Official Red Hat documentation for production Redis setup

--- a/docs/content/advanced-administration/observability.md
+++ b/docs/content/advanced-administration/observability.md
@@ -60,6 +60,33 @@ spec:
     path: /metrics
 ```
 
+## High Availability for MaaS Metrics
+
+For production deployments where metric persistence across pod restarts and scaling events is critical, you should configure Limitador to use Redis as a backend storage solution.
+
+### Why High Availability Matters
+
+By default, Limitador stores rate-limiting counters in memory, which means:
+
+- All hit counts are lost when pods restart
+- Metrics reset when pods are rescheduled or scaled down
+- No persistence across cluster maintenance or updates
+
+### Setting Up Persistent Metrics
+
+To enable persistent metric counts, refer to the detailed guide:
+
+**[Configuring Redis storage for rate limiting](https://docs.redhat.com/en/documentation/red_hat_connectivity_link/1.1/html/installing_connectivity_link_on_openshift/configure-redis_connectivity-link)**
+
+This Red Hat documentation provides:
+
+- Step-by-step Redis configuration for OpenShift
+- Secret management for Redis credentials
+- Limitador custom resource updates
+- Production-ready setup instructions
+
+For local development and testing, you can also use our [Limitador Persistence](limitador-persistence.md) guide which includes a basic Redis setup script that works with any Kubernetes cluster.
+
 ## Grafana Dashboards
 
 ### MaaS Platform Overview Dashboard

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -66,6 +66,7 @@ nav:
     - Model Setup: configuration-and-management/model-setup.md
     - Advanced Administration:
       - Observability: advanced-administration/observability.md
+      - Limitador Persistence: advanced-administration/limitador-persistence.md
   - End User Guide:
     - Self Service Model Access: user-guide/self-service-model-access.md
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add comprehensive documentation for persisting Limitador metric counts across pod restarts and scaling events using Redis as a backend storage solution.



## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Redis-backed persistence for metrics and a one-step script to deploy a Redis instance for local/Kubernetes testing.

* **Documentation**
  * New guide on enabling, validating, and operating persistent metrics with Redis.
  * Added High Availability guidance for metrics using Redis-backed storage.
  * Updated docs navigation to include persistence under Advanced Administration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->