### PR TITLE
docs: add initial contributor guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ Thanks for your interest in contributing. This guide explains how to work with t
 ## Pull request process
 
 1. **Push** your branch to your fork and open a **pull request** against `main`.
-2. **Use semantic PR titles** so CI can accept the PR. Format: `type: subject` (subject in lowercase).
+2. **Use semantic PR titles** so CI can accept the PR. Format: `type: subject` (subject not starting with a capital).
    - Allowed **types:** `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`.
    - Examples: `feat: add TLS option for deploy script`, `fix: correct sourceNamespace for Kuadrant subscription`, `docs: update quickstart`.
    - Draft/WIP PRs can use the `draft` or `wip` label to skip title validation.


### PR DESCRIPTION
Add an initial CONTRIBUTING.md to document how to contribute and what to expect from CI.

- Getting started (fork, clone, branch)
- PR process and semantic titles
- Repo layout and CI checks (Kustomize, MaaS API)
- Note on workflows that need owner approval and validating with the prow script first
- Short testing note: add tests for new functionality (section to be expanded)
- Links to docs and OWNERS

This is a first version we can refine over time.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive contributing guide covering contributor workflow, local development setup and validation, PR requirements and labels, CI/checks and testing expectations, repository layout, how to get help or raise issues, and reviewer/approver guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->