### PR TITLE
fix: note to Create `llm` namespace and add Kuadrant warning

### DIFF
--- a/deployment/scripts/deploy-rhoai-stable.sh
+++ b/deployment/scripts/deploy-rhoai-stable.sh
@@ -171,6 +171,7 @@ EOF
   local rhcl_exists=$(checksubscriptionexists openshift-marketplace redhat-operators rhcl-operator)
   if [[ $rhcl_exists -ne "0" ]]; then
     echo "* The RHCL operator is present in the cluster. Skipping installation."
+    echo "  WARNING: Creating an instance of RHCL is also skipped."
     return 0
   fi
 
@@ -339,6 +340,7 @@ echo "Deployment is complete."
 echo ""
 echo "Next Steps:"
 echo "1. Deploy a sample model:"
+echo "   kubectl create namespace llm"
 echo "   kustomize build 'https://github.com/opendatahub-io/maas-billing.git/docs/samples/models/simulator?ref=${MAAS_REF}' | kubectl apply -f -"
 echo ""
 echo "2. Get Gateway endpoint:"


### PR DESCRIPTION
Fixes for feedback in #224:
* At the end of the script, in the _next steps_, adding missing creation of the `llm` namespace before deploying a sample model.
* Adding a warning when deploying RHCL stating that creating a `Kuadrant` CR is also skipped if RHCL operator is already present.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced deployment script warning messaging to clarify behavior when cloud licensing is already installed.
  * Added namespace creation command to deployment setup instructions for improved clarity during initial setup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->