### PR TITLE
fix(maas-controller): resolve golangci-lint issues in maas-controller

### DIFF
--- a/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
@@ -58,20 +58,6 @@ type MaaSAuthPolicyReconciler struct {
 	ClusterAudience string
 }
 
-func (r *MaaSAuthPolicyReconciler) gatewayName() string {
-	if r.GatewayName != "" {
-		return r.GatewayName
-	}
-	return defaultGatewayName
-}
-
-func (r *MaaSAuthPolicyReconciler) clusterAudience() string {
-	if r.ClusterAudience != "" {
-		return r.ClusterAudience
-	}
-	return defaultClusterAudience
-}
-
 //+kubebuilder:rbac:groups=maas.opendatahub.io,resources=maasauthpolicies,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=maas.opendatahub.io,resources=maasauthpolicies/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=maas.opendatahub.io,resources=maasauthpolicies/finalizers,verbs=update

--- a/maas-controller/pkg/controller/maas/maasauthpolicy_controller_test.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_controller_test.go
@@ -270,6 +270,7 @@ func TestMaaSAuthPolicyReconciler_DeleteAnnotation(t *testing.T) {
 		})
 	}
 }
+
 // TestMaaSAuthPolicyReconciler_MultiplePoliciesDeletion verifies that when multiple
 // MaaSAuthPolicies reference the same model, deleting one does not delete the aggregated
 // AuthPolicy, but deleting the last one does.
@@ -382,4 +383,3 @@ func TestMaaSAuthPolicyReconciler_MultiplePoliciesDeletion(t *testing.T) {
 		t.Errorf("AuthPolicy should be deleted after deleting last parent policy, but got error: %v", err)
 	}
 }
-

--- a/maas-controller/pkg/controller/maas/maasmodelref_controller_test.go
+++ b/maas-controller/pkg/controller/maas/maasmodelref_controller_test.go
@@ -293,7 +293,7 @@ func TestMaaSModelReconciler_LLMISvcReadyTransition_ModelBecomesReady(t *testing
 		t.Fatal("mapLLMISvcToMaaSModels returned no requests; the MaaSModelRef referencing this LLMInferenceService should have been enqueued")
 	}
 	for _, watchReq := range requests {
-		if _, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: watchReq.NamespacedName}); err != nil {
+		if _, err := r.Reconcile(ctx, ctrl.Request(watchReq)); err != nil {
 			t.Fatalf("Reconcile (triggered by LLMInferenceService watch): %v", err)
 		}
 	}
@@ -355,7 +355,7 @@ func TestMaaSModelReconciler_LLMISvcReadyToNotReady_ModelBecomesPending(t *testi
 		t.Fatal("mapLLMISvcToMaaSModels returned no requests; the MaaSModelRef referencing this LLMInferenceService should have been enqueued")
 	}
 	for _, watchReq := range requests {
-		if _, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: watchReq.NamespacedName}); err != nil {
+		if _, err := r.Reconcile(ctx, ctrl.Request(watchReq)); err != nil {
 			t.Fatalf("Reconcile (triggered by LLMInferenceService watch): %v", err)
 		}
 	}

--- a/maas-controller/pkg/controller/maas/maassubscription_controller_test.go
+++ b/maas-controller/pkg/controller/maas/maassubscription_controller_test.go
@@ -273,6 +273,7 @@ func TestMaaSSubscriptionReconciler_DeleteAnnotation(t *testing.T) {
 		})
 	}
 }
+
 // TestMaaSSubscriptionReconciler_MultipleSubscriptionsDeletion verifies that when multiple
 // MaaSSubscriptions reference the same model, deleting one does not delete the aggregated
 // TokenRateLimitPolicy, but deleting the last one does.


### PR DESCRIPTION
## Summary

Fix pre-existing golangci-lint issues (staticcheck, unused, gofmt) in the maas-controller package to achieve a clean lint pass.

## Description

- Remove unused `gatewayName()` and `clusterAudience()` methods from `MaaSAuthPolicyReconciler`. These were dead code — the `MaaSModelRefReconciler` has its own actively-used `gatewayName()` method, but the auth policy reconciler never calls these helpers.
- Replace `ctrl.Request{NamespacedName: watchReq.NamespacedName}` with idiomatic type conversion `ctrl.Request(watchReq)` in two test cases (staticcheck S1016).
- Apply gofmt whitespace fixes (missing/extra blank lines between top-level declarations) in auth policy and subscription controller tests.
- No behavioral changes; all existing tests continue to pass.

## How It Was Tested

- `make test` — all maas-controller unit tests pass.
- `golangci-lint run` — 0 issues (previously 4).

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests to validate deletion behavior when multiple resources reference the same model, ensuring correct lifecycle management.

* **Refactor**
  * Removed internal helper methods to simplify the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->