### PR TITLE
feat: adds optional Keycloak IDP deployment with end-to-end OAuth flow

### DIFF
--- a/deployment/idp/maas-api/policies/auth-policy-oidc.yaml
+++ b/deployment/idp/maas-api/policies/auth-policy-oidc.yaml
@@ -1,0 +1,27 @@
+apiVersion: kuadrant.io/v1
+kind: AuthPolicy
+metadata:
+  name: maas-api-auth-policy
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: maas-api-route
+  rules:
+    # Allow any authenticated user to access the API
+    authentication:
+      keycloak-oidc:
+        jwt:
+          jwksUrl: http://keycloak.keycloak-system.svc.cluster.local:8080/realms/${KEYCLOAK_REALM}/protocol/openid-connect/certs
+        credentials:
+          authorizationHeader:
+            prefix: Bearer
+    response:
+      success:
+        headers:
+          X-MaaS-Username:
+            plain:
+              selector: auth.identity.preferred_username
+          X-MaaS-Group:
+            plain:
+              selector: auth.identity.groups.@tostr

--- a/deployment/idp/maas-api/resources/allow-gateway-networkpolicy.yaml
+++ b/deployment/idp/maas-api/resources/allow-gateway-networkpolicy.yaml
@@ -1,0 +1,22 @@
+# Allow gateway ingress to MaaS API pods for the IDP flow.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: maas-allow-gateway
+  labels:
+    app: maas-api
+    component: networking
+  annotations:
+    opendatahub.io/managed: "false"
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/part-of: models-as-a-service
+      app.kubernetes.io/name: maas-api
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-ingress

--- a/deployment/idp/maas-api/resources/tier-mapping-configmap.yaml
+++ b/deployment/idp/maas-api/resources/tier-mapping-configmap.yaml
@@ -1,0 +1,42 @@
+# Tier to Group Mapping for MaaS API (Keycloak IDP)
+# This ConfigMap defines which Keycloak groups belong to each tier
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tier-to-group-mapping
+  labels:
+    app: maas-api
+    component: tier-mapping
+  annotations:
+    opendatahub.io/managed: "false"
+data:
+  tiers: |
+    # Free tier - default for all authenticated users
+    - name: free
+      displayName: Free Tier
+      level: 0
+      groups:
+        - tier-free-users
+        - free-users
+        - system:authenticated  # Default for all authenticated users
+
+    # Premium tier - for premium users
+    - name: premium
+      displayName: Premium Tier
+      level: 1
+      groups:
+        - tier-premium-users
+        - premium-group
+        - premium-users
+
+    # Enterprise tier - highest level
+    - name: enterprise
+      displayName: Enterprise Tier
+      level: 2
+      groups:
+        - tier-enterprise-users
+        - enterprise-group
+        - enterprise-users
+        - admin-group
+        - admins

--- a/docs/OAUTH_SETUP.md
+++ b/docs/OAUTH_SETUP.md
@@ -1,0 +1,69 @@
+# OAuth Setup Guide (Keycloak OIDC)
+
+This guide describes how to configure Keycloak so MaaS can accept Keycloak access tokens directly for `/maas-api/v1/tokens`.
+
+## Keycloak Configuration
+
+1. Create a realm for MaaS (example: `maas`).
+2. Create an OIDC client for MaaS token requests:
+   - **Client ID**: `maas-cli` (example)
+   - **Client authentication**: On (confidential client)
+   - **Standard flow**: On
+   - **Direct access grants**: On (required if using the password grant in CLI examples)
+3. Ensure tokens include a username and groups:
+   - **preferred_username**: enabled by default in Keycloak tokens.
+   - **groups**: add a client scope with a **Group Membership** mapper and attach it to the client.
+
+MaaS expects:
+- `preferred_username` for user identity
+- `groups` as an array for tier mapping
+
+If you use different claim names, adjust the MaaS AuthPolicy response headers accordingly.
+
+## MaaS AuthPolicy Configuration
+
+Update the MaaS API AuthPolicy JWKS URL to point at your realm:
+
+```shell
+KEYCLOAK_REALM="maas"
+
+kubectl patch authpolicy maas-api-auth-policy -n maas-api --type=merge --patch-file <(cat <<EOF
+spec:
+  rules:
+    authentication:
+      keycloak-oidc:
+        jwt:
+          jwksUrl: "http://keycloak.keycloak-system.svc.cluster.local:8080/realms/${KEYCLOAK_REALM}/protocol/openid-connect/certs"
+EOF
+)
+```
+
+## Request a MaaS Token with a Keycloak Access Token
+
+```shell
+KEYCLOAK_URL="https://keycloak.${CLUSTER_DOMAIN}"
+KEYCLOAK_REALM="maas"
+KEYCLOAK_CLIENT_ID="maas-cli"
+KEYCLOAK_USERNAME="user@example.com"
+KEYCLOAK_PASSWORD="your-password"
+
+KEYCLOAK_RESPONSE=$(curl -sSk \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "grant_type=password" \
+  -d "client_id=${KEYCLOAK_CLIENT_ID}" \
+  -d "username=${KEYCLOAK_USERNAME}" \
+  -d "password=${KEYCLOAK_PASSWORD}" \
+  "${KEYCLOAK_URL}/realms/${KEYCLOAK_REALM}/protocol/openid-connect/token")
+
+KEYCLOAK_ACCESS_TOKEN=$(echo $KEYCLOAK_RESPONSE | jq -r .access_token)
+
+MAAS_API_URL="https://maas.${CLUSTER_DOMAIN}"
+TOKEN_RESPONSE=$(curl -sSk \
+  -H "Authorization: Bearer ${KEYCLOAK_ACCESS_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -X POST \
+  -d '{"expiration": "24h"}' \
+  "${MAAS_API_URL}/maas-api/v1/tokens")
+
+echo $TOKEN_RESPONSE | jq -r .
+```

