### PR TITLE
refactor: move subscription selection endpoint to internal API

### DIFF
--- a/maas-api/architecture.md
+++ b/maas-api/architecture.md
@@ -36,6 +36,7 @@ The MaaS (Models as a Service) API provides a tier-based token management system
 | `/v1/api-keys/{id}`   | DELETE | Revoke specific API key                      | None              | Revoked API key metadata (200 OK) |
 | `/v1/tiers/lookup`    | POST   | Lookup tier for user groups (internal)       | `{"groups"}`      | `{"tier", "displayName"}`   |
 | `/internal/v1/api-keys/validate` | POST | Validate API key (Authorino callback) | `{"key"}`         | `{"valid", "userId", "groups"}` |
+| `/internal/v1/subscriptions/select` | POST | Select subscription for user (Authorino callback) | `{"username", "groups", "requestedSubscription"}` | `{"name", "organizationId", "costCenter", "labels"}` |
 
 ## Core Architecture Components
 

--- a/maas-api/cmd/main.go
+++ b/maas-api/cmd/main.go
@@ -151,7 +151,6 @@ func registerHandlers(ctx context.Context, log *logger.Logger, router *gin.Engin
 	v1Routes.POST("/tiers/lookup", tier.NewHandler(tierMapper).TierLookup)
 
 	subscriptionSelector := subscription.NewSelector(log, cluster.MaaSSubscriptionLister)
-	v1Routes.POST("/subscriptions/select", subscription.NewHandler(log, subscriptionSelector).SelectSubscription)
 
 	modelManager, err := models.NewManager(log)
 	if err != nil {
@@ -178,6 +177,7 @@ func registerHandlers(ctx context.Context, log *logger.Logger, router *gin.Engin
 	// Internal routes for Authorino HTTP callback (no auth required - called by Authorino)
 	internalRoutes := router.Group("/internal/v1")
 	internalRoutes.POST("/api-keys/validate", apiKeyHandler.ValidateAPIKeyHandler)
+	internalRoutes.POST("/subscriptions/select", subscription.NewHandler(log, subscriptionSelector).SelectSubscription)
 
 	return nil
 }

--- a/maas-api/internal/subscription/handler.go
+++ b/maas-api/internal/subscription/handler.go
@@ -26,7 +26,7 @@ func NewHandler(log *logger.Logger, selector *Selector) *Handler {
 	}
 }
 
-// SelectSubscription handles POST /v1/subscriptions/select requests.
+// SelectSubscription handles POST /internal/v1/subscriptions/select requests.
 //
 // This endpoint is called by Authorino during AuthPolicy evaluation to determine
 // which subscription a user should be assigned to. The request contains authenticated

--- a/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
@@ -177,7 +177,7 @@ func (r *MaaSAuthPolicyReconciler) reconcileModelAuthPolicies(ctx context.Contex
 
 		// Construct API URLs using configured namespace
 		apiKeyValidationURL := fmt.Sprintf("https://maas-api.%s.svc.cluster.local:8443/internal/v1/api-keys/validate", r.MaaSAPINamespace)
-		subscriptionSelectorURL := fmt.Sprintf("https://maas-api.%s.svc.cluster.local:8443/v1/subscriptions/select", r.MaaSAPINamespace)
+		subscriptionSelectorURL := fmt.Sprintf("https://maas-api.%s.svc.cluster.local:8443/internal/v1/subscriptions/select", r.MaaSAPINamespace)
 
 		rule := map[string]interface{}{
 			"metadata": map[string]interface{}{
@@ -324,7 +324,7 @@ func (r *MaaSAuthPolicyReconciler) reconcileModelAuthPolicies(ctx context.Contex
 								"keyId": map[string]interface{}{
 									"selector": "auth.metadata.apiKeyValidation.keyId",
 								},
-								// Subscription metadata from /v1/subscriptions/select endpoint
+								// Subscription metadata from /internal/v1/subscriptions/select endpoint
 								"selected_subscription": map[string]interface{}{
 									"expression": `has(auth.metadata["subscription-info"].name) ? auth.metadata["subscription-info"].name : ""`,
 								},

--- a/test/e2e/scripts/auth_utils.sh
+++ b/test/e2e/scripts/auth_utils.sh
@@ -231,7 +231,7 @@ run_auth_debug_report() {
   maas_api_ns=$(kubectl get deployment maas-controller -n $DEPLOYMENT_NAMESPACE -o jsonpath='{.spec.template.spec.containers[0].env}' 2>/dev/null | jq -r '.[] | select(.name=="MAAS_API_NAMESPACE") | .value' 2>/dev/null || echo "$DEPLOYMENT_NAMESPACE")
   [[ -z "$maas_api_ns" ]] && maas_api_ns="$DEPLOYMENT_NAMESPACE"
 
-  local sub_select_url="https://maas-api.${maas_api_ns}.svc.cluster.local:8443/v1/subscriptions/select"
+  local sub_select_url="https://maas-api.${maas_api_ns}.svc.cluster.local:8443/internal/v1/subscriptions/select"
   _section "Subscription Selector Endpoint Validation"
   _append "Expected URL (from maas-controller config): $sub_select_url"
   _append ""

--- a/test/e2e/tests/test_subscription.py
+++ b/test/e2e/tests/test_subscription.py
@@ -678,9 +678,9 @@ class TestSubscriptionEnforcement:
 
     def test_auth_pass_no_subscription_gets_403(self):
         """API key with auth pass but no matching subscription should get 403.
-        
+
         The AuthPolicy includes a subscription-error-check rule that calls
-        /v1/subscriptions/select. If no subscription matches the user's groups,
+        /internal/v1/subscriptions/select. If no subscription matches the user's groups,
         the request is denied with 403 "no matching subscription found for user".
         
         To test this, we temporarily add system:authenticated to the premium model's


### PR DESCRIPTION
                                                                                                        
  ## Description    

For https://redhat.atlassian.net/browse/RHOAIENG-52971                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                            
  This PR moves the subscription selection endpoint from `/v1/subscriptions/select` to `/internal/v1/subscriptions/select`, aligning it with the existing internal endpoint pattern used
   by `/internal/v1/api-keys/validate`.                                                                                                                                                 
                                                                                                                                                                                        
  **Background:**                                                                                                                                                                       
  The subscription selection endpoint is exclusively used as an HTTP callback by Authorino during the authentication/authorization flow. It is not intended for direct user consumption 
  and should not be part of the public `/v1` API.                                                                                                                                       
                                                                                                                                                                                        
  **Changes:**                                                                                                                                                                          
  - **maas-api/cmd/main.go**: Moved endpoint registration from `v1Routes` to `internalRoutes` group                                                                                     
  - **maas-controller/.../maasauthpolicy_controller.go**: Updated AuthPolicy controller to call the new `/internal/v1/subscriptions/select` URL                                         
  - **test/e2e/scripts/auth_utils.sh**: Updated test scripts to use new endpoint path                                                                                                   
  - **test/e2e/tests/test_subscription.py**: Updated test documentation comments                                                                                                        
  - **maas-api/architecture.md**: Added endpoint to API reference table for consistency with other internal endpoints                                                                   
                                                                                                                                                                                        
  **Impact:**                                                                                                                                                                           
  - ✅ No user-facing breaking changes (endpoint was never part of public API)                                                                                                          
  - ✅ Only caller is Authorino via AuthPolicy (internal)                                                                                                                               
  - ✅ Improves API architecture clarity by properly distinguishing public vs internal endpoints                                                                                        
  - ✅ Consistent with existing `/internal/v1/api-keys/validate` pattern                                                                                                                
                                                                                                                                                                                        
  ## How Has This Been Tested?                                                                                                                                                          

  ### Unit Tests
  Ran the subscription handler unit test suite:
  ```bash
  cd maas-api && go test -v ./internal/subscription/...
  Result: ✅ All 7 tests passed

  E2E Subscription Tests

  Ran the complete subscription E2E test suite:
  =============================================================== test session starts ================================================================
  platform linux -- Python 3.13.12, pytest-8.4.2, pluggy-1.6.0 -- /home/jrhyness/src/models-as-a-service/test/e2e/.venv/bin/python
  cachedir: .pytest_cache
  metadata: {'Python': '3.13.12', 'Platform': 'Linux-6.19.6-100.fc42.x86_64-x86_64-with-glibc2.41', 'Packages': {'pytest': '8.4.2', 'pluggy': '1.6.0'}, 'Plugins': {'metadata': '3.1.1',
   'html': '4.2.0'}}
  rootdir: /home/jrhyness/src/models-as-a-service/test/e2e
  plugins: metadata-3.1.1, html-4.2.0
  collected 31 items

  tests/test_subscription.py::TestAuthEnforcement::test_authorized_user_gets_200 PASSED
  tests/test_subscription.py::TestAuthEnforcement::test_no_auth_gets_401 PASSED
  tests/test_subscription.py::TestAuthEnforcement::test_invalid_token_gets_403 PASSED
  tests/test_subscription.py::TestAuthEnforcement::test_wrong_group_gets_403 PASSED
  tests/test_subscription.py::TestSubscriptionEnforcement::test_subscribed_user_gets_200 PASSED
  tests/test_subscription.py::TestSubscriptionEnforcement::test_auth_pass_no_subscription_gets_403 PASSED
  tests/test_subscription.py::TestSubscriptionEnforcement::test_invalid_subscription_header_gets_429 PASSED
  tests/test_subscription.py::TestSubscriptionEnforcement::test_explicit_subscription_header_works PASSED
  tests/test_subscription.py::TestSubscriptionEnforcement::test_rate_limit_exhaustion_gets_429 PASSED
  tests/test_subscription.py::TestMultipleSubscriptionsPerModel::test_user_in_one_of_two_subscriptions_gets_200 PASSED
  tests/test_subscription.py::TestMultipleSubscriptionsPerModel::test_multi_tier_auto_select_highest PASSED
  tests/test_subscription.py::TestMultipleAuthPoliciesPerModel::test_two_auth_policies_or_logic PASSED
  tests/test_subscription.py::TestMultipleAuthPoliciesPerModel::test_delete_one_auth_policy_other_still_works PASSED
  tests/test_subscription.py::TestCascadeDeletion::test_delete_subscription_rebuilds_trlp PASSED
  tests/test_subscription.py::TestCascadeDeletion::test_delete_last_subscription_denies_access PASSED
  tests/test_subscription.py::TestOrderingEdgeCases::test_subscription_before_auth_policy PASSED
  tests/test_subscription.py::TestManagedAnnotation::test_authpolicy_managed_false_prevents_update PASSED
  tests/test_subscription.py::TestManagedAnnotation::test_trlp_managed_false_prevents_update PASSED
  tests/test_subscription.py::TestMaasSubscriptionNamespace::test_authpolicy_and_subscription_in_maas_subscription_namespace PASSED
  tests/test_subscription.py::TestMaasSubscriptionNamespace::test_authpolicy_and_subscription_in_another_namespace PASSED
  tests/test_subscription.py::TestE2ESubscriptionFlow::test_e2e_with_both_access_and_subscription_gets_200 PASSED
  tests/test_subscription.py::TestE2ESubscriptionFlow::test_e2e_with_access_but_no_subscription_gets_403 PASSED
  tests/test_subscription.py::TestE2ESubscriptionFlow::test_e2e_with_subscription_but_no_access_gets_403 PASSED
  tests/test_subscription.py::TestE2ESubscriptionFlow::test_e2e_single_subscription_auto_selects PASSED
  tests/test_subscription.py::TestE2ESubscriptionFlow::test_e2e_multiple_subscriptions_without_header_gets_403 PASSED
  tests/test_subscription.py::TestE2ESubscriptionFlow::test_e2e_multiple_subscriptions_with_valid_header_gets_200 PASSED
  tests/test_subscription.py::TestE2ESubscriptionFlow::test_e2e_multiple_subscriptions_with_invalid_header_gets_403 PASSED
  tests/test_subscription.py::TestE2ESubscriptionFlow::test_e2e_multiple_subscriptions_with_inaccessible_header_gets_403 PASSED
  tests/test_subscription.py::TestE2ESubscriptionFlow::test_e2e_group_based_access_gets_200 PASSED
  tests/test_subscription.py::TestE2ESubscriptionFlow::test_e2e_group_based_auth_but_no_subscription_gets_403 PASSED
  tests/test_subscription.py::TestE2ESubscriptionFlow::test_e2e_group_based_subscription_but_no_auth_gets_403 PASSED

  ================================================================= warnings summary =================================================================
  tests/test_subscription.py: 29 warnings
    /home/jrhyness/src/models-as-a-service/test/e2e/.venv/lib64/python3.13/site-packages/urllib3/connectionpool.py:1097: InsecureRequestWarning: Unverified HTTPS request is being made
  to host 'maas.apps.rosa.u22hm-zn2m5-w2g.1u73.p3.openshiftapps.com'. Adding certificate verification is strongly advised. See:
  https://urllib3.readthedocs.io/en/latest/advanced-usage.html#tls-warnings
      warnings.warn(

  -- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
  =================================================== 31 passed, 29 warnings in 492.93s (0:08:12) ====================================================

  Result: ✅ 31/31 tests passed - All subscription authentication, authorization, multi-subscription, cascade deletion, and E2E flow tests passed successfully.

  Manual Verification

  - ✅ Verified AuthPolicy resources are correctly generated with new internal URL
  - ✅ Confirmed subscription selection callback works correctly during Authorino flow
  - ✅ Validated that old /v1/subscriptions/select endpoint no longer exists

  Merge criteria:

  - [x] The commits are squashed in a cohesive manner and have meaningful messages.
  - [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
  - [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Reorganized internal API endpoint structure for subscription selection to align with authentication workflow architecture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->