### PR TITLE
fix(deploy): detect TLS certificate secret dynamically for MaaS gateway

### DIFF
--- a/deployment/base/networking/maas/maas-gateway-api.yaml
+++ b/deployment/base/networking/maas/maas-gateway-api.yaml
@@ -32,5 +32,5 @@ spec:
        certificateRefs:
        - group: ''
          kind: Secret
-         name: default-ingress-cert
+         name: ${CERT_NAME}
        mode: Terminate


### PR DESCRIPTION
The MaaS gateway deployment was failing on environments where the expected TLS certificate secret name differed from the hardcoded value.

Previously, the script assumed `default-gateway-cert`, which was the default created by RHOAI 3.0. In RHOAI 3.2, this has been renamed to `data-science-gateway-service-tls` as part of a new default gateway mode that uses OpenShift Routes instead of LoadBalancer services. This change broke backward compatibility for existing deployments.

The certificate used in the first fix was created by ROSA/Hypershift and was not portable to other environments.

This commit introduces dynamic detection that iterates through known certificate secret names and uses the first one found. If no certificate is available, the HTTPS listener is omitted gracefully.

Supersedes #293

Tracked in: [issues.redhat.com/browse/RHOAIENG-41342](https://issues.redhat.com/browse/RHOAIENG-41342)

> [!IMPORTANT] 
> Gateway TLS configuration is inherently environment-specific.
>
> Certificate provisioning depends on the cluster's ingress setup, cloud provider integration, and organizational security policies. This makes it impractical to provide a universal default that works across all deployment scenarios. 
>
> Cluster administrators should be responsible for ensuring appropriate TLS certificates are provisioned before deploying the MaaS gateway, or for customizing the gateway configuration to match their infrastructure requirements.
