### PR TITLE
docs: fix non-existent maas-api namespace in validation guide

### DIFF
--- a/docs/content/install/validation.md
+++ b/docs/content/install/validation.md
@@ -99,7 +99,14 @@ done
 Check that all components are running:
 
 ```bash
-kubectl get pods -n maas-api && \
+# For RHOAI:
+kubectl get pods -n redhat-ods-applications -l app.kubernetes.io/name=maas-api && \
+kubectl get pods -n kuadrant-system && \
+kubectl get pods -n kserve && \
+kubectl get pods -n llm
+
+# For ODH:
+kubectl get pods -n opendatahub -l app.kubernetes.io/name=maas-api && \
 kubectl get pods -n kuadrant-system && \
 kubectl get pods -n kserve && \
 kubectl get pods -n llm


### PR DESCRIPTION
## Summary

- Replace non-existent `maas-api` namespace with correct platform-specific namespaces (`redhat-ods-applications` for RHOAI, `opendatahub` for ODH)

The `maas-api` namespace does not exist in any documented installation flow. The validation guide's own namespace reference table (lines 7-11) confirms the correct namespaces.

---
*Created by document-review workflow `/create-prs` phase.*