### PR TITLE
docs: update stale authentication docs and fix typo

### DIFF
--- a/docs/content/configuration-and-management/maas-controller-overview.md
+++ b/docs/content/configuration-and-management/maas-controller-overview.md
@@ -220,7 +220,7 @@ flowchart LR
 
 ## 9. Authentication (Current Behavior)
 
-For **GET /v1/models**, the API forwards the client’s **Authorization** header as-is to each model endpoint (no token exchange). For inference, until MaaS API token minting is in place, use the **OpenShift token**:
+For **GET /v1/models**, the API forwards the client’s **Authorization** header as-is to each model endpoint (no token exchange). For inference, use an **API key** (created via `POST /maas-api/v1/api-keys`) or an **OpenShift token**:
 
 ```bash
 export TOKEN=$(oc whoami -t)

--- a/maas-controller/README.md
+++ b/maas-controller/README.md
@@ -35,7 +35,7 @@ Models with no MaaSAuthPolicy or MaaSSubscription are denied at the gateway leve
 ### CRDs and what they generate
 
 As MaaS API and controller are conventionally deployed in the operator namespace (e.g., `opendatahub`), MaaS CRs need to be separated so that they can be managed with lower cluster privileges. Therefore,
-- **MaasModelRef** is located in the same namespace as the **HTTPRoute** and **LLMInderenceService** it refers to; and
+- **MaasModelRef** is located in the same namespace as the **HTTPRoute** and **LLMInferenceService** it refers to; and
 - **MaaSAuthPolicy** and **MaaSSubscription** are located in a dedicated subscription namespace (default: `models-as-a-service`). Set `--maas-subscription-namespace` or the `MAAS_SUBSCRIPTION_NAMESPACE` env var in `maas-controller` deployment to use another namespace. MaaS controller will only watch and reconcile those CRs this configured namespace.
 
 | You create | Controller generates | Per | Targets |
@@ -182,7 +182,7 @@ deny-unsubscribed (0):        matches "NOT in premium-user AND NOT in free-user"
 
 ## Authentication
 
-Until API token minting is in place, the controller uses **OpenShift tokens directly** for inference:
+The platform supports two authentication methods for inference. **API keys** (recommended) can be created via `POST /maas-api/v1/api-keys`. Alternatively, **OpenShift tokens** can be used directly:
 
 ```bash
 export TOKEN=$(oc whoami -t)


### PR DESCRIPTION
## Summary

- Update "until minting is in place" phrasing to reflect that API key minting is available
- Fix "LLMInderenceService" typo to "LLMInferenceService" in maas-controller README

API key minting via `POST /v1/api-keys` is fully implemented and documented in other guides.

---
*Created by document-review workflow `/create-prs` phase.*