### PR TITLE
fix(deps): pins kserve to upstream pseudo-version

### DIFF
--- a/maas-api/go.mod
+++ b/maas-api/go.mod
@@ -7,7 +7,7 @@ toolchain go1.24.7
 require (
 	github.com/gin-contrib/cors v1.7.6
 	github.com/gin-gonic/gin v1.10.1
-	github.com/kserve/kserve v0.16.0
+	github.com/kserve/kserve v0.0.0-20251121160314-57d83d202f36 // TODO should be available in v0.16.1 when it's out
 	github.com/openai/openai-go/v2 v2.3.1
 	github.com/stretchr/testify v1.11.1
 	gopkg.in/yaml.v3 v3.0.1
@@ -17,9 +17,6 @@ require (
 	k8s.io/utils v0.0.0-20250604170112-4c0f3b243397
 	knative.dev/pkg v0.0.0-20250915135827-db4c336acdbe
 )
-
-// FIXME: remove when there's a release with https://github.com/kserve/kserve/pull/4849, as it's needed for typed clients
-replace github.com/kserve/kserve => github.com/bartoszmajsak/kserve v0.0.0-20251121135318-03d87a27e3b5
 
 require (
 	cel.dev/expr v0.24.0 // indirect

--- a/maas-api/go.sum
+++ b/maas-api/go.sum
@@ -57,8 +57,6 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapp
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.48.1/go.mod h1:viRWSEhtMZqz1rhwmOVKkWl6SwmVowfL9O2YR5gI2PE=
 github.com/aws/aws-sdk-go v1.55.6 h1:cSg4pvZ3m8dgYcgqB97MrcdjUmZ1BeMYKUxMMB89IPk=
 github.com/aws/aws-sdk-go v1.55.6/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=
-github.com/bartoszmajsak/kserve v0.0.0-20251121135318-03d87a27e3b5 h1:oPG4XXNqUJ0wl1VRV6vyKaucwaJEKFEAlAX6MnkCtJM=
-github.com/bartoszmajsak/kserve v0.0.0-20251121135318-03d87a27e3b5/go.mod h1:/+DNge9AVcrDIfjKxb8H5mFI9gz3DDLbFO56T1ZPfiQ=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/blendle/zapdriver v1.3.1 h1:C3dydBOWYRiOk+B8X9IVZ5IOe+7cl+tGOexN4QqHfpE=
@@ -235,6 +233,8 @@ github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/kserve/kserve v0.0.0-20251121160314-57d83d202f36 h1:tgaSRJMHELg9CXalOOrRjOmf/Nua7VuSuZkq1OOSzl0=
+github.com/kserve/kserve v0.0.0-20251121160314-57d83d202f36/go.mod h1:/+DNge9AVcrDIfjKxb8H5mFI9gz3DDLbFO56T1ZPfiQ=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=


### PR DESCRIPTION
Before we have official release we need this.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependency versions to support ongoing development and maintenance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->