### PR TITLE
build: adds multi-arch build support with platform-aware stages

### DIFF
--- a/maas-api/Dockerfile
+++ b/maas-api/Dockerfile
@@ -1,17 +1,23 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24 AS builder
+ARG GOLANG_VERSION=1.24
+
+ARG BUILDPLATFORM
+ARG TARGETPLATFORM
+
+FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:$GOLANG_VERSION AS builder
+ARG CGO_ENABLED=1
+ARG TARGETOS
+ARG TARGETARCH
 
 WORKDIR /app
-
 COPY go.mod go.sum ./
-
 RUN go mod download
-
 COPY . .
 
 USER root
-RUN CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime GOOS=linux go build -a -trimpath -ldflags="-s -w" -o maas-api ./cmd/
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+RUN CGO_ENABLED=${CGO_ENABLED} GOEXPERIMENT=strictfipsruntime GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} go build -a -trimpath -ldflags="-s -w" -o maas-api ./cmd/
+
+FROM --platform=$TARGETPLATFORM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 WORKDIR /app
 

--- a/maas-api/Dockerfile.konflux
+++ b/maas-api/Dockerfile.konflux
@@ -1,18 +1,22 @@
-FROM registry.access.redhat.com/ubi9/go-toolset@sha256:84286c7555df503df0bd3acb86fe2ad50af82a07f35707918bb0fad312fdc193 AS builder
+ARG GOLANG_VERSION=1.24
+
+ARG BUILDPLATFORM
+ARG TARGETPLATFORM
+
+FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset@sha256:84286c7555df503df0bd3acb86fe2ad50af82a07f35707918bb0fad312fdc193 AS builder
+ARG CGO_ENABLED=1
+ARG TARGETOS
+ARG TARGETARCH
 
 WORKDIR /app
-
 COPY go.mod go.sum ./
-
 RUN go mod download
-
 COPY . .
 
 USER root
-RUN CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime GOOS=linux go build -trimpath -ldflags="-s -w" -o maas-api ./cmd/
+RUN CGO_ENABLED=${CGO_ENABLED} GOEXPERIMENT=strictfipsruntime GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} go build -a -trimpath -ldflags="-s -w" -o maas-api ./cmd/
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:7c5495d5fad59aaee12abc3cbbd2b283818ee1e814b00dbc7f25bf2d14fa4f0c
-
+FROM --platform=$TARGETPLATFORM registry.access.redhat.com/ubi9/ubi-minimal@sha256:7c5495d5fad59aaee12abc3cbbd2b283818ee1e814b00dbc7f25bf2d14fa4f0c
 
 WORKDIR /app
 

