### PR TITLE
fix(models): treat HTTP 405 as successful authorization in model access checks

### DIFF
--- a/maas-api/internal/models/kserve_llmisvc_test.go
+++ b/maas-api/internal/models/kserve_llmisvc_test.go
@@ -279,13 +279,9 @@ func TestListAvailableLLMs_Authorization(t *testing.T) {
 	testLogger := logger.Development()
 	gateway := models.GatewayRef{Name: "maas-gateway", Namespace: "gateway-ns"}
 
-	// Create mock HTTP server to simulate authorization responses for OPTIONS requests
+	// Create mock HTTP server to simulate gateway authorization responses.
+	// The auth check uses GET /v1/models to verify access.
 	authServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodOptions {
-			w.WriteHeader(http.StatusMethodNotAllowed)
-			return
-		}
-
 		authHeader := r.Header.Get("Authorization")
 		if authHeader == "Bearer valid-token" {
 			w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
The authorization check incorrectly treated HTTP `405 Method Not Allowed` as an authorization failure. This caused legitimate, authorized traffic to be denied when model servers didn't support the HTTP method used for probing.

A 405 response proves the request successfully traversed the gateway's AuthPolicies. If authorization had failed, the gateway would have returned 401, 403 or 404 before the backend could respond. The 405 simply indicates the HTTP method isn't enabled on that route, not an authorization denial.

"Variations" in CORS OPTIONS handling could affect vLLM deployments. Even though this is enabled by default, the specific behavior is an external decision that remains outside our control.

This PR also switches the probe endpoint from `OPTIONS /v1/chat/completions` to `GET (vllm)/v1/models` for future-proofing, as it's a standard OpenAI-compatible endpoint universally supported by inference servers.

> [!IMPORTANT]
> This is not the same call as `/v1/models` exposed by `maas-api`

Ref: [RHOAIENG-46770](https://issues.redhat.com/browse/RHOAIENG-46770)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced authorization verification mechanism for LLM services to more accurately interpret authorization responses across different scenarios
  * Updated endpoint and HTTP method parameters used for authorization checks to improve system reliability and compatibility
  * Refined error response handling to prevent false access denials in specific authorization scenarios
  * Improved overall consistency and robustness of the access control verification process

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->