### PR TITLE
docs: document to create 'llm' ns before deploying sample models

### DIFF
--- a/docs/samples/models/README.md
+++ b/docs/samples/models/README.md
@@ -16,6 +16,12 @@ This directory contains `LLMInferenceService`s for deploying sample models. Plea
 
 ### Basic Deployment
 
+Create the `llm` namespace where models are deployed (if it doesn't already exist):
+
+```bash
+kubectl create namespace llm
+```
+
 Deploy any model using:
 
 ```bash


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The documentation says to run the following in order to deploy the sample models while assuming that the target 'llm' namespace already exists:

kustomize build docs/samples/models/$MODEL_NAME | kubectl apply -f -

If the 'llm' namespace doesn't exist, the command fails.
Therefore, adding a note in the documentation about creating the 'llm' namespace first.

## How Has This Been Tested?
Tested manually

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added explicit Kubernetes namespace creation to deployment instructions so users are guided to create the required namespace if it doesn’t exist; improves setup clarity and reduces deployment friction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->