### PR TITLE
docs: add git clone instruction to quickstart

### DIFF
--- a/docs/content/quickstart.md
+++ b/docs/content/quickstart.md
@@ -41,6 +41,10 @@ For step-by-step commands, see [TLS Configuration: Authorino TLS Configuration](
 For OpenShift clusters, use the unified automated deployment script:
 
 ```bash
+# Clone the repository
+git clone https://github.com/opendatahub-io/models-as-a-service.git
+cd models-as-a-service
+
 export MAAS_REF="main"  # Use the latest release tag, or "main" for development
 
 # Deploy using RHOAI operator (default)


### PR DESCRIPTION
## Summary

- Add `git clone` and `cd` instructions before the first `deploy.sh` command

Users need to clone the repository before running `./scripts/deploy.sh`. The quickstart assumed users already had the repo cloned without stating this.

---
*Created by document-review workflow `/create-prs` phase.*