### PR TITLE
fix: add a wait if the odh namespace does not exist yet

### DIFF
--- a/scripts/deploy-rhoai-stable.sh
+++ b/scripts/deploy-rhoai-stable.sh
@@ -312,6 +312,19 @@ metadata:
   name: maas-api
 EOF
 
+if kubectl get namespace opendatahub >/dev/null 2>&1; then
+  kubectl wait namespace/opendatahub --for=jsonpath='{.status.phase}'=Active --timeout=60s
+else
+  echo "* Waiting for opendatahub namespace to be created by the operator..."
+  for i in {1..30}; do
+    if kubectl get namespace opendatahub >/dev/null 2>&1; then
+      kubectl wait namespace/opendatahub --for=jsonpath='{.status.phase}'=Active --timeout=60s
+      break
+    fi
+    sleep 5
+  done
+fi
+
 : "${MAAS_REF:=main}"
 kubectl apply --server-side=true \
   -f <(kustomize build "https://github.com/opendatahub-io/models-as-a-service.git/deployment/overlays/openshift?ref=${MAAS_REF}" | \


### PR DESCRIPTION
- Resolves the potential race condition by verifying the NS exists.

Error from a vanilla ROSA ClusterBot instance.

```
telemetrypolicy.extensions.kuadrant.io/user-group serverside-applied
gateway.gateway.networking.k8s.io/maas-default-gateway serverside-applied
authpolicy.kuadrant.io/gateway-auth-policy serverside-applied
ratelimitpolicy.kuadrant.io/gateway-rate-limits serverside-applied
tokenratelimitpolicy.kuadrant.io/gateway-token-rate-limits serverside-applied
servicemonitor.monitoring.coreos.com/limitador-metrics serverside-applied
Error from server (NotFound): namespaces "opendatahub" not found
Error from server (NotFound): namespaces "opendatahub" not found
Error from server (NotFound): namespaces "opendatahub" not found
Error from server (NotFound): namespaces "opendatahub" not found
Error from server (NotFound): namespaces "opendatahub" not found
Error from server (NotFound): namespaces "opendatahub" not found
Error from server (NotFound): namespaces "opendatahub" not found

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced deployment reliability by ensuring the required namespace is ready before MaaS deployment proceeds.
  * Improved cluster domain configuration to correctly use actual cluster environment settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->