### PR TITLE
fix: correct example to use /v1/completions instead of /v1/chat/compl…

### DIFF
--- a/docs/content/install/validation.md
+++ b/docs/content/install/validation.md
@@ -57,7 +57,7 @@ Send a request to the model endpoint (should get a 200 OK response):
 curl -sSk -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d "{\"model\": \"${MODEL_NAME}\", \"prompt\": \"Hello\", \"max_tokens\": 50}" \
-  "${MODEL_URL}/v1/chat/completions"
+  "${MODEL_URL}/v1/completions"
 ```
 
 ### 5. Test Authorization Enforcement
@@ -67,7 +67,7 @@ Send a request to the model endpoint without a token (should get a 401 Unauthori
 ```bash
 curl -sSk -H "Content-Type: application/json" \
   -d "{\"model\": \"${MODEL_NAME}\", \"prompt\": \"Hello\", \"max_tokens\": 50}" \
-  "${MODEL_URL}/v1/chat/completions" -v
+  "${MODEL_URL}/v1/completions" -v
 ```
 
 ### 6. Test Rate Limiting
@@ -80,7 +80,7 @@ for i in {1..16}; do
     -H "Authorization: Bearer $TOKEN" \
     -H "Content-Type: application/json" \
     -d "{\"model\": \"${MODEL_NAME}\", \"prompt\": \"Hello\", \"max_tokens\": 50}" \
-    "${MODEL_URL}/v1/chat/completions"
+    "${MODEL_URL}/v1/completions"
 done
 ```
 


### PR DESCRIPTION
This PR updates the example curl command to use the correct endpoint for non-chat payloads.

## Problem

The documentation/example previously used:

`/v1/chat/completions
`

However, the payload sent in the example uses a raw prompt instead of a chat-style messages array. When calling the chat endpoint with a non-chat payload, the API returns:

`[{'type': 'missing', 'loc': ('body', 'messages'), 'msg': 'Field required', ...}]
`
## Details
The example is updated to use:

`/v1/completions
`

which matches the payload format and avoids the validation error.

## How Has This Been Tested?
The change has been tested by setting up `maas-billing` on a OpenShift AI and running the `curl` commands as shown below. 

<img width="962" height="308" alt="image" src="https://github.com/user-attachments/assets/1acfa425-0b49-4e89-a892-457421ff811d" />

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ x] The developer has manually tested the changes and verified that the changes work
