### PR TITLE
chore: cleans up unused provider

### DIFF
--- a/deployment/base/maas-api/deployment.yaml
+++ b/deployment/base/maas-api/deployment.yaml
@@ -22,8 +22,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        - name: PROVIDER
-          value: sa-tokens
         resources:
           requests:
             memory: "64Mi"

--- a/maas-api/architecture.md
+++ b/maas-api/architecture.md
@@ -587,7 +587,6 @@ Example tier-based access pattern:
 
 **MaaS API Deployment**:
 - `NAMESPACE`: Namespace where MaaS API is deployed (from fieldRef)
-- `PROVIDER`: Token provider type (value: `sa-tokens`)
 - `PORT`: HTTP server port (default: `8080`)
 - `DEBUG_MODE`: Enable CORS and debug logging (default: `false`)
 


### PR DESCRIPTION
This change removes the unused env variable for defining the key provider from the initial prototype.

Follow-up to #151 #248

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the PROVIDER environment variable from deployment configuration and updated documentation accordingly.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->