### PR TITLE
docs: fix access probe response codes in model-listing-flow

### DIFF
--- a/docs/content/configuration-and-management/model-listing-flow.md
+++ b/docs/content/configuration-and-management/model-listing-flow.md
@@ -23,7 +23,7 @@ When the [MaaS controller](https://github.com/opendatahub-io/models-as-a-service
 
 2. For each MaaSModelRef, it reads **id** (`metadata.name`), **url** (`status.endpoint`), **ready** (`status.phase == "Ready"`), and related metadata. The controller has populated `status.endpoint` and `status.phase` from the underlying LLMInferenceService (for llmisvc) or HTTPRoute/Gateway.
 
-3. **Access validation**: The API probes each model’s `/v1/models` endpoint with the **exact Authorization header** the client sent (passed through as-is). Only models that return **2xx**, **3xx** or **405** are included in the response. This ensures the list only shows models the client is authorized to use.
+3. **Access validation**: The API probes each model’s `/v1/models` endpoint with the **exact Authorization header** the client sent (passed through as-is). Only models that return **2xx** or **405** are included in the response. This ensures the list only shows models the client is authorized to use.
 
 4. For each model, the API reads **annotations** from the MaaSModelRef to populate `modelDetails` in the response (display name, description, use case, context window). See [CRD annotations](crd-annotations.md) for the full list.
 


### PR DESCRIPTION
## Summary
- Remove incorrect `3xx` from the list of response codes that grant access in the model-listing-flow documentation
- The source code (`discovery.go:256-300`) confirms that 3xx codes fall into the `default` switch case which returns `authRetry` (not `authGranted`). Only `2xx` and `405` result in `authGranted`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated model listing behavior to refine access validation criteria. The model listing endpoint now filters models more precisely based on HTTP response codes from endpoint probes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->