### PR TITLE
feat: propagate subscription selection errors with XSS-safe messages

### DIFF
--- a/maas-api/internal/subscription/selector.go
+++ b/maas-api/internal/subscription/selector.go
@@ -256,7 +256,7 @@ type SubscriptionNotFoundError struct {
 }
 
 func (e *SubscriptionNotFoundError) Error() string {
-	return fmt.Sprintf("subscription %q not found", e.Subscription)
+	return "requested subscription not found"
 }
 
 // AccessDeniedError indicates user doesn't have access to requested subscription.
@@ -265,7 +265,7 @@ type AccessDeniedError struct {
 }
 
 func (e *AccessDeniedError) Error() string {
-	return fmt.Sprintf("access denied to subscription %q", e.Subscription)
+	return "access denied to requested subscription"
 }
 
 // MultipleSubscriptionsError indicates user has access to multiple subscriptions and must explicitly select one.
@@ -274,5 +274,5 @@ type MultipleSubscriptionsError struct {
 }
 
 func (e *MultipleSubscriptionsError) Error() string {
-	return fmt.Sprintf("user has access to multiple subscriptions [%s], must specify subscription using X-MaaS-Subscription header", strings.Join(e.Subscriptions, ", "))
+	return "user has access to multiple subscriptions, must specify subscription using X-MaaS-Subscription header"
 }

