### PR TITLE
chore: add env var force conflicts to deploy.sh

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -30,6 +30,7 @@
 #   MAAS_CONTROLLER_IMAGE     Custom MaaS controller container image
 #   OPERATOR_TYPE             Operator type (rhoai/odh)
 #   LOG_LEVEL                 Logging verbosity (DEBUG, INFO, WARN, ERROR)
+#   KUSTOMIZE_FORCE_CONFLICTS When true, use --force-conflicts on kubectl apply in kustomize mode
 #
 # EXAMPLES:
 #   # Deploy ODH (default, uses kuadrant policy engine)
@@ -84,6 +85,7 @@ OPERATOR_IMAGE="${OPERATOR_IMAGE:-}"
 OPERATOR_CHANNEL="${OPERATOR_CHANNEL:-}"
 MAAS_API_IMAGE="${MAAS_API_IMAGE:-}"
 MAAS_CONTROLLER_IMAGE="${MAAS_CONTROLLER_IMAGE:-}"
+KUSTOMIZE_FORCE_CONFLICTS="${KUSTOMIZE_FORCE_CONFLICTS:-false}"
 
 #──────────────────────────────────────────────────────────────
 # HELP TEXT
@@ -153,9 +155,10 @@ ENVIRONMENT VARIABLES:
   MAAS_API_IMAGE            Custom MaaS API container image
   MAAS_CONTROLLER_IMAGE     Custom MaaS controller container image
   OPERATOR_CATALOG          Custom operator catalog
-  OPERATOR_IMAGE        Custom operator image
-  OPERATOR_TYPE         Operator type (rhoai/odh)
-  LOG_LEVEL             Logging verbosity (DEBUG, INFO, WARN, ERROR)
+  OPERATOR_IMAGE            Custom operator image
+  OPERATOR_TYPE             Operator type (rhoai/odh)
+  LOG_LEVEL                 Logging verbosity (DEBUG, INFO, WARN, ERROR)
+  KUSTOMIZE_FORCE_CONFLICTS When true, pass --force-conflicts to kubectl apply in kustomize mode (default: false)
 
 EXAMPLES:
   # Deploy ODH (default, uses kuadrant policy engine)
@@ -571,14 +574,14 @@ deploy_via_kustomize() {
   deploy_postgresql
 
   log_info "Applying kustomize manifests..."
-  kubectl apply --server-side=true -f <(kustomize build "$overlay")
+  kubectl apply --server-side=true --force-conflicts="$KUSTOMIZE_FORCE_CONFLICTS" -f <(kustomize build "$overlay")
 
   # Apply gateway policies separately so they stay in openshift-ingress (overlay
   # namespace would otherwise overwrite them to $NAMESPACE)
   local policies_dir="$project_root/deployment/base/maas-controller/policies"
   if [[ -d "$policies_dir" ]]; then
     log_info "Applying gateway policies (openshift-ingress)..."
-    kubectl apply --server-side=true -f <(kustomize build "$policies_dir")
+    kubectl apply --server-side=true --force-conflicts="$KUSTOMIZE_FORCE_CONFLICTS" -f <(kustomize build "$policies_dir")
   fi
 
   # Configure TLS backend (if enabled)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Currently, if `deploy.sh --deployment-mode kustomize` is run multiple times, it won't work because `kubectl apply --server-side=true` conflicts with previous `configure_cluster_audience`. By adding env var `KUSTOMIZE_FORCE_CONFLICTS` and setting it to true, `deploy.sh --deployment-mode kustomize` can be idempotent.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- `./scripts/deploy.sh --deployment-mode kustomize` -> Failure
- `KUSTOMIZE_FORCE_CONFLICTS=true ./scripts/deploy.sh --deployment-mode kustomize` -> Success

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `KUSTOMIZE_FORCE_CONFLICTS` environment variable for deployment configurations (defaults to `false`).

* **Documentation**
  * Updated environment variable documentation to include the new configuration option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->