### PR TITLE
docs(tier): explain security rationale for custom RBAC verb

### DIFF
--- a/docs/content/configuration-and-management/tier-configuration.md
+++ b/docs/content/configuration-and-management/tier-configuration.md
@@ -123,6 +123,9 @@ This annotation automatically sets up the necessary RBAC (Role and RoleBinding) 
       apiGroup: rbac.authorization.k8s.io
     ```
 
+!!!info "Why the custom `post` verb?"
+    We intentionally use a custom verb (`post`) instead of standard Kubernetes verbs like `get` or `create`. This is the **only** RBAC permission required for model access. By using a non-standard verb that doesn't exist in Kubernetes' built-in authorization, we minimize the security surface - these service accounts cannot accidentally read, modify, or delete any cluster resources.
+
 ### 3. Configure Rate Limiting
 
 Add tier-specific rate limits by patching the existing `gateway-token-rate-limits` TokenRateLimitPolicy:


### PR DESCRIPTION
Adds documentation clarifying why model access uses a custom `post` verb instead of standard Kubernetes verbs like `get` or `create`.

This is an intentional security decision.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added explanation of the security rationale behind the custom RBAC post verb
  * Added example configuration showing how to set up token-rate limiting with kubectl

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->