### PR TITLE
docs: replace stale deploy-rhoai-stable.sh reference

### DIFF
--- a/docs/content/quickstart.md
+++ b/docs/content/quickstart.md
@@ -32,7 +32,7 @@ Before deploying MaaS, Authorino's listener TLS must be enabled. This is a platf
 For step-by-step commands, see [TLS Configuration: Authorino TLS Configuration](configuration-and-management/tls-configuration.md#authorino-tls-configuration).
 
 !!! tip "Automated configuration"
-    The `deploy-rhoai-stable.sh` script automatically configures all remaining TLS settings after deployment, including Gateway TLS bootstrap and Authorino → maas-api outbound TLS.
+    The `deploy.sh` script automatically configures all remaining TLS settings after deployment, including Gateway TLS bootstrap and Authorino → maas-api outbound TLS.
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary

- Replace stale `deploy-rhoai-stable.sh` reference with `deploy.sh` in quickstart

The `deploy-rhoai-stable.sh` script does not exist. The unified `deploy.sh` handles TLS configuration with TLS backend enabled by default.

---
*Created by document-review workflow `/create-prs` phase.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated quickstart documentation with corrected script references for automated TLS configuration guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->