### PR TITLE
fix: install ODH operator with generated CRDs

### DIFF
--- a/deployment/scripts/installers/install-odh.sh
+++ b/deployment/scripts/installers/install-odh.sh
@@ -46,6 +46,7 @@ EOF
     pushd ./opendatahub-operator
     cp config/manager/kustomization.yaml.in config/manager/kustomization.yaml
     sed -i 's#REPLACE_IMAGE#quay.io/opendatahub/opendatahub-operator#' config/manager/kustomization.yaml
+    make manifests
     kustomize build --load-restrictor LoadRestrictionsNone config/default | kubectl apply --namespace $ODH_OPERATOR_NS -f -
     popd
     popd


### PR DESCRIPTION
Added make manifests between templating config/manager/kustomization.yaml and running kustomize build in
deployment/scripts/installers/install-odh.sh, ensuring the CRD YAMLs under config/crd/bases are generated before the build step so dev installs no longer fail on missing CRDs

The error it fixes on install is the following. Note: this is a fresh ROSA cluster with nothing installed prior to running the installer:

```
=========================================
🚀 OpenDataHub (ODH) Installation
=========================================

1️⃣ Installing ODH Operator from repository manifests...
namespace/opendatahub-operator-system unchanged
/tmp/tmp.rfcOlyq8J1 ~/maas-prs/9-tls/maas-billing
/tmp/tmp.rfcOlyq8J1/opendatahub-operator /tmp/tmp.rfcOlyq8J1 ~/maas-prs/9-tls/maas-billing
Error: accumulating resources: accumulation err='accumulating resources from '../crd': read /tmp/tmp.rfcOlyq8J1/opendatahub-operator/config/crd: is a directory': recursed accumulation of path '/tmp/tmp.rfcOlyq8J1/opendatahub-operator/config/crd': accumulating resources: accumulation err='accumulating resources from 'bases/dscinitialization.opendatahub.io_dscinitializations.yaml': open /tmp/tmp.rfcOlyq8J1/opendatahub-operator/config/crd/bases/dscinitialization.opendatahub.io_dscinitializations.yaml: no such file or directory': must build at directory: not a valid directory: evalsymlink failure on '/tmp/tmp.rfcOlyq8J1/opendatahub-operator/config/crd/bases/dscinitialization.opendatahub.io_dscinitializations.yaml' : lstat /tmp/tmp.rfcOlyq8J1/opendatahub-operator/config/crd/bases: no such file or directory
error: no objects passed to apply
```

Relevant patch in ODH operator:

```
https://github.com/opendatahub-io/opendatahub-operator/pull/2329
https://github.com/opendatahub-io/opendatahub-operator/commit/8c3f4570d3b2ba9b15495ef8317355fe5c91994a
```
