### PR TITLE
docs: update site and repository URLs in mkdocs.yml

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: ODH Model-as-a-Service Documentation
-site_url: https://opendatahub-io.github.io/maas-billing
-repo_url: https://github.com/opendatahub-io/maas-billing
-repo_name: opendatahub-io/maas-billing
+site_url: https://opendatahub-io.github.io/models-as-a-service
+repo_url: https://github.com/opendatahub-io/models-as-a-service
+repo_name: opendatahub-io/models-as-a-service
 
 # Set the docs directory to the content subdirectory
 docs_dir: content


### PR DESCRIPTION
The repo name has changed to "models-as-a-service"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation and repository reference URLs to align with the project's rebranding.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->