### PR TITLE
fix(config): defaults to HTTP mode to maintain backward compatibility

### DIFF
--- a/maas-api/internal/config/config.go
+++ b/maas-api/internal/config/config.go
@@ -80,7 +80,7 @@ type Config struct {
 func Load() *Config {
 	debugMode, _ := env.GetBool("DEBUG_MODE", false)
 	gatewayName := env.GetString("GATEWAY_NAME", constant.DefaultGatewayName)
-	secure, _ := env.GetBool("SECURE", true)
+	secure, _ := env.GetBool("SECURE", false)
 
 	c := &Config{
 		Name:             env.GetString("INSTANCE_NAME", gatewayName),
@@ -116,7 +116,7 @@ func (c *Config) bindFlags(fs *flag.FlagSet) {
 	fs.StringVar(&c.GatewayNamespace, "gateway-namespace", c.GatewayNamespace, "Namespace where MaaS-enabled Gateway is deployed")
 
 	fs.StringVar(&c.Address, "address", c.Address, "Listen address (default :8443 for secure, :8080 for insecure)")
-	fs.BoolVar(&c.Secure, "secure", c.Secure, "Use HTTPS (default: true)")
+	fs.BoolVar(&c.Secure, "secure", c.Secure, "Use HTTPS (default: false)")
 	c.TLS.bindFlags(fs)
 
 	// Deprecated flag (backward compatibility with pre-TLS version)


### PR DESCRIPTION
Currently running deployments that rely on `:latest` image might not have security-related flags nor settings in their deployment manifests. This breaks backward compatibility and can yield an error on startup:

```
{"level":"error","timestamp":"2026-01-19T08:12:53.474+0100","caller":"cmd/main.go:44","message":"Configuration
validation failed","error":"--secure requires either --tls-cert/--tls-key or --tls-self-signed"}
```

This change sets `SECURE` to `false` by default to ensure backward compatibility.

Existing kustomize manifests explicitly configure the protocol mode, so changing the default has no impact on production environments.

This preserves the original server behavior where HTTP was the default.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Default security mode changed to insecure (secure flag now defaults to false); help text updated to reflect the new default.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->