### PR TITLE
feat(e2e): add HTPasswd IDP setup with multi-user login for smoke tests

### DIFF
--- a/test/e2e/scripts/prow_run_smoke_test.sh
+++ b/test/e2e/scripts/prow_run_smoke_test.sh
@@ -149,6 +149,23 @@ setup_vars_for_tests() {
     if [ "$INSECURE_HTTP" = "true" ]; then
         echo "⚠️  INSECURE_HTTP=true - will use HTTP for tests"
     fi
+
+    # Detect MAAS_API_BASE_URL while logged in as admin (non-admin users can't read cluster ingress)
+    CLUSTER_DOMAIN=$(oc get ingresses.config.openshift.io cluster -o jsonpath='{.spec.domain}' 2>/dev/null || true)
+    if [ -z "$CLUSTER_DOMAIN" ]; then
+        echo "❌ ERROR: Failed to detect cluster ingress domain"
+        exit 1
+    fi
+    HOST="maas.${CLUSTER_DOMAIN}"
+    
+    if [ "$INSECURE_HTTP" = "true" ]; then
+        MAAS_API_BASE_URL="http://${HOST}/maas-api"
+    else
+        MAAS_API_BASE_URL="https://${HOST}/maas-api"
+    fi
+    export HOST
+    export MAAS_API_BASE_URL
+    echo "MAAS_API_BASE_URL: ${MAAS_API_BASE_URL}"
     
     echo "✅ Variables for tests setup completed"
 }
@@ -216,37 +233,59 @@ deploy_models
 print_header "Setting up variables for tests"
 setup_vars_for_tests
 
-# Setup all users first (while logged in as admin)
-print_header "Setting up test users"
-setup_test_user "tester-admin-user" "cluster-admin"
-setup_test_user "tester-edit-user" "edit"
-setup_test_user "tester-view-user" "view"
+# Setup HTPasswd identity provider and capture credentials
+print_header "Setting up HTPasswd Identity Provider"
+IDP_OUTPUT=$("$PROJECT_ROOT/test/e2e/scripts/setup-idp-openshift.sh" 2>&1) || {
+    echo "❌ ERROR: HTPasswd identity provider setup failed"
+    # Print output but filter out export statements containing credentials
+    echo "$IDP_OUTPUT" | grep -v '^export '
+    exit 1
+}
+# Print output but filter out export statements containing credentials
+echo "$IDP_OUTPUT" | grep -v '^export '
+
+# Extract and export credentials from the setup script output (silently)
+eval "$(echo "$IDP_OUTPUT" | grep '^export ')"
+
+if [ -z "${OPENSHIFT_ADMIN_USER:-}" ] || [ -z "${OPENSHIFT_ADMIN_PASS:-}" ]; then
+    echo "❌ ERROR: Failed to retrieve admin credentials from IDP setup"
+    exit 1
+fi
+echo "✅ HTPasswd identity provider setup completed"
+
+# Login as admin user for the next steps
+print_header "Logging in as admin user"
+echo "Logging in as ${OPENSHIFT_ADMIN_USER}..."
+if ! oc login -u "$OPENSHIFT_ADMIN_USER" -p "$OPENSHIFT_ADMIN_PASS" "$K8S_CLUSTER_URL" --insecure-skip-tls-verify=true; then
+    echo "❌ ERROR: Failed to login as admin user"
+    exit 1
+fi
+echo "✅ Logged in as ${OPENSHIFT_ADMIN_USER}"
 
 # Now run tests for each user
 print_header "Running tests for all users"
-
-# Test admin user
-print_header "Running Maas e2e Tests as admin user"
-ADMIN_TOKEN=$(oc create token tester-admin-user -n default)
-oc login --token "$ADMIN_TOKEN" --server "$K8S_CLUSTER_URL"
 
 print_header "Validating Deployment and Token Metadata Logic"
 validate_deployment
 run_token_verification
 
