### PR TITLE
chore: removes obsolete doc string

### DIFF
--- a/deployment/overlays/tls-backend/configure-authorino-tls.sh
+++ b/deployment/overlays/tls-backend/configure-authorino-tls.sh
@@ -4,7 +4,6 @@
 #
 # Prerequisites:
 # - Authorino operator installed in kuadrant-system namespace
-# - service-ca-bundle ConfigMap exists (created by service-ca-bundle.yaml)
 
 set -euo pipefail
 


### PR DESCRIPTION
As per title

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed a documentation comment line from deployment configuration with no impact on functionality or runtime behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->