### PR TITLE
fix(scripts): fix operator subscriptions and activate LWS controller

### DIFF
--- a/scripts/data/cert-manager-subscription.yaml
+++ b/scripts/data/cert-manager-subscription.yaml
@@ -7,11 +7,8 @@ metadata:
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
-  name: cert-manager-operator-operatorgroup
+  name: cert-manager-operator
   namespace: cert-manager-operator
-spec:
-  targetNamespaces:
-    - cert-manager-operator
 ---
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
@@ -20,6 +17,7 @@ metadata:
   namespace: cert-manager-operator
 spec:
   channel: stable-v1
+  installPlanApproval: Automatic
   name: openshift-cert-manager-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace

--- a/scripts/data/lws-operator-cr.yaml
+++ b/scripts/data/lws-operator-cr.yaml
@@ -1,0 +1,7 @@
+apiVersion: operator.openshift.io/v1
+kind: LeaderWorkerSetOperator
+metadata:
+  name: cluster
+  namespace: openshift-lws-operator
+spec:
+  managementState: Managed

--- a/scripts/data/lws-subscription.yaml
+++ b/scripts/data/lws-subscription.yaml
@@ -7,11 +7,11 @@ metadata:
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
-  name: openshift-lws-operator-operatorgroup
+  name: leader-worker-set
   namespace: openshift-lws-operator
 spec:
   targetNamespaces:
-    - openshift-lws-operator
+  - openshift-lws-operator
 ---
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
@@ -20,6 +20,7 @@ metadata:
   namespace: openshift-lws-operator
 spec:
   channel: stable-v1.0
+  installPlanApproval: Automatic
   name: leader-worker-set
   source: redhat-operators
   sourceNamespace: openshift-marketplace

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -453,6 +453,14 @@ install_optional_operators() {
 
   # Wait for both to complete
   wait $cert_wait_pid $lws_wait_pid
+
+  # Create LeaderWorkerSetOperator CR to activate the LWS controller-manager.
+  # The operator subscription alone only installs the operator pod; the CR is
+  # required to actually deploy the LWS API (controller-manager pods).
+  # See: https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/ai_workloads/leader-worker-set-operator
+  log_info "Activating LeaderWorkerSet API..."
+  kubectl apply -f "${data_dir}/lws-operator-cr.yaml"
+
   log_info "Optional operators installed"
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
CI failed with - 
```
2m10s       Warning   Error     llminferenceservice/facebook-opt-125m-simulated   Reconciliation failed: failed to reconcile workload: failed to reconcile multi node workload: failed to reconcile multi-node main workload: failed to build the expected main LWS: failed to get expected leader worker set llm/facebook-opt-125m-simulated-kserve-mn: no matches for kind "LeaderWorkerSet" in version "leaderworkerset.x-k8s.io/v1"
{"component":"entrypoint","error":"wrapped process failed: exit status 1","file":"sigs.k8s.io/prow/pkg/entrypoint/run.go:84","func":"sigs.k8s.io/prow/pkg/entrypoint.Options.internalRun","level":"error","msg":"Error executing test process","severity":"error","time":"2026-02-11T18:23:52Z"}
error: failed to execute wrapped command: exit status 1
---
```
## Description
<!--- Describe your changes in detail -->
- Fix cert-manager OperatorGroup name and remove unnecessary targetNamespaces spec to use AllNamespaces install mode.
- Fix LWS OperatorGroup name for consistency.
- Add installPlanApproval: Automatic to both subscriptions.
- Add LeaderWorkerSetOperator CR to activate the LWS controller-manager after subscription install.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on local following things - 
- [x] Deploy on a fresh cluster and verify cert-manager operator installs successfully
- [x] Verify LWS operator installs and the controller-manager pods come up after the CR is applied
- [x] Verify existing deployments are not broken by OperatorGroup name changes

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new LeaderWorkerSet operator support enabling advanced cluster coordination and management capabilities for improved operational flexibility.
  
* **Chores**
  * Configured automatic installation plan approval for cert-manager and LeaderWorkerSet operators, eliminating the need for manual approval steps.
  * Updated operator configurations and naming conventions to improve consistency and enable more streamlined deployment processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->