### PR TITLE
ci: restrict tekton pipelines to konflux-its branch only

### DIFF
--- a/.tekton/odh-maas-api-pull-request.yaml
+++ b/.tekton/odh-maas-api-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      in ["konflux-its", "stable", "rhoai", "v0.0.x"]
+      in ["konflux-its"]
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: opendatahub-builds

--- a/.tekton/odh-maas-api-push.yaml
+++ b/.tekton/odh-maas-api-push.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      in ["konflux-its", "stable", "rhoai", "v0.0.x"]
+      in ["konflux-its"]
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: opendatahub-builds


### PR DESCRIPTION
## Summary

Temporarily restrict Tekton pipelines to the `konflux-its` branch only, disabling triggers for `stable`, `rhoai`, and `v0.0.x`.

## Description

The Tekton pipelines (pull-request and push) are currently configured to trigger on multiple branches (`konflux-its`, `stable`, `rhoai`, `v0.0.x`). Since Konflux integration is still being validated, triggering on production/release branches is premature and can cause unnecessary pipeline runs or failures.

- Narrow the CEL expression in `odh-maas-api-pull-request.yaml` to `["konflux-its"]` only.
- Narrow the CEL expression in `odh-maas-api-push.yaml` to `["konflux-its"]` only.
- Once Konflux CI is validated end-to-end, the additional branches can be re-enabled.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined build pipeline trigger conditions to optimize CI/CD operations by restricting automated pipeline execution to specific target branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->