### PR TITLE
fix(validate-deployment): resolve gateway host without cluster-admin

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -260,11 +260,18 @@ All scripts require:
 Scripts will automatically detect:
 - `CLUSTER_DOMAIN`: OpenShift cluster domain from `ingresses.config.openshift.io/cluster`
 - OpenShift authentication token via `oc whoami -t`
+- Gateway hostname from the Gateway resource (no cluster-admin needed for `validate-deployment.sh`)
 
 You can override these by exporting before running:
 ```bash
 export CLUSTER_DOMAIN="apps.my-cluster.example.com"
 ./scripts/deploy.sh
+```
+
+**Non-admin users:** If you cannot read `ingresses.config.openshift.io/cluster`, the validation script will try the Gateway's listener hostname. If that is not available, set the gateway URL explicitly:
+```bash
+export MAAS_GATEWAY_HOST="https://maas.apps.your-cluster.example.com"
+./scripts/validate-deployment.sh
 ```
 
 ---


### PR DESCRIPTION
## Problem 
The script was getting the cluster domain only from `kubectl get ingresses.config.openshift.io cluster`. That’s a cluster-scoped resource and usually needs `cluster-admin` (or at least read on that config), so non-admin users got `“Could not determine cluster domain”` and `“Cannot test API endpoints”`.
```
.
🔍 Checking: Gateway hostname
❌ FAIL: Could not determine cluster domain
   Reason: Cannot test API endpoints
   Suggestion: Check: kubectl get ingresses.config.openshift.io cluster

=========================================
4️⃣ API Endpoint Tests
=========================================

❌ FAIL: Cannot test API endpoints
   Reason: No gateway route found
   Suggestion: Fix gateway route issues first
```
<!--- Provide a general summary of your changes in the Title above -->

## Solution
**1. Resolve host from Gateway first**
Read the hostname from `maas-default-gateway` in `openshift-ingress` (e.g. `.spec.listeners[?(@.protocol=="HTTPS")].hostname`). This only needs read access to the Gateway, which non-admins already have when the Gateway check passes.
**2. Keep existing behavior for admins**
If the Gateway hostname is not available, fall back to the cluster domain from `ingresses.config.openshift.io `cluster as before.

## Description
<!--- Describe your changes in detail -->
   - Resolve MaaS gateway host from Gateway spec listener hostname first (no ingresses.config.openshift.io needed).
   - Fall back to cluster ingress config when available.
   - Add MAAS_GATEWAY_HOST env override and document for non-admin users.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
As admin: Run `./scripts/validate-deployment.sh` - behavior unchanged; hostname from cluster config or Gateway.

As non-admin: Run `./scripts/validate-deployment.sh` - hostname should resolve from the Gateway and API endpoint tests should run. If not, set `MAAS_GATEWAY_HOST` to the MaaS gateway URL and re-run.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance and examples for non-admin users on configuring the gateway hostname via environment variables, including a usage snippet for MAAS_GATEWAY_HOST.

* **Improvements**
  * Updated help output and strengthened gateway hostname resolution with a clear hierarchical fallback sequence and improved success/failure messaging to aid troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->