### PR TITLE
fix: added admonition about outdated doc

### DIFF
--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -1,5 +1,8 @@
 # MaaS Platform Documentation
 
+!!! warning "Outdated Blog Post"
+    The blog post [Introducing Models-as-a-Service in OpenShift AI](https://developers.redhat.com/articles/2025/11/25/introducing-models-service-openshift-ai) references old URLs and contains broken instructions. Please use **this documentation** for up-to-date installation and configuration steps.
+
 Welcome to the Models-as-a-Service (MaaS) Platform documentation.
 
 The MaaS Platform enhances the model serving capabilities of [Open Data Hub](https://github.com/opendatahub-io) by adding a management layer for self-service access control, rate limiting, and tier-based subscriptions.


### PR DESCRIPTION
No jira or long description. 

Our article is outdated for now - https://developers.redhat.com/articles/2025/11/25/introducing-models-service-openshift-ai

While we are waiting for the update, we are adding the admonition that it is an outdated source.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a notice on affected documentation pages to alert users that the content may be outdated and to reference the current documentation for the latest information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->