### PR TITLE
chore: updating ODH to deploy maas-controller with the correct image

### DIFF
--- a/deployment/overlays/odh/kustomization.yaml
+++ b/deployment/overlays/odh/kustomization.yaml
@@ -85,6 +85,17 @@ replacements:
     kind: ConfigMap
     version: v1
     name: maas-parameters
+    fieldPath: data.maas-controller-image
+  targets:
+  - select:
+      kind: Deployment
+      name: maas-controller
+    fieldPaths:
+    - spec.template.spec.containers.[name=manager].image
+- source:
+    kind: ConfigMap
+    version: v1
+    name: maas-parameters
     fieldPath: data.gateway-namespace
   targets:
   - select:

--- a/deployment/overlays/odh/params.env
+++ b/deployment/overlays/odh/params.env
@@ -1,4 +1,5 @@
 maas-api-image=quay.io/opendatahub/maas-api:latest
+maas-controller-image=quay.io/opendatahub/maas-controller:latest
 gateway-namespace=openshift-ingress
 gateway-name=maas-default-gateway
 app-namespace=opendatahub


### PR DESCRIPTION
# Update ODH overlay to deploy maas-controller with the correct image

Adds maas-controller image parameterization to the ODH deployment overlay so the controller image can be set via `params.env`, consistent with maas-api.

**Changes:**
- Add `maas-controller-image` to `params.env` (default: `quay.io/opendatahub/maas-controller:latest`)
- Add Kustomize replacement to inject the image into the maas-controller Deployment
