### PR TITLE
fix: add missing /v1/chat/completions to model URLs in validation guide

### DIFF
--- a/docs/content/install/validation.md
+++ b/docs/content/install/validation.md
@@ -57,7 +57,7 @@ Send a request to the model endpoint (should get a 200 OK response):
 curl -sSk -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d "{\"model\": \"${MODEL_NAME}\", \"prompt\": \"Hello\", \"max_tokens\": 50}" \
-  "${MODEL_URL}"
+  "${MODEL_URL}/v1/chat/completions"
 ```
 
 ### 5. Test Authorization Enforcement
@@ -67,7 +67,7 @@ Send a request to the model endpoint without a token (should get a 401 Unauthori
 ```bash
 curl -sSk -H "Content-Type: application/json" \
   -d "{\"model\": \"${MODEL_NAME}\", \"prompt\": \"Hello\", \"max_tokens\": 50}" \
-  "${MODEL_URL}" -v
+  "${MODEL_URL}/v1/chat/completions" -v
 ```
 
 ### 6. Test Rate Limiting
@@ -80,7 +80,7 @@ for i in {1..16}; do
     -H "Authorization: Bearer $TOKEN" \
     -H "Content-Type: application/json" \
     -d "{\"model\": \"${MODEL_NAME}\", \"prompt\": \"Hello\", \"max_tokens\": 50}" \
-    "${MODEL_URL}"
+    "${MODEL_URL}/v1/chat/completions"
 done
 ```
 


### PR DESCRIPTION
Fixes https://github.com/opendatahub-io/maas-billing/issues/214

The validation guide used incomplete model URLs that result in 404 errors
when users follow the documentation. Updated three sections to append
/v1/chat/completions to MODEL_URL:

- Section 4: Test Model Inference Endpoint
- Section 5: Test Authorization Enforcement
- Section 6: Test Rate Limiting

Tested on customer environment to confirm fix works correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated validation documentation examples to reflect the correct API endpoint paths for test requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->