### PR TITLE
fix: found default incorrect images, fixing

### DIFF
--- a/maas-controller/Makefile
+++ b/maas-controller/Makefile
@@ -12,7 +12,7 @@ help:
 	@echo "  make manifests    - generate CRD manifests"
 	@echo "  make install      - apply config/default (CRDs, RBAC, deployment)"
 	@echo "  make uninstall    - delete config/default resources"
-	@echo "  make image-build  - build container image (podman/buildah/docker); default IMAGE=quay.io/maas/maas-controller (temporary)"
+	@echo "  make image-build  - build container image (podman/buildah/docker); default IMAGE=quay.io/opendatahub/maas-controller"
 	@echo "  make image-push   - build and push image; override with IMAGE=... IMAGE_TAG=..."
 
 BINARY_NAME := manager
@@ -20,8 +20,8 @@ BUILD_DIR := bin
 
 # Container build: use podman, buildah, or docker (default: podman if available, else buildah, else docker)
 CONTAINER_RUNTIME := $(shell command -v podman 1>/dev/null 2>&1 && echo podman || (command -v buildah 1>/dev/null 2>&1 && echo buildah || echo docker))
-# Default image; for now you can use quay.io/maas/maas-controller (temporary – replace with your own registry when ready)
-IMAGE ?= quay.io/maas/maas-controller
+# Default image
+IMAGE ?= quay.io/opendatahub/maas-controller
 IMAGE_TAG ?= latest
 FULL_IMAGE := $(IMAGE):$(IMAGE_TAG)
 

--- a/maas-controller/README.md
+++ b/maas-controller/README.md
@@ -187,7 +187,7 @@ kubectl get crd | grep maas.opendatahub.io
 |-----------|------|-------------|
 | CRDs | `config/crd/` | MaaSModelRef, MaaSAuthPolicy, MaaSSubscription |
 | RBAC | `config/rbac/` | ClusterRole, ServiceAccount, bindings |
-| Controller | `config/manager/` | Deployment (`quay.io/maas/maas-controller:latest`) |
+| Controller | `config/manager/` | Deployment (`quay.io/opendatahub/maas-controller:latest`) |
 | Default auth policy | `config/policies/` | Gateway-level AuthPolicy (deny unauthenticated, 401/403) |
 | Default deny policy | `config/policies/` | Gateway-level TokenRateLimitPolicy with 0 tokens (deny unsubscribed, 429) |
 
@@ -259,11 +259,11 @@ kubectl annotate authpolicy <name> -n <namespace> maas.opendatahub.io/managed-
 
 ## Build and push image
 
-The default deployment uses `quay.io/maas/maas-controller:latest` (temporary).
+The default deployment uses `quay.io/opendatahub/maas-controller:latest`.
 
 ```bash
 make -C maas-controller image-build                    # build with podman/buildah/docker
-make -C maas-controller image-push                     # push to quay.io/maas/maas-controller:latest
+make -C maas-controller image-push                     # push to quay.io/opendatahub/maas-controller:latest (this image is created automatically on main branch, so preferably push images with different tag and/or to your temp registry if you are doing some testing and verification)
 
 # Custom image/tag
 make -C maas-controller image-build IMAGE=quay.io/myorg/maas-controller IMAGE_TAG=v0.1.0
@@ -302,5 +302,5 @@ Check that the WasmPlugin exists: `kubectl get wasmplugins -n openshift-ingress`
 ## Configuration
 
 - **Controller namespace**: Default is `opendatahub`. Override via `kustomize build maas-controller/config/default | sed "s/namespace: opendatahub/namespace: <ns>/g" | kubectl apply -f -`.
-- **Image**: Default is `quay.io/maas/maas-controller:latest`. Override in the deployment or via Kustomize.
+- **Image**: Default is `quay.io/opendatahub/maas-controller:latest`. Override in the deployment or via Kustomize.
 - **Gateway name**: The default auth policy targets `maas-default-gateway` in `openshift-ingress`. Edit `config/policies/gateway-default-auth.yaml` if your gateway has a different name.

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -143,7 +143,7 @@ ADVANCED OPTIONS (PR Testing):
 
   --maas-controller-image <image>
       Custom MaaS controller container image (PR testing)
-      Example: quay.io/maas/maas-controller:pr-42
+      Example: quay.io/opendatahub/maas-controller:pr-406
 
   --channel <channel>
       Operator channel override


### PR DESCRIPTION
We had incorrect default images for maas-controller in docs and code (left from development stage), right now we have the latest image build on main branch on every merged PR - so it's better to use it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated container image repository references in deployment guides and configuration.

* **Chores**
  * Updated default container image source to new repository location across build and deployment configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->