### PR TITLE
docs: add missing flags and env var to scripts README

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -52,6 +52,7 @@ Automated deployment script for OpenShift clusters supporting both operator-base
 
 **Environment Variables:**
 - `MAAS_API_IMAGE` - Custom MaaS API container image (works in both operator and kustomize modes)
+- `MAAS_CONTROLLER_IMAGE` - Custom MaaS controller container image
 - `OPERATOR_CATALOG` - Custom operator catalog for PR testing
 - `OPERATOR_IMAGE` - Custom operator image for PR testing
 - `OPERATOR_TYPE` - Operator type (odh/rhoai)
@@ -159,9 +160,13 @@ Installs individual dependencies (Kuadrant, ODH, etc.).
 ```
 
 **Options:**
+- `--all`: Install all components
 - `--kuadrant`: Install Kuadrant operator and dependencies
-- `--istio`: Install Istio
-- `--prometheus`: Install Prometheus
+- `--istio`: Install Istio service mesh
+- `--odh`: Install OpenDataHub operator (OpenShift only)
+- `--kserve`: Install KServe model serving platform
+- `--prometheus`: Install Prometheus operator
+- `--ocp`: Use OpenShift-specific handling
 
 ---
 


### PR DESCRIPTION
## Summary

- Add missing `--all`, `--odh`, `--kserve`, `--ocp` flags to install-dependencies.sh docs
- Add missing `MAAS_CONTROLLER_IMAGE` environment variable to deploy.sh docs

Verified against install-dependencies.sh usage function and deploy.sh argument parser.

---
*Created by document-review workflow `/create-prs` phase.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added support for specifying a custom MaaS controller container image via a new environment variable.
  * Expanded installation documentation with new configuration options and clarified descriptions for existing parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->