### PR TITLE
docs: fix default operator type from rhoai to odh

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,11 @@ Our goal is to create a comprehensive platform for **Models as a Service** with 
 Use the unified deployment script for all deployment scenarios:
 
 ```bash
-# Deploy RHOAI (default)
+# Deploy ODH (default)
 ./scripts/deploy.sh
 
-# Deploy ODH
-./scripts/deploy.sh --operator-type odh
+# Deploy RHOAI
+./scripts/deploy.sh --operator-type rhoai
 
 # Deploy via Kustomize
 ./scripts/deploy.sh --deployment-mode kustomize
@@ -58,7 +58,7 @@ For detailed instructions, see the [Deployment Guide](docs/content/quickstart.md
 | Flag | Values | Default | Description |
 |------|--------|---------|-------------|
 | `--deployment-mode` | `operator`, `kustomize` | `operator` | Deployment method |
-| `--operator-type` | `rhoai`, `odh` | `rhoai` | Which operator to install |
+| `--operator-type` | `odh`, `rhoai` | `odh` | Which operator to install |
 | `--policy-engine` | `rhcl`, `kuadrant` | auto | Gateway policy engine (rhcl for operators, kuadrant for kustomize) |
 | `--enable-tls-backend` | flag | enabled | TLS for Authorino ↔ MaaS API |
 | `--skip-certmanager` | flag | auto-detect | Skip cert-manager installation |

--- a/docs/content/quickstart.md
+++ b/docs/content/quickstart.md
@@ -43,11 +43,11 @@ For OpenShift clusters, use the unified automated deployment script:
 ```bash
 export MAAS_REF="main"  # Use the latest release tag, or "main" for development
 
-# Deploy using RHOAI operator (default)
+# Deploy using ODH operator (default)
 ./scripts/deploy.sh
 
-# Or deploy using ODH operator
-./scripts/deploy.sh --operator-type odh
+# Or deploy using RHOAI operator
+./scripts/deploy.sh --operator-type rhoai
 
 # Or deploy using kustomize
 ./scripts/deploy.sh --deployment-mode kustomize


### PR DESCRIPTION
## Summary

- Fix default operator type from `rhoai` to `odh` in README Quick Start example
- Fix default value in README Key Options table
- Fix default operator type in quickstart deployment example

The deploy.sh script defaults to `odh` (`OPERATOR_TYPE=\"${OPERATOR_TYPE:-odh}\"`) but README.md and quickstart.md both stated `rhoai` was the default.

---
*Created by document-review workflow `/create-prs` phase.*