### PR TITLE
fix: when JWT length is not modulo 4

### DIFF
--- a/docs/content/install/maas-setup.md
+++ b/docs/content/install/maas-setup.md
@@ -45,7 +45,7 @@ The default audience of Kubernetes clusters is usually `https://kubernetes.defau
 You can check the audience of your cluster with the following commands:
 
 ```shell
-AUD="$(kubectl create token default --duration=10m 2>/dev/null | cut -d. -f2 | base64 -d 2>/dev/null | jq -r '.aud[0]' 2>/dev/null)"
+AUD="$(kubectl create token default --duration=10m 2>/dev/null | cut -d. -f2 | jq -Rr '@base64d | fromjson | .aud[0]' 2>/dev/null)"
 echo $AUD
 
 # Output:

--- a/maas-api/README.md
+++ b/maas-api/README.md
@@ -101,8 +101,7 @@ Patch `AuthPolicy` with the correct audience for Openshift Identities:
 ```shell
 AUD="$(kubectl create token default --duration=10m \
   | cut -d. -f2 \
-  | base64 -d 2>/dev/null \
-  | jq -r '.aud[0]')"
+  | jq -Rr '@base64d | fromjson | .aud[0]' 2>/dev/null)"
 
 echo "Patching AuthPolicy with audience: $AUD"
 

--- a/scripts/deploy-openshift.sh
+++ b/scripts/deploy-openshift.sh
@@ -402,13 +402,6 @@ kustomize build deployment/base/policies | sed "s/maas-api\.maas-api\.svc/maas-a
 
 echo ""
 echo "1️⃣2️⃣ Patching AuthPolicy with correct audience..."
-# Cross-platform base64 decode (macOS uses -D, Linux uses -d)
-if [[ "$OSTYPE" == "darwin"* ]]; then
-    BASE64_DECODE="base64 -D"
-else
-    BASE64_DECODE="base64 -d"
-fi
-
 echo "   Attempting to detect audience..."
 TOKEN=$(kubectl create token default --duration=10m 2>/dev/null || echo "")
 if [ -z "$TOKEN" ]; then
@@ -422,7 +415,7 @@ else
         AUD=""
     else
         echo "   JWT payload extracted"
-        DECODED_PAYLOAD=$(echo "$JWT_PAYLOAD" | $BASE64_DECODE 2>/dev/null || echo "")
+        DECODED_PAYLOAD=$(echo "$JWT_PAYLOAD" | jq -Rr '@base64d | fromjson' || echo "")
         if [ -z "$DECODED_PAYLOAD" ]; then
             echo "   ⚠️  Could not decode base64 payload, skipping audience detection"
             AUD=""

--- a/scripts/deploy-rhoai-stable.sh
+++ b/scripts/deploy-rhoai-stable.sh
@@ -300,7 +300,7 @@ echo
 echo "## Installing Models-as-a-Service"
 
 export CLUSTER_DOMAIN=$(kubectl get ingresses.config.openshift.io cluster -o jsonpath='{.spec.domain}')
-export AUD="$(kubectl create token default --duration=10m 2>/dev/null | cut -d. -f2 | base64 -d 2>/dev/null | jq -r '.aud[0]' 2>/dev/null)"
+export AUD="$(kubectl create token default --duration=10m 2>/dev/null | cut -d. -f2 | jq -Rr '@base64d | fromjson | .aud[0]' 2>/dev/null)"
 
 echo "* Cluster domain: ${CLUSTER_DOMAIN}"
 echo "* Cluster audience: ${AUD}"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
allegedly some JWT token are not modulo 4 and fail silently over `base64` decoding (even on Mac OSX even when using `-d` etc).

For example, my (redacted) JWT token over a ROSA cluster is:

```sh
kubectl create token default --duration=10m 2>/dev/null \
| cut -d. -f2 \
| base64 -D 2>/dev/null 
{"aud":["https://rh-oidc.s3.us-east-1.amazonaws.com/**REDACTED**"],"exp":1767599900,"iat":1767599300,"iss":"https://rh-oidc.s3.us-east-1.amazonaws.com/**REDACTED**","jti":"8a7fef11-dbac-4b33-9c8b-8dc4f38b2b93","kubernetes.io":{"namespace":"default","serviceaccount":{"name":"default","uid":"**REDACTED**"}},"nbf":1767599300,"sub":"system:serviceaccount:default:default%     
```

see it's truncated badly. Padding it (for example with `awk`) with the ending `==` would then work as expected.

I propose to simplify the need (extract AUD) by just relying on `jq` capabilities.

## How Has This Been Tested?
I have created as part of this PR a scaled down reproducer `scripts/deploy-dummy.sh`.

See commit 903ae0cac674c33e6f3abf6f6ed7b908fd8ebb5f

```
./scripts/deploy-dummy.sh 
=========================================
🚀 MaaS Platform OpenShift Deployment
=========================================

📋 Checking prerequisites...

Required tools:
  - oc: Client Version: 4.19.7
  - jq: jq-1.8.1
  - yq: yq (https://github.com/mikefarah/yq/) version v4.47.1
  - kustomize: {kustomize/v5.7.1  2025-07-23T12:44:29Z   }
  - git: git version 2.39.3 (Apple Git-145)

ℹ️  Note: OpenShift Service Mesh should be automatically installed when GatewayClass is created.
   If the Gateway gets stuck in 'Waiting for controller', you may need to manually
   install the Red Hat OpenShift Service Mesh operator from OperatorHub.

1️⃣ Checking OpenShift version and Gateway API requirements...
   OpenShift version: 4.18.26

1️⃣2️⃣ Patching AuthPolicy with correct audience...
   Attempting to detect audience...
   Token created successfully
   JWT payload extracted
   Payload decoded successfully
   ⚠️  Could not detect audience, skipping AuthPolicy patch
      You may need to manually configure the audience later
```

Then see commit 2da2b251bbbc4b3f6b29fd899dc068cf01ba5a7f

```
./scripts/deploy-dummy.sh                             
=========================================
🚀 MaaS Platform OpenShift Deployment
=========================================

📋 Checking prerequisites...

Required tools:
  - oc: Client Version: 4.19.7
  - jq: jq-1.8.1
  - yq: yq (https://github.com/mikefarah/yq/) version v4.47.1
  - kustomize: {kustomize/v5.7.1  2025-07-23T12:44:29Z   }
  - git: git version 2.39.3 (Apple Git-145)

ℹ️  Note: OpenShift Service Mesh should be automatically installed when GatewayClass is created.
   If the Gateway gets stuck in 'Waiting for controller', you may need to manually
   install the Red Hat OpenShift Service Mesh operator from OperatorHub.

1️⃣ Checking OpenShift version and Gateway API requirements...
   OpenShift version: 4.18.26

1️⃣2️⃣ Patching AuthPolicy with correct audience...
   Attempting to detect audience...
   Token created successfully
   JWT payload extracted
   Payload decoded successfully
   Detected audience: https://rh-oidc.s3.us-east-1.amazonaws.com/**REDACTED**
```


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated installation and deployment documentation for token handling procedures

* **Improvements**
  * Enhanced deployment scripts with improved feedback messages during token creation and authentication operations
  * Optimized token authentication process with better error handling and logging visibility

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->