### PR TITLE
ci: ensure CI uses the correct golangci-lint version source

### DIFF
--- a/.github/workflows/maas-api-ci.yml
+++ b/.github/workflows/maas-api-ci.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Align golangci-lint version with Makefile
         id: golangci-version
         run: |
-          VERSION=$(grep '^GOLANGCI_LINT_VERSION' Makefile | cut -d'=' -f2 | tr -d ' ?')
+          VERSION=$(grep '^GOLANGCI_LINT_VERSION' tools.mk | cut -d'=' -f2 | tr -d ' ?')
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - uses: actions/setup-go@v6


### PR DESCRIPTION
The CI pipeline was reading the golangci-lint version from an outdated location, which could lead to mismatches between local builds and CI runs.

The workflow now derives the golangci-lint version from the same makefile used by the build tooling, keeping version resolution consistent across environments.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to reference version information from an alternate source file, ensuring consistent version management across build processes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->