--- a/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
@@ -221,22 +221,12 @@ func (r *MaaSAuthPolicyReconciler) reconcileModelAuthPolicies(ctx context.Contex
 		// Build authorization rules
 		authRules := make(map[string]interface{})
 
-		// Add subscription error check - deny if subscription selector returned an error
-		// Uses OPA Rego policy to check if error field exists in subscription-info metadata
-		// The policy allows requests only when the error field does not exist
-		// Custom denial message uses the error message from subscription selector
+		// Check for subscription selection errors and deny if present
 		authRules["subscription-error-check"] = map[string]interface{}{
 			"metrics":  false,
 			"priority": int64(0),
 			"opa": map[string]interface{}{
 				"rego": `allow { not object.get(input.auth.metadata["subscription-info"], "error", false) }`,
-			},
-			"when": []interface{}{
-				map[string]interface{}{
-					"selector": `has(auth.metadata["subscription-info"].error)`,
-					"operator": "eq",
-					"value":    "true",
-				},
 			},
 		}
 


### PR DESCRIPTION
Add custom denial responses to AuthPolicy that display specific error messages from the subscription selector instead of generic "Unauthorized". Users now see actionable error messages explaining why their request was denied (multiple subscriptions require selection, subscription not found, or access denied).

Follow-up to https://github.com/opendatahub-io/models-as-a-service/pull/427/
For https://issues.redhat.com/browse/RHOAIENG-49787

## Description
Error propagation:
- OPA authorization rule checks for subscription-info error field
- Custom denial responses use CEL expressions to extract error details
- Error message appears in response body
- Error code appears in x-ext-auth-reason header

XSS safety:
- Remove subscription names from all error messages
- Prevents XSS attacks if errors are displayed in browsers
- Subscription names remain in server-side logs for debugging

Error codes for programmatic handling: not_found, access_denied, multiple_subscriptions

## How Has This Been Tested?

<details>

<summary>Test Script</summary>

```
#!/bin/bash
set -e

GATEWAY_HOST="maas.$(kubectl get ingresses.config.openshift.io cluster -o jsonpath='{.spec.domain}')"
TOKEN=$(kubectl create token default -n default --audience="maas-default-gateway-sa" --duration=1h)

echo "=========================================================================="
echo "=== Custom Error Message Propagation Test                            ==="
echo "=========================================================================="
echo ""
echo "Gateway: $GATEWAY_HOST"
echo ""

# Test 1: Multiple subscriptions without header - should fail with custom error
echo "TEST 1: Multiple subscriptions without X-MaaS-Subscription header"
echo "Expected: HTTP 403 with 'multiple_subscriptions' error (no subscription names for consistency)"
echo ""
curl -sSk --max-time 30 "https://${GATEWAY_HOST}/llm/facebook-opt-125m-simulated/v1/chat/completions" \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{"model":"facebook/opt-125m","messages":[{"role":"user","content":"Test"}],"max_tokens":5}' \
  -i 2>&1 | grep -E "^(HTTP|x-ext-auth-reason|content-type)" | head -5
echo ""
curl -sSk --max-time 30 "https://${GATEWAY_HOST}/llm/facebook-opt-125m-simulated/v1/chat/completions" \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{"model":"facebook/opt-125m","messages":[{"role":"user","content":"Test"}],"max_tokens":5}' \
  2>&1
echo ""
echo "=========================================================================="
echo ""

# Test 2: With valid subscription header - should succeed
echo "TEST 2: Valid subscription with X-MaaS-Subscription: shared-premium"
echo "Expected: HTTP 200 with successful inference response"
echo ""
HTTP_CODE=$(curl -sSk --max-time 30 "https://${GATEWAY_HOST}/llm/facebook-opt-125m-simulated/v1/chat/completions" \
  -H "Authorization: Bearer $TOKEN" \
  -H "X-MaaS-Subscription: shared-premium" \
  -H "Content-Type: application/json" \
  -d '{"model":"facebook/opt-125m","messages":[{"role":"user","content":"Test"}],"max_tokens":5}' \
  -w "%{http_code}" -o /tmp/test2-response.json 2>/dev/null)

if [[ "$HTTP_CODE" == "200" ]]; then
  echo "✓ SUCCESS: HTTP 200"
  jq -r '.choices[0].message.content // "no content"' /tmp/test2-response.json 2>/dev/null || cat /tmp/test2-response.json
else
  echo "✗ FAILED: HTTP $HTTP_CODE"
  cat /tmp/test2-response.json
fi
echo ""
echo "=========================================================================="
echo ""

# Test 3: Non-existent subscription - should fail with custom error
echo "TEST 3: Non-existent subscription"
echo "Expected: HTTP 403 with 'not_found' error (no subscription name in message for XSS safety)"
echo ""
curl -sSk --max-time 30 "https://${GATEWAY_HOST}/llm/facebook-opt-125m-simulated/v1/chat/completions" \
  -H "Authorization: Bearer $TOKEN" \
  -H "X-MaaS-Subscription: non-existent-sub" \
  -H "Content-Type: application/json" \
  -d '{"model":"facebook/opt-125m","messages":[{"role":"user","content":"Test"}],"max_tokens":5}' \
  -i 2>&1 | grep -E "^(HTTP|x-ext-auth-reason)" | head -5
echo ""
curl -sSk --max-time 30 "https://${GATEWAY_HOST}/llm/facebook-opt-125m-simulated/v1/chat/completions" \
  -H "Authorization: Bearer $TOKEN" \
  -H "X-MaaS-Subscription: non-existent-sub" \
  -H "Content-Type: application/json" \
  -d '{"model":"facebook/opt-125m","messages":[{"role":"user","content":"Test"}],"max_tokens":5}' \
  2>&1
echo ""
echo "=========================================================================="
echo ""

# Test 4: Subscription user doesn't have access to - should fail with custom error
echo "TEST 4: Subscription user doesn't have access to"
echo "Requesting: simulator-subscription (requires basic-tier group)"
echo "User has: system:authenticated group only"
echo "Expected: HTTP 403 with 'access_denied' error (no subscription name in message for XSS safety)"
echo ""
curl -sSk --max-time 30 "https://${GATEWAY_HOST}/llm/facebook-opt-125m-simulated/v1/chat/completions" \
  -H "Authorization: Bearer $TOKEN" \
  -H "X-MaaS-Subscription: simulator-subscription" \
  -H "Content-Type: application/json" \
  -d '{"model":"facebook/opt-125m","messages":[{"role":"user","content":"Test"}],"max_tokens":5}' \
  -i 2>&1 | grep -E "^(HTTP|x-ext-auth-reason)" | head -5
echo ""
curl -sSk --max-time 30 "https://${GATEWAY_HOST}/llm/facebook-opt-125m-simulated/v1/chat/completions" \
  -H "Authorization: Bearer $TOKEN" \
  -H "X-MaaS-Subscription: simulator-subscription" \
  -H "Content-Type: application/json" \
  -d '{"model":"facebook/opt-125m","messages":[{"role":"user","content":"Test"}],"max_tokens":5}' \
  2>&1
echo ""
echo "=========================================================================="
echo ""

echo "✓ Error propagation test complete!"
echo ""
echo "Summary:"
echo "  TEST 1: Multiple subscriptions → HTTP 403 'multiple_subscriptions' (no names for XSS safety)"
echo "  TEST 2: Valid subscription → HTTP 200 (success)"
echo "  TEST 3: Non-existent subscription → HTTP 403 'not_found' (no names for XSS safety)"
echo "  TEST 4: Access denied → HTTP 403 'access_denied' (no names for XSS safety)"
echo ""

```
</details>

<details>

<summary>Test Output</summary>

```
==========================================================================
=== Custom Error Message Propagation Test                            ===
==========================================================================

Gateway: maas.apps.rosa.w33yo-7uiuz-hdr.jbid.p3.openshiftapps.com

TEST 1: Multiple subscriptions without X-MaaS-Subscription header
Expected: HTTP 403 with 'multiple_subscriptions' error (no subscription names for consistency)

HTTP/2 403 
content-type: text/plain
x-ext-auth-reason: multiple_subscriptions
x-ext-auth-reason: Unauthorized

user has access to multiple subscriptions, must specify subscription using X-MaaS-Subscription header
==========================================================================

TEST 2: Valid subscription with X-MaaS-Subscription: shared-premium
Expected: HTTP 200 with successful inference response

✓ SUCCESS: HTTP 200
Today it is partially 

==========================================================================

TEST 3: Non-existent subscription
Expected: HTTP 403 with 'not_found' error (no subscription name in message for XSS safety)

HTTP/2 403 
x-ext-auth-reason: not_found
x-ext-auth-reason: Unauthorized

requested subscription not found
==========================================================================

TEST 4: Subscription user doesn't have access to
Requesting: simulator-subscription (requires basic-tier group)
User has: system:authenticated group only
Expected: HTTP 403 with 'access_denied' error (no subscription name in message for XSS safety)

HTTP/2 403 
x-ext-auth-reason: access_denied
x-ext-auth-reason: Unauthorized

access denied to requested subscription
==========================================================================

✓ Error propagation test complete!

Summary:
  TEST 1: Multiple subscriptions → HTTP 403 'multiple_subscriptions' (no names for XSS safety)
  TEST 2: Valid subscription → HTTP 200 (success)
  TEST 3: Non-existent subscription → HTTP 403 'not_found' (no names for XSS safety)
  TEST 4: Access denied → HTTP 403 'access_denied' (no names for XSS safety)

```
</details>


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
