### PR TITLE
fix: konflux does not run on push for main branch 

### DIFF
--- a/.tekton/odh-maas-api-push.yaml
+++ b/.tekton/odh-maas-api-push.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      in ["main", "stable", "rhoai", "v0.0.x"]
+      in ["konflux-its", "stable", "rhoai", "v0.0.x"]
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: opendatahub-builds


### PR DESCRIPTION
No longer run the Konflux pipeline on pushes to main branch for now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline configuration to target different branches for automated deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->