### PR TITLE
docs: fix OpenShift version and add maas-controller to layout

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,8 @@ This project follows a **Stream-Lake-Ocean** release model. Code flows from acti
 |------|--------|
 | `scripts/` | Deployment and install scripts (e.g. `deploy.sh`, `deployment-helpers.sh`, `install-dependencies.sh`) |
 | `deployment/` | Kustomize manifests (base, overlays, networking, components) |
-| `maas-api/` | Go API service (keys, tokens, tiers); see [maas-api/README.md](maas-api/README.md) |
+| `maas-api/` | Go API service (keys, tokens, subscriptions); see [maas-api/README.md](maas-api/README.md) |
+| `maas-controller/` | Kubernetes controller for MaaS CRDs; see [maas-controller/README.md](maas-controller/README.md) |
 | `docs/` | User and admin documentation (MkDocs); [online docs](https://opendatahub-io.github.io/models-as-a-service/) |
 | `test/` | E2E and billing/smoke tests |
 | `.github/workflows/` | CI (build, PR title validation, MaaS API lint/build) |

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -44,7 +44,7 @@ Automated deployment script for OpenShift clusters supporting both operator-base
 - `--channel <channel>` - Operator channel override (default: fast-3 for ODH, fast-3.x for RHOAI)
 
 **Requirements:**
-- OpenShift cluster (4.16+)
+- OpenShift cluster (4.19.9+)
 - `oc` CLI installed and logged in
 - `kubectl` installed
 - `jq` installed


### PR DESCRIPTION
## Summary

- Update OpenShift version requirement from 4.16+ to 4.19.9+ in scripts/README.md
- Add missing `maas-controller/` to CONTRIBUTING.md repository layout table


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated repository layout documentation to reflect additional service areas
  * Updated minimum supported OpenShift version requirement to 4.19.9+

<!-- end of auto-generated comment: release notes by coderabbit.ai -->