### PR TITLE
feat: enable FIPS compliance in maas-api build

### DIFF
--- a/maas-api/Dockerfile
+++ b/maas-api/Dockerfile
@@ -9,7 +9,7 @@ RUN go mod download
 COPY . .
 
 USER root
-RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w" -o maas-api ./cmd/
+RUN CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime GOOS=linux go build -trimpath -ldflags="-s -w" -o maas-api ./cmd/
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 

--- a/maas-api/Makefile
+++ b/maas-api/Makefile
@@ -17,7 +17,8 @@ BUILD_DIR := $(PROJECT_DIR)/bin
 GO_VERSION := 1.24.2
 GOOS ?= linux
 GOARCH ?= amd64
-CGO_ENABLED ?= 0
+CGO_ENABLED ?= 1
+GOEXPERIMENT ?= strictfipsruntime
 
 # Git settings
 GIT_COMMIT := $(shell git rev-parse --short HEAD)
@@ -80,7 +81,7 @@ deps: ## Download Go dependencies
 build: deps fmt test ## Build the maas-api binary
 	@echo "Building $(BINARY_NAME)..."
 	@mkdir -p $(BUILD_DIR)
-	CGO_ENABLED=$(CGO_ENABLED) GOOS=$(GOOS) GOARCH=$(GOARCH) go build $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY_NAME) ./cmd/
+	CGO_ENABLED=$(CGO_ENABLED) GOEXPERIMENT=$(GOEXPERIMENT) GOOS=$(GOOS) GOARCH=$(GOARCH) go build $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY_NAME) ./cmd/
 	@echo "Built $(BUILD_DIR)/$(BINARY_NAME)"
 
 SRC_DIRS := $(PROJECT_DIR)/cmd $(PROJECT_DIR)/internal


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Set CGO_ENABLED=1 to enable CGO in Dockerfile and Makefile
- Add GOEXPERIMENT=strictfipsruntime for FIPS compliance
- Update build commands to include GOEXPERIMENT flag

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to enable CGo and a stricter FIPS-compatible runtime mode, improving cryptographic compliance and binary compatibility. No runtime behavior or public APIs were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->