--- a/maas-api/Makefile
+++ b/maas-api/Makefile
@@ -1,27 +1,17 @@
-# MaaS Billing Makefile
-
-# Container Engine to be used for building image and with kind
-CONTAINER_ENGINE ?= podman
-
-# Image settings
-REPO ?= quay.io/opendatahub/maas-api
-TAG ?= latest
-FULL_IMAGE ?= $(REPO):$(TAG)
-
 PROJECT_DIR:=$(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 
 BINARY_NAME := maas-api
 BUILD_DIR := $(PROJECT_DIR)/bin
 LOCALBIN := $(BUILD_DIR)/tools
 
-# Go settings
 GOOS   ?= $(shell go env GOOS)
 GOARCH ?= $(shell go env GOARCH)
 GO_STRICTFIPS ?= false
 
+CGO_ENABLED  ?= 0
 ifeq ($(GO_STRICTFIPS),true)
   GOEXPERIMENT ?= strictfipsruntime
-  CGO_ENABLED  ?= 1
+  CGO_ENABLED  = 1
 endif
 
 GO_ENV := GOOS=$(GOOS) GOARCH=$(GOARCH)
@@ -32,7 +22,6 @@ ifdef CGO_ENABLED
   GO_ENV += CGO_ENABLED=$(CGO_ENABLED)
 endif
 
-# Git settings
 GIT_COMMIT := $(shell git rev-parse --is-inside-work-tree >/dev/null 2>&1 && git rev-parse --short HEAD)
 GIT_BRANCH := $(shell git rev-parse --is-inside-work-tree >/dev/null 2>&1 && git rev-parse --abbrev-ref HEAD)
 BUILD_TIME := $(shell date -u '+%Y-%m-%d_%H:%M:%S')
@@ -90,20 +79,8 @@ test: ## Run Go tests
 	@go tool cover -html=coverage.out -o coverage.html
 	@echo "Test coverage report generated: $(abspath coverage.html)"
 
-.PHONY: build-image
-build-image: ## Build container image (use REPO= and TAG= to specify image)
-	@echo "Building container image $(FULL_IMAGE)..."
-	$(CONTAINER_ENGINE) build $(CONTAINER_ENGINE_EXTRA_FLAGS) -t $(FULL_IMAGE) .
-	@echo "Container image $(FULL_IMAGE) built successfully"
-
-.PHONY: push-image
-push-image: ## Push container image (use REPO= and TAG= to specify image)
-	@echo "Pushing container image $(FULL_IMAGE)..."
-	@$(CONTAINER_ENGINE) push $(FULL_IMAGE)
-	@echo "Container image $(FULL_IMAGE) pushed successfully"
-
-.PHONY: build-push-image
-build-push-image: build-image push-image ## Build and push container image
+## Container image
+include container.mk
 
 ## Deployment
 

--- a/maas-api/container.mk
+++ b/maas-api/container.mk
@@ -1,0 +1,33 @@
+## Container image configuration and targets
+
+CONTAINER_ENGINE ?= podman
+REPO ?= quay.io/opendatahub/maas-api
+TAG ?= latest
+FULL_IMAGE ?= $(REPO):$(TAG)
+
+DOCKER_BUILD_ARGS := --build-arg CGO_ENABLED=$(CGO_ENABLED)
+ifdef GOEXPERIMENT
+  DOCKER_BUILD_ARGS += --build-arg GOEXPERIMENT=$(GOEXPERIMENT)
+endif
+
+.PHONY: build-image
+build-image: ## Build container image (use REPO= and TAG= to specify image)
+	@echo "Building container image $(FULL_IMAGE)..."
+	$(CONTAINER_ENGINE) build $(DOCKER_BUILD_ARGS) $(CONTAINER_ENGINE_EXTRA_FLAGS) -t $(FULL_IMAGE) .
+	@echo "Container image $(FULL_IMAGE) built successfully"
+
+.PHONY: build-image-konflux
+build-image-konflux: ## Build container image with Dockerfile.konflux
+	@echo "Building container image $(FULL_IMAGE) using Dockerfile.konflux..."
+	$(CONTAINER_ENGINE) build $(DOCKER_BUILD_ARGS) $(CONTAINER_ENGINE_EXTRA_FLAGS) -f Dockerfile.konflux -t $(FULL_IMAGE) .
+	@echo "Container image $(FULL_IMAGE) built successfully"
+
+.PHONY: push-image
+push-image: ## Push container image (use REPO= and TAG= to specify image)
+	@echo "Pushing container image $(FULL_IMAGE)..."
+	@$(CONTAINER_ENGINE) push $(FULL_IMAGE)
+	@echo "Container image $(FULL_IMAGE) pushed successfully"
+
+.PHONY: build-push-image
+build-push-image: build-image push-image ## Build and push container image
+


### PR DESCRIPTION
Enables cross-platform container builds by using `BUILDPLATFORM` for builder stages and `TARGETPLATFORM` for runtime stages. This allows building images for different architectures (e.g., building on `aarch64` for `x86_64` clusters) without compatibility issues.

Without `BUILDPLATFORM`, the builder stage would use the target platform's binaries (e.g., `x86_64` go binary on an `aarch64` host), which fails with:

```shell
  gcc: error: unrecognized command line option '-m64'
```

### Changes
- Adds `BUILDPLATFORM`/`TARGETPLATFORM` support to both `Dockerfiles` (auto-detected by BuildKit/Podman)
- Parameterizes `CGO_ENABLED` and `GOEXPERIMENT` build args
- Aligns `Dockerfile` and `Dockerfile.konflux`
- Extracts container targets and build args to `container.mk`
- Set `CGO_ENABLED=0` by default (enabled with `GO_STRICTFIPS=true`)

### Example usage

```shell
  make build-image                          # build for host architecture
  make build-image GO_STRICTFIPS=true      # build with FIPS support
```

Ref: [RHOAIENG-38240](https://issues.redhat.com/browse/RHOAIENG-38240)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized container image builds with multi-stage Docker workflows for improved efficiency and reduced image size.
  * Enhanced cross-platform build support with platform-aware configuration for consistent builds across different architectures.
  * Improved container security by enforcing non-root user execution (USER 1001).
  * Streamlined build system with centralized container configuration management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->