### PR TITLE
test: ignore apps directory in Snyk Code

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,3 @@
+exclude:
+    code:
+    - apps/


### PR DESCRIPTION
This adds a new `.snyk` file with a rule to omit the `apps/` directory from Code Analysis. This is because the content of this directory is not being delivered in builds.

Related to https://issues.redhat.com/browse/RHOAIENG-38235

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code analysis configuration to refine scanning scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->