### PR TITLE
fix: generate ODH manifests before install

### DIFF
--- a/deployment/scripts/installers/install-odh.sh
+++ b/deployment/scripts/installers/install-odh.sh
@@ -46,6 +46,7 @@ EOF
     pushd ./opendatahub-operator
     cp config/manager/kustomization.yaml.in config/manager/kustomization.yaml
     sed -i 's#REPLACE_IMAGE#quay.io/opendatahub/opendatahub-operator#' config/manager/kustomization.yaml
+    make manifests
     kustomize build --load-restrictor LoadRestrictionsNone config/default | kubectl apply --namespace $ODH_OPERATOR_NS -f -
     popd
     popd


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This generates manifests for ODH operator installation. 

Fixes the error - 
```
 Installing ODH Operator from repository manifests...
namespace/opendatahub-operator-system created
/tmp/tmp.vayOfSnfSk ~/Projects/maas-billing
/tmp/tmp.vayOfSnfSk/opendatahub-operator /tmp/tmp.vayOfSnfSk ~/Projects/maas-billing
Error: accumulating resources: accumulation err='accumulating resources from '../crd': read /tmp/tmp.vayOfSnfSk/opendatahub-operator/config/crd: is a directory': recursed accumulation of path '/tmp/tmp.vayOfSnfSk/opendatahub-operator/config/crd': accumulating resources: accumulation err='accumulating resources from 'bases/dscinitialization.opendatahub.io_dscinitializations.yaml': open /tmp/tmp.vayOfSnfSk/opendatahub-operator/config/crd/bases/dscinitialization.opendatahub.io_dscinitializations.yaml: no such file or directory': must build at directory: not a valid directory: evalsymlink failure on '/tmp/tmp.vayOfSnfSk/opendatahub-operator/config/crd/bases/dscinitialization.opendatahub.io_dscinitializations.yaml' : lstat /tmp/tmp.vayOfSnfSk/opendatahub-operator/config/crd/bases: no such file or directory
error: no objects passed to apply
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Running `./deployment/scripts/deploy-openshift.sh` in root directory.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated installation script to optimize the build process in development environments by adding a manifest generation step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->