### PR TITLE
docs: replace GET /v1/api-keys with POST /v1/api-keys/search

### DIFF
--- a/maas-api/README.md
+++ b/maas-api/README.md
@@ -222,10 +222,13 @@ API_KEY=$(echo $API_KEY_RESPONSE | jq -r .key)
 **Managing API Keys:**
 
 ```shell
-# List all your API keys
+# Search your API keys
 curl -sSk \
   -H "Authorization: Bearer $(oc whoami -t)" \
-  "${HOST}/maas-api/v1/api-keys" | jq .
+  -H "Content-Type: application/json" \
+  -X POST \
+  -d '{}' \
+  "${HOST}/maas-api/v1/api-keys/search" | jq .
 
 # Get specific API key by ID
 API_KEY_ID="<id-from-list>"


### PR DESCRIPTION
## Summary

- Replace `GET /v1/api-keys` with `POST /v1/api-keys/search` in managing API keys example

The GET route for listing all keys is not wired. The search endpoint (POST /v1/api-keys/search) is the functional alternative.

`/api-keys` routes are defined in: https://github.com/opendatahub-io/models-as-a-service/blob/main/maas-api/cmd/main.go#L169-L175

---
*Created by document-review workflow `/create-prs` phase.*