### PR TITLE
chore: default maxExpiration of an API Key to 90 days if `expiresIn` not provided

### DIFF
--- a/maas-api/README.md
+++ b/maas-api/README.md
@@ -181,18 +181,18 @@ TOKEN=$(echo $TOKEN_RESPONSE | jq -r .token)
 
 ##### API Keys
 
-The API uses hash-based API keys with OpenAI-compatible format (`sk-oai-*`). These keys support both permanent and expiring modes.
+The API uses hash-based API keys with OpenAI-compatible format (`sk-oai-*`). Keys expire after a configurable duration (default: 90 days via `API_KEY_MAX_EXPIRATION_DAYS`).
 
 ```shell
 HOST="$(kubectl get gateway -l app.kubernetes.io/instance=maas-default-gateway -n openshift-ingress -o jsonpath='{.items[0].status.addresses[0].value}')"
 
-# Create a permanent API key (no expiration)
+# Create an API key (defaults to API_KEY_MAX_EXPIRATION_DAYS, typically 90 days)
 API_KEY_RESPONSE=$(curl -sSk \
   -H "Authorization: Bearer $(oc whoami -t)" \
   -H "Content-Type: application/json" \
   -X POST \
   -d '{
-    "name": "my-permanent-key",
+    "name": "my-api-key",
     "description": "Production API key for my application"
   }' \
   "${HOST}/maas-api/v1/api-keys")
@@ -200,15 +200,15 @@ API_KEY_RESPONSE=$(curl -sSk \
 echo $API_KEY_RESPONSE | jq -r .
 API_KEY=$(echo $API_KEY_RESPONSE | jq -r .key)
 
-# Create an expiring API key (90 days)
+# Create an API key with custom expiration (30 days)
 API_KEY_RESPONSE=$(curl -sSk \
   -H "Authorization: Bearer $(oc whoami -t)" \
   -H "Content-Type: application/json" \
   -X POST \
   -d '{
-    "name": "my-expiring-key",
-    "description": "90-day test key",
-    "expiresIn": "90d"
+    "name": "my-short-lived-key",
+    "description": "30-day test key",
+    "expiresIn": "30d"
   }' \
   "${HOST}/maas-api/v1/api-keys")
 

--- a/maas-api/internal/api_keys/handler.go
+++ b/maas-api/internal/api_keys/handler.go
@@ -241,17 +241,17 @@ func (h *Handler) GetAPIKey(c *gin.Context) {
 }
 
 // CreateAPIKeyRequest is the request body for creating an API key.
-// Keys can be permanent (no expiresIn) or expiring (with expiresIn).
+// If expiresIn is not provided, defaults to API_KEY_MAX_EXPIRATION_DAYS.
 // Users can only create keys for themselves - the key inherits the user's groups.
 type CreateAPIKeyRequest struct {
 	Name        string          `binding:"required"           json:"name"`
 	Description string          `json:"description,omitempty"`
-	ExpiresIn   *token.Duration `json:"expiresIn,omitempty"` // Optional - nil means permanent
+	ExpiresIn   *token.Duration `json:"expiresIn,omitempty"` // Optional - defaults to API_KEY_MAX_EXPIRATION_DAYS
 }
 
 // CreateAPIKey handles POST /v1/api-keys
 // Creates a new API key (sk-oai-* format) per Feature Refinement.
-// Keys can be permanent (no expiresIn) or expiring (with expiresIn).
+// If expiresIn is not provided, defaults to API_KEY_MAX_EXPIRATION_DAYS.
 // Per "Keys Shown Only Once": key is returned ONCE at creation and never again.
 // Users can only create keys for themselves - the key inherits the user's groups.
 func (h *Handler) CreateAPIKey(c *gin.Context) {

--- a/maas-api/internal/api_keys/service.go
+++ b/maas-api/internal/api_keys/service.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/opendatahub-io/models-as-a-service/maas-api/internal/config"
+	"github.com/opendatahub-io/models-as-a-service/maas-api/internal/constant"
 	"github.com/opendatahub-io/models-as-a-service/maas-api/internal/logger"
 )
 
@@ -50,7 +51,7 @@ type CreateAPIKeyResponse struct {
 }
 
 // CreateAPIKey creates a new API key (sk-oai-* format).
-// Keys can be permanent (expiresIn=nil) or expiring (expiresIn set).
+// If expiresIn is not provided, defaults to APIKeyMaxExpirationDays.
 // Per Feature Refinement "Key Format & Security":
 // - Generates cryptographically secure key with sk-oai-* prefix
 // - Stores ONLY the SHA-256 hash (plaintext never stored)
@@ -58,16 +59,22 @@ type CreateAPIKeyResponse struct {
 // - Stores user groups for subscription-based authorization.
 // Admins can create keys for other users by specifying a different username.
 func (s *Service) CreateAPIKey(ctx context.Context, username string, userGroups []string, name, description string, expiresIn *time.Duration) (*CreateAPIKeyResponse, error) {
-	// Validate expiration based on policy
-	if s.config != nil && s.config.APIKeyExpirationPolicy == "required" && expiresIn == nil {
-		return nil, errors.New("expiration is required by system policy")
+	// Default to max expiration if not provided
+	if expiresIn == nil {
+		maxDays := constant.DefaultAPIKeyMaxExpirationDays
+		if s.config != nil && s.config.APIKeyMaxExpirationDays > 0 {
+			maxDays = s.config.APIKeyMaxExpirationDays
+		}
+		defaultExpiration := time.Duration(maxDays) * 24 * time.Hour
+		expiresIn = &defaultExpiration
 	}
-	if expiresIn != nil && *expiresIn <= 0 {
+
+	if *expiresIn <= 0 {
 		return nil, errors.New("expiration must be positive")
 	}
 
 	// Validate against maximum expiration limit
-	if s.config != nil && expiresIn != nil {
+	if s.config != nil && s.config.APIKeyMaxExpirationDays > 0 {
 		maxDuration := time.Duration(s.config.APIKeyMaxExpirationDays) * 24 * time.Hour
 		if *expiresIn > maxDuration {
 			return nil, fmt.Errorf("requested expiration (%v) exceeds maximum allowed (%d days)",
@@ -75,12 +82,8 @@ func (s *Service) CreateAPIKey(ctx context.Context, username string, userGroups 
 		}
 	}
 
-	// Calculate absolute expiration timestamp
-	var expiresAt *time.Time
-	if expiresIn != nil {
-		expiry := time.Now().UTC().Add(*expiresIn)
-		expiresAt = &expiry
-	}
+	// Calculate absolute expiration timestamp (always set since we default to max)
+	expiresAt := time.Now().UTC().Add(*expiresIn)
 
 	// Generate the API key
 	plaintext, hash, prefix, err := GenerateAPIKey()
@@ -94,23 +97,21 @@ func (s *Service) CreateAPIKey(ctx context.Context, username string, userGroups 
 	// Store in database (hash only, plaintext NEVER stored)
 	// Note: prefix is NOT stored (security - reduces brute-force attack surface)
 	// userGroups stored as PostgreSQL TEXT[] array (no JSON marshaling needed)
-	if err := s.store.AddKey(ctx, username, keyID, hash, name, description, userGroups, expiresAt); err != nil {
+	if err := s.store.AddKey(ctx, username, keyID, hash, name, description, userGroups, &expiresAt); err != nil {
 		return nil, fmt.Errorf("failed to store API key: %w", err)
 	}
 
 	s.logger.Info("Created API key", "user", username, "groups", userGroups, "id", keyID)
 
 	// Return plaintext to user - THIS IS THE ONLY TIME IT'S AVAILABLE
+	formatted := expiresAt.Format(time.RFC3339)
 	response := &CreateAPIKeyResponse{
 		Key:       plaintext, // SHOWN ONCE, NEVER AGAIN
 		KeyPrefix: prefix,
 		ID:        keyID,
 		Name:      name,
 		CreatedAt: time.Now().UTC().Format(time.RFC3339),
-	}
-	if expiresAt != nil {
-		formatted := expiresAt.Format(time.RFC3339)
-		response.ExpiresAt = &formatted
+		ExpiresAt: &formatted,
 	}
 
 	return response, nil

--- a/maas-api/internal/api_keys/service_test.go
+++ b/maas-api/internal/api_keys/service_test.go
@@ -344,11 +344,12 @@ func TestCreateAPIKey_MaxExpirationLimit(t *testing.T) {
 		}
 		svc := api_keys.NewServiceWithLogger(store, cfg, logger.Development())
 
-		// Request permanent key (nil expiration) - should succeed (max limit only applies to expiring keys)
+		// No expiration requested - should default to APIKeyMaxExpirationDays (30 days)
 		result, err := svc.CreateAPIKey(ctx, "alice", []string{"users"}, "Test Key", "", nil)
 
 		require.NoError(t, err)
 		require.NotNil(t, result)
+		require.NotNil(t, result.ExpiresAt, "should default to max expiration when not provided")
 	})
 }
 

--- a/maas-api/internal/config/config.go
+++ b/maas-api/internal/config/config.go
@@ -37,10 +37,6 @@ type Config struct {
 	// Format: postgresql://user:password@host:port/database
 	DBConnectionURL string
 
-	// APIKeyExpirationPolicy controls whether API keys must have expiration
-	// Values: "optional" (default) or "required"
-	APIKeyExpirationPolicy string
-
 	// APIKeyMaxExpirationDays is the maximum allowed expiration in days for API keys.
 	// Users cannot create API keys with expiration longer than this value.
 	// Default: 30 days. Minimum: 1 day.
@@ -67,7 +63,6 @@ func Load() *Config {
 		TLS:                     loadTLSConfig(),
 		DebugMode:               debugMode,
 		DBConnectionURL:         "", // Loaded from K8s secret via LoadDatabaseURL()
-		APIKeyExpirationPolicy:  env.GetString("API_KEY_EXPIRATION_POLICY", "optional"),
 		APIKeyMaxExpirationDays: maxExpirationDays,
 		// Deprecated env var (backward compatibility with pre-TLS version)
 		deprecatedHTTPPort: env.GetString("PORT", ""),
@@ -126,11 +121,6 @@ func (c *Config) Validate() error {
 		} else {
 			c.Address = DefaultInsecureAddr
 		}
-	}
-
-	// Validate API key expiration policy
-	if c.APIKeyExpirationPolicy != "optional" && c.APIKeyExpirationPolicy != "required" {
-		return errors.New("API_KEY_EXPIRATION_POLICY must be 'optional' or 'required'")
 	}
 
 	// Validate API key max expiration days

--- a/maas-api/internal/config/config_test.go
+++ b/maas-api/internal/config/config_test.go
@@ -46,7 +46,6 @@ func TestConfig_Validate_APIKeyMaxExpirationDays(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &config.Config{
 				DBConnectionURL:         "postgresql://test:test@localhost/test",
-				APIKeyExpirationPolicy:  "optional",
 				APIKeyMaxExpirationDays: tt.maxDays,
 			}
 

--- a/maas-api/internal/constant/const.go
+++ b/maas-api/internal/constant/const.go
@@ -16,7 +16,7 @@ const (
 
 	// API Key configuration defaults.
 	// DefaultAPIKeyMaxExpirationDays is the default maximum allowed expiration for API keys.
-	DefaultAPIKeyMaxExpirationDays = 30
+	DefaultAPIKeyMaxExpirationDays = 90
 
 	// LLMInferenceService annotation keys for model metadata.
 	AnnotationGenAIUseCase = "opendatahub.io/genai-use-case"

--- a/maas-api/openapi3.yaml
+++ b/maas-api/openapi3.yaml
@@ -171,7 +171,7 @@ paths:
             tags:
                 - api-keys-v2
             summary: Create a new hash-based API key
-            description: Creates a new OpenAI-compatible API key (sk-oai-* format). Supports both permanent keys (no expiration) and expiring keys (with expiresIn parameter). The plaintext key is shown ONLY ONCE at creation time and cannot be retrieved again.
+            description: Creates a new OpenAI-compatible API key (sk-oai-* format). If expiresIn is not provided, defaults to API_KEY_MAX_EXPIRATION_DAYS (default 90 days). The plaintext key is shown ONLY ONCE at creation time and cannot be retrieved again.
             operationId: api-keys-v2#create
             requestBody:
                 required: true
@@ -190,19 +190,19 @@ paths:
                                     description: Optional description
                                 expiresIn:
                                     type: string
-                                    description: Optional expiration duration (e.g., "30d", "90d", "1h"). Omit for permanent key.
+                                    description: Expiration duration (e.g., "30d", "90d", "1h"). Defaults to API_KEY_MAX_EXPIRATION_DAYS if not provided.
                         examples:
-                            permanent_key:
-                                summary: Permanent API key (no expiration)
+                            default_expiration:
+                                summary: API key with default expiration (API_KEY_MAX_EXPIRATION_DAYS)
                                 value:
-                                    name: my-permanent-key
+                                    name: my-api-key
                                     description: Production API key
-                            expiring_key:
-                                summary: Expiring API key (90 days)
+                            custom_expiration:
+                                summary: API key with custom expiration (30 days)
                                 value:
-                                    name: my-expiring-key
-                                    description: 90-day test key
-                                    expiresIn: 90d
+                                    name: my-short-lived-key
+                                    description: 30-day test key
+                                    expiresIn: 30d
             responses:
                 "201":
                     description: Created response.
@@ -230,7 +230,7 @@ paths:
                                     expiresAt:
                                         type: string
                                         format: date-time
-                                        description: Expiration timestamp (RFC3339), omitted for permanent keys
+                                        description: Expiration timestamp (RFC3339)
                 "400":
                     description: Bad Request response.
                 "401":
@@ -642,7 +642,7 @@ components:
                 expirationDate:
                     type: string
                     format: date-time
-                    description: When the API key expires (empty for permanent keys)
+                    description: When the API key expires
                 status:
                     type: string
                     enum: [active, revoked, expired]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR removes support for permanent API keys and introduces default expiration for all API keys.

### Changes
**Behavior Change:**
* API keys now default to `API_KEY_MAX_EXPIRATION_DAYS (90 days)` when expiresIn is not provided
* Permanent keys (keys without expiration) are no longer supported
* This improves security by ensuring all API keys have a bounded lifetime
**Configuration:**
* Removed `API_KEY_EXPIRATION_POLICY` environment variable (no longer needed since all keys must expire)
* Changed DefaultAPIKeyMaxExpirationDays from 30 to 90 days

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* Unit tests
* Manual testing

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API keys now expire by default (90 days) and the expiration is configurable; creation responses always include an expiresAt timestamp and the plaintext key on creation.

* **Documentation**
  * Updated API docs and examples to reflect default expiration, new example key names, and short-lived key example (30 days).

* **Chores**
  * Removed legacy API key expiration policy configuration field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->