### PR TITLE
docs: add upstream source links to release strategy table

### DIFF
--- a/docs/release-strategy.md
+++ b/docs/release-strategy.md
@@ -9,8 +9,8 @@ The release flow moves code through four stages, each mapped to a branch and env
 | Body of Water | Branch | Repository | Purpose |
 |---|---|---|---|
 | **Stream** | `main` | `opendatahub-io/models-as-a-service` | Active development — all feature work lands here |
-| **Lake** | `stable` | `opendatahub-io/models-as-a-service` | ODH quality-gated — validated and ready for ODH consumption |
-| **RHOAI** | `rhoai` | `opendatahub-io/models-as-a-service` | Created from stable — source for downstream RHOAI builds |
+| **Lake** | `stable` | `opendatahub-io/models-as-a-service` | Created from main — source for [upstream ODH](https://github.com/opendatahub-io/opendatahub-operator/blob/cd1a94b265255a80a127939fef901f2d630f7bc6/get_all_manifests.sh) builds |
+|  | `rhoai` | `opendatahub-io/models-as-a-service` | Created from stable — source for downstream RHOAI builds |
 | **Ocean** | `main` | `red-hat-data-services/models-as-a-service` | DevOps-owned — production RHOAI deliverables |
 
 


### PR DESCRIPTION
## Description

Add direct upstream source links to the release strategy documentation table for traceability.
Group `stable` and `rhoai` branches under the same "Lake" stage to better reflect the promotion flow.

## How it was tested
Documentation-only change.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reworked the release-strategy documentation: the Bodies of Water table now shows Lake as derived from main with an upstream link to upstream builds, RHOAI moved under Lake as a downstream entry with its link, and Ocean remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->