### PR TITLE
docs: add missing documentation links to landing page

### DIFF
--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -22,3 +22,17 @@ Use this platform to streamline the deployment of your models, monitor usage, an
 ### 🔧 Advanced Administration
 
 - **[Observability](advanced-administration/observability.md)** - Monitoring, metrics, and dashboards
+- **[Limitador Persistence](advanced-administration/limitador-persistence.md)** - Redis backend for persistent rate-limit counters
+- **[TLS Configuration](configuration-and-management/tls-configuration.md)** - Configuring TLS for MaaS API, Authorino, and Gateway
+- **[Token Management](configuration-and-management/token-management.md)** - Token authentication system and lifecycle
+
+### 📖 Installation Guide
+
+- **[Prerequisites](install/prerequisites.md)** - Requirements and database setup
+- **[Platform Setup](install/platform-setup.md)** - Install ODH/RHOAI with MaaS
+- **[MaaS Setup](install/maas-setup.md)** - Gateway AuthPolicy and policies
+- **[Validation](install/validation.md)** - Verify your deployment
+
+### 🔄 Migration
+
+- **[Tier to Subscription Migration](migration/tier-to-subscription.md)** - Migrate from tier-based to subscription-based access control


### PR DESCRIPTION
## Summary

- Add links for installation guide, TLS configuration, token management, Limitador persistence, and migration guide to the documentation landing page

The index page only linked to 5 of 20+ documentation sections. Users could not discover installation guides, TLS configuration, or the migration guide from the landing page.

## Human Input Needed

- [ ] Confirm which access-control model is current vs legacy (tier-based vs subscription-based) and add appropriate labels

---
*Created by document-review workflow `/create-prs` phase.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded documentation with new advanced administration guides covering Limitador Persistence, TLS Configuration, and Token Management features.
  * Added comprehensive Installation Guide with sections on Prerequisites, Platform Setup, MaaS Setup, and Validation procedures.
  * Introduced Migration guide specifically for Tier to Subscription Migration scenarios.
  * Updated navigation structure to reflect all new documentation additions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->