### PR TITLE
fix(rbac): adds missing cfgmap role for informer

### DIFF
--- a/deployment/base/maas-api/rbac/clusterrole.yaml
+++ b/deployment/base/maas-api/rbac/clusterrole.yaml
@@ -5,7 +5,7 @@ metadata:
 rules:
 - apiGroups: [""]
   resources: ["configmaps"]
-  verbs: ["get", "list", "create", "update", "patch", "delete"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 
 # SA token provider resources
 - apiGroups: [""]


### PR DESCRIPTION
Without it cache cannot be updated, and following error is shown:

```
"Failed to watch" err="configmaps is forbidden:
User \"system:serviceaccount:maas-api:maas-api\"
cannot watch resource \"configmaps\" in API group \"\" in the
namespace \"maas-api\"" logger="UnhandledError"
reflector="k8s.io/client-go@v0.34.0/tools/cache/reflector.go:290" type="*v1.ConfigMap"
```

Follow-up to #287


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated permissions configuration to enable enhanced resource monitoring capabilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->