### PR TITLE
docs: resurrects token mgmt deep dive

### DIFF
--- a/docs/content/configuration-and-management/model-setup.md
+++ b/docs/content/configuration-and-management/model-setup.md
@@ -38,6 +38,14 @@ graph TB
 !!! note
     The `maas-default-gateway` is created automatically during MaaS platform installation. You don't need to create it manually.
 
+### Benefits
+
+. **Flexibility**: Different models can have different security and access requirements
+. **Progressive Adoption**: Teams can adopt MaaS features incrementally
+. **Production Control**: Production models get full policy enforcement if needed
+. **Multi-Tenancy**: Different teams can use different gateways in the same cluster
+. **Blast Radius Containment**: Issues with one gateway don't affect the other
+
 ## Prerequisites
 
 Before configuring a model for MaaS, ensure you have:

--- a/docs/content/configuration-and-management/token-management.md
+++ b/docs/content/configuration-and-management/token-management.md
@@ -1,0 +1,180 @@
+# Understanding Token Management
+
+This guide explains the token-based authentication system used to access models in the tier-based access control system. 
+It covers how token issuance works, the underlying service account architecture, and token lifecycle management.
+
+!!! note
+    **Prerequisites**: This document assumes you have already configured tiers, RBAC, and rate limits. 
+    See [Configuring Subscription Tiers](tier-configuration.md) for setup instructions.
+
+---
+
+## Table of Contents
+
+1. [Overview](#overview)
+1. [How Token Issuance Works](#how-token-issuance-works)
+1. [Practical Usage](#practical-usage)
+1. [Token Lifecycle Management](#token-lifecycle-management)
+1. [Frequently Asked Questions (FAQ)](#frequently-asked-questions-faq)
+1. [Related Documentation](#related-documentation)
+
+---
+
+## Overview
+
+The platform uses a secure, token-based authentication system. Instead of using your primary OpenShift credentials to 
+access models directly, you first exchange them for a temporary, specialized access token. This approach provides several key benefits:
+
+- **Enhanced Security**: Tokens are short-lived, reducing the risk of compromised credentials. They are also narrowly scoped for model access only.
+- **Tier-Based Access Control**: The token you receive is automatically associated with your subscription tier (e.g., free, premium), ensuring you get the correct permissions and rate limits.
+- **Auditability**: Every request made with a token is tied to a specific identity and can be audited.
+- **Kubernetes-Native Integration**: The system leverages standard, Kubernetes authentication and authorization mechanisms.
+
+The process is simple:
+
+```text
+You authenticate with OpenShift → Request a token from the API → Use that token to call models
+```
+
+---
+
+## How Token Issuance Works
+
+When you request a token, you are essentially trading your long-term OpenShift identity for a short-term, 
+purpose-built identity in the form of a Kubernetes Service Account.
+
+### Key Concepts
+
+- **Tier Namespace**: The platform maintains a separate Kubernetes namespace for each subscription tier (e.g., `...-tier-free`, `...-tier-premium`). These namespaces isolate users based on their access level. 
+- **Service Account (SA)**: When you request a token for the first time, the system creates a Service Account that represents you inside your designated tier namespace. This SA inherits all the permissions assigned to that tier.
+- **Access Token**: The token you receive is a standard JSON Web Token (JWT) that authenticates you as that specific Service Account. When you present this token to the gateway, the system knows your identity, your tier, and what permissions you have.
+- **Token Audience**: The intended recipient of your token. This is validated during authentication and must match the gateway's configuration.
+- **Token Expiration**: The time after which the token expires. Tokens are short-lived to reduce the risk of compromised credentials.
+
+### Token Issuance Flow
+
+This diagram illustrates the process of obtaining a token.
+
+```mermaid
+sequenceDiagram
+    participant User as OpenShift User
+    participant MaaS as maas-api
+    participant K8s as Kubernetes API
+    participant TierNS as Tier Namespace<br/>(e.g., *-tier-premium)
+    participant Gateway
+    participant Model as Model Backend
+
+    Note over User,MaaS: Token Issuance
+    User->>MaaS: 1. Authenticate with OpenShift token
+    MaaS->>K8s: Validate token (TokenReview)
+    K8s-->>MaaS: username, groups
+    Note right of MaaS: Determine tier from<br/>tier-to-group-mapping
+    MaaS->>K8s: Ensure tier namespace exists
+    K8s->>TierNS: Create if needed
+    MaaS->>TierNS: Create/get Service Account for user
+    TierNS-->>MaaS: SA ready
+    MaaS->>K8s: Request SA token (TokenRequest)
+    K8s-->>MaaS: Issued token
+    MaaS-->>User: Return issued token
+
+    Note over User,Model: Model Access
+    User->>Gateway: 3. Request with issued token
+    Gateway->>K8s: Validate token (TokenReview)
+    Note right of K8s: Token from SA in<br/>tier namespace
+    K8s-->>Gateway: Valid, with groups
+    Note right of Gateway: Tier lookup,<br/>SAR check,<br/>Rate limits
+    Gateway->>Model: 4. Authorized request
+    Model-->>Gateway: Response
+    Gateway-->>User: Response
+```
+
+---
+
+## Practical Usage
+
+For step-by-step instructions on obtaining and using tokens to access models, including practical examples and troubleshooting, see the [Self-Service Model Access Guide](../user-guide/self-service-model-access.md).
+
+That guide provides:
+- Complete walkthrough for getting your OpenShift token
+- How to request an access token from the API
+- Examples of making inference requests with your token
+- Troubleshooting common authentication issues
+
+---
+
+## Token Lifecycle Management
+
+Access tokens are ephemeral and must be managed accordingly.
+
+### Token Expiration
+
+Tokens have a finite lifetime for security purposes:
+
+- **Default lifetime**: 4 hours (configurable when requesting)
+- **Maximum lifetime**: Determined by your Kubernetes cluster configuration
+
+When a token expires, any API request using it will fail with an `HTTP 401 Unauthorized error`. 
+To continue, you must request a new token using the process described above.
+
+**Tips:**
+- For interactive use, request tokens with a lifetime that covers your session (e.g., 4h).
+- For automated scripts or applications, implement logic to refresh the token proactively before it expires.
+
+### Token Revocation
+
+You can invalidate all active tokens associated with your user account. This is a key security feature if you believe a token has been exposed.
+
+To revoke all your tokens, send a `DELETE` request to the `/v1/tokens` endpoint.
+
+```shell
+curl -sSk -X DELETE "${MAAS_API_URL}/v1/tokens" \
+  -H "Authorization: Bearer $(oc whoami -t)"
+```
+This action immediately deletes your underlying Service Account, which invalidates all tokens that have ever been issued for it. 
+The Service Account will be automatically recreated the next time you request a token.
+
+!!! warning "Important"
+    **For Platform Administrators**: Admins can manually revoke a user's tokens by finding and deleting their Service Account 
+    in the appropriate tier namespace (e.g., `<instance-name>-tier-premium`). This is an effective way to immediately cut 
+    off access for a specific user in response to a security event.
+
+---
+
+## Frequently Asked Questions (FAQ)
+
+**Q: My tier is wrong or shows as "free". How do I fix it?**
+
+A: Your tier is determined by your group membership in OpenShift. Contact your platform administrator to ensure you 
+are in the correct user group, which should be mapped to your desired tier in the [tier mapping configuration](tier-configuration.md).
+
+---
+
+**Q: How long should my tokens be valid for?**
+
+A: It's a balance of security and convenience. For interactive command-line use, 1-8 hours is common. For applications, request shorter-lived tokens (e.g., 15-60 minutes) and refresh them automatically.
+
+---
+
+**Q: Can I have multiple active tokens at once?**
+
+A: Yes. Each call to the `/v1/tokens` endpoint issues a new, independent token. All of them will be valid until they expire or are revoked.
+
+---
+
+**Q: What happens if the `maas-api` service is down?**
+
+A: You will not be able to issue *new* tokens. However, any existing, non-expired tokens will continue to work for calling models, as the gateway validates them directly with the Kubernetes API.
+
+---
+
+**Q: Can I use one token to access multiple different models?**
+
+A: Yes. Your token grants you access based on your tier's RBAC permissions. If your tier is authorized to use multiple models, a single token will work for all of them.
+
+---
+
+## Related Documentation
+
+- **[Configuring Subscription Tiers](tier-configuration.md)**: For operators - tier setup, RBAC, and rate limiting configuration
+
+---

--- a/docs/content/install/validation.md
+++ b/docs/content/install/validation.md
@@ -34,6 +34,9 @@ TOKEN_RESPONSE=$(curl -sSk \
 TOKEN=$(echo $TOKEN_RESPONSE | jq -r .token)
 ```
 
+!!! note
+    For more information about how tokens work, see [Understanding Token Management](../configuration-and-management/token-management.md).
+
 ### 3. List Available Models
 
 ```bash

--- a/docs/content/user-guide/self-service-model-access.md
+++ b/docs/content/user-guide/self-service-model-access.md
@@ -8,6 +8,9 @@ The Model-as-a-Service (MaaS) platform provides access to AI models through a si
 
 ## Getting Your Access Token
 
+!!! tip
+    For a detailed explanation of how token authentication works, including the underlying service account architecture and security model, see [Understanding Token Management](../configuration-and-management/token-management.md).
+
 ### Step 1: Get Your OpenShift Authentication Token
 
 First, you need your OpenShift token to prove your identity to the maas-api.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -64,6 +64,7 @@ nav:
       - Tier Management: configuration-and-management/tier-overview.md
       - Tier Configuration: configuration-and-management/tier-configuration.md
       - Tier Concepts: configuration-and-management/tier-concepts.md
+      - Token Management: configuration-and-management/token-management.md
     - Model Setup: configuration-and-management/model-setup.md
     - Advanced Administration:
       - Observability: advanced-administration/observability.md


### PR DESCRIPTION
The content explaining the details behind user - SA tokens got lost in restructuring to `mkdocs`. As we see questions about SA tokens, if they are stored, how they work etc, bringing back tailored version of the docs introduced in #125 might make sense.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive token management documentation covering authentication workflows, lifecycle management, token expiration and revocation, and admin procedures
  * Enhanced model setup documentation with expanded Gateway Architecture section
  * Added cross-references to token management documentation in installation and self-service access guides
  * Updated documentation navigation structure with new Token Management entry

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->