+echo "Waiting for the rate limit to reset..."
 sleep 120       # Wait for the rate limit to reset
 run_smoke_tests
 
-# Test edit user  
-print_header "Running Maas e2e Tests as edit user"
-EDIT_TOKEN=$(oc create token tester-edit-user -n default)
-oc login --token "$EDIT_TOKEN" --server "$K8S_CLUSTER_URL"
+# Test dev user (edit role)
+print_header "Running Maas e2e Tests as dev user"
+if [ -z "${OPENSHIFT_DEV_USER:-}" ] || [ -z "${OPENSHIFT_DEV_PASS:-}" ]; then
+    echo "❌ ERROR: Dev user credentials not available"
+    exit 1
+fi
+echo "Logging in as ${OPENSHIFT_DEV_USER}..."
+if ! oc login -u "$OPENSHIFT_DEV_USER" -p "$OPENSHIFT_DEV_PASS" "$K8S_CLUSTER_URL" --insecure-skip-tls-verify=true; then
+    echo "❌ ERROR: Failed to login as dev user"
+    exit 1
+fi
+echo "✅ Logged in as ${OPENSHIFT_DEV_USER}"
 run_smoke_tests
 
-# Test view user
-print_header "Running Maas e2e Tests as view user"
-VIEW_TOKEN=$(oc create token tester-view-user -n default)
-oc login --token "$VIEW_TOKEN" --server "$K8S_CLUSTER_URL"
-run_smoke_tests
 
 echo "🎉 Deployment completed successfully!"