--- a/docs/content/install/idp-deployment.md
+++ b/docs/content/install/idp-deployment.md
@@ -1,0 +1,84 @@
+# IDP Deployment (Keycloak OAuth)
+
+This document describes the optional Keycloak IDP deployment for MaaS. It is additive and does not change the default deployment unless explicitly enabled.
+
+## Scope and Safety
+
+- The default deployment path is unchanged when `ENABLE_KEYCLOAK_IDP` is unset or `false`.
+- Keycloak-related manifests are stored separately under `deployment/idp/`.
+- Base manifests under `deployment/base/` remain vanilla (OpenShift identities, default tier mapping).
+
+## Enable IDP Mode
+
+Run the deployment with the feature flag enabled:
+
+```bash
+export ENABLE_KEYCLOAK_IDP=true
+./scripts/deploy-rhoai-stable.sh
+```
+
+For the generic OpenShift script:
+
+```bash
+export ENABLE_KEYCLOAK_IDP=true
+./scripts/deploy-openshift.sh
+```
+
+## What Changes With IDP Enabled
+
+Only when `ENABLE_KEYCLOAK_IDP=true`, the scripts will:
+
+- Deploy Keycloak in `keycloak-system` and import the `maas` realm.
+- Apply the Keycloak AuthPolicy in the MaaS API namespace.
+- Apply Keycloak group-to-tier mappings in both `maas-api` and `opendatahub` namespaces.
+- Exclude `/maas-api` paths from the gateway AuthPolicy.
+- Switch MaaS API image to `quay.io/opendatahub/maas-api:latest` unless overridden.
+
+## Key Files (IDP Only)
+
+- `deployment/idp/maas-api/policies/auth-policy-oidc.yaml`
+- `deployment/idp/maas-api/resources/tier-mapping-configmap.yaml`
+- `deployment/idp/maas-api/resources/allow-gateway-networkpolicy.yaml`
+
+## Base Deployment (Unchanged)
+
+When `ENABLE_KEYCLOAK_IDP=false`, these remain active:
+
+- `deployment/base/maas-api/policies/auth-policy.yaml` (OpenShift token review)
+- `deployment/base/maas-api/resources/tier-mapping-configmap.yaml` (default groups)
+
+## Validate IDP Flow
+
+Use the validation steps printed by `./scripts/deploy-rhoai-stable.sh` or follow `install/keycloak-idp.md` for the full end-to-end flow:
+
+- Keycloak token for MaaS API access (`/maas-api/v1/tokens`, `/maas-api/v1/models`)
+- MaaS ServiceAccount token for inference
+
+## Token Minting + Inference Flow
+
+This flow is the same regardless of deployment script; the IDP path just replaces the initial auth token with a Keycloak JWT.
+
+1) User authenticates to Keycloak and receives an access token (JWT).
+2) User calls `POST /maas-api/v1/tokens` with the Keycloak token.
+3) `maas-api-auth-policy` validates the JWT and injects identity headers.
+4) MaaS API maps Keycloak groups to a tier from the tier-to-group mapping ConfigMap.
+5) MaaS API creates a Kubernetes ServiceAccount for the user in the tier namespace and mints a ServiceAccount token.
+6) User calls the model inference endpoint with the MaaS ServiceAccount token.
+7) `gateway-auth-policy` validates the ServiceAccount token via Kubernetes TokenReview/SAR.
+8) Limitador enforces tier-based rate limits before forwarding to the model.
+
+Kubernetes ServiceAccount mapping:
+- Each Keycloak user is mapped to a ServiceAccount created by MaaS API.
+- The ServiceAccount is created in a tier namespace (for example, `maas-default-gateway-tier-free`).
+- The MaaS token returned from `/maas-api/v1/tokens` is a ServiceAccount token.
+
+## Customization
+
+You can override Keycloak settings and the MaaS API image before running the scripts:
+
+```bash
+export KEYCLOAK_REALM="maas"
+export KEYCLOAK_CLIENT_ID="maas-cli"
+export KEYCLOAK_CLIENT_SECRET="maas-cli-secret"
+export MAAS_API_IMAGE="quay.io/opendatahub/maas-api:latest"
+```

