### PR TITLE
feat: add Konflux Dockerfile with FIPS compliance

### DIFF
--- a/maas-api/Dockerfile.konflux
+++ b/maas-api/Dockerfile.konflux
@@ -1,0 +1,42 @@
+FROM registry.access.redhat.com/ubi9/go-toolset@sha256:84286c7555df503df0bd3acb86fe2ad50af82a07f35707918bb0fad312fdc193 AS builder
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+
+RUN go mod download
+
+COPY . .
+
+USER root
+RUN CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime GOOS=linux go build -trimpath -ldflags="-s -w" -o maas-api ./cmd/
+
+FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:7c5495d5fad59aaee12abc3cbbd2b283818ee1e814b00dbc7f25bf2d14fa4f0c
+
+
+WORKDIR /app
+
+COPY --from=builder /app/maas-api .
+
+# Make binary executable and fix permissions for OpenShift
+RUN chmod +x maas-api && \
+    chgrp -R 0 /app && \
+    chmod -R g=u /app
+
+# Use a non-root user (OpenShift will assign random UID)
+USER 1001
+
+EXPOSE 8080
+
+CMD ["./maas-api"]
+
+LABEL com.redhat.component="odh-maas-api-rhel9" \
+      name="rhoai/odh-maas-api-rhel9" \
+      description="odh-maas-api" \
+      summary="odh-maas-api" \
+      maintainer="['managed-open-data-hub@redhat.com']" \
+      io.openshift.expose-services="" \
+      io.k8s.display-name="odh-maas-api" \
+      io.k8s.description="odh-maas-api" \
+      com.redhat.license_terms="https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf"
+


### PR DESCRIPTION
- Add Dockerfile.konflux for Konflux/Red Hat builds
- Enable FIPS 140-2 compliance (CGO_ENABLED=1, GOEXPERIMENT=strictfipsruntime)
- Use pinned SHA256 digests for base images (reproducibility)
- Include Red Hat labels for EULA compliance and metadata
- Aligns with main Dockerfile FIPS compliance changes

This Dockerfile is used by Konflux for building the maas-api container image with Red Hat-specific requirements.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build and deployment configuration for improved container practices and security standards.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->