### PR TITLE
fix(ci): handle Kustomize Components in manifest validation

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -27,4 +27,4 @@ jobs:
 
     - name: Validate Kustomize manifests
       run: |
-        ./scripts/validate-manifests.sh
+        ./scripts/ci/validate-manifests.sh

--- a/scripts/ci/validate-manifests.sh
+++ b/scripts/ci/validate-manifests.sh
@@ -6,6 +6,11 @@ bold='\033[1m'
 normal='\033[0m'
 underline='\033[4m'
 
+is_kustomize_component() {
+    local kustomization_file="$1"
+    grep -q "^kind: Component" "$kustomization_file" 2>/dev/null
+}
+
 validate_kustomization() {
     local kustomization_file="$1"
     local project_root="${2:-$(git rev-parse --show-toplevel)}"
@@ -14,8 +19,14 @@ validate_kustomization() {
     local relative_path=${kustomization_file#"$project_root/"}
     local message="${bold}Validating${normal} ${underline}$relative_path${normal}"
     
+    # Skip Component files - they can't be built standalone, they must be included via 'components:' in another Kustomization
+    if is_kustomize_component "$kustomization_file"; then
+        echo -e "⏭️  ${bold}Skipping${normal} ${underline}$relative_path${normal} (Component - cannot be validated standalone)"
+        return 0
+    fi
+    
     echo -n -e "⏳ ${message}"
-    if output=$(kustomize build --load-restrictor LoadRestrictionsNone --stack-trace "$dir" 2>&1); then
+    if output=$(kustomize build --stack-trace "$dir" 2>&1); then
         echo -e "\r✅ ${message}"
         return 0
     else
@@ -41,6 +52,7 @@ validate_all() {
 # When script is not sourced, but directly invoked, validate all manifests in the project
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
     PROJECT_ROOT=$(git rev-parse --show-toplevel)
+
     validate_all "$PROJECT_ROOT"
     exit $?
 fi


### PR DESCRIPTION
Kustomize Components (`kind: Component`) cannot be built standalone and must be included via the `components:` directive in another Kustomization. 

Adds detection for Component manifests and skips them during validation, providing clear feedback about why they are excluded. That's a simple, future-proofing change for further enhancements of our manifests.

Also removes the `--load-restrictor LoadRestrictionsNone` flag to enforce stricter path boundaries during validation, and relocates the script to `scripts/ci/` for better organization.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized CI/CD build validation pipeline infrastructure by restructuring script dependencies and improving workflow organization for manifest verification.
  * Enhanced manifest validation logic to intelligently detect and skip component files during build verification, reducing validation overhead and improving build pipeline efficiency while maintaining comprehensive checks on standard manifest files.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->