### PR TITLE
fix: update red hat connectivity link urls to version 1.2

### DIFF
--- a/docs/content/advanced-administration/limitador-persistence.md
+++ b/docs/content/advanced-administration/limitador-persistence.md
@@ -63,7 +63,7 @@ To configure Limitador to use Redis for persistent storage, you need to:
 
 For detailed, official instructions on production Redis setup, refer to the Red Hat documentation:
 
-- [Red Hat Connectivity Link - Configure Redis](https://docs.redhat.com/en/documentation/red_hat_connectivity_link/1.1/html/installing_connectivity_link_on_openshift/configure-redis_connectivity-link)
+- [Red Hat Connectivity Link - Configure Redis](https://docs.redhat.com/en/documentation/red_hat_connectivity_link/1.2/html/installing_on_openshift_container_platform/configure-redis_connectivity-link)
 
 ---
 
@@ -151,4 +151,4 @@ The script will:
 
 ## Related Documentation
 
-- [Red Hat Connectivity Link - Configure Redis](https://docs.redhat.com/en/documentation/red_hat_connectivity_link/1.1/html/installing_connectivity_link_on_openshift/configure-redis_connectivity-link) - Official Red Hat documentation for production Redis setup
+- [Red Hat Connectivity Link - Configure Redis](https://docs.redhat.com/en/documentation/red_hat_connectivity_link/1.2/html/installing_on_openshift_container_platform/configure-redis_connectivity-link) - Official Red Hat documentation for production Redis setup

--- a/docs/content/advanced-administration/observability.md
+++ b/docs/content/advanced-administration/observability.md
@@ -246,7 +246,7 @@ By default, Limitador stores rate-limiting counters in memory, which means:
 
 To enable persistent metric counts, refer to the detailed guide:
 
-**[Configuring Redis storage for rate limiting](https://docs.redhat.com/en/documentation/red_hat_connectivity_link/1.1/html/installing_connectivity_link_on_openshift/configure-redis_connectivity-link)**
+**[Configuring Redis storage for rate limiting](https://docs.redhat.com/en/documentation/red_hat_connectivity_link/1.2/html/installing_on_openshift_container_platform/configure-redis_connectivity-link)**
 
 This Red Hat documentation provides:
 


### PR DESCRIPTION
## Summary
Fix broken Red Hat Connectivity Link documentation URLs in the advanced administration docs.

## Description
The Red Hat Connectivity Link documentation has moved from version 1.1 to 1.2, and the URL path has changed from `installing_connectivity_link_on_openshift` to `installing_on_openshift_container_platform`. This PR updates all affected links to point to the correct location.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Verified that the old URLs return 404.
- Verified that the updated URLs resolve to the correct Red Hat documentation page.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated references to Redis storage and persistence guidance in advanced administration documentation to the latest available versions. The changes ensure users are directed to current best practices for configuring high availability metrics and persistent storage solutions, providing access to the most relevant and up-to-date guidance materials for implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->