### PR TITLE
test: added wait time for rate limit to reset for smoke tests

### DIFF
--- a/test/e2e/scripts/prow_run_smoke_test.sh
+++ b/test/e2e/scripts/prow_run_smoke_test.sh
@@ -223,6 +223,7 @@ print_header "Validating Deployment and Token Metadata Logic"
 validate_deployment
 run_token_verification
 
+sleep 120       # Wait for the rate limit to reset
 run_smoke_tests
 
 # Test edit user  


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
In CI we test rate limit via `validate-deployment.sh` script and right after we also use the pytest smoke tests to validate this again which results in hitting the rate limit and failing smoke tests. For now, just added extra sleep time to reset the rate limit. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Enhanced error handling and diagnostics for OpenShift service readiness verification during deployment, providing clearer failure messages and resource information when issues occur.
  * Introduced a deliberate 120-second pause between token verification and smoke tests to reduce transient failures from rate limiting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->