### PR TITLE
fix(scripts): resolve subscription resource ambiguity in deployment helpers

### DIFF
--- a/scripts/deployment-helpers.sh
+++ b/scripts/deployment-helpers.sh
@@ -125,9 +125,9 @@ waitsubscriptioninstalled() {
   local name=${1?subscription name is required}; shift
 
   echo "  * Waiting for Subscription $ns/$name to start setup..."
-  kubectl wait subscription --timeout=300s -n "$ns" "$name" --for=jsonpath='{.status.currentCSV}'
+  kubectl wait subscription.operators.coreos.com --timeout=300s -n "$ns" "$name" --for=jsonpath='{.status.currentCSV}'
   local csv
-  csv=$(kubectl get subscription -n "$ns" "$name" -o jsonpath='{.status.currentCSV}')
+  csv=$(kubectl get subscription.operators.coreos.com -n "$ns" "$name" -o jsonpath='{.status.currentCSV}')
 
   # Because, sometimes, the CSV is not there immediately.
   while ! kubectl get -n "$ns" csv "$csv" > /dev/null 2>&1; do
@@ -154,7 +154,7 @@ checksubscriptionexists() {
   local op_cond=".spec.name == \"${operator_name}\""
   local query="${catalogns_cond} and ${catalog_cond} and ${op_cond}"
 
-  kubectl get subscriptions -A -ojson | jq ".items | map(select(${query})) | length"
+  kubectl get subscriptions.operators.coreos.com -A -ojson | jq ".items | map(select(${query})) | length"
 }
 
 # checkcsvexists csv_prefix


### PR DESCRIPTION
## Summary                                                                                                                                         
Fixes deployment script failures on clusters with multiple subscription CRDs by using fully qualified resource names.                              
                                                                                                                                                     
## Problem                                                                                                                                         
Script fails with `Error from server (NotFound): subscriptions.messaging.knative.dev` when clusters have both Knative and OLM subscription resources.                                                                                                                                         
                                                                                                                                                     
## Solution                                                                                                                                        
- Updated `waitsubscriptioninstalled()` to use `subscription.operators.coreos.com`                                                                 
- Ensures script targets OLM subscriptions specifically                                                                                            
                                                                                                                                                     
## Testing                                                                                                                                         
- [x] Tested on cluster with both Knative and OLM subscriptions                                                                                    
- [x] Script now successfully detects existing OLM subscriptions                                                                                   
- [x] Deployment proceeds past subscription check phase 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment reliability by ensuring proper handling of operator subscription resources during the installation process. Updated deployment helper scripts to correctly reference and track subscription status, preventing potential failures during operator initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->