### PR TITLE
fix(docs): descriptions for the cpu model and mock inference in quickstart

### DIFF
--- a/docs/content/quickstart.md
+++ b/docs/content/quickstart.md
@@ -112,12 +112,16 @@ For detailed validation and troubleshooting, see the [Validation Guide](install/
 
 #### Simulator Model (CPU)
 
+A lightweight mock service for testing that generates responses without running an actual language model.
+
 ```bash
 PROJECT_DIR=$(git rev-parse --show-toplevel)
 kustomize build ${PROJECT_DIR}/docs/samples/models/simulator/ | kubectl apply -f -
 ```
 
 #### Facebook OPT-125M Model (CPU)
+
+An inference deployment that loads and runs a 125M parameter model without the need for a GPU.
 
 ```bash
 PROJECT_DIR=$(git rev-parse --show-toplevel)
@@ -126,8 +130,7 @@ kustomize build ${PROJECT_DIR}/docs/samples/models/facebook-opt-125m-cpu/ | kube
 
 #### Qwen3 Model (GPU Required)
 
-!!! warning
-    This model requires GPU nodes with `nvidia.com/gpu` resources available in your cluster.
+⚠️ This model requires GPU nodes with `nvidia.com/gpu` resources available in your cluster.
 
 ```bash
 PROJECT_DIR=$(git rev-parse --show-toplevel)


### PR DESCRIPTION
- Add some clarity about the difference between the CPU compatable models.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added brief descriptive text clarifying the Simulator Model (CPU) and Facebook OPT-125M Model (CPU) are lightweight/mock deployments.
  * Replaced the explicit warning block for the Qwen3 model with a concise emoji-based (⚠️) GPU requirement notice.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->