### PR TITLE
feat: Add ValidatingWebhookConfiguration for tier ConfigMap validation

### DIFF
--- a/deployment/base/maas-api/resources/kustomization.yaml
+++ b/deployment/base/maas-api/resources/kustomization.yaml
@@ -6,3 +6,4 @@ metadata:
 
 resources:
   - tier-mapping-configmap.yaml
+  - tier-configmap-webhook.yaml

--- a/deployment/base/maas-api/resources/tier-configmap-webhook.yaml
+++ b/deployment/base/maas-api/resources/tier-configmap-webhook.yaml
@@ -1,0 +1,45 @@
+# ValidatingWebhookConfiguration for Tier ConfigMap validation
+# This webhook validates the tier-to-group-mapping ConfigMap to ensure:
+# 1. Tier names are valid Kubernetes DNS-1123 labels
+# 2. Each tier has a unique level value
+# 3. Existing tier names cannot be removed or renamed (immutability)
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: tier-configmap-validator.odh-model-controller.opendatahub.io
+  labels:
+    app: maas-api
+    component: tier-validation
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"
+webhooks:
+  - name: validating.configmap.odh-model-controller.opendatahub.io
+    admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        # For RHOAI: namespace is redhat-ods-applications
+        # For ODH: namespace is opendatahub
+        name: odh-model-controller-webhook-service
+        namespace: redhat-ods-applications
+        path: /validate--v1-configmap
+        port: 443
+    failurePolicy: Fail
+    matchPolicy: Equivalent
+    objectSelector:
+      matchLabels:
+        component: tier-mapping
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - configmaps
+        scope: Namespaced
+    sideEffects: None
+    timeoutSeconds: 10

--- a/deployment/overlays/odh/kustomization.yaml
+++ b/deployment/overlays/odh/kustomization.yaml
@@ -41,6 +41,14 @@ patches:
   target:
     kind: Deployment
     name: maas-api
+# Patch webhook to use opendatahub namespace for ODH deployments
+- patch: |-
+    - op: replace
+      path: /webhooks/0/clientConfig/service/namespace
+      value: opendatahub
+  target:
+    kind: ValidatingWebhookConfiguration
+    name: tier-configmap-validator.odh-model-controller.opendatahub.io
 
 replacements:
 - source:

--- a/deployment/overlays/openshift/kustomization.yaml
+++ b/deployment/overlays/openshift/kustomization.yaml
@@ -9,3 +9,13 @@ resources:
   - ../odh
   - ../../base/policies/usage-policies
   - ../../base/observability
+
+patches:
+# Patch webhook to use redhat-ods-applications namespace for RHOAI deployments
+- patch: |-
+    - op: replace
+      path: /webhooks/0/clientConfig/service/namespace
+      value: redhat-ods-applications
+  target:
+    kind: ValidatingWebhookConfiguration
+    name: tier-configmap-validator.odh-model-controller.opendatahub.io


### PR DESCRIPTION
Adds a `ValidatingWebhookConfiguration` to enable tier ConfigMap validation via the odh-model-controller webhook.

This configuration enables the following validations on the `tier-to-group-mapping` ConfigMap:
- **DNS-1123 name validation**: Tier names must be valid Kubernetes labels (lowercase alphanumeric and hyphens)
- **Unique tier levels**: Each tier must have a unique level value
- **Tier name immutability**: Existing tier names cannot be removed or renamed

Requires odh-model-controller with the tier ConfigMap webhook implementation https://github.com/opendatahub-io/odh-model-controller/pull/667

Test it with a temp image of odh-model-controller, but has to be tested again when that [PR](https://github.com/opendatahub-io/odh-model-controller/pull/667) is merged

JIRA - https://issues.redhat.com/projects/RHOAIENG/issues/RHOAIENG-42588

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation for tier configurations, enforcing valid naming conventions, unique tier levels, and immutability of existing tier names.

* **Chores**
  * Updated deployment configurations to include webhook validation resource management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->