### PR TITLE
test: manifest changes

### DIFF
--- a/deployment/overlays/odh/params.env
+++ b/deployment/overlays/odh/params.env
@@ -1,3 +1,3 @@
 maas-api-image=quay.io/opendatahub/maas-api:latest
 gateway-namespace=openshift-ingress
-gateway-name=maas-non-default-gateway
+gateway-name=maas-default-gateway


### PR DESCRIPTION
> [!WARNING]
> This is not intended to be merged, testing prow config :)

This PR has two commits which should be caught by tests:

- misconfigured manifests
- change in `/v1/models` to always return empty model list

In both cases prow tests are passing.

### Root cause

https://github.com/opendatahub-io/models-as-a-service/blob/30f93ad170ff45e8b7ef2e686bde26e5f9ad8907/test/e2e/scripts/prow_run_smoke_test.sh#L98

That deploys latest odh-operator using `deploy-rhoai-stable.sh` script which has:

- bundled manifests from `main`
- latest image built from `main`

instead of incorporating both based on this PR.

As a consequence changes in this PR are not exercised by tests as we are testing entirely different build. Potential bugs can only happen after merge to `main` that will result in new `maas-api` image and eventually sync manifests in the operator (they're now [a few commits behind](https://github.com/opendatahub-io/opendatahub-operator/blob/3af61803f9ac78c8ddb4504979766c25caf50eaa/get_all_manifests.sh#L31) ->  https://github.com/opendatahub-io/models-as-a-service/commit/96f6b1416aba742ffe9c61993a4a70434db926a7)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated deployment gateway configuration parameter.

* **Bug Fixes**
  * Models listing endpoint now returns an empty list placeholder instead of prior handler output.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->