### PR TITLE
build(maas-controller): add tools.mk to maas-controller 

### DIFF
--- a/maas-controller/Makefile
+++ b/maas-controller/Makefile
@@ -52,10 +52,14 @@ $(CONTROLLER_GEN): | $(BUILD_DIR)
 	GOBIN=$(abspath $(BUILD_DIR)) go install sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_GEN_VERSION)
 
 LINT_FIX ?= false
-.PHONY: lint
 lint: $(GOLANGCI_LINT) ## Run golangci-lint (use LINT_FIX=true to fix lint issues)
+ifeq ($(LINT_FIX),true)
 	$(GOLANGCI_LINT) fmt
-	$(GOLANGCI_LINT) run $(if $(filter true,$(LINT_FIX)),--fix)
+	$(GOLANGCI_LINT) run --fix
+else
+	$(GOLANGCI_LINT) fmt --diff
+	$(GOLANGCI_LINT) run
+endif
 
 # Generate deepcopy code for API types
 generate: $(CONTROLLER_GEN)

--- a/maas-controller/tools.mk
+++ b/maas-controller/tools.mk
@@ -8,8 +8,10 @@ $(LOCALBIN):
 GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint
 
 GOLANGCI_LINT_VERSION ?= v2.6.2
-$(GOLANGCI_LINT): $(LOCALBIN)
+# Target the versioned binary so version bumps trigger reinstall
+$(GOLANGCI_LINT)-$(GOLANGCI_LINT_VERSION): $(LOCALBIN)
 	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
+$(GOLANGCI_LINT): $(GOLANGCI_LINT)-$(GOLANGCI_LINT_VERSION)
 
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
 # $1 - target path with name of binary (ideally with version)


### PR DESCRIPTION
## Summary
Add `tools.mk` to maas-controller for golangci-lint installation similar to `maas-api`.

## Description
- Introduce `tools.mk` that installs golangci-lint v2.6.2 into a local `bin/tools/` directory with version-based caching.
- Add a `lint` make target (`golangci-lint fmt` + `run`) with optional `LINT_FIX=true` for auto-fixing.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Ran `make lint` — confirmed golangci-lint is downloaded, cached, and runs against the codebase.
- Verified `bin/tools/` is covered by the root `.gitignore`.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated linting with an option to auto-fix formatting and lint issues, and surfaced a new lint command in the project tooling.
  * Introduced local tool installation and versioned binaries with symlink management to ensure reproducible, project-local developer tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->