### PR TITLE
chore: added e2e test to validate 429 rate limiting when token limit is exceeded

### DIFF
--- a/test/e2e/tests/test_subscription.py
+++ b/test/e2e/tests/test_subscription.py
@@ -735,6 +735,116 @@ class TestSubscriptionEnforcement:
         r = _inference(api_key, extra_headers={"x-maas-subscription": SIMULATOR_SUBSCRIPTION})
         assert r.status_code == 200, f"Expected 200, got {r.status_code}: {r.text[:200]}"
 
+    def test_rate_limit_exhaustion_gets_429(self):
+        """
+        Test that a user gets 429 when they actually exceed their token rate limit.
+
+        This test creates a dedicated subscription with a very low token limit,
+        sends enough requests to exhaust it, and verifies a 429 response.
+
+        Uses the unconfigured model to avoid interfering with other tests.
+        """
+        # Use unconfigured model to isolate this test
+        model_ref = UNCONFIGURED_MODEL_REF
+        model_path = UNCONFIGURED_MODEL_PATH
+
+        # Create unique subscription and auth policy names
+        auth_policy_name = "e2e-rate-limit-test-auth"
+        subscription_name = "e2e-rate-limit-test-subscription"
+
+        # Very low limit for fast test: 15 tokens/min with max_tokens=3 per request
+        # Expected behavior:
+        #   - Requests 1-5 succeed (use 15 tokens total)
+        #   - Request 6 gets 429 (would need 18 tokens total)
+        token_limit = 15
+        window = "1m"
+        max_tokens = 3  # Explicitly track tokens per request for clarity
+
+        try:
+            # 1. Create auth policy allowing system:authenticated
+            _create_test_auth_policy(
+                name=auth_policy_name,
+                model_refs=[model_ref],
+                groups=["system:authenticated"]
+            )
+            _wait_reconcile()
+
+            # 2. Create subscription with low token limit
+            _create_test_subscription(
+                name=subscription_name,
+                model_refs=[model_ref],
+                groups=["system:authenticated"],
+                token_limit=token_limit,
+                window=window
+            )
+            _wait_reconcile()
+
+            # 3. Get API key for testing
+            api_key = _get_default_api_key()
+
+            # 4. Send requests to exhaust the limit
+            # Calculate expected successful requests: token_limit / max_tokens = 15 / 3 = 5
+            expected_success = token_limit // max_tokens
+            # Send 2 extra requests to ensure we hit the limit
+            total_requests = expected_success + 2
+
+            rate_limited = False
+            success_count = 0
+
+            for i in range(total_requests):
+                r = _inference(api_key, path=model_path, subscription=subscription_name)
+                request_num = i + 1
+                log.info(f"Request {request_num}/{total_requests}: {r.status_code}")
+
+                if r.status_code == 200:
+                    success_count += 1
+                elif r.status_code == 429:
+                    rate_limited = True
+                    log.info(f"Rate limit exceeded after {success_count} successful requests "
+                            f"({success_count * max_tokens} tokens used)")
+
+                    # Verify we hit the limit at approximately the right point (±1 for rounding)
+                    assert abs(success_count - expected_success) <= 1, \
+                        f"Expected ~{expected_success} successful requests before 429, got {success_count}"
+
+                    # Verify it's a rate limit 429, not a subscription error
+                    response_text = r.text.lower() if r.text else ""
+                    # Rate limit 429s typically mention "rate", "limit", or "quota"
+                    # Subscription 429s mention "subscription" without "rate"
+                    is_rate_limit_error = any(keyword in response_text
+                                             for keyword in ["rate", "limit", "quota", "too many"])
+                    is_subscription_error = "subscription" in response_text and not is_rate_limit_error
+
+                    assert is_rate_limit_error or not is_subscription_error, \
+                        f"Expected rate limit 429, not subscription error. Response: {r.text[:500]}"
+
+                    # Check for Retry-After header (optional but good practice)
+                    retry_after = r.headers.get("Retry-After") or r.headers.get("retry-after")
+                    if retry_after:
+                        log.info(f"Retry-After header present: {retry_after}")
+
+                    break
+                else:
+                    # Unexpected status code
+                    raise AssertionError(f"Unexpected status {r.status_code} at request {request_num}: {r.text[:200]}")
+
+                # Brief pause to avoid overwhelming the system, but stay within the window
+                time.sleep(0.1)
+
+            assert rate_limited, \
+                f"Expected 429 after ~{expected_success} requests with {token_limit} tokens/{window} limit, " \
+                f"but got {success_count} successful requests without hitting limit"
+
+            # Note: Skipping rate limit reset test to keep test fast (<5s)
+            # Reset behavior is tested manually via scripts/test-rate-limit.sh
+
+        finally:
+            # Clean up in reverse order of creation
+            _delete_cr("maassubscription", subscription_name)
+            _delete_cr("maasauthpolicy", auth_policy_name)
+            _wait_reconcile()
+            log.info("Cleaned up rate limit test resources")
+
 
 class TestMultipleSubscriptionsPerModel:
     """Multiple subscriptions for one model — API key in ONE subscription should get access.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Related to https://issues.redhat.com/browse/RHOAIENG-51958

Our current e2e tests only validate 429 responses for missing/invalid subscriptions (no subscription, wrong subscription header). We don't have a test that verifies a user gets 429 when they actually exceed their token rate limit.

This gap was discovered when the shared simulator-subscription (100 tokens/min) caused flaky 429s in unrelated tests.

**Acceptance criteria:**

- Add a test that creates a subscription with a deliberately low token limit (e.g., 100 tokens/min).
- Send enough requests to exceed the limit.
- Assert that the response is 429.
- We should avoid interfering with other tests.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested on cluster - https://console-openshift-console.apps.ci-ln-tmqjkpb-76ef8.aws-4.ci.openshift.org

```
somyabhatnagar@Somyas-MacBook-Pro models-as-a-service % cd /Users/somyabhatnagar/Documents/Projects/redhat/models-as-a-service/test/e2e && ./run-tests-quick.sh
      tests/test_subscription.py::TestSubscriptionEnforcement::test_rate_limit_exhaustion_gets_429 -v
==========================================
Quick E2E Test Runner
==========================================

Environment:
  GATEWAY_HOST: maas.apps.ci-ln-tmqjkpb-76ef8.aws-4.ci.openshift.org
  DEPLOYMENT_NAMESPACE: opendatahub
  MAAS_SUBSCRIPTION_NAMESPACE: models-as-a-service
  MAAS_API_BASE_URL: https://maas.apps.ci-ln-tmqjkpb-76ef8.aws-4.ci.openshift.org/maas-api
  TOKEN: sha256~UEcYhFLTEY5xL...

Running tests...

======================================================= test session starts ========================================================
platform darwin -- Python 3.13.3, pytest-8.4.2, pluggy-1.6.0 -- /Users/somyabhatnagar/Documents/Projects/redhat/models-as-a-service/test/e2e/.venv/bin/python
cachedir: .pytest_cache
metadata: {'Python': '3.13.3', 'Platform': 'macOS-15.7.4-arm64-arm-64bit-Mach-O', 'Packages': {'pytest': '8.4.2', 'pluggy': '1.6.0'}, 'Plugins': {'metadata': '3.1.1', 'html': '4.2.0'}}
rootdir: /Users/somyabhatnagar/Documents/Projects/redhat/models-as-a-service/test/e2e
plugins: metadata-3.1.1, html-4.2.0
collected 61 items                                                                                                                 

tests/test_api_keys.py::TestAPIKeyCRUD::test_create_api_key PASSED                                                           [  1%]
tests/test_api_keys.py::TestAPIKeyCRUD::test_list_api_keys PASSED                                                            [  3%]
tests/test_api_keys.py::TestAPIKeyCRUD::test_revoke_api_key PASSED                                                           [  4%]
tests/test_api_keys.py::TestAPIKeyAuthorization::test_admin_manage_other_users_keys PASSED                                   [  6%]
tests/test_api_keys.py::TestAPIKeyAuthorization::test_non_admin_cannot_access_other_users_keys FAILED                        [  8%]
tests/test_api_keys.py::TestAPIKeyBulkOperations::test_bulk_revoke_own_keys PASSED                                           [  9%]
tests/test_api_keys.py::TestAPIKeyBulkOperations::test_bulk_revoke_other_user_forbidden PASSED                               [ 11%]
tests/test_api_keys.py::TestAPIKeyBulkOperations::test_bulk_revoke_admin_can_revoke_any_user PASSED                          [ 13%]
tests/test_api_keys.py::TestAPIKeyExpiration::test_create_key_within_expiration_limit SKIPPED (API_KEY_MAX_EXPIRATION_DA...) [ 14%]
tests/test_api_keys.py::TestAPIKeyExpiration::test_create_key_at_expiration_limit SKIPPED (API_KEY_MAX_EXPIRATION_DAYS n...) [ 16%]
tests/test_api_keys.py::TestAPIKeyExpiration::test_create_key_exceeds_expiration_limit SKIPPED (API_KEY_MAX_EXPIRATION_D...) [ 18%]
tests/test_api_keys.py::TestAPIKeyExpiration::test_create_key_without_expiration SKIPPED (API_KEY_MAX_EXPIRATION_DAYS no...) [ 19%]
tests/test_api_keys.py::TestAPIKeyExpiration::test_create_key_with_short_expiration PASSED                                   [ 21%]
tests/test_api_keys.py::TestAPIKeyModelInference::test_api_key_model_access_success PASSED                                   [ 22%]
tests/test_api_keys.py::TestAPIKeyModelInference::test_invalid_api_key_rejected PASSED                                       [ 24%]
tests/test_api_keys.py::TestAPIKeyModelInference::test_no_auth_header_rejected PASSED                                        [ 26%]
tests/test_api_keys.py::TestAPIKeyModelInference::test_revoked_api_key_rejected PASSED                                       [ 27%]
tests/test_api_keys.py::TestAPIKeyModelInference::test_api_key_chat_completions PASSED                                       [ 29%]
tests/test_api_keys.py::TestAPIKeyModelInference::test_api_key_with_explicit_subscription_header PASSED                      [ 31%]
tests/test_api_keys.py::TestAPIKeyModelInference::test_api_key_with_invalid_subscription_header PASSED                       [ 32%]
tests/test_namespace_scoping.py::TestCrossNamespaceAuthPolicy::test_auth_policy_in_different_namespace PASSED                [ 34%]
tests/test_namespace_scoping.py::TestCrossNamespaceAuthPolicy::test_multiple_policies_different_namespaces_same_model PASSED [ 36%]
tests/test_namespace_scoping.py::TestCrossNamespaceSubscription::test_subscription_in_different_namespace FAILED             [ 37%]
tests/test_namespace_scoping.py::TestCrossNamespaceSubscription::test_multiple_subscriptions_different_namespaces_same_model FAILED [ 39%]
tests/test_namespace_scoping.py::TestAuthorizationBoundary::test_model_isolation_between_namespaces PASSED                   [ 40%]
tests/test_smoke.py::test_healthz_or_404 PASSED                                                                              [ 42%]
tests/test_smoke.py::test_tokens_endpoint_replaced_by_api_keys PASSED                                                        [ 44%]
tests/test_smoke.py::test_models_catalog PASSED                                                                              [ 45%]
tests/test_smoke.py::test_chat_completions_gateway_alive PASSED                                                              [ 47%]
tests/test_smoke.py::test_legacy_completions_optionally PASSED                                                               [ 49%]
tests/test_subscription.py::TestAuthEnforcement::test_authorized_user_gets_200 PASSED                                        [ 50%]
tests/test_subscription.py::TestAuthEnforcement::test_no_auth_gets_401 PASSED                                                [ 52%]
tests/test_subscription.py::TestAuthEnforcement::test_invalid_token_gets_403 PASSED                                          [ 54%]
tests/test_subscription.py::TestAuthEnforcement::test_wrong_group_gets_403 PASSED                                            [ 55%]
tests/test_subscription.py::TestSubscriptionEnforcement::test_subscribed_user_gets_200 PASSED                                [ 57%]
tests/test_subscription.py::TestSubscriptionEnforcement::test_auth_pass_no_subscription_gets_403 PASSED                      [ 59%]
tests/test_subscription.py::TestSubscriptionEnforcement::test_invalid_subscription_header_gets_429 PASSED                    [ 60%]
tests/test_subscription.py::TestSubscriptionEnforcement::test_explicit_subscription_header_works PASSED                      [ 62%]
tests/test_subscription.py::TestSubscriptionEnforcement::test_rate_limit_exhaustion_gets_429 PASSED                          [ 63%]
tests/test_subscription.py::TestMultipleSubscriptionsPerModel::test_user_in_one_of_two_subscriptions_gets_200 PASSED         [ 65%]
tests/test_subscription.py::TestMultipleSubscriptionsPerModel::test_multi_tier_auto_select_highest PASSED                    [ 67%]
tests/test_subscription.py::TestMultipleAuthPoliciesPerModel::test_two_auth_policies_or_logic PASSED                         [ 68%]
tests/test_subscription.py::TestMultipleAuthPoliciesPerModel::test_delete_one_auth_policy_other_still_works PASSED           [ 70%]
tests/test_subscription.py::TestCascadeDeletion::test_delete_subscription_rebuilds_trlp PASSED                               [ 72%]
tests/test_subscription.py::TestCascadeDeletion::test_delete_last_subscription_denies_access PASSED                          [ 73%]
tests/test_subscription.py::TestOrderingEdgeCases::test_subscription_before_auth_policy PASSED                               [ 75%]
tests/test_subscription.py::TestManagedAnnotation::test_authpolicy_managed_false_prevents_update PASSED                      [ 77%]
tests/test_subscription.py::TestManagedAnnotation::test_trlp_managed_false_prevents_update PASSED                            [ 78%]
tests/test_subscription.py::TestMaasSubscriptionNamespace::test_authpolicy_and_subscription_in_maas_subscription_namespace PASSED [ 80%]
tests/test_subscription.py::TestMaasSubscriptionNamespace::test_authpolicy_and_subscription_in_another_namespace PASSED      [ 81%]
tests/test_subscription.py::TestE2ESubscriptionFlow::test_e2e_with_both_access_and_subscription_gets_200 PASSED              [ 83%]
tests/test_subscription.py::TestE2ESubscriptionFlow::test_e2e_with_access_but_no_subscription_gets_403 PASSED                [ 85%]
tests/test_subscription.py::TestE2ESubscriptionFlow::test_e2e_with_subscription_but_no_access_gets_403 PASSED                [ 86%]
tests/test_subscription.py::TestE2ESubscriptionFlow::test_e2e_single_subscription_auto_selects PASSED                        [ 88%]
tests/test_subscription.py::TestE2ESubscriptionFlow::test_e2e_multiple_subscriptions_without_header_gets_403 PASSED          [ 90%]
tests/test_subscription.py::TestE2ESubscriptionFlow::test_e2e_multiple_subscriptions_with_valid_header_gets_200 PASSED       [ 91%]
tests/test_subscription.py::TestE2ESubscriptionFlow::test_e2e_multiple_subscriptions_with_invalid_header_gets_403 PASSED     [ 93%]
tests/test_subscription.py::TestE2ESubscriptionFlow::test_e2e_multiple_subscriptions_with_inaccessible_header_gets_403 PASSED [ 95%]
tests/test_subscription.py::TestE2ESubscriptionFlow::test_e2e_group_based_access_gets_200 PASSED                             [ 96%]
tests/test_subscription.py::TestE2ESubscriptionFlow::test_e2e_group_based_auth_but_no_subscription_gets_403 PASSED           [ 98%]
tests/test_subscription.py::TestE2ESubscriptionFlow::test_e2e_group_based_subscription_but_no_auth_gets_403 PASSED           [100%]

============================================================= FAILURES =============================================================
______________________________ TestAPIKeyAuthorization.test_non_admin_cannot_access_other_users_keys _______________________________
tests/test_api_keys.py:205: in test_non_admin_cannot_access_other_users_keys
    assert r_get.status_code == 404, f"Expected 404 (IDOR protection), got {r_get.status_code}"
E   AssertionError: Expected 404 (IDOR protection), got 200
E   assert 200 == 404
E    +  where 200 = <Response [200]>.status_code
_____________________________ TestCrossNamespaceSubscription.test_subscription_in_different_namespace ______________________________
tests/test_namespace_scoping.py:504: in test_subscription_in_different_namespace
    assert r.status_code == 200, f"Model listing failed: {r.status_code}"
E   AssertionError: Model listing failed: 429
E   assert 429 == 200
E    +  where 429 = <Response [429]>.status_code
____________________ TestCrossNamespaceSubscription.test_multiple_subscriptions_different_namespaces_same_model ____________________
tests/test_namespace_scoping.py:601: in test_multiple_subscriptions_different_namespaces_same_model
    assert r.status_code == 200, f"Model listing failed: {r.status_code}"
E   AssertionError: Model listing failed: 429
E   assert 429 == 200
E    +  where 429 = <Response [429]>.status_code
========================================================= warnings summary =========================================================
tests/test_api_keys.py: 16 warnings
tests/test_namespace_scoping.py: 6 warnings
tests/test_smoke.py: 4 warnings
tests/test_subscription.py: 29 warnings
  /Users/somyabhatnagar/Documents/Projects/redhat/models-as-a-service/test/e2e/.venv/lib/python3.13/site-packages/urllib3/connectionpool.py:1097: InsecureRequestWarning: Unverified HTTPS request is being made to host 'maas.apps.ci-ln-tmqjkpb-76ef8.aws-4.ci.openshift.org'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#tls-warnings
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
===================================================== short test summary info ======================================================
FAILED tests/test_api_keys.py::TestAPIKeyAuthorization::test_non_admin_cannot_access_other_users_keys - AssertionError: Expected 404 (IDOR protection), got 200
FAILED tests/test_namespace_scoping.py::TestCrossNamespaceSubscription::test_subscription_in_different_namespace - AssertionError: Model listing failed: 429
FAILED tests/test_namespace_scoping.py::TestCrossNamespaceSubscription::test_multiple_subscriptions_different_namespaces_same_model - AssertionError: Model listing failed: 429
================================= 3 failed, 54 passed, 4 skipped, 55 warnings in 910.52s (0:15:10) =================================
```

```
tests/test_subscription.py::TestSubscriptionEnforcement::test_rate_limit_exhaustion_gets_429 PASSED                          [ 63%]
```


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for rate-limit enforcement, verifying that exceeding token limits returns the appropriate response code and headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->