### PR TITLE
fix(models): correct authorization check to target actual API endpoint

### DIFF
--- a/maas-api/internal/models/kserve_llmisvc_test.go
+++ b/maas-api/internal/models/kserve_llmisvc_test.go
@@ -279,9 +279,9 @@ func TestListAvailableLLMs_Authorization(t *testing.T) {
 	testLogger := logger.Development()
 	gateway := models.GatewayRef{Name: "maas-gateway", Namespace: "gateway-ns"}
 
-	// Create mock HTTP server to simulate authorization responses for HEAD requests
+	// Create mock HTTP server to simulate authorization responses for OPTIONS requests
 	authServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodHead {
+		if r.Method != http.MethodOptions {
 			w.WriteHeader(http.StatusMethodNotAllowed)
 			return
 		}


### PR DESCRIPTION
Authorization checks were previously hitting the model's base URL with a HEAD request, which resulted in 404 as `vLLM` does not serve anything in the root context. With the change of DENY on 404 it broke the listing logic. Not sure why builds were passing.

The auth check targets now the `/v1/chat/completions` endpoint directly and uses `OPTIONS` method, ensuring authorization validation occurs against the same path and method semantics that actual API requests will use.

Follow-up for #294 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Switched authorization verification to use OPTIONS for better compatibility with API endpoints.
  * Improved error handling to explicitly fail after retry/backoff limits.
  * Fixed endpoint URL construction for API calls.

* **Tests**
  * Updated authorization tests to align with OPTIONS-based verification.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->