### PR TITLE
fix: fixing konflux test

### DIFF
--- a/test/e2e/scripts/prow_run_smoke_test.sh
+++ b/test/e2e/scripts/prow_run_smoke_test.sh
@@ -473,34 +473,76 @@ run_e2e_tests() {
 }
 
 
+# Namespace for admin SA in SA fallback (avoids both admin+regular in default → both would be admin)
+E2E_ADMIN_SA_NAMESPACE="${E2E_ADMIN_SA_NAMESPACE:-maas-admin}"
+
 setup_test_user() {
     local username="$1"
     local cluster_role="$2"
+    local namespace="${3:-default}"
+    
+    # Create namespace if it doesn't exist
+    if ! oc get namespace "$namespace" &>/dev/null; then
+        echo "Creating namespace: $namespace"
+        oc create namespace "$namespace"
+    fi
     
     # Check and create service account
-    if ! oc get serviceaccount "$username" -n default >/dev/null 2>&1; then
-        echo "Creating service account: $username"
-        oc create serviceaccount "$username" -n default
+    if ! oc get serviceaccount "$username" -n "$namespace" >/dev/null 2>&1; then
+        echo "Creating service account: $username in $namespace"
+        oc create serviceaccount "$username" -n "$namespace"
     else
-        echo "Service account $username already exists"
+        echo "Service account $username already exists in $namespace"
     fi
     
     # Check and create cluster role binding
     if ! oc get clusterrolebinding "${username}-binding" >/dev/null 2>&1; then
         echo "Creating cluster role binding for $username"
-        oc adm policy add-cluster-role-to-user "$cluster_role" "system:serviceaccount:default:$username"
+        oc adm policy add-cluster-role-to-user "$cluster_role" "system:serviceaccount:${namespace}:${username}"
     else
         echo "Cluster role binding for $username already exists"
     fi
     
-    echo "✅ User setup completed: $username"
+    echo "✅ User setup completed: $username (namespace: $namespace)"
+}
+
+# Patch Auth CR to add system:serviceaccounts:${admin_namespace} so SA-based admin token works.
+# maas-api AdminChecker checks user.Groups against Auth CR spec.adminGroups.
+# SA in namespace X has groups: system:serviceaccounts, system:serviceaccounts:X.
+# We use a dedicated admin namespace (maas-admin) so the regular user (in default) is NOT admin.
+_patch_auth_cr_for_sa_admin() {
+    local admin_namespace="${1:-$E2E_ADMIN_SA_NAMESPACE}"
+    local admin_group="system:serviceaccounts:${admin_namespace}"
+    
+    local auth_cr
+    for gvr in "auths.services.platform.opendatahub.io" "auths.platform.opendatahub.io"; do
+        if oc get "$gvr" auth &>/dev/null; then
+            auth_cr="$gvr"
+            break
+        fi
+    done
+    if [[ -z "$auth_cr" ]]; then
+        echo "⚠️  Auth CR not found - admin tests may fail (SA token not in adminGroups)"
+        return 0
+    fi
+    local current
+    current=$(oc get "$auth_cr" auth -o jsonpath='{.spec.adminGroups[*]}' 2>/dev/null || true)
+    if [[ "$current" == *"${admin_group}"* ]]; then
+        echo "✅ Auth CR already has ${admin_group} in adminGroups"
+        return 0
+    fi
+    if oc patch "$auth_cr" auth --type=json -p="[{\"op\": \"add\", \"path\": \"/spec/adminGroups/-\", \"value\": \"${admin_group}\"}]" 2>/dev/null; then
+        echo "✅ Added ${admin_group} to Auth CR adminGroups (SA admin fallback)"
+    else
+        echo "⚠️  Failed to patch Auth CR - admin tests may fail"
+    fi
 }
 
 setup_test_tokens() {
     # ═══════════════════════════════════════════════════════════════════════════
     # Extract test tokens WITHOUT switching the main oc session.
     # 
-    # Architecture:
+    # Architecture: 
     #   - Main oc session stays as system:admin (for any cluster operations)
     #   - Test tokens are extracted into env vars using a TEMPORARY kubeconfig
     #   - Tests use TOKEN/ADMIN_OC_TOKEN env vars for API authentication
@@ -576,18 +618,22 @@ setup_test_tokens() {
             echo "✅ Admin token for $current_user (added to odh-admins)"
         else
             echo "⚠️  No htpasswd token available - using SA token (admin tests may fail)"
-            setup_test_user "tester-admin-user" "cluster-admin"
-            ADMIN_OC_TOKEN=$(oc create token tester-admin-user -n default --duration=1h)
+            setup_test_user "tester-admin-user" "cluster-admin" "$E2E_ADMIN_SA_NAMESPACE"
+            # maas-api AdminChecker uses Auth CR adminGroups; SA in maas-admin has system:serviceaccounts:maas-admin
+            # Patch Auth CR so only tester-admin-user is admin (regular user stays in default → not admin)
+            _patch_auth_cr_for_sa_admin "$E2E_ADMIN_SA_NAMESPACE"
+            ADMIN_OC_TOKEN=$(oc create token tester-admin-user -n "$E2E_ADMIN_SA_NAMESPACE" --duration=1h)
         fi
     fi
     
     # 3. Fallback for regular user: always use a separate SA to ensure distinct users
     # This is required for IDOR tests that verify users cannot access each other's keys
+    # Regular user stays in default namespace (system:serviceaccounts:default) - NOT in adminGroups
     if [[ -z "$TOKEN" ]]; then
         echo "Creating separate SA token for regular user (required for IDOR tests)..."
-        setup_test_user "tester-regular-user" "view"
+        setup_test_user "tester-regular-user" "view" "default"
         TOKEN=$(oc create token tester-regular-user -n default --duration=1h)
-        echo "✅ Regular user token for tester-regular-user (SA-based)"
+        echo "✅ Regular user token for tester-regular-user (SA-based, namespace: default)"
     fi
     
     echo "Token setup complete (main session unchanged: $(oc whoami))"


### PR DESCRIPTION
Patching the `Auth` cr object to include the group of the SA account that is designated admin.

Also putting the admin account in its own namespace so it gets a unique group.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced E2E test infrastructure with dedicated admin service account namespace isolation for improved test isolation.
  * Implemented namespace-aware test account setup with automatic namespace creation and configuration patching.
  * Improved separation between admin and regular user test accounts for more comprehensive testing coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->