### PR TITLE
Fixing user subscription to key off the userid being passed in from t…

### DIFF
--- a/maas-controller/pkg/controller/maas/maassubscription_controller.go
+++ b/maas-controller/pkg/controller/maas/maassubscription_controller.go
@@ -182,7 +182,7 @@ func (r *MaaSSubscriptionReconciler) reconcileTokenRateLimitPolicies(ctx context
 				parts = append(parts, fmt.Sprintf(`auth.identity.groups_str.split(",").exists(g, %s)`, strings.Join(comparisons, " || ")))
 			}
 			for _, u := range users {
-				parts = append(parts, fmt.Sprintf(`auth.identity.user.username == "%s"`, u))
+				parts = append(parts, fmt.Sprintf(`auth.identity.userid == "%s"`, u))
 			}
 			return strings.Join(parts, " || ")
 		}


### PR DESCRIPTION
Update the created TokenRateLimit to use `userid` passed in from AuthPolicy instead of directly using the username in auth which is not always there.
