### PR TITLE
test: add maas e2e smoke test

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -1,35 +1,23 @@
-# e2e Smoke Tests
+# MaaS E2E Testing
 
-## Setup (one-time per workspace)
+## Quick Start
 
-**Prereqs:** Python 3.11+, `oc`, `kubectl`, `kustomize`, `jq` (and `yq` optional).
+### Prerequisites
+
+- **OpenShift Cluster**: Must be logged in as cluster admin
+- **Required Tools**: `oc`, `kubectl`, `kustomize`, `jq`
+- **Python**: with pip
+
+### Complete End-to-End Testing
+Deploys MaaS platform, creates test users, and runs smoke tests:
 
 ```bash
-# create & activate a virtualenv
-python3.11 -m venv .venv
-source .venv/bin/activate          # Windows PowerShell: .\.venv\Scripts\Activate.ps1
+./test/e2e/scripts/prow_run_smoke_test.sh
+```
 
-# install Python deps used by the tests
-pip install --upgrade pip
-pip install -r test/e2e/requirements.txt
+### Smoke Tests Only
 
-## What Prow needs to provide (exports)
-- `CLUSTER_DOMAIN` – from cluster (e.g., `oc get ingresses.config.openshift.io cluster -o jsonpath='{.spec.domain}'`)
-- `HOST` – maas.${CLUSTER_DOMAIN}
-- `MAAS_API_BASE_URL` – `https://${HOST}/maas-api` (or `http://` if TLS isn’t ready)
-- `MODEL_NAME` – gateway model id (e.g., `facebook/opt-125m`)
-- `ISVC_NAME` (optional) – CR name without slashes (e.g., `facebook-opt-125m-cpu`) if you deploy a sample
-
-## Typical run
+If MaaS is already deployed and you just want to run tests:
 ```bash
-export CLUSTER_DOMAIN="$(oc get ingresses.config.openshift.io cluster -o jsonpath='{.spec.domain}')"
-export HOST="maas.${CLUSTER_DOMAIN}"
-export MAAS_API_BASE_URL="https://${HOST}/maas-api"
-export MODEL_NAME="facebook/opt-125m"
-# optional if you deploy a sample:
-# export ISVC_NAME="facebook-opt-125m-cpu"
-
-# Deploy + smoke:
-bash test/e2e/run-model-and-smoke.sh
-# Or only smoke (if model is already there):
-bash test/e2e/smoke.sh
+./test/e2e/smoke.sh
+```

