### PR TITLE
docs: follow-up fixes to install guides

### DIFF
--- a/docs/content/install/maas-setup.md
+++ b/docs/content/install/maas-setup.md
@@ -67,3 +67,11 @@ spec:
             - $AUD
             - maas-default-gateway-sa")
 ```
+
+## Next steps
+
+* **Deploy models.** In the Quick Start, we provide
+  [sample deployments](../quickstart.md#deploy-sample-models-optional) that you 
+  can use to try the MaaS capability.
+* **Perform validation.** Follow the [validation guide](validation.md) to verify that 
+  MaaS is working correctly.

--- a/docs/content/install/odh-setup.md
+++ b/docs/content/install/odh-setup.md
@@ -174,15 +174,12 @@ kubectl apply -f - <<EOF
     name: opendatahub-operator
     namespace: openshift-operators
   spec:
-    channel: fast-3.x
+    channel: fast-3
     name: opendatahub-operator
     source: community-operators
     sourceNamespace: openshift-marketplace
 EOF
 ```
-
-!!! note
-    As of Oct 24th, 2025, ODH v3 is not released yet.
 
 Set up the inference Gateway, required by ODH's Model Serving, by creating the 
 following resources:

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -51,11 +51,13 @@ nav:
   - Quick Start: quickstart.md
   - Architecture: architecture.md
   - Administrator Guide:
+    - Prerequisites:
+      - Overview: install/prerequisites.md
+      - Operators:
+        - Open Data Hub: install/odh-setup.md
+        - Red Hat OpenShift AI: install/rhoai-setup.md
     - Installation:
-      - Overview and Prerequisites: install/prerequisites.md
-      - install/odh-setup.md
-      - install/rhoai-setup.md
-      - install/maas-setup.md
+      - Model-as-a-Service: install/maas-setup.md
       - Validation: install/validation.md
     - Configuration & Management:
       - Tier Management: configuration-and-management/tier-overview.md


### PR DESCRIPTION
* Follow-up comments from pull request #197.
* Use right channel for ODH operator.
* Remove note about ODH is not released yet (it is available now).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added post-install guidance for deploying models and performing validation in MaaS setup documentation.
  * Updated Open Data Hub operator channel information and removed outdated version notes.
  * Reorganized administrator guide navigation for improved documentation structure and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->