### PR TITLE
fix: handle non-admin user tests for local e2e testing

### DIFF
--- a/test/e2e/scripts/prow_run_smoke_test.sh
+++ b/test/e2e/scripts/prow_run_smoke_test.sh
@@ -579,17 +579,13 @@ setup_test_tokens() {
         fi
     fi
     
-    # 3. Fallback for regular user: use current user's token (same as admin for local testing)
-    # Local runs typically use the same htpasswd user for both roles
+    # 3. Fallback for regular user: always use a separate SA to ensure distinct users
+    # This is required for IDOR tests that verify users cannot access each other's keys
     if [[ -z "$TOKEN" ]]; then
-        TOKEN=$(oc whoami -t 2>/dev/null || true)
-        if [[ -n "$TOKEN" ]]; then
-            echo "✅ Regular user token for $current_user (same as admin for local testing)"
-        else
-            echo "⚠️  No htpasswd token - using SA token (model catalog may be empty)"
-            setup_test_user "tester-regular-user" "view"
-            TOKEN=$(oc create token tester-regular-user -n default --duration=1h)
-        fi
+        echo "Creating separate SA token for regular user (required for IDOR tests)..."
+        setup_test_user "tester-regular-user" "view"
+        TOKEN=$(oc create token tester-regular-user -n default --duration=1h)
+        echo "✅ Regular user token for tester-regular-user (SA-based)"
     fi
     
     echo "Token setup complete (main session unchanged: $(oc whoami))"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When running e2e tests locally, few e2e tests are failing as the prow script is not able to accurately get the OC tokens for regular users. The PR tries to fix that issue and enables local testing of all test cases.

[RHOAIENG-52470](https://issues.redhat.com/browse/RHOAIENG-52470)

## How Has This Been Tested?
```
SKIP_DEPLOYMENT=true SKIP_VALIDATION=true ./test/e2e/scripts/prow_run_smoke_test.sh
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test credential isolation by ensuring distinct service account tokens for automated testing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->