--- a/test/e2e/scripts/prow_run_smoke_test.sh
+++ b/test/e2e/scripts/prow_run_smoke_test.sh
@@ -1,2 +1,258 @@
-#!/usr/bin/env bash
-echo "Hello MaaS here :)"
+#!/bin/bash
+
+# =============================================================================
+# MaaS Platform End-to-End Testing Script
+# =============================================================================
+#
+# This script automates the complete deployment and validation of the MaaS 
+# platform on OpenShift with multi-user testing capabilities.
+#
+# WHAT IT DOES:
+#   1. Deploy MaaS platform on OpenShift
+#   2. Deploy simulator model for testing
+#   3. Validate deployment functionality
+#   4. Create test users with different permission levels:
+#      - Admin user (cluster-admin role)
+#      - Edit user (edit role) 
+#      - View user (view role)
+#   5. Run smoke tests for each user
+# 
+# USAGE:
+#   ./test/e2e/scripts/prow_run_smoke_test.sh
+#
+# ENVIRONMENT VARIABLES:
+#   SKIP_VALIDATION - Skip deployment validation (default: false)
+#   SKIP_SMOKE      - Skip smoke tests (default: false)
+#
+# =============================================================================
+
+set -euo pipefail
+
+find_project_root() {
+  local start_dir="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
+  local marker="${2:-.git}"
+  local dir="$start_dir"
+
+  while [[ "$dir" != "/" && ! -e "$dir/$marker" ]]; do
+    dir="$(dirname "$dir")"
+  done
+
+  if [[ -e "$dir/$marker" ]]; then
+    printf '%s\n' "$dir"
+  else
+    echo "Error: couldn’t find '$marker' in any parent of '$start_dir'" >&2
+    return 1
+  fi
+}
+
+# Configuration
+PROJECT_ROOT="$(find_project_root)"
+
+# Options (can be set as environment variables)
+SKIP_VALIDATION=${SKIP_VALIDATION:-false}
+SKIP_SMOKE=${SKIP_SMOKE:-false}
+
+print_header() {
+    echo ""
+    echo "----------------------------------------"
+    echo "$1"
+    echo "----------------------------------------"
+    echo ""
+}
+
+check_prerequisites() {
+    echo "Checking prerequisites..."
+    
+    # Get current user (also checks if logged in)
+    local current_user
+    if ! current_user=$(oc whoami 2>/dev/null); then
+        echo "❌ ERROR: Not logged into OpenShift. Please run 'oc login' first"
+        exit 1
+    fi
+    
+    # Combined check: admin privileges + OpenShift cluster
+    if ! oc auth can-i '*' '*' --all-namespaces >/dev/null 2>&1; then
+        echo "❌ ERROR: User '$current_user' does not have admin privileges"
+        echo "   This script requires cluster-admin privileges to deploy and manage resources"
+        echo "   Please login as an admin user with 'oc login' or contact your cluster administrator"
+        exit 1
+    elif ! kubectl get --raw /apis/config.openshift.io/v1/clusterversions >/dev/null 2>&1; then
+        echo "❌ ERROR: This script is designed for OpenShift clusters only"
+        exit 1
+    fi
+    
+    echo "✅ Prerequisites met - logged in as: $current_user on OpenShift"
+}
+
+deploy_maas_platform() {
+    echo "Deploying MaaS platform on OpenShift..."
+    if ! "$PROJECT_ROOT/deployment/scripts/deploy-openshift.sh"; then
+        echo "❌ ERROR: MaaS platform deployment failed"
+        exit 1
+    fi
+    echo "✅ MaaS platform deployment completed"
+}
+
+deploy_models() {
+    echo "Deploying simulator Model"
+    if ! (cd "$PROJECT_ROOT" && kustomize build docs/samples/models/simulator/ | kubectl apply -f -); then
+        echo "❌ ERROR: Failed to deploy simulator model"
+        exit 1
+    fi
+    echo "✅ Simulator model deployed"
+    
+    echo "Waiting for model to be ready..."
+    oc wait llminferenceservice/facebook-opt-125m-simulated -n llm --for=condition=Ready --timeout=300s
+    echo "✅ Simulator Model deployed"
+}
+
+validate_deployment() {
+    echo "Deployment Validation"
+    if [ "$SKIP_VALIDATION" = false ]; then
+        if ! "$PROJECT_ROOT/deployment/scripts/validate-deployment.sh"; then
+            echo "❌ ERROR: Deployment validation failed"
+        else
+            echo "✅ Deployment validation completed"
+        fi
+    else
+        echo "⏭️  Skipping validation"
+    fi
+}
+
+setup_maas_users() {
+    echo "Setting up Maas users for testing"
+    
+    # Capture the script output in a variable
+    local script_output
+    if ! script_output=$(cd "$PROJECT_ROOT" && bash test/e2e/scripts/setup_maas_users_openshift.sh 2>&1); then
+        echo "❌ ERROR: Failed to setup Maas users on OpenShift"
+        exit 1
+    fi
+    
+    # Display the script output (excluding export statements for security)
+    echo "$script_output" | grep -v "^export "
+    
+    # Extract and evaluate the export statements
+    local export_statements
+    export_statements=$(echo "$script_output" | grep "^export " || true)
+    
+    if [ -n "$export_statements" ]; then
+        eval "$export_statements"
+        echo "✅ Credentials loaded for users:"
+        echo "   Admin user: ${OPENSHIFT_ADMIN_USER}"
+        echo "   Dev user: ${OPENSHIFT_DEV_USER}"
+        echo "✅ Maas users setup completed"
+    else
+        echo "❌ ERROR: Credentials not found"
+        echo "❌ ERROR: Maas users setup failed"
+        exit 1
+    fi
+}
+
+login_as_user() {
+    echo "Logging in as user: $1"
+    if ! (oc login -u "$1" -p "$2"); then
+        echo "❌ ERROR: Failed to login as user: $1"
+        exit 1
+    fi
+    echo "✅ User: $1 logged in successfully as: $(oc whoami)"
+}
+
+setup_vars_for_tests() {
+    echo "-- Setting up variables for tests --"
+    K8S_CLUSTER_URL=$(oc whoami --show-server)
+    export K8S_CLUSTER_URL
+    if [ -z "$K8S_CLUSTER_URL" ]; then
+        echo "❌ ERROR: Failed to retrieve Kubernetes cluster URL. Please check if you are logged in to the cluster."
+        exit 1
+    fi
+    echo "K8S_CLUSTER_URL: ${K8S_CLUSTER_URL}"
+
+    export CLUSTER_DOMAIN="$(oc get ingresses.config.openshift.io cluster -o jsonpath='{.spec.domain}')"
+    export HOST="maas.${CLUSTER_DOMAIN}"
+    export MAAS_API_BASE_URL="http://${HOST}/maas-api"
+    echo "CLUSTER_DOMAIN: ${CLUSTER_DOMAIN}"
+    echo "HOST: ${HOST}"
+    echo "MAAS_API_BASE_URL: ${MAAS_API_BASE_URL}"
+    echo "✅ Variables for tests setup completed"
+}
+
+run_smoke_tests() {
+    echo "-- Smoke Testing --"
+    
+    if [ "$SKIP_SMOKE" = false ]; then
+        if ! (cd "$PROJECT_ROOT" && bash test/e2e/smoke.sh); then
+            echo "❌ ERROR: Smoke tests failed"
+        else
+            echo "✅ Smoke tests completed successfully"
+        fi
+    else
+        echo "⏭️  Skipping smoke tests"
+    fi
+}
+
+# Main execution
+print_header "Deploying Maas on OpenShift"
+check_prerequisites
+deploy_maas_platform
+
+print_header "Deploying Models"  
+deploy_models
+
+print_header "Setting up variables for tests"
+setup_vars_for_tests
+
+print_header "Validating Deployment"
+validate_deployment
+
+setup_test_user() {
+    local username="$1"
+    local cluster_role="$2"
+    
+    # Check and create service account
+    if ! oc get serviceaccount "$username" -n default >/dev/null 2>&1; then
+        echo "Creating service account: $username"
+        oc create serviceaccount "$username" -n default
+    else
+        echo "Service account $username already exists"
+    fi
+    
+    # Check and create cluster role binding
+    if ! oc get clusterrolebinding "${username}-binding" >/dev/null 2>&1; then
+        echo "Creating cluster role binding for $username"
+        oc adm policy add-cluster-role-to-user "$cluster_role" "system:serviceaccount:default:$username"
+    else
+        echo "Cluster role binding for $username already exists"
+    fi
+    
+    echo "✅ User setup completed: $username"
+}
+
+# Setup all users first (while logged in as admin)
+print_header "Setting up test users"
+setup_test_user "tester-admin-user" "cluster-admin"
+setup_test_user "tester-edit-user" "edit"
+setup_test_user "tester-view-user" "view"
+
+# Now run tests for each user
+print_header "Running tests for all users"
+
+# Test admin user
+print_header "Running Maas e2e Tests as admin user"
+ADMIN_TOKEN=$(oc create token tester-admin-user -n default)
+oc login --token "$ADMIN_TOKEN" --server "$K8S_CLUSTER_URL"
+run_smoke_tests
+
+# Test edit user  
+print_header "Running Maas e2e Tests as edit user"
+EDIT_TOKEN=$(oc create token tester-edit-user -n default)
+oc login --token "$EDIT_TOKEN" --server "$K8S_CLUSTER_URL"
+run_smoke_tests
+
+# Test view user
+print_header "Running Maas e2e Tests as view user"
+VIEW_TOKEN=$(oc create token tester-view-user -n default)
+oc login --token "$VIEW_TOKEN" --server "$K8S_CLUSTER_URL"
+run_smoke_tests
+
+echo "🎉 Deployment completed successfully!"

