### PR TITLE
feat: support /v1/models using api-keys

### DIFF
--- a/deployment/base/maas-api/policies/auth-policy.yaml
+++ b/deployment/base/maas-api/policies/auth-policy.yaml
@@ -8,19 +8,74 @@ spec:
     kind: HTTPRoute
     name: maas-api-route
   rules:
-    # Allow any authenticated user to access the API
     authentication:
+      # API key authentication (for sk-oai-* tokens)
+      api-keys:
+        when:
+          - predicate: request.headers.authorization.startsWith("Bearer sk-oai-")
+        plain:
+          selector: request.headers.authorization
+        priority: 0
+      # OpenShift token authentication (fallback for non-API-key tokens)
       openshift-identities:
         kubernetesTokenReview:
           audiences:
             - https://kubernetes.default.svc
             - maas-default-gateway-sa
+        priority: 1
+    metadata:
+      # Validate API key via HTTP callback (only runs for API key auth)
+      apiKeyValidation:
+        when:
+          - predicate: request.headers.authorization.startsWith("Bearer sk-oai-")
+        http:
+          url: https://maas-api.opendatahub.svc.cluster.local:8443/internal/v1/api-keys/validate
+          method: POST
+          contentType: application/json
+          body:
+            expression: '{"key": request.headers.authorization.replace("Bearer ", "")}'
+        priority: 0
+    authorization:
+      # Check API key is valid (only for API key auth)
+      api-key-valid:
+        when:
+          - predicate: request.headers.authorization.startsWith("Bearer sk-oai-")
+        patternMatching:
+          patterns:
+            - selector: auth.metadata.apiKeyValidation.valid
+              operator: eq
+              value: "true"
+        priority: 0
     response:
       success:
         headers:
+          # Username: from API key validation (when API key used)
           X-MaaS-Username:
+            when:
+              - predicate: request.headers.authorization.startsWith("Bearer sk-oai-")
+            plain:
+              selector: auth.metadata.apiKeyValidation.username
+            priority: 0
+          # Username: from OpenShift identity (when OC token used)
+          X-MaaS-Username-OC:
+            when:
+              - predicate: '!request.headers.authorization.startsWith("Bearer sk-oai-")'
             plain:
               selector: auth.identity.user.username
+            key: X-MaaS-Username
+            priority: 1
+          # Groups: from API key validation as JSON array (when API key used)
           X-MaaS-Group:
+            when:
+              - predicate: request.headers.authorization.startsWith("Bearer sk-oai-")
+            plain:
+              expression: '''["'' + auth.metadata.apiKeyValidation.groups.join(''","'') + ''"]'''
+            priority: 0
+          # Groups: from OpenShift identity as JSON array (when OC token used)
+          X-MaaS-Group-OC:
+            when:
+              - predicate: '!request.headers.authorization.startsWith("Bearer sk-oai-")'
             plain:
               selector: auth.identity.user.groups.@tostr
+            key: X-MaaS-Group
+            priority: 1


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds API key authentication support to the maas-api AuthPolicy, enabling users to access /v1/models and other maas-api endpoints using permanent API keys (sk-oai-* format) in addition to OpenShift tokens.



## How Has This Been Tested?
1. Create an API key (using OpenShift token)
```
curl -sSk -X POST "https://maas.apps.isequeir.dfhf.s1.devshift.org/maas-api/v1/api-keys" \
-H "Authorization: Bearer $(oc whoami -t)" \
-H "Content-Type: application/json" \
-d '{"name": "test-api-key", "description": "Testing API key with models endpoint"}'
```
Result: `HTTP 201`

2. Test /v1/models with API key
```
API_KEY="sk-oai-9Ocjyd0djaeXjrhvGI5yuGgPg2OPB1XJJvSAgOMK9z8"
curl -sSk "https://maas.apps.isequeir.dfhf.s1.devshift.org/maas-api/v1/models" \
-H "Authorization: Bearer $API_KEY" \
-H "Content-Type: application/json"
```
Before fix: `HTTP 401 Unauthorized`
After fix: `HTTP 200`

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Added API key-based authentication support using Bearer tokens
* Implemented remote API key validation capability
* Enhanced response headers to include authenticated user and group information based on the authentication method (API key or OpenShift token)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->