### PR TITLE
feat(maas-controller): enable FIPS compliance in Dockerfile.konflux

### DIFF
--- a/maas-controller/Dockerfile.konflux
+++ b/maas-controller/Dockerfile.konflux
@@ -4,7 +4,7 @@ ARG BUILDPLATFORM
 ARG TARGETPLATFORM
 
 FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset@sha256:799cc027d5ad58cdc156b65286eb6389993ec14c496cf748c09834b7251e78dc AS builder
-ARG CGO_ENABLED=0
+ARG CGO_ENABLED=1
 ARG TARGETOS
 ARG TARGETARCH
 
@@ -14,7 +14,7 @@ RUN go mod download
 COPY . .
 
 USER root
-RUN CGO_ENABLED=${CGO_ENABLED} GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} go build -a -trimpath -ldflags="-s -w" -o manager ./cmd/manager
+RUN CGO_ENABLED=${CGO_ENABLED} GOEXPERIMENT=strictfipsruntime GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} go build -a -trimpath -ldflags="-s -w" -o manager ./cmd/manager
 
 FROM --platform=$TARGETPLATFORM registry.access.redhat.com/ubi9/ubi-minimal@sha256:80f3902b6dcb47005a90e14140eef9080ccc1bb22df70ee16b27d5891524edb2
 


### PR DESCRIPTION
## Summary
Enable FIPS compliance in `maas-controller/Dockerfile.konflux` by aligning it with `maas-api/Dockerfile.konflux` (introduced in PR #255).

## Description
- Set `CGO_ENABLED=1` — required to link against system crypto libraries (OpenSSL) instead of Go's built-in crypto
- Add `GOEXPERIMENT=strictfipsruntime` — enables startup validation that a FIPS-compatible crypto backend is active at runtime

No behavioral changes to the controller logic or deployment manifests.

## How it was tested
- Built `Dockerfile.konflux` locally using `podman build` targeting `linux/amd64`, image built successfully through both builder and runtime stages

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to enforce stricter compliance standards and optimize native library integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->