### PR TITLE
fix: resolve intermittent 429 failures in namespace scoping e2e tests

### DIFF
--- a/test/e2e/tests/test_namespace_scoping.py
+++ b/test/e2e/tests/test_namespace_scoping.py
@@ -520,9 +520,18 @@ class TestCrossNamespaceAuthPolicy:
             log.info("✓ Multiple policies deletion test passed (bug fix verified)")
 
         finally:
-            _delete_cr("MaaSAuthPolicy", policy1_name, policy_namespace)
-            _delete_cr("MaaSAuthPolicy", policy2_name, policy_namespace2)
-            _delete_namespace(policy_namespace2)
+            for resource, name, ns in [
+                ("MaaSAuthPolicy", policy1_name, policy_namespace),
+                ("MaaSAuthPolicy", policy2_name, policy_namespace2),
+            ]:
+                try:
+                    _delete_cr(resource, name, ns)
+                except Exception as e:
+                    log.warning(f"Cleanup failed for {resource}/{name}: {e}")
+            try:
+                _delete_namespace(policy_namespace2)
+            except Exception as e:
+                log.warning(f"Cleanup failed for namespace {policy_namespace2}: {e}")
 
 
 class TestCrossNamespaceSubscription:
@@ -619,8 +628,14 @@ class TestCrossNamespaceSubscription:
             log.info("✓ Cross-namespace Subscription test passed")
 
         finally:
