### PR TITLE
fix: remove RateLimitPolicy from the default deployment

### DIFF
--- a/deployment/base/policies/kustomization.yaml
+++ b/deployment/base/policies/kustomization.yaml
@@ -8,4 +8,4 @@ resources:
 # Gateway policies - default for all models
 - gateway-auth-policy.yaml
 - token-limit-policy.yaml
-- rate-limit-policy.yaml
+# - rate-limit-policy.yaml - RateLimitPolicy can be run in tandem with TokenRateLimitPolicy if desired

--- a/deployment/base/policies/rate-limit-policy.yaml
+++ b/deployment/base/policies/rate-limit-policy.yaml
@@ -1,3 +1,4 @@
+# disabled by the default deployment, enable in  deployment/base/policies/kustomization.yaml
 apiVersion: kuadrant.io/v1
 kind: RateLimitPolicy
 metadata:


### PR DESCRIPTION
- Leaving the manifest and line in deployment/base/policies/kustomization.yaml as a reference if the user wants to enable it.
- Showcasing TRLP as the default is probably the most appropriate install.


** Note: ** leaving this in draft until we resolve the flapping of TRLP limits as the demos are basically working from RateLimitPolicy rather than TokenRateLimitPolicy.

Example output without RateLimitPolicy applied where you see the random flapping between 200s and 429s.

```
$ for i in {1..16}; do curl -sSk -o /dev/null -w "%{http_code}\n" -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -d "{\"model\": \"${MODEL_NAME}\", \"prompt\": \"Hello\", \"max_tokens\": 50}" "${MODEL_URL}"; done
429
429
200
200
200
200
200
200
200
200
200
200
200
200
429
429

$ for i in {1..16}; do curl -sSk -o /dev/null -w "%{http_code}\n" -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -d "{\"model\": \"${MODEL_NAME}\", \"prompt\": \"Hello\", \"max_tokens\": 50}" "${MODEL_URL}"; done
429
429
429
429
429
429
429
429
429
429
429
429
200
200
200
200

$ for i in {1..16}; do curl -sSk -o /dev/null -w "%{http_code}\n" -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -d "{\"model\": \"${MODEL_NAME}\", \"prompt\": \"Hello\", \"max_tokens\": 50}" "${MODEL_URL}"; done
200
200
200
200
429
200
200
200
200
200
200
200
200
200
200
200
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Disabled the rate-limiting policy by default in configuration and added clarifying comments about enabling it.
  * Noted that the rate-limiting policy can be enabled via configuration and may be run alongside token-based rate limiting when desired.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->