### PR TITLE
test: ignore apps directory in Snyk Code

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,3 @@
+exclude:
+  code:
+  - apps/


### PR DESCRIPTION
This adds a new `.snyk` file with a rule to omit the `apps/` directory from Code Analysis. This is because the content of this directory is not being delivered in builds.

Related to https://issues.redhat.com/browse/RHOAIENG-38235

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Snyk configuration to explicitly exclude the apps directory from security code scans, clarifying the exclusion in the configuration and reducing noise from those scans.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->