### PR TITLE
fix(docs): add configurable fail-on-broken-links for external link validation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,6 +18,12 @@ on:
 permissions:
   contents: write
 
+env:
+  # Set to 'false' to allow external link failures without failing the build
+  # Configure via: Settings → Secrets and variables → Actions → Variables → New repository variable ->
+  # Name: FAIL_ON_BROKEN_LINKS, Value: false
+  FAIL_ON_BROKEN_LINKS: ${{ vars.FAIL_ON_BROKEN_LINKS || 'true' }}
+
 concurrency:
   group: "pages"
   cancel-in-progress: false
@@ -30,11 +36,37 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Check Markdown Links
+      - name: Check Internal Links
         uses: becheran/mlc@v1.2.0
         with:
-          # To skip checking http/https links, add: --offline
-          args: .
+          # Only check local/internal links - these must pass
+          args: --offline .
+
+      - name: Check External Links
+        run: |
+          # Install mlc
+          curl -sLO https://github.com/becheran/mlc/releases/download/v1.2.0/mlc-x86_64-linux
+          chmod +x mlc-x86_64-linux
+          sudo mv mlc-x86_64-linux /usr/local/bin/mlc
+          
+          # Run external link check and capture output
+          set +e
+          OUTPUT=$(mlc . 2>&1)
+          EXIT_CODE=$?
+          set -e
+          echo "$OUTPUT"
+          if [ $EXIT_CODE -eq 0 ]; then
+            echo "✅ All external links are valid"
+          else
+            echo "FAIL_ON_BROKEN_LINKS value: '$FAIL_ON_BROKEN_LINKS'"
+            if [ "$FAIL_ON_BROKEN_LINKS" == "true" ]; then
+              echo "❌ External link check failed. See broken links above."
+              exit 1
+            else
+              echo "::warning::Some external links may be broken (FAIL_ON_BROKEN_LINKS=false, continuing)"
+            fi
+          fi
+        shell: bash
 
   # Build job for PRs - just validates the docs build
   build-pr:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR improves the markdown link checker in the docs workflow by separating internal and external link validation:
- Changes
  - Internal links (local file references) are checked first and will fail the build if broken - Uses mlc `--offline` to validate local   links (fails on errors)
  - External links (http/https URLs) are checked separately and only produce warnings if broken, without failing the build - Runs mlc via shell, captures errors as warnings using ::warning:: annotation

### Configuration

The `FAIL_ON_BROKEN_LINKS` repository variable controls external link check behavior:

| Value | Behavior |
|-------|----------|
| `true` (default) | Fail the build on broken external links |
| `false` | Show warnings only, build continues |

**To configure:**

1. Go to repo **Settings** → **Secrets and variables** → **Actions** → **Variables** tab
2. Click **New repository variable**
3. Set:
   - **Name:** `FAIL_ON_BROKEN_LINKS`
   - **Value:** `false`

> **Note:** Once external sites are stable, delete the variable to restore default strict checking (`true`).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on personal fork.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Split link validation into two sequential checks: strict internal link verification followed by external link validation.
  * Added a configurable external-link check that either fails the run or emits a warning based on a new FAIL_ON_BROKEN_LINKS setting (default: true).
  * Renamed and clarified the internal check step for readability and intent.
  * Preserves the existing documentation build/deploy flow while extending link validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->