--- a/test/e2e/scripts/setup-idp-openshift.sh
+++ b/test/e2e/scripts/setup-idp-openshift.sh
@@ -1,0 +1,132 @@
+
+#!/usr/bin/env bash
+# ==========================================================
+# Minimal OpenShift HTPasswd setup
+# ==========================================================
+# Creates two users:
+#   - admin-user (cluster-admin)
+#   - dev-user   (edit cluster-wide)
+# Does NOT remove or modify existing identity providers/users
+# Assumes 'htpasswd' is already installed.
+# ==========================================================
+
+set -euo pipefail
+
+# --- Configuration ---
+HTPASSWD_SECRET_NAME="htpasswd-secret"
+IDP_NAME="htpasswd-provider"
+
+# Openshift users
+OPENSHIFT_ADMIN_USER="admin-user"
+OPENSHIFT_DEV_USER="dev-user"
+
+# Passwords
+OPENSHIFT_ADMIN_PASS="${ADMIN_PASSWORD:-$(openssl rand -hex 12)}"
+OPENSHIFT_DEV_PASS="${DEV_PASSWORD:-$(openssl rand -hex 12)}"
+
+echo "=== Setting up HTPasswd Identity Provider ==="
+
+# --- Create htpasswd file ---
+{
+  printf '%s\n' "$OPENSHIFT_ADMIN_PASS" | htpasswd -nB -C 12 -i "$OPENSHIFT_ADMIN_USER"
+  printf '%s\n' "$OPENSHIFT_DEV_PASS"   | htpasswd -nB -C 12 -i "$OPENSHIFT_DEV_USER"
+} | oc create secret generic "$HTPASSWD_SECRET_NAME" \
+      --from-file=htpasswd=/dev/stdin \
+      -n openshift-config --dry-run=client -o yaml | oc apply -f -
+
+# --- Create or patch OAuth configuration ---
+if ! oc get oauth cluster &>/dev/null; then
+  echo "No existing OAuth found. Creating a new one..."
+  cat <<EOF | oc apply -f -
+apiVersion: config.openshift.io/v1
+kind: OAuth
+metadata:
+  name: cluster
+spec:
+  identityProviders:
+  - name: ${IDP_NAME}
+    mappingMethod: claim
+    type: HTPasswd
+    htpasswd:
+      fileData:
+        name: ${HTPASSWD_SECRET_NAME}
+EOF
+else
+  echo "OAuth exists. Checking if HTPasswd provider already exists..."
+  
+  # Check if our identity provider already exists
+  if oc get oauth cluster -o jsonpath="{.spec.identityProviders[?(@.name=='${IDP_NAME}')].name}" 2>/dev/null | grep -q "${IDP_NAME}"; then
+    echo "HTPasswd provider already exists, skipping..."
+  else
+    echo "Adding new HTPasswd provider..."
+    # Create a simple patch file to avoid YAML escaping issues
+    PATCH_FILE="/tmp/oauth-patch.json"
+    # Cleanup
+    trap 'rm -f "${PATCH_FILE}"' EXIT
+    cat > "${PATCH_FILE}" <<JSONEOF
+{
+  "spec": {
+    "identityProviders": [
+      {
+        "name": "${IDP_NAME}",
+        "mappingMethod": "claim",
+        "type": "HTPasswd",
+        "htpasswd": {
+          "fileData": {
+            "name": "${HTPASSWD_SECRET_NAME}"
+          }
+        }
+      }
+    ]
+  }
+}
+JSONEOF
+    
+    # Apply the patch from file
+    if oc patch oauth cluster --type=merge --patch-file "${PATCH_FILE}"; then
+      echo "Successfully added HTPasswd provider"
+    else
+      echo "Patch failed, but continuing..."
+    fi
+  fi
+fi
+
+# --- Wait for rollout ---
+echo "Waiting for authentication rollout..."
+echo "This may take several minutes as OAuth pods restart..."
+
+# Manually trigger rollout restart to ensure OAuth picks up changes
+oc -n openshift-authentication rollout restart deployment/oauth-openshift
+oc -n openshift-authentication rollout status deployment/oauth-openshift --timeout=300s
+echo "✅ OAuth deployment restarted and ready"
+
+# --- Wait for identity provider to be fully ready ---
+echo "Waiting for identity provider to be ready..."
+sleep 10
+echo "Checking OAuth configuration..."
+if oc get oauth cluster -o jsonpath='{.spec.identityProviders[?(@.name=="'"${IDP_NAME}"'")]}' 2>/dev/null; then
+    echo "✅ Identity provider configured successfully"
+else
+    echo "⚠️  WARNING: Could not verify identity provider configuration"
+fi
+
+# --- Grant roles ---
+echo "Granting cluster-admin role to ${OPENSHIFT_ADMIN_USER}..."
+oc adm policy add-cluster-role-to-user cluster-admin "${OPENSHIFT_ADMIN_USER}" 2>/dev/null || echo "Note: User will be created on first login"
+
+echo "Granting edit role (cluster-wide) to ${OPENSHIFT_DEV_USER}..."
+oc adm policy add-cluster-role-to-user edit "${OPENSHIFT_DEV_USER}" 2>/dev/null || echo "Note: User will be created on first login"
+
+echo "=== Done! ==="
+echo
+echo "Users created:"
+echo "  Admin user: ${OPENSHIFT_ADMIN_USER}"
+echo "  Dev user:   ${OPENSHIFT_DEV_USER}"
+
+cat <<EOF
+export OPENSHIFT_ADMIN_USER="${OPENSHIFT_ADMIN_USER}"
+export OPENSHIFT_ADMIN_PASS="${OPENSHIFT_ADMIN_PASS}"
+export OPENSHIFT_DEV_USER="${OPENSHIFT_DEV_USER}"
+export OPENSHIFT_DEV_PASS="${OPENSHIFT_DEV_PASS}"
+EOF
+echo "✅ Users setup completed"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds HTPasswd identity provider setup and multi-user authentication support to the e2e smoke tests.

**Changes**

- Integrate `setup-idp-openshift.sh` to create `admin` and `dev` users
- Login as admin and dev users to run validation and token verification tests

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on cluster bot. Need to test on CI with this PR. 

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced test infrastructure with automated identity provider configuration for improved authentication workflows.
  * Implemented dynamic endpoint discovery to streamline test environment setup.
  * Strengthened test security through role-based user provisioning and automated credential management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->