--- a/docs/content/install/keycloak-idp.md
+++ b/docs/content/install/keycloak-idp.md
@@ -1,0 +1,306 @@
+# Quickstart: Keycloak IDP (MaaS)
+
+This quickstart deploys MaaS with Keycloak as the IDP and validates the token issuance + inference flow.
+
+OAuth lets external users (no K8s credentials) authenticate via Keycloak and receive a Kubernetes-native token scoped to their tier. OAuth bridges external identity -> Kubernetes identity. Inference uses native K8s auth.
+
+For IDP-specific deployment details and file layout, see `install/idp-deployment.md`.
+
+
+## Prerequisites
+
+- OpenShift cluster (4.19.9+)
+- `kubectl` or `oc`
+- `kustomize`
+- `jq`
+
+This quickstart uses the Keycloak IDP feature flag. Set `ENABLE_KEYCLOAK_IDP=true` before running the deploy script. If you want the vanilla deployment path, omit the flag.
+
+## 1) Deploy MaaS + Keycloak
+
+From the repo root:
+
+```bash
+export MAAS_REF="main"
+export ENABLE_KEYCLOAK_IDP="true"
+./scripts/deploy-rhoai-stable.sh
+
+# Deploy a model
+kubectl create namespace llm
+kustomize build 'https://github.com/opendatahub-io/models-as-a-service.git/docs/samples/models/simulator?ref=main' | kubectl apply -f -
+```
+
+Follow the validation instructions after the script runs. Here is the quick paste:
+
+```bash
+CLUSTER_DOMAIN=$(kubectl get ingresses.config.openshift.io cluster -o jsonpath='{.spec.domain}')
+HOST="maas.${CLUSTER_DOMAIN}"
+
+# Core namespaces and gateway
+kubectl get ns | grep -E "maas-api|opendatahub|kuadrant-system|kserve|redhat-ods-applications"
+kubectl get gateway -n openshift-ingress maas-default-gateway
+kubectl get httproute -n opendatahub maas-api-route
+
+# AuthPolicy in place
+kubectl get authpolicy -n opendatahub maas-api-auth-policy
+
+# Keycloak token -> MaaS token
+KEYCLOAK_URL="https://keycloak.${CLUSTER_DOMAIN}"
+KEYCLOAK_REALM="maas"
+KEYCLOAK_CLIENT_ID="maas-cli"
+KEYCLOAK_CLIENT_SECRET="maas-cli-secret"
+KEYCLOAK_USERNAME="freeuser1"
+KEYCLOAK_PASSWORD="password123"
+KEYCLOAK_ACCESS_TOKEN=$(curl -sSk \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "grant_type=password" \
+  -d "client_id=${KEYCLOAK_CLIENT_ID}" \
+  -d "client_secret=${KEYCLOAK_CLIENT_SECRET}" \
+  -d "username=${KEYCLOAK_USERNAME}" \
+  -d "password=${KEYCLOAK_PASSWORD}" \
+  "${KEYCLOAK_URL}/realms/${KEYCLOAK_REALM}/protocol/openid-connect/token" | jq -r .access_token)
+
+TOKEN=$(curl -sSk \
+  -H "Authorization: Bearer ${KEYCLOAK_ACCESS_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -X POST \
+  -d '{"expiration": "24h"}' \
+  "https://${HOST}/maas-api/v1/tokens" | jq -r .token)
+
+# Models list + simple inference
+MODELS=$(curl -sSk "https://${HOST}/maas-api/v1/models" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer ${KEYCLOAK_ACCESS_TOKEN}")
+MODEL_NAME=$(echo $MODELS | jq -r '.data[0].id')
+MODEL_URL=$(echo $MODELS | jq -r '.data[0].url')
+
+curl -sSk \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d "{\"model\": \"${MODEL_NAME}\", \"messages\": [{\"role\": \"user\", \"content\": \"Hello\"}], \"max_tokens\": 50}" \
+  "${MODEL_URL}/v1/chat/completions"
+```
+
+With `ENABLE_KEYCLOAK_IDP=true`, the script deploys:
+- RHOAI prerequisites
+- MaaS API + policies
+- Keycloak (Deployment/Service/Route) and the `maas` realm bootstrap
+- Keycloak AuthPolicy and tier-to-group mappings
+
+## 2) Keycloak realm bootstrap (automatic)
+
+The deploy script imports a `maas` realm and a `maas-cli` client automatically via a Keycloak admin job.
+You can override defaults with env vars before running the script:
+
+```bash
+export KEYCLOAK_REALM="maas"
+export KEYCLOAK_CLIENT_ID="maas-cli"
+export KEYCLOAK_CLIENT_SECRET="maas-cli-secret"
+export MAAS_API_IMAGE="quay.io/opendatahub/maas-api:latest"
+```
+
+The imported realm includes:
+- `groups` claim in access tokens
+- Sample users (`freeuser1`, `premiumuser1`, password: `password123`).
+
+If you override the realm or client values, use the same values in the steps below.
+
+## 3) Get a Keycloak access token
+
+```bash
+CLUSTER_DOMAIN=$(kubectl get ingresses.config.openshift.io cluster -o jsonpath='{.spec.domain}')
+KEYCLOAK_URL="https://keycloak.${CLUSTER_DOMAIN}"
+KEYCLOAK_REALM="maas"
+KEYCLOAK_CLIENT_ID="maas-cli"
+KEYCLOAK_CLIENT_SECRET="maas-cli-secret"
+KEYCLOAK_USERNAME="freeuser1"
+KEYCLOAK_PASSWORD="password123"
+
+KEYCLOAK_RESPONSE=$(curl -sSk \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "grant_type=password" \
+  -d "client_id=${KEYCLOAK_CLIENT_ID}" \
+  -d "client_secret=${KEYCLOAK_CLIENT_SECRET}" \
+  -d "username=${KEYCLOAK_USERNAME}" \
+  -d "password=${KEYCLOAK_PASSWORD}" \
+  "${KEYCLOAK_URL}/realms/${KEYCLOAK_REALM}/protocol/openid-connect/token")
+
+KEYCLOAK_ACCESS_TOKEN=$(echo $KEYCLOAK_RESPONSE | jq -r .access_token)
+```
+
+## 4) Mint a MaaS token
+
+```bash
+HOST="maas.${CLUSTER_DOMAIN}"
+
+TOKEN_RESPONSE=$(curl -sSk \
+  -H "Authorization: Bearer ${KEYCLOAK_ACCESS_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -X POST \
+  -d '{"expiration": "24h"}' \
+  "https://${HOST}/maas-api/v1/tokens")
+
+TOKEN=$(echo $TOKEN_RESPONSE | jq -r .token)
+```
+
+## 5) List models (Keycloak token) and call inference (MaaS token)
+
+```bash
+MODELS=$(curl -sSk "https://${HOST}/maas-api/v1/models" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer ${KEYCLOAK_ACCESS_TOKEN}")
+
+MODEL_NAME=$(echo $MODELS | jq -r '.data[0].id')
+MODEL_URL=$(echo $MODELS | jq -r '.data[0].url')
+
+curl -sSk \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d "{\"model\": \"${MODEL_NAME}\", \"messages\": [{\"role\": \"user\", \"content\": \"Hello\"}], \"max_tokens\": 50}" \
+  "${MODEL_URL}/v1/chat/completions"
+```
+
+## Architecture (OAuth/Keycloak Flow)
+
+The MaaS Platform uses Keycloak OAuth for MaaS API access and MaaS ServiceAccount tokens for inference. Requests flow through `maas-default-gateway` and RHCL (Red Hat Connectivity Link) policies.
+
+### Request Paths
+
+- **`/maas-api/*`** → MaaS API (validates Keycloak OIDC token via `maas-api-auth-policy`)
+- **Inference requests** (`/<namespace>/<model>/v1/*`) → Model Serving (validates MaaS ServiceAccount tokens via `gateway-auth-policy`)
+
+### Authentication and Inference Flow
+
+**Token generation flow:**
+
+  1. User authenticates to Keycloak with credentials → receives JWT with groups/tier claims
+  2. User sends JWT to /maas-api/v1/tokens via maas-default-gateway
+  3. maas-api-auth-policy validates JWT via JWKS, injects X-MaaS-Username/Group headers
+  4. MaaS API maps group to tier using tier-to-group-mapping ConfigMap
+  5. MaaS API mints K8s ServiceAccount token with tier annotations → returns MaaS token
+
+**Inference flow**
+
+1. User sends MaaS token (K8s SA) to inference endpoint
+2. gateway-auth-policy validates via TokenReview/SubjectAccessReview
+3. Limitador enforces tier-based rate limits
+4. Request forwarded to model
+
+The point: OAuth (steps 1-5) bridges external identity -> Kubernetes identity. Inference uses native K8s auth.
+
+### User Mapping to OpenShift Objects
+
+- Each Keycloak user is mapped to a Kubernetes ServiceAccount created by MaaS API.
+- The ServiceAccount lives in the tier namespace (for example, `maas-default-gateway-tier-free`), and the minted MaaS token is a ServiceAccount token.
+- Gateway/AuthPolicy uses Kubernetes TokenReview/SubjectAccessReview to authorize inference with the tier-based ServiceAccount identity.
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Keycloak
+    participant Gateway as maas-default-gateway
+    participant Authorino
+    participant MaaSAPI as MaaS API
+    participant Limitador
+    participant Model as LLMInferenceService
+
+    %% Token Acquisition Phase
+    rect rgb(240, 248, 255)
+        Note over User,MaaSAPI: Token Acquisition
+        User->>Keycloak: POST /realms/maas/protocol/openid-connect/token
+        Keycloak-->>User: JWT Access Token (with groups, tier claims)
+
+        User->>Gateway: POST /maas-api/v1/tokens (Bearer JWT)
+        Gateway->>Authorino: Validate JWT (maas-api-auth-policy)
+        Authorino->>Keycloak: Fetch JWKS
+        Keycloak-->>Authorino: Public Keys
+        Authorino-->>Gateway: Valid + X-MaaS-Username, X-MaaS-Group headers
+        Gateway->>MaaSAPI: Forward request with identity headers
+        MaaSAPI->>MaaSAPI: Map group to tier (free/premium/enterprise)
+        MaaSAPI->>MaaSAPI: Mint K8s ServiceAccount token
+        MaaSAPI-->>User: MaaS Token (K8s SA token with tier)
+    end
+
+    %% Inference Phase
+    rect rgb(255, 248, 240)
+        Note over User,Model: Model Inference
+        User->>Gateway: POST /{namespace}/{model}/v1/chat/completions (Bearer MaaS Token)
+        Gateway->>Authorino: Validate token (gateway-auth-policy)
+        Authorino->>Authorino: TokenReview (validate K8s SA)
+        Authorino->>Authorino: SubjectAccessReview (check tier access)
+        Authorino-->>Gateway: Valid + tier metadata
+        Gateway->>Limitador: Check rate limit for tier
+        Limitador-->>Gateway: Allowed / Rate Limited
+        alt Rate limit OK
+            Gateway->>Model: Forward inference request
+            Model-->>User: Chat completion response
+        else Rate limited
+            Gateway-->>User: 429 Too Many Requests
+        end
+    end
+```
+
+### Tier-to-Group Mapping
+
+The `tier-to-group-mapping` ConfigMap defines which Keycloak groups map to which tiers:
+
+
+```yaml
+tiers:
+  - name: free
+    level: 0
+    groups: [free-users, system:authenticated]
+  - name: premium
+    level: 1
+    groups: [premium-users, premium-group]
+  - name: enterprise
+    level: 2
+    groups: [enterprise-users, admins]
+```
+
+### Keycloak Realm Configuration
+
+The `maas` realm includes:
+
+| Entity | Details |
+|--------|---------|
+| **Client** | `maas-cli` with client credentials and device authorization grant |
+| **Groups** | `free-users`, `premium-users`, `enterprise-users`, `admins` |
+| **Users** | `freeuser1`, `freeuser2`, `premiumuser1`, `premiumuser2`, `enterpriseuser1`, `alice` (admin), `bob` |
+| **Protocol Mappers** | `groups` (group membership → `groups` claim), `tier` (user attribute → `tier` claim) |
+
+### AuthPolicy Configuration
+
+The `maas-api-auth-policy` in `opendatahub` namespace:
+
+```yaml
+spec:
+  targetRef:
+    kind: HTTPRoute
+    name: maas-api-route
+  rules:
+    authentication:
+      keycloak-oidc:
+        jwt:
+          jwksUrl: http://keycloak.keycloak-system.svc.cluster.local:8080/realms/maas/protocol/openid-connect/certs
+        credentials:
+          authorizationHeader:
+            prefix: Bearer
+    response:
+      success:
+        headers:
+          X-MaaS-Username:
+            plain:
+              selector: auth.identity.preferred_username
+          X-MaaS-Group:
+            plain:
+              selector: auth.identity.groups.@tostr
+```
+
+The `gateway-auth-policy` in `openshift-ingress` namespace uses a `when` predicate to exclude `/maas-api` paths:
+
+```yaml
+spec:
+  when:
+  - predicate: '!request.path.startsWith("/maas-api")'
+```

--- a/docs/content/keycloak-oauth-integration.md
+++ b/docs/content/keycloak-oauth-integration.md
@@ -1,0 +1,124 @@
+# Keycloak OAuth Integration Proposal
+
+This document summarizes how Keycloak OAuth integrates with MaaS for token minting and inference access.
+
+## Goals
+
+- Use Keycloak as the identity provider (IDP) for MaaS.
+- Validate user identity and group membership at the gateway.
+- Mint MaaS service tokens scoped to tier namespaces.
+- Keep the flow reproducible on redeploy via manifests and scripts.
+
+## Components
+
+- **Keycloak** (deployment + route): hosts the `maas` realm and `maas-cli` client.
+- **Kuadrant AuthPolicy** on `maas-api-route`: validates Keycloak JWTs and injects identity headers.
+- **MaaS API**: maps groups to tiers and mints ServiceAccount tokens.
+- **Tier mapping ConfigMap**: defines which groups map to which tiers.
+
+## Auth Flow (End-to-End)
+
+1. User authenticates to Keycloak and receives an **access token**.
+2. Request hits the gateway `maas-api-route` with `Authorization: Bearer <kc-access-token>`.
+3. AuthPolicy validates the JWT and injects identity headers:
+   - `X-MaaS-Username` from `auth.identity.preferred_username`
+   - `X-MaaS-Group` from `auth.identity.groups.@tostr` (JSON array)
+4. MaaS API reads those headers, maps groups to a tier, and mints a **ServiceAccount token**.
+5. Client uses the MaaS token for inference calls through the gateway.
+
+## How a User Maps to OpenShift Objects
+
+This is the object-level mapping for a user request:
+
+1. **Keycloak user** logs in and receives an access token with `preferred_username` and `groups`.
+2. **AuthPolicy** validates the token and injects:
+   - `X-MaaS-Username` = `preferred_username`
+   - `X-MaaS-Group` = JSON array of group names
+3. **Tier mapping** resolves groups to a tier using `tier-to-group-mapping` ConfigMap.
+4. **Tier namespace** is created or reused:
+   - `maas-default-gateway-tier-<tier>` (e.g., `maas-default-gateway-tier-free`)
+5. **ServiceAccount** is created or reused in that tier namespace:
+   - Name is a sanitized username plus hash.
+6. **TokenRequest** is created for that ServiceAccount.
+7. The resulting **ServiceAccount token** is returned to the client as the MaaS token.
+
+## Tiering and Groups (Current Behavior)
+
+Tiering is derived from group membership. The MaaS API expects `X-MaaS-Group` and uses it to select a tier. If you remove groups from the flow, MaaS API will not be able to determine a tier and token minting fails. OAuth is only used to authenticate identity; groups are the input to tier selection.
+
+## Token Types
+
+- **Keycloak access token**: OAuth JWT issued by Keycloak for user identity.
+- **MaaS token**: Kubernetes ServiceAccount token minted per user and tier namespace.
+  - Issued via `TokenRequest` and returned to client.
+  - Not stored in MaaS; only API key metadata is stored (if enabled).
+
+## Configuration Summary
+
+### Keycloak Realm
+
+- Realm: `maas`
+- Client: `maas-cli` (confidential, direct grant enabled)
+- Protocol mapper: `groups` claim in access token
+- Users: `freeuser1`, `premiumuser1` (password: `password123`)
+
+### AuthPolicy (OIDC via JWKS)
+
+Use JWKS from the in-cluster Keycloak service to avoid TLS trust issues with the Route cert:
+
+```
+spec:
+  rules:
+    authentication:
+      keycloak-oidc:
+        jwt:
+          jwksUrl: http://keycloak.keycloak-system.svc.cluster.local:8080/realms/maas/protocol/openid-connect/certs
+        credentials:
+          authorizationHeader:
+            prefix: Bearer
+```
+
+### Header Mapping
+
+```
+spec:
+  rules:
+    response:
+      success:
+        headers:
+          X-MaaS-Username:
+            plain:
+              selector: auth.identity.preferred_username
+          X-MaaS-Group:
+            plain:
+              selector: auth.identity.groups.@tostr
+```
+
+### Tier Mapping
+
+The tier mapping must include Keycloak group names:
+
+```
+free: free-users, system:authenticated
+premium: premium-users
+enterprise: enterprise-users, admins
+```
+
+## Deployment Hooks
+
+The deployment scripts should:
+
+- Create Keycloak and import the realm.
+- Patch AuthPolicy to use JWKS URL from the in-cluster Keycloak service.
+- Ensure the tier mapping ConfigMap includes Keycloak group names.
+
+## Known Caveats
+
+- If AuthPolicy uses `issuerUrl` with the Keycloak Route, Authorino may fail OIDC discovery due to TLS trust.
+- Validation scripts should look for `maas-api-route` in the namespace where MaaS is deployed (typically `opendatahub`).
+
+## Reference Files
+
+- AuthPolicy: `deployment/base/maas-api/policies/auth-policy.yaml`
+- Tier map: `deployment/base/maas-api/resources/tier-mapping-configmap.yaml`
+- Deployment script: `scripts/deploy-rhoai-stable.sh`

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -59,6 +59,8 @@ nav:
         - Red Hat OpenShift AI: install/rhoai-setup.md
     - Installation:
       - Models-as-a-Service: install/maas-setup.md
+      - Keycloak IDP Quickstart: install/keycloak-idp.md
+      - IDP Deployment Details: install/idp-deployment.md
       - Validation: install/validation.md
     - Configuration & Management:
       - Tier Management: configuration-and-management/tier-overview.md

--- a/keycloak/maas-realm-config.yaml
+++ b/keycloak/maas-realm-config.yaml
@@ -1,0 +1,316 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: maas-realm-config
+  namespace: keycloak-system
+data:
+  maas-realm.json: |
+    {
+      "realm": "maas",
+      "enabled": true,
+      "displayName": "Models as a Service",
+      "accessTokenLifespan": 3600,
+      "refreshTokenMaxReuse": 0,
+      "sslRequired": "external",
+      "clients": [
+        {
+          "clientId": "maas-cli",
+          "enabled": true,
+          "clientAuthenticatorType": "client-secret",
+          "secret": "maas-cli-secret",
+          "directAccessGrantsEnabled": true,
+          "serviceAccountsEnabled": true,
+          "standardFlowEnabled": true,
+          "implicitFlowEnabled": false,
+          "publicClient": false,
+          "protocol": "openid-connect",
+          "attributes": {
+            "access.token.lifespan": "3600",
+            "oauth2.device.authorization.grant.enabled": "true",
+            "oauth2DeviceAuthorizationGrantEnabled": "true"
+          },
+          "redirectUris": [
+            "https://httpbin.org/get"
+          ],
+          "webOrigins": [
+            "https://httpbin.org"
+          ],
+          "protocolMappers": [
+            {
+              "name": "realm roles",
+              "protocol": "openid-connect",
+              "protocolMapper": "oidc-usermodel-realm-role-mapper",
+              "consentRequired": false,
+              "config": {
+                "id.token.claim": "true",
+                "access.token.claim": "true",
+                "claim.name": "realm_access.roles",
+                "userinfo.token.claim": "true",
+                "multivalued": "true"
+              }
+            },
+            {
+              "name": "groups",
+              "protocol": "openid-connect",
+              "protocolMapper": "oidc-group-membership-mapper",
+              "consentRequired": false,
+              "config": {
+                "full.path": "false",
+                "id.token.claim": "true",
+                "access.token.claim": "true",
+                "claim.name": "groups",
+                "userinfo.token.claim": "true"
+              }
+            },
+            {
+              "name": "tier",
+              "protocol": "openid-connect",
+              "protocolMapper": "oidc-usermodel-attribute-mapper",
+              "consentRequired": false,
+              "config": {
+                "user.attribute": "tier",
+                "id.token.claim": "true",
+                "access.token.claim": "true",
+                "claim.name": "tier",
+                "userinfo.token.claim": "true"
+              }
+            }
+          ]
+        }
+      ],
+      "roles": {
+        "realm": [
+          {
+            "name": "maas-admin",
+            "description": "MaaS platform administrator"
+          },
+          {
+            "name": "maas-user", 
+            "description": "MaaS platform user"
+          }
+        ]
+      },
+      "groups": [
+        {
+          "name": "free-users",
+          "path": "/free-users",
+          "attributes": {
+            "tier": ["free"],
+            "rate-limit": ["5"]
+          }
+        },
+        {
+          "name": "premium-users", 
+          "path": "/premium-users",
+          "attributes": {
+            "tier": ["premium"],
+            "rate-limit": ["20"]
+          }
+        },
+        {
+          "name": "enterprise-users",
+          "path": "/enterprise-users", 
+          "attributes": {
+            "tier": ["enterprise"],
+            "rate-limit": ["100"]
+          }
+        },
+        {
+          "name": "admins",
+          "path": "/admins",
+          "attributes": {
+            "tier": ["admin"]
+          },
+          "realmRoles": ["maas-admin"]
+        }
+      ],
+      "users": [
+        {
+          "username": "freeuser1",
+          "enabled": true,
+          "email": "freeuser1@example.com",
+          "firstName": "Free",
+          "lastName": "User1",
+          "credentials": [
+            {
+              "type": "password",
+              "value": "password123",
+              "temporary": false
+            }
+          ],
+          "groups": ["/free-users"],
+          "attributes": {
+            "tier": ["free"]
+          },
+          "realmRoles": ["maas-user"]
+        },
+        {
+          "username": "freeuser2", 
+          "enabled": true,
+          "email": "freeuser2@example.com",
+          "firstName": "Free",
+          "lastName": "User2",
+          "credentials": [
+            {
+              "type": "password",
+              "value": "password123",
+              "temporary": false
+            }
+          ],
+          "groups": ["/free-users"],
+          "attributes": {
+            "tier": ["free"]
+          },
+          "realmRoles": ["maas-user"]
+        },
+        {
+          "username": "premiumuser1",
+          "enabled": true,
+          "email": "premiumuser1@example.com", 
+          "firstName": "Premium",
+          "lastName": "User1",
+          "credentials": [
+            {
+              "type": "password",
+              "value": "password123",
+              "temporary": false
+            }
+          ],
+          "groups": ["/premium-users"],
+          "attributes": {
+            "tier": ["premium"]
+          },
+          "realmRoles": ["maas-user"]
+        },
+        {
+          "username": "premiumuser2",
+          "enabled": true,
+          "email": "premiumuser2@example.com",
+          "firstName": "Premium", 
+          "lastName": "User2",
+          "credentials": [
+            {
+              "type": "password",
+              "value": "password123",
+              "temporary": false
+            }
+          ],
+          "groups": ["/premium-users"],
+          "attributes": {
+            "tier": ["premium"]
+          },
+          "realmRoles": ["maas-user"]
+        },
+        {
+          "username": "enterpriseuser1",
+          "enabled": true,
+          "email": "enterpriseuser1@example.com",
+          "firstName": "Enterprise",
+          "lastName": "User1", 
+          "credentials": [
+            {
+              "type": "password",
+              "value": "password123",
+              "temporary": false
+            }
+          ],
+          "groups": ["/enterprise-users"],
+          "attributes": {
+            "tier": ["enterprise"]
+          },
+          "realmRoles": ["maas-user"]
+        },
+        {
+          "username": "alice",
+          "enabled": true,
+          "email": "alice@example.com",
+          "firstName": "Alice", 
+          "lastName": "Admin",
+          "credentials": [
+            {
+              "type": "password",
+              "value": "password123",
+              "temporary": false
+            }
+          ],
+          "groups": ["/admins"],
+          "attributes": {
+            "tier": ["admin"]
+          },
+          "realmRoles": ["maas-admin"]
+        },
+        {
+          "username": "bob",
+          "enabled": true,
+          "email": "bob@example.com",
+          "firstName": "Bob",
+          "lastName": "User",
+          "credentials": [
+            {
+              "type": "password",
+              "value": "password123",
+              "temporary": false
+            }
+          ],
+          "groups": ["/premium-users"],
+          "attributes": {
+            "tier": ["premium"]
+          },
+          "realmRoles": ["maas-user"]
+        }
+      ],
+      "identityProviders": [
+        {
+          "alias": "github",
+          "providerId": "github",
+          "enabled": true,
+          "trustEmail": true,
+          "storeToken": true,
+          "firstBrokerLoginFlowAlias": "first broker login",
+          "config": {
+            "clientId": "${GITHUB_CLIENT_ID}",
+            "clientSecret": "${GITHUB_CLIENT_SECRET}",
+            "defaultScope": "read:user user:email"
+          }
+        }
+      ],
+      "identityProviderMappers": [
+        {
+          "name": "github-hardcode-maas-user",
+          "identityProviderAlias": "github",
+          "identityProviderMapper": "oidc-hardcoded-role-idp-mapper",
+          "config": {
+            "role": "maas-user"
+          }
+        }
+      ],
+      "protocolMappers": [
+        {
+          "name": "groups",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-group-membership-mapper",
+          "consentRequired": false,
+          "config": {
+            "full.path": "false",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "groups",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "name": "tier",
+          "protocol": "openid-connect", 
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "tier",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "tier",
+            "userinfo.token.claim": "true"
+          }
+        }
+      ]
+    }

--- a/scripts/deploy-keycloak-idp.sh
+++ b/scripts/deploy-keycloak-idp.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+MAAS_API_NAMESPACE=${MAAS_API_NAMESPACE:-maas-api}
+KEYCLOAK_REALM=${KEYCLOAK_REALM:-"maas"}
+MAAS_API_IMAGE=${MAAS_API_IMAGE:-"quay.io/opendatahub/maas-api:latest"}
+
+export KEYCLOAK_REALM
+
+echo "   Deploying Keycloak tier mapping ConfigMap..."
+for ns in "${MAAS_API_NAMESPACE}" maas-api; do
+  if kubectl get namespace "${ns}" >/dev/null 2>&1; then
+    kubectl apply --server-side=true --force-conflicts -n "${ns}" \
+      -f "${PROJECT_ROOT}/deployment/idp/maas-api/resources/tier-mapping-configmap.yaml"
+    kubectl apply --server-side=true --force-conflicts -n "${ns}" \
+      -f "${PROJECT_ROOT}/deployment/idp/maas-api/resources/allow-gateway-networkpolicy.yaml"
+  fi
+done
+
+echo "   Applying AuthPolicy for Keycloak OIDC..."
+envsubst '$KEYCLOAK_REALM' < "${PROJECT_ROOT}/deployment/idp/maas-api/policies/auth-policy-oidc.yaml" | \
+  kubectl apply --server-side=true --force-conflicts -n "${MAAS_API_NAMESPACE}" -f - 2>/dev/null && \
+  echo "   ✅ AuthPolicy applied" || echo "   ⚠️  Failed to apply AuthPolicy (may need manual configuration)"
+
+echo "   Excluding /maas-api paths from Gateway AuthPolicy..."
+kubectl patch authpolicy gateway-auth-policy -n openshift-ingress --type=merge --patch='
+spec:
+  when:
+  - predicate: "!request.path.startsWith(\"/maas-api\")"
+' 2>/dev/null || echo "   ⚠️  Could not patch gateway-auth-policy (may not exist yet)"
+
+echo "   Setting MaaS API image for Keycloak IDP..."
+kubectl set image -n "${MAAS_API_NAMESPACE}" deployment/maas-api maas-api="${MAAS_API_IMAGE}" 2>/dev/null || \
+  echo "   ⚠️  Could not update maas-api image (deployment may not be ready yet)"

--- a/scripts/deploy-rhoai-stable.sh
+++ b/scripts/deploy-rhoai-stable.sh
@@ -29,6 +29,8 @@
 
 set -e
 
+PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+
 waitsubscriptioninstalled() {
   local ns=${1?namespace is required}; shift
   local name=${1?subscription name is required}; shift
@@ -299,11 +301,199 @@ deploy_rhoai
 echo
 echo "## Installing Models-as-a-Service"
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
 export CLUSTER_DOMAIN=$(kubectl get ingresses.config.openshift.io cluster -o jsonpath='{.spec.domain}')
 export AUD="$(kubectl create token default --duration=10m 2>/dev/null | cut -d. -f2 | jq -Rr '@base64d | fromjson | .aud[0]' 2>/dev/null)"
+export ENABLE_KEYCLOAK_IDP=${ENABLE_KEYCLOAK_IDP:-false}
+# Get the TLS certificate secret name from the default ingress controller
+export CERT_NAME=$(kubectl get ingresscontroller default -n openshift-ingress-operator -o jsonpath='{.spec.defaultCertificate.name}' 2>/dev/null)
+if [[ -z "$CERT_NAME" ]]; then
+  # No custom cert configured - discover the auto-generated secret from the router deployment
+  CERT_NAME=$(kubectl get deployment router-default -n openshift-ingress -o jsonpath='{.spec.template.spec.volumes[?(@.name=="default-certificate")].secret.secretName}' 2>/dev/null)
+fi
 
 echo "* Cluster domain: ${CLUSTER_DOMAIN}"
 echo "* Cluster audience: ${AUD}"
+echo "* Keycloak IDP enabled: ${ENABLE_KEYCLOAK_IDP}"
+echo "* TLS certificate: ${CERT_NAME}"
+
+if [[ "${ENABLE_KEYCLOAK_IDP}" == "true" ]]; then
+  export KEYCLOAK_HOST=${KEYCLOAK_HOST:-"keycloak.${CLUSTER_DOMAIN}"}
+  export KEYCLOAK_REALM=${KEYCLOAK_REALM:-"maas"}
+  export KEYCLOAK_CLIENT_ID=${KEYCLOAK_CLIENT_ID:-"maas-cli"}
+  export KEYCLOAK_CLIENT_SECRET=${KEYCLOAK_CLIENT_SECRET:-"maas-cli-secret"}
+
+  echo "* Keycloak issuer: https://${KEYCLOAK_HOST}/realms/${KEYCLOAK_REALM}"
+  echo "* Keycloak client: ${KEYCLOAK_CLIENT_ID}"
+
+  echo "* Deploying Keycloak..."
+  cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: keycloak-system
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: keycloak
+  namespace: keycloak-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: keycloak
+  template:
+    metadata:
+      labels:
+        app: keycloak
+    spec:
+      containers:
+      - name: keycloak
+        image: quay.io/keycloak/keycloak:23.0.7
+        args: ["start-dev"]
+        env:
+        - name: KEYCLOAK_ADMIN
+          value: "admin"
+        - name: KEYCLOAK_ADMIN_PASSWORD
+          value: "admin123"
+        - name: KC_PROXY
+          value: "edge"
+        - name: KC_HOSTNAME_STRICT
+          value: "false"
+        - name: KC_HOSTNAME_STRICT_HTTPS
+          value: "false"
+        - name: KC_HTTP_ENABLED
+          value: "true"
+        - name: KC_PROXY_ADDRESS_FORWARDING
+          value: "true"
+        - name: KC_HOSTNAME
+          value: "${KEYCLOAK_HOST}"
+        ports:
+        - name: http
+          containerPort: 8080
+        readinessProbe:
+          httpGet:
+            path: /realms/master
+            port: 8080
+          initialDelaySeconds: 30
+          periodSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /realms/master
+            port: 8080
+          initialDelaySeconds: 60
+          periodSeconds: 30
+        resources:
+          requests:
+            memory: "512Mi"
+            cpu: "50m"
+          limits:
+            memory: "2Gi"
+            cpu: "1000m"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak
+  namespace: keycloak-system
+spec:
+  selector:
+    app: keycloak
+  ports:
+  - name: http
+    port: 8080
+    targetPort: 8080
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: keycloak
+  namespace: keycloak-system
+spec:
+  host: ${KEYCLOAK_HOST}
+  to:
+    kind: Service
+    name: keycloak
+    weight: 100
+  port:
+    targetPort: http
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Allow
+EOF
+  kubectl rollout status deployment/keycloak -n keycloak-system --timeout=180s || true
+
+  echo "* Configuring Keycloak realm from manifests..."
+  kubectl apply -f "${PROJECT_ROOT}/keycloak/maas-realm-config.yaml"
+
+  kubectl delete job keycloak-realm-import -n keycloak-system --ignore-not-found
+  cat <<EOF | kubectl apply -f -
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: keycloak-realm-import
+  namespace: keycloak-system
+spec:
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+      - name: realm-import
+        image: curlimages/curl:8.5.0
+        command: ["/bin/sh"]
+        args:
+        - -c
+        - |
+          set -euo pipefail
+          KC_BASE="https://${KEYCLOAK_HOST}"
+          REALM="${KEYCLOAK_REALM}"
+          echo "Waiting for Keycloak at \$KC_BASE..."
+          until curl -ks "\$KC_BASE/realms/master" >/dev/null; do sleep 5; done
+
+          echo "Getting admin token..."
+          ADMIN_TOKEN=\$(curl -ks -X POST \
+            -H "Content-Type: application/x-www-form-urlencoded" \
+            -d "username=admin&password=admin123&grant_type=password&client_id=admin-cli" \
+            "\$KC_BASE/realms/master/protocol/openid-connect/token" | \
+            grep -o '"access_token":"[^"]*' | cut -d':' -f2- | tr -d '"' )
+
+          if [ -z "\$ADMIN_TOKEN" ]; then
+            echo "Failed to get admin token"
+            exit 1
+          fi
+
+          echo "Got admin token, importing realm..."
+          cp /tmp/realm-config/maas-realm.json /tmp/maas-realm.rendered.json
+
+          if curl -ks -f -H "Authorization: Bearer \$ADMIN_TOKEN" \
+             "\$KC_BASE/admin/realms/\$REALM" >/dev/null 2>&1; then
+            echo "Realm exists, updating..."
+            curl -ks -X PUT \
+              -H "Authorization: Bearer \$ADMIN_TOKEN" \
+              -H "Content-Type: application/json" \
+              -d @/tmp/maas-realm.rendered.json \
+              "\$KC_BASE/admin/realms/\$REALM"
+          else
+            echo "Realm does not exist, creating..."
+            curl -ks -X POST \
+              -H "Authorization: Bearer \$ADMIN_TOKEN" \
+              -H "Content-Type: application/json" \
+              -d @/tmp/maas-realm.rendered.json \
+              "\$KC_BASE/admin/realms"
+          fi
+          echo "Done!"
+        volumeMounts:
+        - name: realm-config
+          mountPath: /tmp/realm-config
+      volumes:
+      - name: realm-config
+        configMap:
+          name: maas-realm-config
+EOF
+fi
 
 cat <<EOF | kubectl apply -f -
 apiVersion: v1
@@ -324,15 +514,14 @@ else
     sleep 5
   done
 fi
-
 : "${MAAS_REF:=main}"
-kubectl apply --server-side=true \
+kubectl apply --server-side=true --force-conflicts \
   -f <(kustomize build "https://github.com/opendatahub-io/models-as-a-service.git/deployment/overlays/openshift?ref=${MAAS_REF}" | \
-       envsubst '$CLUSTER_DOMAIN')
+       envsubst '$CLUSTER_DOMAIN $CERT_NAME')
 
-if [[ -n "$AUD" && "$AUD" != "https://kubernetes.default.svc"  ]]; then
+if [[ "${ENABLE_KEYCLOAK_IDP}" != "true" && -n "$AUD" && "$AUD" != "https://kubernetes.default.svc"  ]]; then
   echo "* Configuring audience in MaaS AuthPolicy"
-  kubectl patch authpolicy maas-api-auth-policy -n maas-api --type=merge --patch-file <(echo "
+  kubectl patch authpolicy maas-api-auth-policy -n opendatahub --type=merge --patch-file <(echo "
 spec:
   rules:
     authentication:
@@ -343,9 +532,81 @@ spec:
             - maas-default-gateway-sa")
 fi
 
-# Patch maas-api Deployment with stable image
-: "${MAAS_RHOAI_IMAGE:=v3.0.0}"
-kubectl set image -n maas-api deployment/maas-api maas-api=registry.redhat.io/rhoai/odh-maas-api-rhel9:${MAAS_RHOAI_IMAGE}
+# Wait for gateway deployment to be created and patch resource requirements
+echo "* Waiting for gateway deployment to be created..."
+for i in {1..30}; do
+  if kubectl get deployment maas-default-gateway-openshift-default -n openshift-ingress >/dev/null 2>&1; then
+    echo "  * Gateway deployment found, reducing CPU requirements for scheduling..."
+    kubectl patch deployment maas-default-gateway-openshift-default -n openshift-ingress --type='strategic' --patch='
+spec:
+  template:
+    spec:
+      containers:
+      - name: istio-proxy
+        resources:
+          requests:
+            cpu: "25m"
+            memory: "64Mi"
+          limits:
+            cpu: "1000m"
+            memory: "512Mi"
+' >/dev/null 2>&1
+    break
+  fi
+  echo "  * Waiting for gateway deployment... ($i/30)"
+  sleep 2
+done
+
+if [[ "${ENABLE_KEYCLOAK_IDP}" == "true" ]]; then
+  export MAAS_API_NAMESPACE=opendatahub
+  echo "* Configuring Keycloak IDP..."
+  "${SCRIPT_DIR}/deploy-keycloak-idp.sh"
+fi
+
+echo "* Creating OpenShift Route for Gateway..."
+cat <<EOF | kubectl apply -f -
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: maas-gateway-route
+  namespace: openshift-ingress
+  labels:
+    app.kubernetes.io/name: maas
+    app.kubernetes.io/component: gateway
+spec:
+  host: maas.${CLUSTER_DOMAIN}
+  to:
+    kind: Service
+    name: maas-default-gateway-openshift-default
+    weight: 100
+  port:
+    targetPort: 443
+  tls:
+    termination: passthrough
+  wildcardPolicy: None
+EOF
+
+if [[ "${ENABLE_KEYCLOAK_IDP}" != "true" ]]; then
+  # Patch maas-api Deployment with stable RHOAI image
+  : "${MAAS_RHOAI_IMAGE:=v3.0.0}"
+  kubectl set image -n opendatahub deployment/maas-api \
+    maas-api="registry.redhat.io/rhoai/odh-maas-api-rhel9:${MAAS_RHOAI_IMAGE}"
+fi
+
+echo "* Waiting for KServe webhook to be ready (up to 2 minutes)..."
+WEBHOOK_READY=false
+for i in {1..24}; do
+  ENDPOINTS=$(kubectl get endpoints kserve-webhook-server-service -n redhat-ods-applications -o jsonpath='{.subsets[*].addresses[*].ip}' 2>/dev/null)
+  if [[ -n "$ENDPOINTS" ]]; then
+    echo "  * KServe webhook ready"
+    WEBHOOK_READY=true
+    break
+  fi
+  sleep 5
+done
+if [[ "$WEBHOOK_READY" != "true" ]]; then
+  echo "  * WARNING: KServe webhook may not be ready yet. LLMInferenceService creation may fail until the webhook is available."
+fi
 
 echo ""
 echo "========================================="
@@ -360,21 +621,45 @@ echo "2. Get Gateway endpoint:"
 echo "   CLUSTER_DOMAIN=\$(kubectl get ingresses.config.openshift.io cluster -o jsonpath='{.spec.domain}')"
 echo "   HOST=\"maas.\${CLUSTER_DOMAIN}\""
 echo ""
-echo "3. Get authentication token:"
-echo "   TOKEN_RESPONSE=\$(curl -sSk --oauth2-bearer '\$(oc whoami -t)' --json '{\"expiration\": \"10m\"}' \"\${HOST}/maas-api/v1/tokens\")"
-echo "   TOKEN=\$(echo \$TOKEN_RESPONSE | jq -r .token)"
-echo ""
-echo "4. Test model endpoint:"
-echo "   MODELS=\$(curl -sSk \${HOST}/maas-api/v1/models -H \"Content-Type: application/json\" -H \"Authorization: Bearer \$TOKEN\" | jq -r .)"
-echo "   MODEL_NAME=\$(echo \$MODELS | jq -r '.data[0].id')"
-echo "   MODEL_URL=\"\${HOST}/llm/facebook-opt-125m-simulated/v1/chat/completions\" # Note: This may be different for your model"
-echo "   curl -sSk -H \"Authorization: Bearer \$TOKEN\" -H \"Content-Type: application/json\" -d \"{\\\"model\\\": \\\"\${MODEL_NAME}\\\", \\\"prompt\\\": \\\"Hello\\\", \\\"max_tokens\\\": 50}\" \"\${MODEL_URL}\""
-echo ""
-echo "5. Test authorization limiting (no token 401 error):"
-echo "   curl -sSk -H \"Content-Type: application/json\" -d \"{\\\"model\\\": \\\"\${MODEL_NAME}\\\", \\\"prompt\\\": \\\"Hello\\\", \\\"max_tokens\\\": 50}\" \"\${MODEL_URL}\" -v"
-echo ""
-echo "6. Test rate limiting (200 OK followed by 429 Rate Limit Exceeded after about 4 requests):"
-echo "   for i in {1..16}; do curl -sSk -o /dev/null -w \"%{http_code}\\n\" -H \"Authorization: Bearer \$TOKEN\" -H \"Content-Type: application/json\" -d \"{\\\"model\\\": \\\"\${MODEL_NAME}\\\", \\\"prompt\\\": \\\"Hello\\\", \\\"max_tokens\\\": 50}\" \"\${MODEL_URL}\"; done"
+if [[ "${ENABLE_KEYCLOAK_IDP}" == "true" ]]; then
+  echo "3. Get authentication token:"
+  echo "   KEYCLOAK_URL=\"https://keycloak.\${CLUSTER_DOMAIN}\""
+  echo "   KEYCLOAK_REALM=\"maas\""
+  echo "   KEYCLOAK_CLIENT_ID=\"maas-cli\""
+  echo "   KEYCLOAK_CLIENT_SECRET=\"maas-cli-secret\""
+  echo "   KEYCLOAK_USERNAME=\"freeuser1\""
+  echo "   KEYCLOAK_PASSWORD=\"password123\""
+  echo "   KEYCLOAK_ACCESS_TOKEN=\$(curl -sSk -H \"Content-Type: application/x-www-form-urlencoded\" -d \"grant_type=password\" -d \"client_id=\${KEYCLOAK_CLIENT_ID}\" -d \"client_secret=\${KEYCLOAK_CLIENT_SECRET}\" -d \"username=\${KEYCLOAK_USERNAME}\" -d \"password=\${KEYCLOAK_PASSWORD}\" \"\${KEYCLOAK_URL}/realms/\${KEYCLOAK_REALM}/protocol/openid-connect/token\" | jq -r .access_token)"
+  echo "   TOKEN=\$(curl -sSk -H \"Authorization: Bearer \${KEYCLOAK_ACCESS_TOKEN}\" -H \"Content-Type: application/json\" -X POST -d '{\"expiration\": \"24h\"}' \"https://\${HOST}/maas-api/v1/tokens\" | jq -r .token)"
+  echo ""
+  echo "4. List models (Keycloak token) and call inference (MaaS token):"
+  echo "   MODELS=\$(curl -sSk \"https://\${HOST}/maas-api/v1/models\" -H \"Content-Type: application/json\" -H \"Authorization: Bearer \${KEYCLOAK_ACCESS_TOKEN}\")"
+  echo "   MODEL_NAME=\$(echo \$MODELS | jq -r '.data[0].id')"
+  echo "   MODEL_URL=\$(echo \$MODELS | jq -r '.data[0].url')"
+  echo "   curl -sSk -H \"Authorization: Bearer \${TOKEN}\" -H \"Content-Type: application/json\" -d \"{\\\"model\\\": \\\"\${MODEL_NAME}\\\", \\\"messages\\\": [{\\\"role\\\": \\\"user\\\", \\\"content\\\": \\\"Hello\\\"}], \\\"max_tokens\\\": 50}\" \"\${MODEL_URL}/v1/chat/completions\""
+  echo ""
+  echo "5. Test authorization limiting (no token 401 error):"
+  echo "   curl -sSk -H \"Content-Type: application/json\" -d \"{\\\"model\\\": \\\"\${MODEL_NAME}\\\", \\\"messages\\\": [{\\\"role\\\": \\\"user\\\", \\\"content\\\": \\\"Hello\\\"}], \\\"max_tokens\\\": 50}\" \"\${MODEL_URL}/v1/chat/completions\" -v"
+  echo ""
+  echo "6. Test rate limiting (200 OK followed by 429 Rate Limit Exceeded after about 4 requests):"
+  echo "   for i in {1..16}; do curl -sSk -o /dev/null -w \"%{http_code}\\n\" -H \"Authorization: Bearer \${TOKEN}\" -H \"Content-Type: application/json\" -d \"{\\\"model\\\": \\\"\${MODEL_NAME}\\\", \\\"messages\\\": [{\\\"role\\\": \\\"user\\\", \\\"content\\\": \\\"Hello\\\"}], \\\"max_tokens\\\": 50}\" \"\${MODEL_URL}/v1/chat/completions\"; done"
+else
+  echo "3. Get authentication token:"
+  echo "   TOKEN_RESPONSE=\$(curl -sSk --oauth2-bearer '\$(oc whoami -t)' --json '{\"expiration\": \"24h\"}' \"\${HOST}/maas-api/v1/tokens\")"
+  echo "   TOKEN=\$(echo \$TOKEN_RESPONSE | jq -r .token)"
+  echo ""
+  echo "4. Test model endpoint:"
+  echo "   MODELS=\$(curl -sSk \${HOST}/maas-api/v1/models -H \"Content-Type: application/json\" -H \"Authorization: Bearer \$TOKEN\" | jq -r .)"
+  echo "   MODEL_NAME=\$(echo \$MODELS | jq -r '.data[0].id')"
+  echo "   MODEL_URL=\"\${HOST}/llm/facebook-opt-125m-simulated/v1/chat/completions\" # Note: This may be different for your model"
+  echo "   curl -sSk -H \"Authorization: Bearer \$TOKEN\" -H \"Content-Type: application/json\" -d \"{\\\"model\\\": \\\"\${MODEL_NAME}\\\", \\\"prompt\\\": \\\"Hello\\\", \\\"max_tokens\\\": 50}\" \"\${MODEL_URL}\""
+  echo ""
+  echo "5. Test authorization limiting (no token 401 error):"
+  echo "   curl -sSk -H \"Content-Type: application/json\" -d \"{\\\"model\\\": \\\"\${MODEL_NAME}\\\", \\\"prompt\\\": \\\"Hello\\\", \\\"max_tokens\\\": 50}\" \"\${MODEL_URL}\" -v"
+  echo ""
+  echo "6. Test rate limiting (200 OK followed by 429 Rate Limit Exceeded after about 4 requests):"
+  echo "   for i in {1..16}; do curl -sSk -o /dev/null -w \"%{http_code}\\n\" -H \"Authorization: Bearer \$TOKEN\" -H \"Content-Type: application/json\" -d \"{\\\"model\\\": \\\"\${MODEL_NAME}\\\", \\\"prompt\\\": \\\"Hello\\\", \\\"max_tokens\\\": 50}\" \"\${MODEL_URL}\"; done"
+fi
 echo ""
 echo "7. Run validation script (Runs all the checks again):"
 echo "   curl https://raw.githubusercontent.com/opendatahub-io/models-as-a-service/refs/heads/${MAAS_REF}/scripts/validate-deployment.sh | sh -v -"


### PR DESCRIPTION
Add optional Keycloak IDP flow for MaaS without changing the default deployment by adding a separate, opt‑in Keycloak OIDC deployment path behind ENABLE_KEYCLOAK_IDP. The default MaaS deployment and architecture remain unchanged unless the feature flag is enabled.

Keycloak integration flow:

- Users authenticate with Keycloak and receive a JWT.
- The MaaS API AuthPolicy validates the JWT and injects identity headers.
- MaaS maps Keycloak groups to tiers and mints a Kubernetes ServiceAccount token in the tier namespace.
- Inference calls use the ServiceAccount token; the gateway validates it viaTokenReview/SAR and applies tier‑based rate limits.
- added an IDP‑only NetworkPolicy to allow gateway traffic from openshift-ingress to maas-api in opendatahub; without it, the ODH default/Authorino‑only policy blocks the gateway and /maas-api/v1/tokens times out.

All IDP-specific manifests and policies are isolated under deployment/idp/ and only applied when the flag is enabled, preserving the existing kube‑auth flow for non‑IDP deployments.

Docs could probably be tightened up but I was thinking more docs rather than less to start with this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional Keycloak-based authentication for MaaS with OIDC auth policy and propagated username/group headers
  * Tier-based access control via a new tier-to-group mapping ConfigMap
  * Network policy to allow gateway ingress to MaaS API

* **Documentation**
  * Added Keycloak OAuth integration, IDP deployment quickstart, and setup guides; navigation updated

* **Chores**
  * Deployment scripts updated and a new helper script to install/configure the Keycloak IDP and related resources

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->