### PR TITLE
fix the namespace references in scripts/deploy-rhoai-stable.sh 

### DIFF
--- a/scripts/deploy-rhoai-stable.sh
+++ b/scripts/deploy-rhoai-stable.sh
@@ -332,7 +332,7 @@ kubectl apply --server-side=true \
 
 if [[ -n "$AUD" && "$AUD" != "https://kubernetes.default.svc"  ]]; then
   echo "* Configuring audience in MaaS AuthPolicy"
-  kubectl patch authpolicy maas-api-auth-policy -n maas-api --type=merge --patch-file <(echo "
+  kubectl patch authpolicy maas-api-auth-policy -n opendatahub --type=merge --patch-file <(echo "
 spec:
   rules:
     authentication:
@@ -345,7 +345,7 @@ fi
 
 # Patch maas-api Deployment with stable image
 : "${MAAS_RHOAI_IMAGE:=v3.0.0}"
-kubectl set image -n maas-api deployment/maas-api maas-api=registry.redhat.io/rhoai/odh-maas-api-rhel9:${MAAS_RHOAI_IMAGE}
+kubectl set image -n opendatahub deployment/maas-api maas-api=registry.redhat.io/rhoai/odh-maas-api-rhel9:${MAAS_RHOAI_IMAGE}
 
 echo ""
 echo "========================================="


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Namespace Mismatch: The script creates resources in the opendatahub namespace but tries to patch them in the maas-api namespace.

## How Has This Been Tested?

### Test Steps

1. **Deployed using the fixed script:**
   ```bash
   export MAAS_REF="main"
   ./scripts/deploy-rhoai-stable.sh
   ```

2. **Verified successful execution:**
   ```
   deployment.apps/maas-api serverside-applied
   authpolicy.kuadrant.io/maas-api-auth-policy serverside-applied
   ...
   deployment.apps/maas-api image updated

   =========================================
   Deployment is complete.
   ```

3. **Verified deployment exists in correct namespace:**
   ```bash
   kubectl get deployment -n opendatahub maas-api
   ```

   Output:
   ```
   NAME       READY   UP-TO-DATE   AVAILABLE   AGE
   maas-api   1/1     1            1           61m
   ```

4. **Verified image was updated correctly:**
   ```bash
   kubectl get deployment -n opendatahub maas-api -o jsonpath='{.spec.template.spec.containers[0].image}'
   ```

   Output:
   ```
   registry.redhat.io/rhoai/odh-maas-api-rhel9:v3.0.0
   ```

5. **Confirmed deployment does NOT exist in maas-api namespace (expected):**
   ```bash
   kubectl get deployment -n maas-api maas-api
   ```

   Output:
   ```
   Error from server (NotFound): deployments.apps "maas-api" not found
   ```


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
