### PR TITLE
fix(lint): resolve unused nolint directives for ireturn linter

### DIFF
--- a/maas-api/.golangci.yml
+++ b/maas-api/.golangci.yml
@@ -64,17 +64,6 @@ linters:
         - empty
         - stdlib
         - generic
-        - EventHandler
-        - discovery.DiscoveryInterface
-        - dynamic.Interface
-        - predicate.Predicate
-        - client.Object
-        - client.Client
-        - types.AsyncAssertion
-        - kubernetes.Interface
-        - gomega.AsyncAssertion
-        - labels.Selector
-        - manager.Manager
     lll:
       line-length: 180
     nolintlint:

--- a/maas-api/internal/api_keys/store_test.go
+++ b/maas-api/internal/api_keys/store_test.go
@@ -12,8 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-//nolint:ireturn // Returns MetadataStore interface for test flexibility.
-func createTestStore(t *testing.T) api_keys.MetadataStore {
+func createTestStore(t *testing.T) *api_keys.SQLStore {
 	t.Helper()
 	ctx := context.Background()
 	testLogger := logger.Development()

--- a/maas-api/test/fixtures/fake_listers.go
+++ b/maas-api/test/fixtures/fake_listers.go
@@ -10,12 +10,12 @@ import (
 	gatewaylisters "sigs.k8s.io/gateway-api/pkg/client/listers/apis/v1"
 )
 
-//nolint:ireturn // test helper
+//nolint:nolintlint,ireturn // test helper returning external interface
 func newIndexer() cache.Indexer {
 	return cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
-//nolint:ireturn // test helper
+//nolint:nolintlint,ireturn // test helper returning external interface
 func NewLLMInferenceServiceLister(items ...runtime.Object) kservelistersv1alpha1.LLMInferenceServiceLister {
 	indexer := newIndexer()
 	for _, item := range items {
@@ -24,7 +24,7 @@ func NewLLMInferenceServiceLister(items ...runtime.Object) kservelistersv1alpha1
 	return kservelistersv1alpha1.NewLLMInferenceServiceLister(indexer)
 }
 
-//nolint:ireturn // test helper
+//nolint:nolintlint,ireturn // test helper returning external interface
 func NewInferenceServiceLister(items ...runtime.Object) kservelistersv1beta1.InferenceServiceLister {
 	indexer := newIndexer()
 	for _, item := range items {
@@ -33,7 +33,7 @@ func NewInferenceServiceLister(items ...runtime.Object) kservelistersv1beta1.Inf
 	return kservelistersv1beta1.NewInferenceServiceLister(indexer)
 }
 
-//nolint:ireturn // test helper
+//nolint:nolintlint,ireturn // test helper returning external interface
 func NewConfigMapLister(items ...*corev1.ConfigMap) corelisters.ConfigMapLister {
 	indexer := newIndexer()
 	for _, item := range items {
@@ -42,7 +42,7 @@ func NewConfigMapLister(items ...*corev1.ConfigMap) corelisters.ConfigMapLister 
 	return corelisters.NewConfigMapLister(indexer)
 }
 
-//nolint:ireturn // test helper
+//nolint:nolintlint,ireturn // test helper returning external interface
 func NewHTTPRouteLister(items ...runtime.Object) gatewaylisters.HTTPRouteLister {
 	indexer := newIndexer()
 	for _, item := range items {


### PR DESCRIPTION
## Description of the problem

The nolintlint linter was flagging unused `//nolint:ireturn` directives in test files. Removing explicit exclusion lead to exact opposite error reported - that functions return interfaces (`ireturn` errors)

Not sure what is the exact issue here, but I see this failing in seemingly unrelated PR (#227) where I think golangci-linter GitHub Action runs against a diff that include merge commits.

Tested with `act -j lint -W .github/workflows/maas-api-ci.yml`

## Proposed Fixes

Returns concrete type `*SQLStore` instead of `MetadataStore` interface in test helper where possible. For test fixtures that must return external interfaces (listers from client-go, kserve, gateway-api), uses `//nolint:nolintlint,ireturn` to handle both scenarios: when ireturn fires and when it doesn't.

Cleans up `.golangci.yml` by removing bloated ireturn allow list, keeping only built-in keywords. Edge cases are now handled locally with inline directives, making exceptions visible where they occur and avoiding config bloat.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored test helpers and fixtures to improve test infrastructure reliability.

* **Chores**
  * Updated linting configuration and test directives to align with current code standards.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->