### PR TITLE
fix: improve deploy.sh script 

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -972,9 +972,9 @@ apply_dsc() {
       return 0
     fi
 
-    log_warn "Existing DataScienceCluster '$existing_dsc' does not meet MaaS requirements:"
+    log_error "Existing DataScienceCluster '$existing_dsc' does not meet MaaS requirements:"
     for mismatch in "${mismatches[@]}"; do
-      log_warn "  $mismatch"
+      log_error "  $mismatch"
     done
 
     log_error "Fix the required fields in DSC deployment and try again..."


### PR DESCRIPTION
## Description
This PR focuses on some improvements for `deploy.sh` script that I came across when tried using it. Main reason for fixes was caused by a presence of **another** `operator` in my cluster before installing `odh-operator` with the script. As such:
- [x] (fix 1 for proof of testing below) the script now checks whether there are existing operators that might cause conflict and abort installer sooner for the user to remove the current operator and avoid any issues with the installation (including suggested steps for the user).
- [x] (fix 2 for proof of testing below) the script will now check whether the prerequisite toolset is installed to avoid any hiccups down the line.  
- [x] (fix 3 for proof of testing below) Additionally, there were scenarios where we had a pre-installed DSC by maybe another operator. In such cases, the script checks whether the required components for MaaS are set to the right values. If not, we will propagate a warning message to have the user make adjustments before trying to run the script again. **Note:** I have followed the already existing code flow and used `scripts/data/datasciencecluster.yaml` as the source of truth as to what is needed for MaaS DSC.


## How Has This Been Tested?
Manually tested on both empty cluster and a cluster that had `redhat-ods-operator` installed.

### Fix 1 ###
**Before:** The script would hang at this stage.
```
[INFO] Applying Kuadrant custom resource in kuadrant-system...
kuadrant.kuadrant.io/kuadrant unchanged
[INFO] Waiting for Kuadrant to become ready (initial check)...
[INFO] Waiting for: Kuadrant ready in kuadrant-system (timeout: 60s)
[INFO] Kuadrant ready in kuadrant-system - Ready
[INFO] Kuadrant setup complete
[INFO] Deploying usage policies (TokenRateLimitPolicy)...
[INFO] Usage policies deployed successfully
[INFO] Installing primary operator: odh
[INFO] Installing ODH operator...
[INFO] Installing operator: opendatahub-operator in namespace: opendatahub
[INFO] Subscription opendatahub-operator already exists in opendatahub, skipping
[INFO] Applying custom resources...
[INFO] Waiting for operator CRDs to be established...
⏳ Waiting for CRD datascienceclusters.datasciencecluster.opendatahub.io to appear (timeout: 180s)…
✅ CRD datascienceclusters.datasciencecluster.opendatahub.io detected, waiting for it to become Established...
customresourcedefinition.apiextensions.k8s.io/datascienceclusters.datasciencecluster.opendatahub.io condition met
[INFO] Waiting for operator webhook to be ready...
* Waiting for deployment/opendatahub-operator-controller-manager in opendatahub-operator-system...
```

**After:**
```
[INFO] Waiting for Kuadrant to become ready (initial check)...
[INFO] Waiting for: Kuadrant ready in kuadrant-system (timeout: 60s)
[INFO] Kuadrant ready in kuadrant-system - Ready
[INFO] Kuadrant setup complete
[INFO] Deploying usage policies (TokenRateLimitPolicy)...
[INFO] Usage policies deployed successfully
[INFO] Checking if there are any conflicting operators...
[ERROR] Conflicting operator found: rhods-operator in namespace redhat-ods-operator. ODH and RHOAI operators cannot coexist (they manage the same CRDs).
[INFO] Remove the conflicting operator before proceeding (suggested steps):
[INFO]   1. Delete custom resources: oc delete datasciencecluster --all && oc delete dscinitializations --all
[INFO]   2. Delete subscription: oc delete subscription.operators.coreos.com rhods-operator -n redhat-ods-operator
[INFO]   3. Delete CSV: oc delete csv -n redhat-ods-operator -l operators.coreos.com/rhods-operator
[INFO]   4. Try uninstalling rhods-operator (can be done via a console as well) before attempting to run deploy.sh again.
[INFO]   5. Sanity check: delete any lingering operator groups, old namespaces and projects.
[ERROR] Quit the execution of the script. You may try re-running again.**
```

### Fix 2 ###
**Before:** the installation would fail due to one of the tools missing without clear indication what went wrong. Following the notion of "fail fast", we now check if the user installed all the tools before invoking the script.

**After:**
#### Example 1 ####

```
  brew uninstall gnu-sed
Uninstalling /opt/homebrew/Cellar/gnu-sed/4.9... (13 files, 633.1KB)

 oc login --token=sha256~kZ_--FDxgEUerIzgmAcOQZPQ59kceYBuVC3P1YVaXHU --server=https://api.yt-cluster.stev.p3.openshiftapps.com:443

Logged into "https://api.yt-cluster.stev.p3.openshiftapps.com:443" as "cluster-admin" using the token provided.

You have access to 89 projects, the list has been suppressed. You can list all projects with 'oc projects'

Using project "opendatahub".

󰀵 yuriyt  …/models-as-a-service   yt-add-conflicting-controller-check !   10:22 
 ./scripts/deploy.sh --operator-type odh
[INFO] ===================================================
[INFO]   Models-as-a-Service Deployment
[INFO] ===================================================
[ERROR] Missing required tools:
[ERROR]   - gsed (GNU sed)
```

#### Example 2 ####

```
 brew uninstall kustomize
Uninstalling /opt/homebrew/Cellar/kustomize/5.8.1... (10 files, 17.4MB)

󰀵 yuriyt  …/models-as-a-service   yt-add-conflicting-controller-check !   10:28 
 ./scripts/deploy.sh --operator-type odh
[INFO] ===================================================
[INFO]   Models-as-a-Service Deployment
[INFO] ===================================================
[ERROR] Missing or incompatible required tools:
[ERROR]   - kustomize (v5.7.0+)
```

#### Example 3 (install outdated version of kustomize) ####

```
curl -L https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv5.6.0/kustomize_v5.6.0_darwin_arm64.tar.gz | tar xz
  sudo mv kustomize /usr/local/bin/kustomize
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 5321k  100 5321k    0     0  6244k      0 --:--:-- --:--:-- --:--:-- 12.3M
Password:

󰀵 yuriyt  …/models-as-a-service   yt-add-conflicting-controller-check !   10:30 
 ./scripts/deploy.sh --operator-type odh
[INFO] ===================================================
[INFO]   Models-as-a-Service Deployment
[INFO] ===================================================
[ERROR] Missing or incompatible required tools:
[ERROR]   - kustomize (v5.7.0+ required, found 5.6.0)
```

### Fix 3 ###
**Before:** If DSC was configured differently by a different operator, we can run into a loop like this (context: a pre-existing DSC from the previous RHOAI installation that has **kserve.managementState: Removed**, which is a required component for MaaS):
```
[WARN] Webhook deployment not found after 120s, proceeding anyway...
[INFO] Applying DSCInitialization...
[INFO] DSCInitialization already exists, skipping creation (operator auto-created)
[INFO] Applying DataScienceCluster with ModelsAsService...
[INFO] DataScienceCluster already exists in the cluster. Skipping creation.
[INFO] Waiting for DataScienceCluster to be ready...
* Waiting for DataScienceCluster 'default-dsc' KServe and ModelsAsService components to be ready...
  - KServe state: Removed, KserveReady: False, ModelsAsServiceReady: False, ModelControllerReady: False  
  - KServe state: Removed, KserveReady: False, ModelsAsServiceReady: False, ModelControllerReady: False
  - KServe state: Removed, KserveReady: False, ModelsAsServiceReady: False, ModelControllerReady: False
  - KServe state: Removed, KserveReady: False, ModelsAsServiceReady: False, ModelControllerReady: False

Described:
oc get datasciencecluster -A -o yaml
apiVersion: v1
items:
- apiVersion: datasciencecluster.opendatahub.io/v2
  kind: DataScienceCluster
  metadata:
    creationTimestamp: "2026-01-29T19:23:35Z"
    generation: 2
    labels:
      app.kubernetes.io/created-by: rhods-operator
      app.kubernetes.io/instance: default-dsc
      app.kubernetes.io/managed-by: kustomize
      app.kubernetes.io/name: datasciencecluster
      app.kubernetes.io/part-of: rhods-operator
    name: default-dsc
    resourceVersion: "12858248"
    uid: a40bf029-e0d3-473f-9a56-9a29be82c047
  spec:
    components:
      aipipelines:
        argoWorkflowsControllers:
          managementState: Managed
        managementState: Managed
      dashboard:
        managementState: Managed
      feastoperator:
        managementState: Removed
      kserve:
        managementState: Removed **<---------------**

```

**After:**
```
  [WARN] Existing DataScienceCluster 'default-dsc' does not meet MaaS requirements:
  [WARN]   .spec.components.dashboard.managementState: 'Managed' (expected 'Removed')
  [WARN]   .spec.components.kserve.managementState: 'Removed' (expected 'Managed')
  [WARN]   .spec.components.kserve.modelsAsService.managementState: 'Removed' (expected 'Managed')
  [WARN]   .spec.components.kserve.rawDeploymentServiceConfig: 'Headless' (expected 'Headed')
  [ERROR] Fix the required fields in DSC deployment and try again...
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deployment now validates prerequisites (required CLIs and minimum versions), aborting early with clear guidance when requirements are missing.
  * Installer detects conflicting operators across namespaces, prevents incompatible installs, and prints remediation steps before proceeding.
  * Safer apply behavior for existing cluster configurations: extracts and compares current vs desired settings, skips unchanged resources, and reports detailed mismatches before aborting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->