### PR TITLE
fix: patch maas-api URL placeholder in kustomize deployment mode

### DIFF
--- a/deployment/base/maas-api/policies/auth-policy.yaml
+++ b/deployment/base/maas-api/policies/auth-policy.yaml
@@ -29,7 +29,9 @@ spec:
         when:
           - predicate: request.headers.authorization.startsWith("Bearer sk-oai-")
         http:
-          # Overwritten by ODH overlay replacement (app-namespace param). Use placeholder.
+          # Placeholder URL - gets patched based on deployment mode:
+          #   - Operator mode (ODH/RHOAI): ODH overlay replacement (app-namespace param)
+          #   - Kustomize mode: deploy.sh script patches with $NAMESPACE via sed
           url: https://maas-api.placehold.svc.cluster.local:8443/internal/v1/api-keys/validate
           method: POST
           contentType: application/json

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -574,7 +574,8 @@ deploy_via_kustomize() {
   deploy_postgresql
 
   log_info "Applying kustomize manifests..."
-  kubectl apply --server-side=true --force-conflicts="$KUSTOMIZE_FORCE_CONFLICTS" -f <(kustomize build "$overlay")
+  # Patch the maas-api URL placeholder with actual namespace
+  kubectl apply --server-side=true --force-conflicts="$KUSTOMIZE_FORCE_CONFLICTS" -f <(kustomize build "$overlay" | sed "s/maas-api\.placehold\.svc/maas-api.$NAMESPACE.svc/g")
 
   # Apply gateway policies separately so they stay in openshift-ingress (overlay
   # namespace would otherwise overwrite them to $NAMESPACE)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Related to - https://redhat.atlassian.net/browse/RHOAIENG-53772

Background
PR #527 updated the maas-api auth policy to use a placeholder URL (maas-api.placehold.svc) instead of hardcoded namespace (opendatahub). The placeholder gets replaced via kustomize replacements in the ODH overlay using the app-namespace parameter from params.env. This change was intended to support flexible namespace deployment for different operators (ODH vs RHOAI).

Problem
  The TLS backend (tls-backend) and HTTP backend (http-backend) overlays used in kustomize deployment mode do not have:
  - params.env file with namespace configuration
  - ConfigMap generator for parameters
  - Kustomize replacements to patch the placeholder URL

  This caused the auth policy to be deployed with the literal placeholder URL
  https://maas-api.placehold.svc.cluster.local:8443/internal/v1/api-keys/validate, breaking API key authentication.

  Steps to Reproduce
  1. Deploy MaaS using kustomize mode:
  ./scripts/deploy.sh --deployment-mode kustomize --enable-tls-backend
  2. Check the deployed AuthPolicy:
  kubectl get authpolicy maas-api-auth-policy -n opendatahub -o yaml | grep "api-keys/validate"

  Expected Behavior
  The auth policy URL should be patched to use the actual deployment namespace:
  url: https://maas-api.opendatahub.svc.cluster.local:8443/internal/v1/api-keys/validate

  Actual Behavior
  The auth policy URL contains the unpatched placeholder:
  url: https://maas-api.placehold.svc.cluster.local:8443/internal/v1/api-keys/validate

  This causes API key validation requests to fail with DNS resolution errors, breaking all API key-based authentication.

  Root Cause
  The kustomize overlays (tls-backend, http-backend) lack the replacement configuration that exists in the odh overlay:

  ODH overlay has:
  - params.env with app-namespace=opendatahub
  - ConfigMapGenerator creating maas-parameters
  - Kustomize replacement targeting spec.rules.metadata.apiKeyValidation.http.url

  TLS/HTTP backend overlays missing:
  - All of the above components

  Impact

  - Severity: High - Breaks API key authentication completely in kustomize deployment mode
  - Scope: Affects all deployments using --deployment-mode kustomize (both TLS and HTTP backends)
  - Workaround: None - deployment is broken for kustomize mode
  - Operator mode: Not affected (ODH/RHOAI overlays have proper replacement logic)

  Solution
  Added sed-based patching in scripts/deploy.sh to replace the placeholder URL with the actual namespace during kustomize build:
  kustomize build "$overlay" | sed "s/maas-api\.placehold\.svc/maas-api.$NAMESPACE.svc/g"

  Design Decision: Chose script-based patching over duplicating params.env files across three overlays to maintain DRY principles
  and avoid configuration drift.

  Files Changed
  1. scripts/deploy.sh:577 - Added sed patching to replace placeholder with $NAMESPACE
  2. deployment/base/maas-api/policies/auth-policy.yaml:32-34 - Updated comment to document both patching methods (ODH overlay
  replacement vs deploy.sh sed)

  ```
Testing/Verification

  ✅ Tested on cluster:
  ./scripts/deploy.sh --deployment-mode kustomize --enable-tls-backend

  ✅ Verified URL patching:
  kubectl get authpolicy maas-api-auth-policy -n opendatahub -o yaml | grep "api-keys/validate"
  # Output: url: https://maas-api.opendatahub.svc.cluster.local:8443/internal/v1/api-keys/validate

  ✅ Verified both overlays work:
  - tls-backend overlay: ✅ URL correctly patched
  - http-backend overlay: ✅ URL correctly patched
  - odh overlay: ✅ Still works with kustomize replacements

  ✅ CodeRabbit review: No findings
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested on live cluster 
```
somyabhatnagar@Somyas-MacBook-Pro models-as-a-service % oc login https://api.ci-ln-hlkdrfk-76ef8.aws-4.ci.openshift.org:6443 --web
The server uses a certificate signed by an unknown authority.
You can bypass the certificate check, but any data you send to the server could be intercepted by others.
Use insecure connections? (y/n): y

WARNING: Using insecure TLS client config. Setting this option is not supported!

Opening login URL in the default browser: https://oauth-openshift.apps.ci-ln-hlkdrfk-76ef8.aws-4.ci.openshift.org/oauth/authorize?client_id=openshift-cli-client&code_challenge=fvLt3bBVCbvYdSatndrZg_2MK5869FIZ7abjlUxLDsA&code_challenge_method=S256&redirect_uri=http%3A%2F%2F127.0.0.1%3A52210%2Fcallback&response_type=code
Login successful.

You have access to 74 projects, the list has been suppressed. You can list all projects with 'oc projects'

Using project "default".
somyabhatnagar@Somyas-MacBook-Pro models-as-a-service % ./scripts/deploy.sh --deployment-mode kustomize --enable-tls-backend
[INFO] ===================================================
[INFO]   Models-as-a-Service Deployment
[INFO] ===================================================
[INFO] Validating configuration...
[INFO] Configuration validated successfully
[INFO] Deployment configuration:
[INFO]   Mode: kustomize
[INFO]   Policy Engine: kuadrant
[INFO]   Namespace: opendatahub
[INFO]   TLS Backend: true
[INFO] Starting kustomize-based deployment...
[INFO] Installing policy engine: kuadrant
[INFO] Installing Kuadrant v1.3.1 (upstream community)
[INFO] Creating Kuadrant v1.3.1 catalog source...
namespace/kuadrant-system created
catalogsource.operators.coreos.com/kuadrant-operator-catalog created
[INFO] Waiting for Kuadrant catalog to be ready...
operatorgroup.operators.coreos.com/kuadrant-operator-group created
[INFO] Installing operator: kuadrant-operator in namespace: kuadrant-system
namespace/kuadrant-system condition met
[INFO] Creating Subscription for kuadrant-operator from kuadrant-operator-catalog (channel: stable)
subscription.operators.coreos.com/kuadrant-operator created
[INFO] Waiting for subscription to install...
  * Waiting for Subscription kuadrant-system/kuadrant-operator to start setup...
subscription.operators.coreos.com/kuadrant-operator condition met
  * Waiting for Subscription setup to finish setup. CSV = kuadrant-operator.v1.3.1 ...
clusterserviceversion.operators.coreos.com/kuadrant-operator.v1.3.1 condition met
[INFO] Operator kuadrant-operator installed successfully
[INFO] Patching kuadrant-operator CSV for OpenShift Gateway controller...
clusterserviceversion.operators.coreos.com/kuadrant-operator.v1.3.1 patched
[INFO] CSV patched for OpenShift Gateway controller
[INFO] Forcing operator restart to apply new Gateway controller configuration...
pod "kuadrant-operator-controller-manager-54b54c8744-smx2q" force deleted from kuadrant-system namespace
pod "kuadrant-operator-controller-manager-68d7ff44d6-srsgr" force deleted from kuadrant-system namespace
pod "limitador-operator-controller-manager-84d8fbb794-zp7mt" force deleted from kuadrant-system namespace
[INFO] Waiting for operator pod to restart...
Waiting for deployment "kuadrant-operator-controller-manager" rollout to finish: 1 old replicas are pending termination...
Waiting for deployment "kuadrant-operator-controller-manager" rollout to finish: 1 old replicas are pending termination...
Waiting for deployment "kuadrant-operator-controller-manager" rollout to finish: 1 old replicas are pending termination...
deployment "kuadrant-operator-controller-manager" successfully rolled out
[WARN] Operator pod may not have correct env yet: 
[INFO] Waiting 15s for operator to fully initialize with Gateway controller configuration...
[INFO] Initializing Gateway API and ModelsAsService gateway...
[INFO] Setting up Gateway API infrastructure...
gatewayclass.gateway.networking.k8s.io/openshift-default created
[INFO] Setting up ModelsAsService gateway...
[INFO]   Cluster domain: apps.ci-ln-hlkdrfk-76ef8.aws-4.ci.openshift.org
[INFO]   Detecting TLS certificate secret...
[INFO]   * Found certificate from router deployment: router-certs-default
[INFO]   TLS certificate secret: router-certs-default
[INFO] Creating maas-default-gateway resource (allowing routes from all namespaces)...
gateway.gateway.networking.k8s.io/maas-default-gateway serverside-applied
[INFO] Waiting for Gateway to be Programmed (Service Mesh initialization)...
gateway.gateway.networking.k8s.io/maas-default-gateway condition met
[INFO] Applying Kuadrant custom resource in kuadrant-system...
kuadrant.kuadrant.io/kuadrant created
[INFO] Waiting for Kuadrant to become ready (initial check)...
[INFO] Waiting for: Kuadrant ready in kuadrant-system (timeout: 60s)
[WARN] Kuadrant ready in kuadrant-system - Timeout after 60s
[INFO] Kuadrant shows MissingDependency - restarting operator to re-register Gateway controller...
pod "authorino-76d7b84c9-8d5dj" force deleted from kuadrant-system namespace
pod "kuadrant-operator-controller-manager-68d7ff44d6-lqn8z" force deleted from kuadrant-system namespace
pod "limitador-operator-controller-manager-84d8fbb794-95tvc" force deleted from kuadrant-system namespace
[INFO] Retrying Kuadrant readiness check after operator restart...
[INFO] Waiting for: Kuadrant ready in kuadrant-system (timeout: 120s)
[INFO] Kuadrant ready in kuadrant-system - Ready
[INFO] Kuadrant setup complete
[INFO] Using TLS backend overlay
[INFO] Creating namespace: opendatahub
namespace/opendatahub created
[INFO] Deploying PostgreSQL for API key storage...
[INFO]   Generated random PostgreSQL password (stored in secret postgres-creds)
[INFO]   Creating PostgreSQL deployment...
[INFO]   ⚠️  Using POC configuration (ephemeral storage)
secret/postgres-creds created
deployment.apps/postgres created
service/postgres created
secret/maas-db-config created
[INFO]   Waiting for PostgreSQL to be ready...
deployment.apps/postgres condition met
[INFO]   PostgreSQL deployed successfully
[INFO]   Database: maas
[INFO]   User: maas
[INFO]   Secret: maas-db-config (contains DB_CONNECTION_URL)
[INFO] 
[INFO]   ⚠️  For production, use AWS RDS, Crunchy Operator, or Azure Database
[INFO]   Note: Schema migrations run automatically when maas-api starts
[INFO] Applying kustomize manifests...
customresourcedefinition.apiextensions.k8s.io/maasauthpolicies.maas.opendatahub.io serverside-applied
customresourcedefinition.apiextensions.k8s.io/maasmodelrefs.maas.opendatahub.io serverside-applied
customresourcedefinition.apiextensions.k8s.io/maassubscriptions.maas.opendatahub.io serverside-applied
serviceaccount/maas-api serverside-applied
serviceaccount/maas-controller serverside-applied
role.rbac.authorization.k8s.io/maas-controller-leader-election-role serverside-applied
clusterrole.rbac.authorization.k8s.io/maas-api serverside-applied
clusterrole.rbac.authorization.k8s.io/maas-controller-role serverside-applied
rolebinding.rbac.authorization.k8s.io/maas-controller-leader-election-rolebinding serverside-applied
clusterrolebinding.rbac.authorization.k8s.io/maas-api serverside-applied
clusterrolebinding.rbac.authorization.k8s.io/maas-controller-rolebinding serverside-applied
configmap/tier-to-group-mapping serverside-applied
service/maas-api serverside-applied
deployment.apps/maas-api serverside-applied
deployment.apps/maas-controller serverside-applied
httproute.gateway.networking.k8s.io/maas-api-route serverside-applied
authpolicy.kuadrant.io/maas-api-auth-policy serverside-applied
destinationrule.networking.istio.io/maas-api-backend-tls serverside-applied
networkpolicy.networking.k8s.io/maas-authorino-allow serverside-applied
[INFO] Applying gateway policies (openshift-ingress)...
authpolicy.kuadrant.io/gateway-default-auth serverside-applied
tokenratelimitpolicy.kuadrant.io/gateway-default-deny serverside-applied
[INFO] Configuring TLS backend for Authorino and MaaS API...
* Waiting for deployment/authorino in kuadrant-system...
  * Found deployment/authorino
[INFO] Running TLS configuration script...
[INFO] TLS configuration script completed successfully
[INFO] Restarting deployments to pick up TLS configuration...
deployment.apps/maas-api restarted
deployment.apps/authorino restarted
[INFO] Waiting for Authorino deployment to be ready...
Waiting for deployment "authorino" rollout to finish: 1 old replicas are pending termination...
Waiting for deployment "authorino" rollout to finish: 1 old replicas are pending termination...
deployment "authorino" successfully rolled out
[INFO] TLS backend configuration complete
[INFO] Checking cluster OIDC audience...
[INFO] Standard Kubernetes audience detected, no patching needed
[INFO] Kustomize deployment completed
[INFO] 
[INFO] MaaS Subscription Controller...
[INFO]   Controller deployed via kustomize overlay (deployment/base/maas-controller/default)
[INFO]   Waiting for maas-controller to be ready...
deployment "maas-controller" successfully rolled out
[INFO]   Subscription controller ready.
[INFO]   Create MaaSModelRef, MaaSAuthPolicy, and MaaSSubscription to enable per-model auth and rate limiting.
[INFO] ===================================================
[INFO]   Deployment completed successfully!
[INFO] ===================================================
somyabhatnagar@Somyas-MacBook-Pro models-as-a-service %  kubectl get authpolicy maas-api-auth-policy -n opendatahub -o yaml | grep -A2 "api-keys/validate"
          url: https://maas-api.opendatahub.svc.cluster.local:8443/internal/v1/api-keys/validate
        metrics: false
        priority: 0

```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment configuration to automatically replace placeholder API URLs with actual namespace-specific addresses, ensuring correct API connectivity across different deployment environments and reducing manual configuration errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->