### PR TITLE
fix: resolve /v1/models empty results and null data bugs

### DIFF
--- a/maas-api/cmd/main.go
+++ b/maas-api/cmd/main.go
@@ -166,7 +166,7 @@ func registerHandlers(ctx context.Context, log *logger.Logger, router *gin.Engin
 
 	tokenHandler := token.NewHandler(log, cfg.Name)
 
-	modelsHandler := handlers.NewModelsHandler(log, modelManager, subscriptionSelector, cluster.MaaSModelRefLister, cfg.Namespace)
+	modelsHandler := handlers.NewModelsHandler(log, modelManager, subscriptionSelector, cluster.MaaSModelRefLister)
 
 	apiKeyService := api_keys.NewServiceWithLogger(store, cfg, log)
 	apiKeyHandler := api_keys.NewHandler(log, apiKeyService, cluster.AdminChecker)

--- a/maas-api/internal/config/cluster_config.go
+++ b/maas-api/internal/config/cluster_config.go
@@ -46,7 +46,7 @@ type maasModelRefLister struct {
 	lister cache.GenericLister
 }
 
-func (m *maasModelRefLister) List(namespace string) ([]*unstructured.Unstructured, error) {
+func (m *maasModelRefLister) List() ([]*unstructured.Unstructured, error) {
 	objs, err := m.lister.List(labels.Everything())
 	if err != nil {
 		return nil, err
@@ -57,9 +57,7 @@ func (m *maasModelRefLister) List(namespace string) ([]*unstructured.Unstructure
 		if !ok {
 			continue
 		}
-		if namespace != "" && u.GetNamespace() != namespace {
-			continue
-		}
+		// Return all MaaSModelRefs from all namespaces (no filtering)
 		out = append(out, u)
 	}
 	return out, nil

--- a/maas-api/internal/handlers/models.go
+++ b/maas-api/internal/handlers/models.go
@@ -20,7 +20,6 @@ type ModelsHandler struct {
 	subscriptionSelector *subscription.Selector
 	logger               *logger.Logger
 	maasModelRefLister   models.MaaSModelRefLister
-	maasModelNamespace   string
 }
 
 // NewModelsHandler creates a new models handler.
@@ -30,7 +29,6 @@ func NewModelsHandler(
 	modelMgr *models.Manager,
 	subscriptionSelector *subscription.Selector,
 	maasModelRefLister models.MaaSModelRefLister,
-	maasModelNamespace string,
 ) *ModelsHandler {
 	if log == nil {
 		log = logger.Production()
@@ -40,7 +38,6 @@ func NewModelsHandler(
 		subscriptionSelector: subscriptionSelector,
 		logger:               log,
 		maasModelRefLister:   maasModelRefLister,
-		maasModelNamespace:   maasModelNamespace,
 	}
 }
 
@@ -158,10 +155,11 @@ func (h *ModelsHandler) ListLLMs(c *gin.Context) {
 		selectedSubscription = requestedSubscription
 	}
 
-	var modelList []models.Model
-	if h.maasModelRefLister != nil && h.maasModelNamespace != "" {
-		h.logger.Debug("Listing models from MaaSModelRef cache", "namespace", h.maasModelNamespace)
-		list, err := models.ListFromMaaSModelRefLister(h.maasModelRefLister, h.maasModelNamespace)
+	// Initialize to empty slice (not nil) so JSON marshals as [] instead of null
+	modelList := []models.Model{}
+	if h.maasModelRefLister != nil {
+		h.logger.Debug("Listing models from MaaSModelRef cache (all namespaces)")
+		list, err := models.ListFromMaaSModelRefLister(h.maasModelRefLister)
 		if err != nil {
 			h.logger.Error("Listing from MaaSModelRef failed", "error", err)
 			c.JSON(http.StatusInternalServerError, gin.H{
@@ -175,7 +173,7 @@ func (h *ModelsHandler) ListLLMs(c *gin.Context) {
 		modelList = h.modelMgr.FilterModelsByAccess(c.Request.Context(), list, authHeader, selectedSubscription)
 		h.logger.Debug("Access validation complete", "listed", len(list), "accessible", len(modelList))
 	} else {
-		h.logger.Debug("MaaSModelRef not configured (lister or namespace unset), returning empty model list")
+		h.logger.Debug("MaaSModelRef lister not configured, returning empty model list")
 	}
 
 	h.logger.Debug("GET /v1/models returning models", "count", len(modelList))

--- a/maas-api/internal/handlers/models_test.go
+++ b/maas-api/internal/handlers/models_test.go
@@ -55,14 +55,13 @@ func maasModelRefUnstructured(name, namespace, endpoint string, ready bool) *uns
 // fakeMaaSModelRefLister implements models.MaaSModelRefLister for tests (namespace -> items).
 type fakeMaaSModelRefLister map[string][]*unstructured.Unstructured
 
-func (f fakeMaaSModelRefLister) List(namespace string) ([]*unstructured.Unstructured, error) {
-	items := f[namespace]
-	if items == nil {
-		return nil, nil
-	}
-	out := make([]*unstructured.Unstructured, len(items))
-	for i, u := range items {
-		out[i] = u.DeepCopy()
+func (f fakeMaaSModelRefLister) List() ([]*unstructured.Unstructured, error) {
+	// Return all items from all namespaces
+	var out []*unstructured.Unstructured
+	for _, items := range f {
+		for _, u := range items {
+			out = append(out, u.DeepCopy())
+		}
 	}
 	return out, nil
 }
@@ -324,7 +323,7 @@ func TestListingModels(t *testing.T) {
 	// Create a mock subscription selector that auto-selects for single subscription users
 	subscriptionSelector := subscription.NewSelector(testLogger, &fakeSubscriptionLister{})
 
-	modelsHandler := handlers.NewModelsHandler(testLogger, modelMgr, subscriptionSelector, maasModelRefLister, fixtures.TestNamespace)
+	modelsHandler := handlers.NewModelsHandler(testLogger, modelMgr, subscriptionSelector, maasModelRefLister)
 
 	// Create token handler to extract user info middleware
 	tokenHandler := token.NewHandler(testLogger, fixtures.TestTenant)
@@ -431,7 +430,7 @@ func TestListingModelsWithSubscriptionHeader(t *testing.T) {
 	}
 	subscriptionSelector := subscription.NewSelector(testLogger, multiSubLister)
 
-	modelsHandler := handlers.NewModelsHandler(testLogger, modelMgr, subscriptionSelector, maasModelRefLister, fixtures.TestNamespace)
+	modelsHandler := handlers.NewModelsHandler(testLogger, modelMgr, subscriptionSelector, maasModelRefLister)
 	tokenHandler := token.NewHandler(testLogger, fixtures.TestTenant)
 
 	v1 := router.Group("/v1")

--- a/maas-api/internal/models/discovery.go
+++ b/maas-api/internal/models/discovery.go
@@ -72,7 +72,8 @@ func (m *Manager) FilterModelsByAccess(ctx context.Context, models []Model, auth
 		return models
 	}
 	m.logger.Debug("FilterModelsByAccess: validating access for models", "count", len(models), "subscriptionHeaderProvided", subscriptionHeader != "")
-	var out []Model
+	// Initialize to empty slice (not nil) so JSON marshals as [] instead of null when no models are accessible
+	out := []Model{}
 	var mu sync.Mutex
 	g, ctx := errgroup.WithContext(ctx)
 	g.SetLimit(maxDiscoveryConcurrency)

--- a/maas-api/internal/models/maasmodelref.go
+++ b/maas-api/internal/models/maasmodelref.go
@@ -17,16 +17,16 @@ const (
 
 // MaaSModelRefLister lists MaaSModelRef CRs from a cache (e.g. informer-backed). Used for GET /v1/models.
 type MaaSModelRefLister interface {
-	// List returns MaaSModelRef unstructured items in the given namespace.
-	List(namespace string) ([]*unstructured.Unstructured, error)
+	// List returns all MaaSModelRef unstructured items from all namespaces.
+	List() ([]*unstructured.Unstructured, error)
 }
 
 // ListFromMaaSModelRefLister converts cached MaaSModelRef items to API models. Uses status.endpoint and status.phase.
-func ListFromMaaSModelRefLister(lister MaaSModelRefLister, namespace string) ([]Model, error) {
-	if lister == nil || namespace == "" {
+func ListFromMaaSModelRefLister(lister MaaSModelRefLister) ([]Model, error) {
+	if lister == nil {
 		return nil, nil
 	}
-	items, err := lister.List(namespace)
+	items, err := lister.List()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
 <!--- Provide a general summary of your changes in the Title above -->                                                                                                                
   
  ## Description                                                                                                                                                                        
  <!--- Describe your changes in detail -->

  This PR fixes two related bugs in the `/v1/models` endpoint:

  ### Bug 1: Empty Results ([RHOAIENG-52646](https://issues.redhat.com/browse/RHOAIENG-52646))

  **Problem:** `/v1/models` returned empty list `{"data": []}` even when MaaSModelRefs existed and users had proper authorization.

  **Root Cause:** The maas-api searched for MaaSModelRefs only in its own namespace (`opendatahub`), but after PR #483, all MaaSModelRefs are deployed in the `llm` namespace (where
  models live). The informer watches all namespaces, but the code filtered results to only include models from a single namespace.

  **Solution:** Remove namespace filtering entirely. Since models can be deployed in any namespace, the `/v1/models` endpoint now returns models from all namespaces that are accessible
   to the user.

  **Changes:**
  - Remove `maasModelNamespace` parameter from `ModelsHandler`
  - Remove `namespace` parameter from `MaaSModelRefLister` interface
  - Remove namespace filtering logic in `cluster_config.go`
  - Update unit tests to match new interface

  ### Bug 2: Null Data ([RHOAIENG-52505](https://issues.redhat.com/browse/RHOAIENG-52505))

  **Problem:** `/v1/models` returned `{"data": null}` instead of `{"data": []}` when users had no accessible models.

  **Root Cause:** Two locations initialized model slices using `var modelList []Model` (nil slice) instead of `modelList := []Model{}` (empty slice). In Go, nil slices marshal to JSON
  `null` while empty slices marshal to `[]`.

  **Solution:** Initialize model slices to empty slices in both locations:
  - `handlers/models.go`: Initialize `modelList` at declaration
  - `models/discovery.go`: Initialize `out` in `FilterModelsByAccess`

  **Changes:**
  - `handlers/models.go:159`: `modelList := []models.Model{}`
  - `models/discovery.go:75`: `out := []Model{}`

  ## How Has This Been Tested?
  <!--- Please describe in detail how you tested your changes. -->
  <!--- Include details of your testing environment, and the tests you ran to -->
  <!--- see how your change affects other areas of the code, etc. -->

  **Unit Tests:**
  ```bash
  cd maas-api
  go test ./internal/handlers/... -v
  go test ./internal/models/... -v
  All existing tests pass with updated interfaces.

  E2E Tests:  Using new tests from https://github.com/opendatahub-io/models-as-a-service/pull/509
  cd test/e2e
  ./scripts/prow_run_smoke_test.sh

  Results:
  - test_single_subscription_auto_select: ✅ XPASS (now returns models from all namespaces)
  - test_explicit_subscription_header: ✅ XPASS (now returns models from all namespaces)
  - test_empty_model_list: ✅ XPASS (now returns [] instead of null)
  - All other /v1/models tests: ✅ PASS

  Manual Testing:
  1. Deployed fix to test cluster
  2. Created test service account with no model access
  3. Verified /v1/models returns {"object": "list", "data": []} (not null)
  4. Created service account with model access in llm namespace
  5. Verified /v1/models returns models from llm namespace (not empty)

  Environment:
  - OpenShift cluster with MaaS components deployed
  - maas-controller watching models-as-a-service namespace
  - Models deployed in llm namespace (post PR #483)
  - Kuadrant/Authorino for authorization
  - PostgreSQL backend for API key storage


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed JSON responses returning null for empty model lists; now correctly returns empty arrays.

* **Refactor**
  * Simplified model listing to retrieve models across all namespaces instead of single namespace filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->