### PR TITLE
fix: use --upgrade-deps when creating venv to ensure pip is available

### DIFF
--- a/test/e2e/smoke.sh
+++ b/test/e2e/smoke.sh
@@ -13,7 +13,7 @@ setup_python_venv() {
     # Create virtual environment if it doesn't exist
     if [[ ! -d "${VENV_DIR}" ]]; then
         echo "[smoke] Creating virtual environment at ${VENV_DIR}"
-        python3 -m venv "${VENV_DIR}"
+        python3 -m venv "${VENV_DIR}" --upgrade-deps
     fi
     
     # Activate virtual environment


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
On some systems, `python3 -m venv` does not include `pip` by default. Adding `--upgrade-deps` ensures pip is installed and upgraded when creating the virtual environment.
```
$ ./test/e2e/smoke.sh
[smoke] Setting up Python virtual environment...
[smoke] Activating virtual environment
[smoke] Installing Python dependencies
/home/chkulkar/Projects/maas-billing/test/e2e/.venv/bin/python: No module named pip
```

## How Has This Been Tested?
Tested using `./test/e2e/smoke.sh` and in the e2e flow - `./test/e2e/scripts/prow_run_smoke_test.sh`

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
