### PR TITLE
feat: (tekton) DO-NOT-MERGE: use revision param name in PR pipeline run

### DIFF
--- a/.tekton/odh-maas-api-pull-request.yaml
+++ b/.tekton/odh-maas-api-pull-request.yaml
@@ -8,6 +8,7 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/source-branch: '{{source_branch}}'
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
       in ["konflux-its", "stable", "rhoai", "v0.0.x"]
   creationTimestamp: null


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

rename git-rev to revision so the param matches what the central
pipeline (odh-konflux-central multi-arch-container-build) expects.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Renamed a CI/CD pipeline parameter from "git-rev" to "revision" to align naming conventions; parameter value reference unchanged.
  * Added a pipeline run metadata annotation to include the source branch, enabling clearer build/run traceability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->