-            _delete_cr("MaaSSubscription", subscription_name, maas_subscription_ns)
-            _delete_cr("MaaSAuthPolicy", maas_auth_policy_name, maas_subscription_ns)
+            for resource, name, ns in [
+                ("MaaSSubscription", subscription_name, maas_subscription_ns),
+                ("MaaSAuthPolicy", maas_auth_policy_name, maas_subscription_ns),
+            ]:
+                try:
+                    _delete_cr(resource, name, ns)
+                except Exception as e:
+                    log.warning(f"Cleanup failed for {resource}/{name}: {e}")
 
     def test_multiple_subscriptions_different_namespaces_same_model(self, policy_namespace, api_key):
         """
@@ -819,9 +834,15 @@ class TestCrossNamespaceSubscription:
             log.info("✓ Multiple subscriptions deletion test passed (bug fix verified)")
 
         finally:
-            _delete_cr("MaaSSubscription", sub1_name, maas_subscription_ns)
-            _delete_cr("MaaSSubscription", sub2_name, maas_subscription_ns)
-            _delete_cr("MaaSAuthPolicy", maas_auth_policy_name, maas_subscription_ns)
+            for resource, name, ns in [
+                ("MaaSSubscription", sub1_name, maas_subscription_ns),
+                ("MaaSSubscription", sub2_name, maas_subscription_ns),
+                ("MaaSAuthPolicy", maas_auth_policy_name, maas_subscription_ns),
+            ]:
+                try:
+                    _delete_cr(resource, name, ns)
+                except Exception as e:
+                    log.warning(f"Cleanup failed for {resource}/{name}: {e}")
 
 
 class TestAuthorizationBoundary:
@@ -881,5 +902,11 @@ class TestAuthorizationBoundary:
             log.info("✓ Authorization boundary test passed - policies only affect listed models")
 
         finally:
-            _delete_cr("MaaSAuthPolicy", policy_name, policy_namespace)
-            _delete_cr("MaaSModelRef", unmanaged_model_name, MODEL_NAMESPACE)
+            for resource, name, ns in [
+                ("MaaSAuthPolicy", policy_name, policy_namespace),
+                ("MaaSModelRef", unmanaged_model_name, MODEL_NAMESPACE),
+            ]:
+                try:
+                    _delete_cr(resource, name, ns)
+                except Exception as e:
+                    log.warning(f"Cleanup failed for {resource}/{name}: {e}")


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Related to https://redhat.atlassian.net/browse/RHOAIENG-52941

The test test_multiple_subscriptions_different_namespaces_same_model intermittently fails in Prow with a 429 (Too Many Requests) when calling the model listing endpoint. The test expects 200 but receives 429.

**Observed failure:**
```

r = _list_models(api_key, MODEL_REF, MODEL_NAMESPACE, subscription=sub1_name)
assert r.status_code == 200, f"Model listing failed: {r.status_code}"
AssertionError: Model listing failed: 429
assert 429 == 200
Test location: test/e2e/tests/test_namespace_scoping.py — TestCrossNamespaceSubscription.test_multiple_subscriptions_different_namespaces_same_model
```

**Test flow:**

- Creates two MaaSSubscription}}s in different namespaces for the same model (sub1: {{system:authenticated, 100/min; sub2: test_group, 200/min)
- Waits RECONCILE_WAIT (default 10s) for reconciliation
- Waits for AuthPolicy to be enforced
- Verifies TokenRateLimitPolicy exists
- Calls _list_models with subscription=sub1_name — fails here with 429

**Suspected Causes**
Rate limit exhaustion: Previous tests in the suite may have consumed the rate limit for the same model/API key before this test runs

TRLP reconciliation timing: TokenRateLimitPolicy or Limitador may not be fully synced when the test runs; RECONCILE_WAIT (10s) may be insufficient under Prow load

Shared rate limit state: Multiple subscriptions aggregating into one TRLP may have unexpected interaction with Limitador counters

Gateway default TRLP: Default deny or low default limits may apply before subscription-specific limits are enforced

**Acceptance Criteria**
```
Given the Prow E2E suite runs test_multiple_subscriptions_different_namespaces_same_model,
When the test creates MaaSSubscriptions and calls the model listing endpoint with a valid subscription,
Then the response is 200, not 429.
```

```
Given the test runs in isolation (e.g. pytest test_namespace_scoping.py::TestCrossNamespaceSubscription::test_multiple_subscriptions_different_namespaces_same_model),
When run multiple times,
Then the test passes consistently (or root cause is identified if 429 persists).
```

**Verification**
Reproduce: Run full e2e suite in Prow or locally; observe intermittent 429
Isolate: Run test_multiple_subscriptions_different_namespaces_same_model in isolation; check if 429 still occurs
Increase E2E_RECONCILE_WAIT (e.g. 15–20s) and re-run; check if failure rate decreases
Inspect Limitador/TRLP state and gateway logs when 429 occurs

**Root cause:** 
MaaSSubscription resources were being created in random test namespaces, but the maas-controller only watches the models-as-a-service namespace (configured via MAAS_SUBSCRIPTION_NAMESPACE). This meant subscriptions were never reconciled, TokenRateLimitPolicy was never updated, and requests hit the default-deny policy resulting in 429 errors.

**Changes:**
      - Fixed test_subscription_in_different_namespace to use MAAS_SUBSCRIPTION_NAMESPACE
      - Fixed test_multiple_subscriptions_different_namespaces_same_model to use MAAS_SUBSCRIPTION_NAMESPACE
      - Added _wait_for_trlp_enforced() to check TokenRateLimitPolicy enforcement status
      - Added _wait_for_trlp_enforced_with_retry() with 3 retry attempts and 5s backoff
      - Added _get_trlp_generation() to track TRLP metadata.generation changes
      - Added _get_trlp_metadata() to track uid/resourceVersion/generation for verification
      - Increased RECONCILE_WAIT from 10s to 15s for better Prow tolerance
      - Added TRLP enforcement waits before making requests
      - Added TRLP re-enforcement wait after subscription deletion
      - Updated test docstrings to clarify namespace requirements

      CodeRabbit fixes:
      - Fixed race condition: moved TRLP enforcement wait before existence checks
      - Added comprehensive metadata verification to ensure TRLP was actually updated
      - Fixed type annotation: expected_generation parameter now uses Optional[int]

**Test Results:**
- Before: ~0% success rate (intermittent 429 errors)
- After: 100% success rate (5/5 consecutive test runs passed)

The test is now production-ready and will pass reliably in Prow CI.

<!--- Provide a general summary of your changes in the Title above -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


Tested on live cluster :

 ```
GATEWAY_HOST=maas.apps.ci-ln-3rxf0wb-76ef8.aws-4.ci.openshift.org
E2E_SKIP_TLS_VERIFY=true
MAAS_API_BASE_URL=https://maas.apps.ci-ln-3rxf0wb-76ef8.aws-4.ci.openshift.org/maas-api
E2E_RECONCILE_WAIT=15 (default)
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end coverage for cross-namespace subscription and rate-limit policy enforcement.
  * Increased reconciliation timeout and added stronger wait/retry logic to reduce flakiness.
  * Added metadata and generation checks to verify policy presence, updates, and recreation after subscription changes.
  * Enhanced multi-subscription scenarios, cleanup, and logging to better validate cross-namespace interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->