### PR TITLE
feat: bump llm-d inference sim image

### DIFF
--- a/docs/samples/models/simulator-premium/model.yaml
+++ b/docs/samples/models/simulator-premium/model.yaml
@@ -21,7 +21,7 @@ spec:
   template:
     containers:
       - name: main
-        image: "ghcr.io/llm-d/llm-d-inference-sim:v0.5.1"
+        image: "ghcr.io/llm-d/llm-d-inference-sim:v0.6.1"
         imagePullPolicy: Always
         command: ["/app/llm-d-inference-sim"]
         args:

--- a/docs/samples/models/simulator/model.yaml
+++ b/docs/samples/models/simulator/model.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     containers:
       - name: main
-        image: "ghcr.io/llm-d/llm-d-inference-sim:v0.5.1"
+        image: "ghcr.io/llm-d/llm-d-inference-sim:v0.6.1"
         imagePullPolicy: Always
         command: ["/app/llm-d-inference-sim"]
         args:


### PR DESCRIPTION
bump from v0.5.1 to [v0.6.1](https://github.com/llm-d/llm-d-inference-sim/releases/tag/v0.6.1)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated container image versions to v0.6.1 for simulator models, ensuring the sample simulator manifests reference the newer runtime image.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->