### PR TITLE
docs: fix dCERT_NAME typo in Gateway setup command

### DIFF
--- a/docs/content/install/maas-setup.md
+++ b/docs/content/install/maas-setup.md
@@ -57,7 +57,7 @@ The Gateway must exist before enabling modelsAsService in your DataScienceCluste
 ```yaml
 CLUSTER_DOMAIN=$(kubectl get ingresses.config.openshift.io cluster -o jsonpath='{.spec.domain}')
 # Use default ingress cert for HTTPS, or set CERT_NAME to your TLS secret name
-dCERT_NAME=${CERT_NAME:-$(kubectl get ingresscontroller default -n openshift-ingress-operator -o jsonpath='{.spec.defaultCertificate.name}' 2>/dev/null)}
+CERT_NAME=${CERT_NAME:-$(kubectl get ingresscontroller default -n openshift-ingress-operator -o jsonpath='{.spec.defaultCertificate.name}' 2>/dev/null)}
 [[ -z "$CERT_NAME" ]] && CERT_NAME="router-certs-default"
 
 kubectl apply -f - <<EOF


### PR DESCRIPTION
## Summary

- Fix typo `dCERT_NAME` → `CERT_NAME` in Gateway setup command that caused silent failure of certificate auto-detection

Users with custom ingress certificates would always get `router-certs-default` instead of their actual certificate, potentially causing the Gateway to fail to program.

---
*Created by document-review workflow `/create-prs` phase.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed a typo in the Gateway setup documentation that prevented the TLS certificate name from being properly configured during installation, ensuring correct certificate assignment in your Gateway manifest.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->