### PR TITLE
fix: fix cve-2025-68121 (crypto/tls session resumption)

### DIFF
--- a/maas-api/Dockerfile.konflux
+++ b/maas-api/Dockerfile.konflux
@@ -3,7 +3,7 @@ ARG GOLANG_VERSION=1.25
 ARG BUILDPLATFORM
 ARG TARGETPLATFORM
 
-FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset@sha256:eaa6e2e560935e4b19c6c877d679c4b48b5dd7d9f87c3d6aa141d03da7bf0815 AS builder
+FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset@sha256:799cc027d5ad58cdc156b65286eb6389993ec14c496cf748c09834b7251e78dc AS builder
 ARG CGO_ENABLED=1
 ARG TARGETOS
 ARG TARGETARCH


### PR DESCRIPTION
## Summary

Updates go-toolset base image SHA in Dockerfile.konflux from Go 1.25.3 to Go 1.25.7 to resolve a critical crypto/tls session resumption vulnerability in production builds.

### CVE Details
- **CVE ID**: CVE-2025-68121 (GO-2026-4337)
- **Package**: crypto/tls (Go standard library)
- **Severity**: HIGH (CVSS 7.4)
- **Impact**: During TLS session resumption, if the underlying Config has its ClientCAs or RootCAs fields mutated between the initial handshake and the resumed handshake, the resumed handshake may succeed when it should have failed. Additionally, only the leaf certificate expiration was checked during session resumption, allowing sessions to resume even if intermediate or root certificates had expired.
- **Vulnerable versions**: Go < 1.25.7
- **Fixed version**: Go 1.25.7
- **Jira Issues**: [RHOAIENG-49745](https://issues.redhat.com/browse/RHOAIENG-49745)

### Root Cause

The production Dockerfile (`Dockerfile.konflux`) uses a pinned SHA that pointed to Go 1.25.3. While Red Hat updated the `:1.25` floating tag to Go 1.25.7, the pinned SHA remained on the vulnerable version.

- Development builds (using floating tag in `Dockerfile`) were automatically fixed
- Production builds (using pinned SHA in `Dockerfile.konflux`) remained vulnerable

### Changes

- Updated `maas-api/Dockerfile.konflux` builder stage base image SHA
- Old SHA (Go 1.25.3): `eaa6e2e560935e4b19c6c877d679c4b48b5dd7d9f87c3d6aa141d03da7bf0815`
- New SHA (Go 1.25.7): `799cc027d5ad58cdc156b65286eb6389993ec14c496cf748c09834b7251e78dc`
- No application code changes required (stdlib-only fix)

### Test Results

**Status**: All tests passed
**Test command**: `go test -v -race ./cmd/... ./internal/...`
**Result**: PASSED

<details>
<summary>Test Summary</summary>

All unit tests in `cmd/...` and `internal/...` packages passed successfully with race detector enabled.

</details>

### Breaking Changes

None. This is a Go standard library security patch applied via base image SHA update. No API or behavioral changes.

### Testing Checklist

- [x] Pre-PR Go unit tests executed and passed
- [ ] CI/CD pipeline passes
- [ ] Verify production image contains Go 1.25.7 (`govulncheck --mode binary`)
- [ ] Confirm CVE-2025-68121 is no longer present in built binary
- [ ] QE verification of production builds

### Risk Assessment

| Factor | Assessment |
|--------|-----------|
| Change scope | Minimal - single SHA update in Dockerfile.konflux |
| Breaking changes | None |
| Code changes | None (stdlib-only fix) |
| Rollback | Simple - revert SHA to previous value |
| Risk level | LOW |

### Verification Steps

```bash
# After merge, verify the fix in production image:
docker pull registry.redhat.io/rhoai/odh-maas-api-rhel9:<new-tag>
CONTAINER_ID=$(docker create registry.redhat.io/rhoai/odh-maas-api-rhel9:<new-tag>)
docker cp "$CONTAINER_ID:/app/maas-api" /tmp/maas-api-binary
docker rm "$CONTAINER_ID"
strings /tmp/maas-api-binary | grep "go1\."
# Expected: go1.25.7
govulncheck --mode binary /tmp/maas-api-binary
# Expected: CVE-2025-68121 NOT present
```

---

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build infrastructure dependencies for improved stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->