### PR TITLE
docs: improve gateway architecture diagram to be dark-mode friendly

### DIFF
--- a/docs/content/configuration-and-management/model-setup.md
+++ b/docs/content/configuration-and-management/model-setup.md
@@ -7,15 +7,15 @@ This guide explains how to configure `LLMInferenceService` resources to be picke
 The MaaS platform uses a **segregated gateway approach**, where models explicitly opt-in to MaaS capabilities by referencing the `maas-default-gateway`. This provides flexibility and isolation between different model deployment scenarios.
 
 ```mermaid
-%%{init: {'theme':'base', 'themeVariables': { 'fontSize':'17px', 'fontFamily':'system-ui, -apple-system, sans-serif', 'clusterBkg':'#f5f5f5', 'clusterBorder':'#666', 'edgeLabelBackground':'transparent', 'labelBackground':'transparent', 'tertiaryColor':'transparent'}}}%%
+%%{init: {'theme':'base', 'themeVariables': { 'fontSize':'16px', 'fontFamily':'system-ui, -apple-system, sans-serif', 'edgeLabelBackground':'transparent', 'labelBackground':'transparent', 'tertiaryColor':'transparent'}}}%%
 graph TB
-    subgraph cluster["<span style='font-size:18px;font-weight:700;color:#000'>OpenShift/Kubernetes Cluster</span>"]
-        subgraph gateways["<span style='font-size:16px;font-weight:600;color:#000'>Gateway Layer</span>"]
+    subgraph cluster["OpenShift/K8s Cluster"]
+        subgraph gateways["Gateway Layer"]
             defaultGW["Default Gateway<br/>(ODH/KServe)<br/><br/>✓ Existing auth model<br/>✓ No rate limits<br/>"]
             maasGW["MaaS Gateway<br/>(maas-default-gateway)<br/><br/>✓ Token authentication<br/>✓ Tier-based rate limits<br/>✓ Token consumption "]
         end
 
-        subgraph models["<span style='font-size:16px;font-weight:600;color:#000'>Model Deployments</span>"]
+        subgraph models["Model Deployments"]
             standardModel["LLMInferenceService<br/>(Standard)<br/><br/>spec:<br/>  model: ...<br/>  # Managed default Gateway instance"]
             maasModel["LLMInferenceService<br/>(MaaS-enabled)<br/><br/>spec:<br/>  model: ...<br/>  router:<br/>    gateway:<br/>      refs:<br/>        - name: maas-default-gateway"]
         end
@@ -30,14 +30,10 @@ graph TB
     style defaultGW fill:#1976d2,stroke:#0d47a1,stroke-width:3px,color:#fff
     style maasGW fill:#f57c00,stroke:#e65100,stroke-width:3px,color:#fff
     style standardModel fill:#78909c,stroke:#546e7a,stroke-width:3px,color:#fff
-    style maasModel fill:#ffa726,stroke:#f57c00,stroke-width:3px,color:#000
-    style cluster fill:#f5f5f5,stroke:#666,stroke-width:2px
-    style gateways fill:#e8eaf6,stroke:#999,stroke-width:2px
-    style models fill:#e8eaf6,stroke:#999,stroke-width:2px
-    linkStyle 0 stroke-width:2px,color:#000
-    linkStyle 1 stroke-width:2px,color:#000
-    linkStyle 2 stroke-width:2px,color:#000
-    linkStyle 3 stroke-width:2px,color:#000
+    style maasModel fill:#ffa726,stroke:#f57c00,stroke-width:3px,color:#fff
+    style cluster fill:none,stroke:#666,stroke-width:2px
+    style gateways fill:none,stroke:#5c6bc0,stroke-width:2px
+    style models fill:none,stroke:#5c6bc0,stroke-width:2px
 ```
 
 !!! note


### PR DESCRIPTION
The diagram uses light colors that don't work well in dark mode. This PR improves it.

  Changes Made:

  Before (light colors, invisible in dark mode):
<img width="717" height="824" alt="image" src="https://github.com/user-attachments/assets/fc037338-75f8-40e3-b651-2fd03b8bf30c" />


  After (dark-mode friendly):
<img width="832" height="789" alt="image" src="https://github.com/user-attachments/assets/393b4b49-8f79-4747-b89e-5161698a396c" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Mermaid initialization for theme and fonts in architecture diagrams.
  * Renamed cluster label to "OpenShift/K8s Cluster" and adjusted wording for consistency.
  * Standardized gateway and node labels (removed bold formatting) for clearer readability.
  * Switched edge labels to pipe-delimited style and updated connections for clarity.
  * Applied explicit styling for nodes, gateways, clusters, and links to unify colors and sizing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->