--- a/test/e2e/smoke.sh
+++ b/test/e2e/smoke.sh
@@ -4,6 +4,33 @@ set -euo pipefail
 DIR="$(cd "$(dirname "$0")" && pwd)"
 export PYTHONPATH="${DIR}:${PYTHONPATH:-}"
 
+# Python virtual environment setup
+VENV_DIR="${DIR}/.venv"
+
+setup_python_venv() {
+    echo "[smoke] Setting up Python virtual environment..."
+    
+    # Create virtual environment if it doesn't exist
+    if [[ ! -d "${VENV_DIR}" ]]; then
+        echo "[smoke] Creating virtual environment at ${VENV_DIR}"
+        python3 -m venv "${VENV_DIR}"
+    fi
+    
+    # Activate virtual environment
+    echo "[smoke] Activating virtual environment"
+    source "${VENV_DIR}/bin/activate"
+    
+    # Upgrade pip and install requirements
+    echo "[smoke] Installing Python dependencies"
+    python -m pip install --upgrade pip --quiet
+    python -m pip install -r "${DIR}/requirements.txt" --quiet
+    
+    echo "[smoke] Virtual environment setup complete"
+}
+
+# Setup and activate virtual environment
+setup_python_venv
+
 # Inputs via env or auto-discovery
 HOST="${HOST:-}"
 MAAS_API_BASE_URL="${MAAS_API_BASE_URL:-}"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added a wrapper to run maas e2e deployment including smoke tests.
This will also be used in openshift-ci for automated deployments and PR testing. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Just run `./test/e2e/scripts/prow_run_smoke_test.sh` in root dir.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded end-to-end smoke test to include full platform deployment, model deployment, multi-user orchestration (admin/edit/view), token-based logins, deployment validation, improved logging/error handling, and test user/service-account setup.
  * Added Python virtual environment bootstrap for isolated test dependencies.

* **Documentation**
  * Updated E2E README into a MaaS Quick Start with prerequisites, simplified entry points, and instructions for full setup or standalone smoke tests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->