### PR TITLE
fix: include PVC in maas-api kustomization resources

### DIFF
--- a/deployment/base/maas-api/kustomization.yaml
+++ b/deployment/base/maas-api/kustomization.yaml
@@ -6,6 +6,7 @@ namespace: maas-api
 resources:
   - deployment.yaml
   - service.yaml
+  - pvc.yaml
   - rbac
   - networking
   - policies


### PR DESCRIPTION
- maas-api can't be scheduled because the PVC isn't getting created from #232 e.g. `persistentvolumeclaim "maas-api-db" not found`.
- Fixes pod scheduling failure by adding missing pvc.yaml to the kustomization resources list.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration to support persistent volume storage, improving data persistence and reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->