### PR TITLE
chore(makefile): removes commented out section

### DIFF
--- a/maas-api/Makefile
+++ b/maas-api/Makefile
@@ -15,12 +15,6 @@ ifeq ($(GO_STRICTFIPS),true)
   GOEXPERIMENT ?= strictfipsruntime
 endif
 
-# temp commenting to make main image working while we still have sqlite, and working on better solution
-# ifeq ($(GO_STRICTFIPS),true)
-#   GOEXPERIMENT ?= strictfipsruntime
-#   CGO_ENABLED  = 1
-# endif
-
 GO_ENV := GOOS=$(GOOS) GOARCH=$(GOARCH)
 ifdef GOEXPERIMENT
   GO_ENV += GOEXPERIMENT=$(GOEXPERIMENT)


### PR DESCRIPTION
Due to SQLite dependency we have to use `CGO_ENABLED=1` for our builds, otherwise the api_key endpoint is not functional.

The previously commented-out FIPS block no longer provides value and instead introduces confusion about when CGO should be enabled.

Leftover from #302 #303


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Cleaned up build configuration by removing redundant code, with no impact to functionality or end-user experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->