### PR TITLE
fix: correct RHOAI channel to 'fast' to match the RHOAI Self-Managed Life Cycle policy

### DIFF
--- a/deployment/scripts/deploy-rhoai-stable.sh
+++ b/deployment/scripts/deploy-rhoai-stable.sh
@@ -261,7 +261,7 @@ metadata:
   name: rhoai3-operator
   namespace: redhat-ods-operator
 spec:
-  channel: fast-3.x
+  channel: fast
   installPlanApproval: Automatic
   name: rhods-operator
   source: redhat-operators


### PR DESCRIPTION


Change the RHOAI subscription channel from 'fast-3.x' to 'fast' in 'deployment/scripts/deploy-rhoai-stable.sh' to match the official Red Hat OpenShift AI Self-Managed Life Cycle policy for version 3.0.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched the RHOAI operator subscription to the latest stable channel so new deployments receive the updated operator stream.
  * This change does not alter the installation flow or public APIs; no user-facing behavior or signatures were modified.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->