### PR TITLE
feat(config): makes MaaS gateway configurable

### DIFF
--- a/maas-api/internal/config/config.go
+++ b/maas-api/internal/config/config.go
@@ -15,20 +15,29 @@ type Config struct {
 	// Namespace where maas-api is deployed
 	Namespace string
 
-	DebugMode bool
+	// MaaS enabled Gateway configuration
+	GatewayName      string
+	GatewayNamespace string
+
 	// Server configuration
 	Port string
+
+	// Executable-specific configuration
+	DebugMode bool
 }
 
 // Load loads configuration from environment variables
 func Load() *Config {
 	debugMode, _ := env.GetBool("DEBUG_MODE", false)
+	gatewayName := env.GetString("GATEWAY_NAME", constant.DefaultGatewayName)
 
 	c := &Config{
-		Name:      env.GetString("INSTANCE_NAME", constant.DefaultGatewayName),
-		Namespace: env.GetString("NAMESPACE", constant.DefaultNamespace),
-		Port:      env.GetString("PORT", "8080"),
-		DebugMode: debugMode,
+		Name:             env.GetString("INSTANCE_NAME", gatewayName),
+		Namespace:        env.GetString("NAMESPACE", constant.DefaultNamespace),
+		GatewayName:      env.GetString("GATEWAY_NAME", gatewayName),
+		GatewayNamespace: env.GetString("GATEWAY_NAMESPACE", constant.DefaultGatewayNamespace),
+		Port:             env.GetString("PORT", "8080"),
+		DebugMode:        debugMode,
 	}
 	c.bindFlags(flag.CommandLine)
 
@@ -38,7 +47,9 @@ func Load() *Config {
 // bindFlags will parse the given flagset and bind values to selected config options
 func (c *Config) bindFlags(fs *flag.FlagSet) {
 	fs.StringVar(&c.Name, "name", c.Name, "Name of the MaaS instance")
-	fs.StringVar(&c.Namespace, "namespace", c.Namespace, "Namespace")
+	fs.StringVar(&c.Namespace, "namespace", c.Namespace, "Namespace of the MaaS instance")
+	fs.StringVar(&c.GatewayName, "gateway-name", c.GatewayName, "Name of the Gateway that has MaaS capabilities")
+	fs.StringVar(&c.GatewayNamespace, "gateway-namespace", c.GatewayNamespace, "Namespace where MaaS-enabled Gateway is deployed")
 	fs.StringVar(&c.Port, "port", c.Port, "Port to listen on")
 	fs.BoolVar(&c.DebugMode, "debug", c.DebugMode, "Enable debug mode")
 }

--- a/maas-api/internal/constant/const.go
+++ b/maas-api/internal/constant/const.go
@@ -1,7 +1,8 @@
 package constant
 
 const (
-	TierMappingConfigMap = "tier-to-group-mapping"
-	DefaultNamespace     = "maas-api"
-	DefaultGatewayName   = "maas-default-gateway"
+	TierMappingConfigMap    = "tier-to-group-mapping"
+	DefaultNamespace        = "maas-api"
+	DefaultGatewayName      = "maas-default-gateway"
+	DefaultGatewayNamespace = "openshift-ingress"
 )


### PR DESCRIPTION
This change adds a simple configuration mechanism (via env vars and startup flags). This can be used to handle only the models exposed by given "MaaS instance".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MaaS gateway configuration options for gateway name and namespace
  * New command-line flags: --gateway-name and --gateway-namespace
  * Environment variable support for gateway name (GATEWAY_NAME) and namespace
  * Default gateway namespace set to openshift-ingress
  * Debug mode remains configurable and preserved in startup flow

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->