### PR TITLE
chore(deployment): add automated deployment script for RHOAI

### DIFF
--- a/deployment/overlays/openshift/kustomization.yaml
+++ b/deployment/overlays/openshift/kustomization.yaml
@@ -7,4 +7,5 @@ metadata:
 resources:
   - ../../base/networking/maas
   - ../../base/policies
+  - ../../base/observability
   - ../../base/maas-api

--- a/docs/content/quickstart.md
+++ b/docs/content/quickstart.md
@@ -12,7 +12,7 @@ This guide provides quickstart instructions for deploying the MaaS Platform infr
 - **ODH/RHOAI requirements**:
       - RHOAI 3.0 +
       - ODH 3.0 +
-- **RHCL requirements**:
+- **RHCL requirements** (Note: This can be installed automatically by the script below):
       - RHCL 1.2 +
 - **Cluster admin** or equivalent permissions
 - **Required tools**:
@@ -28,25 +28,25 @@ This guide provides quickstart instructions for deploying the MaaS Platform infr
 For OpenShift clusters, use the automated deployment script:
 
 ```bash
-./deployment/scripts/deploy-openshift.sh
+export MAAS_REF="main"
+./deployment/scripts/deploy-rhoai-stable.sh
 ```
 
 ### Verify Deployment
 
 The deployment script creates the following core resources:
 
-- **Namespaces**: `maas-api`, `kuadrant-system`, `kserve`, `opendatahub`, `llm`
 - **Gateway**: `maas-default-gateway` in `openshift-ingress` namespace
 - **HTTPRoutes**: `maas-api-route` in the `openshift-ingress` namespace
 - **Policies**: `AuthPolicy`, `TokenRateLimitPolicy`, `RateLimitPolicy`, `TelemetryPolicy`
 - **MaaS API**: Deployment and service in `maas-api` namespace
-- **Operators**: Kuadrant, Authorino, Limitador in `kuadrant-system` namespace
+- **Operators**: Cert-manager, LWS, Red Hat Connectivity Link and Red Hat OpenShift AI.
 
 Check deployment status:
 
 ```bash
 # Check all namespaces
-kubectl get ns | grep -E "maas-api|kuadrant|kserve|opendatahub|llm"
+kubectl get ns | grep -E "maas-api|kuadrant-system|kserve|opendatahub|redhat-ods-applications|llm"
 
 # Check Gateway status
 kubectl get gateway -n openshift-ingress maas-default-gateway
@@ -66,6 +66,7 @@ kubectl get pods -n kuadrant-system
 # Check KServe (if deployed)
 kubectl get pods -n kserve
 kubectl get pods -n opendatahub
+kubectl get pods -n redhat-ods-applications
 ```
 
 ## Model Setup (Optional)


### PR DESCRIPTION
Introduces a comprehensive deployment automation script for MaaS, using
Red Hat OpenShift AI as the base platform.

The script automates the deployment of all required prerequisites including
cert-manager, Leader Worker Set, and Red Hat Connectivity Link, followed by
RHOAI v3 with KServe model serving capabilities and MaaS standalone functionality.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adds an automated, idempotent installer for Red Hat OpenShift AI v3 with Model-as-a-Service, streamlining platform and MaaS setup, readiness checks, and stable image pinning; emits cluster domain and MaaS audience with clear timeout reporting.
* **Documentation**
  * Updates the quickstart to reflect the new installer flow, revised prerequisites, verification steps, and additional pod/namespace checks.
* **Chores**
  * Expands OpenShift overlay to include observability resources.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->