### PR TITLE
docs: remove envsubst from required tools in maas-setup.md

### DIFF
--- a/docs/content/install/maas-setup.md
+++ b/docs/content/install/maas-setup.md
@@ -28,7 +28,6 @@ The tools you will need:
 
 * `kubectl` or `oc` client (this guide uses `kubectl`)
 * `kustomize`
-* `envsubst`
 
 ## Install Gateway AuthPolicy
 


### PR DESCRIPTION
## Summary

- Remove `envsubst` from required tools list in maas-setup.md

The tool is listed as required but never used in any command in the document.

---
*Created by document-review workflow `/create-prs` phase.*