### PR TITLE
fix: updating the maas-api-auth policy to read from the params.env file instead of being hardcoded

### DIFF
--- a/deployment/base/maas-api/policies/auth-policy.yaml
+++ b/deployment/base/maas-api/policies/auth-policy.yaml
@@ -29,7 +29,8 @@ spec:
         when:
           - predicate: request.headers.authorization.startsWith("Bearer sk-oai-")
         http:
-          url: https://maas-api.opendatahub.svc.cluster.local:8443/internal/v1/api-keys/validate
+          # Overwritten by ODH overlay replacement (app-namespace param). Use placeholder.
+          url: https://maas-api.placehold.svc.cluster.local:8443/internal/v1/api-keys/validate
           method: POST
           contentType: application/json
           body:

--- a/deployment/overlays/odh/kustomization.yaml
+++ b/deployment/overlays/odh/kustomization.yaml
@@ -126,6 +126,14 @@ replacements:
     fieldPath: data.app-namespace
   targets:
   - select:
+      kind: AuthPolicy
+      name: maas-api-auth-policy
+    fieldPaths:
+    - spec.rules.metadata.apiKeyValidation.http.url
+    options:
+      delimiter: "."
+      index: 1
+  - select:
       kind: DestinationRule
       name: maas-api-backend-tls
     fieldPaths:


### PR DESCRIPTION
During testing on the lates RHOAI operator build noticed that the namespace for our auth policy is still opendatahub.

I updated it so it should be pulling from the `params.env` now. Also changes the url to try to make it easier to identify this mistake earlier (fail fast).

How did I test:

Can change the app_namespace in the `params.env` to whatever `my_totally_correct_namespace` and validate the url looks correct
```
jland@fedora:~/Documents/RedHat/poc/models-as-a-service$ 
kustomize build deployment/overlays/odh | grep -E "url:|api-keys/validate"
          url: https://maas-api.my_totally_correct_namespace.svc.cluster.local:8443/internal/v1/api-keys/validate
```

And I checked the actual prams being installed with the operator and that looks right.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal authentication policy configuration to use overlay-based URL replacement pattern, improving deployment flexibility across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->