### PR TITLE
fix: update TLS certificate paths to match KServe mount location

### DIFF
--- a/docs/samples/models/qwen3/model.yaml
+++ b/docs/samples/models/qwen3/model.yaml
@@ -43,8 +43,8 @@ spec:
               --port 8000 \
               --trust-remote-code \
               --disable-log-requests \
-              --ssl-certfile /etc/ssl/certs/tls.crt \
-              --ssl-keyfile /etc/ssl/certs/tls.key \
+              --ssl-certfile /var/run/kserve/tls/tls.crt \
+              --ssl-keyfile /var/run/kserve/tls/tls.key \
               --enforce-eager \
               --max-model-len 8192
         env:

--- a/docs/samples/models/simulator/model.yaml
+++ b/docs/samples/models/simulator/model.yaml
@@ -30,9 +30,9 @@ spec:
         - --mode
         - random
         - --ssl-certfile
-        - /etc/ssl/certs/tls.crt
+        - /var/run/kserve/tls/tls.crt
         - --ssl-keyfile
-        - /etc/ssl/certs/tls.key
+        - /var/run/kserve/tls/tls.key
         env:
           - name: POD_NAME
             valueFrom:


### PR DESCRIPTION
- Models were failing to start due to certificate path mismatch
- The KServe 0DH image `quay.io/opendatahub/kserve-controller:v0.15-latest` is mounting certificates at /var/run/kserve/tls/ but models were configured to look for them at /etc/ssl/certs/ which worked a day or two ago.

Some more details:

```
I1102 04:18:39.458064       1 server.go:37] "Server starting" port=8000
I1102 04:18:39.458296       1 server_tls.go:43] "HTTPS server starting with certificate files" cert="/etc/ssl/certs/tls.crt" key="/etc/ssl/certs/tls.key"
E1102 04:18:39.458365       1 server_tls.go:51] "failed to create TLS certificate" err="open /etc/ssl/certs/tls.crt: no such file or directory"
E1102 04:18:39.458396       1 cmd.go:44] "vLLM simulator failed" err="open /etc/ssl/certs/tls.crt: no such file or directory"
```

KServe mounts TLS certs at `/var/run/kserve/tls/` volume mount but model containers were hardcoded to look for certificates at `/etc/ssl/certs/`. At a quick glance,I think kserve v0.15.0 certs path was changed to `/etc/ssl/certs/` but it looks like something regressed? ¯\\_(ツ)_/¯. Guessing those on the team with more intimate knowledge of kserve will know cc/ @israel-hdez @pierDipi

Either way this gets our deployment working with the deployment script until this gets resolved. I validated the bug on two ROSA clusters in the past 24h.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated sample model deployment configurations to reflect new certificate path locations across multiple sample models.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->