### PR TITLE
test(e2e): improve debugging output when model deployment times out

### DIFF
--- a/test/e2e/scripts/prow_run_smoke_test.sh
+++ b/test/e2e/scripts/prow_run_smoke_test.sh
@@ -105,7 +105,14 @@ deploy_models() {
     echo "✅ Simulator model deployed"
     
     echo "Waiting for model to be ready..."
-    oc wait llminferenceservice/facebook-opt-125m-simulated -n llm --for=condition=Ready --timeout=300s
+    if ! oc wait llminferenceservice/facebook-opt-125m-simulated -n llm --for=condition=Ready --timeout=300s; then
+        echo "❌ ERROR: Timed out waiting for model to be ready"
+        echo "=== LLMInferenceService YAML dump ==="
+        oc get llminferenceservice/facebook-opt-125m-simulated -n llm -o yaml || true
+        echo "=== Events in llm namespace ==="
+        oc get events -n llm --sort-by='.lastTimestamp' || true
+        exit 1
+    fi
     echo "✅ Simulator Model deployed"
 }
 


### PR DESCRIPTION
Adds diagnostic output when the simulator model fails to become ready within the timeout period. This helps identify deployment issues in CI environments where interactive debugging is not possible.

When a timeout occurs, the script now dumps the LLMInferenceService resource state and namespace events before exiting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved error handling and diagnostics in testing infrastructure to better capture and report model initialization failures, including detailed logging and status information when timeouts occur.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->