### PR TITLE
fix(manager) : service account name collision via SHA256 truncation  @somya-bhatnagar

### DIFF
--- a/maas-api/internal/token/manager.go
+++ b/maas-api/internal/token/manager.go
@@ -135,7 +135,7 @@ func (m *Manager) RevokeTokens(ctx context.Context, user *UserContext) error {
 		return fmt.Errorf("failed to determine namespace for tier %s: %w", userTier.Name, errNS)
 	}
 
-	saName, errName := m.sanitizeServiceAccountName(user.Username)
+	saName, errName := m.SanitizeServiceAccountName(user.Username)
 	if errName != nil {
 		return fmt.Errorf("failed to sanitize service account name for user %s: %w", user.Username, errName)
 	}
@@ -205,7 +205,7 @@ func (m *Manager) ensureTierNamespace(ctx context.Context, tier string) (string,
 // ensureServiceAccount creates a service account if it doesn't exist.
 // It takes a raw username, sanitizes it for Kubernetes naming, and returns the sanitized name.
 func (m *Manager) ensureServiceAccount(ctx context.Context, namespace, username, userTier string) (string, error) {
-	saName, errName := m.sanitizeServiceAccountName(username)
+	saName, errName := m.SanitizeServiceAccountName(username)
 	if errName != nil {
 		return "", fmt.Errorf("failed to sanitize service account name for user %s: %w", username, errName)
 	}
@@ -275,10 +275,11 @@ func (m *Manager) deleteServiceAccount(ctx context.Context, namespace, saName st
 	return nil
 }
 
-// sanitizeServiceAccountName ensures the service account name follows Kubernetes naming conventions.
+// SanitizeServiceAccountName ensures the service account name follows Kubernetes naming conventions.
 // While ideally usernames should be pre-validated, Kubernetes TokenReview can return usernames
 // in various formats (OIDC emails, LDAP DNs, etc.) that need sanitization for use as SA names.
-func (m *Manager) sanitizeServiceAccountName(username string) (string, error) {
+// Exported for testing.
+func (m *Manager) SanitizeServiceAccountName(username string) (string, error) {
 	// Kubernetes ServiceAccount names must be valid DNS-1123 labels:
 	// [a-z0-9-], 1-63 chars, start/end alphanumeric.
 	name := strings.ToLower(username)

--- a/maas-api/internal/token/manager_test.go
+++ b/maas-api/internal/token/manager_test.go
@@ -1,19 +1,21 @@
-package token
+package token_test
 
 import (
 	"crypto/sha256"
 	"encoding/hex"
 	"strings"
 	"testing"
+
+	"github.com/opendatahub-io/models-as-a-service/maas-api/internal/token"
 )
 
 func TestSanitizeServiceAccountName(t *testing.T) {
 	t.Parallel()
 
-	manager := &Manager{}
+	manager := &token.Manager{}
 	username := "Alice@example.com"
 
-	name, err := manager.sanitizeServiceAccountName(username)
+	name, err := manager.SanitizeServiceAccountName(username)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 		return
@@ -42,8 +44,8 @@ func TestSanitizeServiceAccountName(t *testing.T) {
 func TestSanitizeServiceAccountName_InvalidUsername(t *testing.T) {
 	t.Parallel()
 
-	manager := &Manager{}
-	if _, err := manager.sanitizeServiceAccountName("!!!"); err == nil {
+	manager := &token.Manager{}
+	if _, err := manager.SanitizeServiceAccountName("!!!"); err == nil {
 		t.Error("expected error for invalid username, got nil")
 	}
 }
@@ -51,10 +53,10 @@ func TestSanitizeServiceAccountName_InvalidUsername(t *testing.T) {
 func TestSanitizeServiceAccountName_Truncation(t *testing.T) {
 	t.Parallel()
 
-	manager := &Manager{}
+	manager := &token.Manager{}
 	username := strings.Repeat("a", 200) + "@example.com"
 
-	name, err := manager.sanitizeServiceAccountName(username)
+	name, err := manager.SanitizeServiceAccountName(username)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 		return


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
In maas-api/internal/token/manager.go:278–311, service account names are derived from a truncated SHA1 hash. While collisions are extremely unlikely at current and near-term scale, this approach theoretically allows two different users to resolve to the same service account name, which could impact user isolation if it ever occurred.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```
somyabhatnagar@Somyas-MacBook-Pro maas-api % go test ./...
?       github.com/opendatahub-io/models-as-a-service/maas-api/cmd      [no test files]
ok      github.com/opendatahub-io/models-as-a-service/maas-api/internal/api_keys        0.469s
?       github.com/opendatahub-io/models-as-a-service/maas-api/internal/cert    [no test files]
?       github.com/opendatahub-io/models-as-a-service/maas-api/internal/config  [no test files]
?       github.com/opendatahub-io/models-as-a-service/maas-api/internal/constant        [no test files]
ok      github.com/opendatahub-io/models-as-a-service/maas-api/internal/handlers        1.575s
?       github.com/opendatahub-io/models-as-a-service/maas-api/internal/logger  [no test files]
ok      github.com/opendatahub-io/models-as-a-service/maas-api/internal/models  1.536s
ok      github.com/opendatahub-io/models-as-a-service/maas-api/internal/tier    2.053s
ok      github.com/opendatahub-io/models-as-a-service/maas-api/internal/token   2.861s
?       github.com/opendatahub-io/models-as-a-service/maas-api/internal/types   [no test files]
?       github.com/opendatahub-io/models-as-a-service/maas-api/test/fixtures    [no test files]
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
