### PR TITLE
fix(maas): use explicit app-namespace for auth policy URL

### DIFF
--- a/deployment/overlays/odh/kustomization.yaml
+++ b/deployment/overlays/odh/kustomization.yaml
@@ -109,7 +109,7 @@ replacements:
     kind: ConfigMap
     version: v1
     name: maas-parameters
-    fieldPath: metadata.namespace
+    fieldPath: data.app-namespace
   targets:
   - select:
       kind: AuthPolicy

--- a/deployment/overlays/odh/params.env
+++ b/deployment/overlays/odh/params.env
@@ -1,3 +1,4 @@
 maas-api-image=quay.io/opendatahub/maas-api:latest
 gateway-namespace=openshift-ingress
 gateway-name=maas-default-gateway
+app-namespace=opendatahub


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
Updates the ODH overlay to use a configurable 'app-namespace' parameter instead of relying on 'metadata.namespace' for constructing the MaaS API URL in AuthPolicy and DestinationRule.

This ensures that when the ODH Operator overrides the namespace (e.g. for RHOAI flavor), the authorization layer correctly points to the service in the target namespace, resolving rate limit bypass issues.
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted how the authentication policy determines its namespace, affecting policy resolution during deployment.
  * Added an application namespace environment variable (opendatahub) to deployment configuration.
  * No user-facing UI changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->