### PR TITLE
feat: enable FIPS compliance in maas-controller

### DIFF
--- a/maas-controller/Dockerfile
+++ b/maas-controller/Dockerfile
@@ -5,6 +5,7 @@ ARG TARGETPLATFORM
 
 FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:$GOLANG_VERSION AS builder
 ARG CGO_ENABLED=1
+ARG GOEXPERIMENT=strictfipsruntime
 ARG TARGETOS
 ARG TARGETARCH
 
@@ -15,7 +16,7 @@ COPY . .
 
 USER root
 
-RUN CGO_ENABLED=${CGO_ENABLED} GOEXPERIMENT=strictfipsruntime GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} go build -a -trimpath -ldflags="-s -w" -o manager ./cmd/manager
+RUN CGO_ENABLED=${CGO_ENABLED} GOEXPERIMENT=${GOEXPERIMENT} GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} go build -a -trimpath -ldflags="-s -w" -o manager ./cmd/manager
 
 FROM --platform=$TARGETPLATFORM registry.access.redhat.com/ubi9/ubi-minimal:latest
 

--- a/maas-controller/Dockerfile.konflux
+++ b/maas-controller/Dockerfile.konflux
@@ -5,6 +5,7 @@ ARG TARGETPLATFORM
 
 FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset@sha256:799cc027d5ad58cdc156b65286eb6389993ec14c496cf748c09834b7251e78dc AS builder
 ARG CGO_ENABLED=1
+ARG GOEXPERIMENT=strictfipsruntime
 ARG TARGETOS
 ARG TARGETARCH
 
@@ -14,7 +15,7 @@ RUN go mod download
 COPY . .
 
 USER root
-RUN CGO_ENABLED=${CGO_ENABLED} GOEXPERIMENT=strictfipsruntime GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} go build -a -trimpath -ldflags="-s -w" -o manager ./cmd/manager
+RUN CGO_ENABLED=${CGO_ENABLED} GOEXPERIMENT=${GOEXPERIMENT} GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} go build -a -trimpath -ldflags="-s -w" -o manager ./cmd/manager
 
 FROM --platform=$TARGETPLATFORM registry.access.redhat.com/ubi9/ubi-minimal@sha256:80f3902b6dcb47005a90e14140eef9080ccc1bb22df70ee16b27d5891524edb2
 

--- a/maas-controller/Makefile
+++ b/maas-controller/Makefile
@@ -1,45 +1,65 @@
 # MaaS Controller Makefile
 # Build and deploy the MaaS control plane (MaaSModelRef, MaaSAuthPolicy, MaaSSubscription)
 
+PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
+
 include tools.mk
 
-.PHONY: build run test tidy lint install uninstall image-build image-push docker-build generate manifests verify-codegen help
+.PHONY: build run test tidy lint install uninstall generate manifests verify-codegen help
 
 help:
 	@echo "MaaS Controller make targets:"
-	@echo "  make build        - build manager binary to bin/manager"
-	@echo "  make run          - build and run manager locally"
-	@echo "  make test         - run tests"
-	@echo "  make lint         - run golangci-lint"
-	@echo "  make generate     - generate deepcopy code for API types"
-	@echo "  make manifests    - generate CRD manifests"
-	@echo "  make install      - apply deployment/base/maas-controller/default (CRDs, RBAC, deployment)"
-	@echo "  make uninstall    - delete deployment/base/maas-controller/default resources"
-	@echo "  make verify-codegen - run generate + manifests and fail if files changed (CI check)"
-	@echo "  make image-build  - build container image (podman/buildah/docker); default IMAGE=quay.io/opendatahub/maas-controller"
-	@echo "  make image-push   - build and push image; override with IMAGE=... IMAGE_TAG=..."
+	@echo "  make build              - build manager binary to bin/manager"
+	@echo "  make run                - build and run manager locally"
+	@echo "  make test               - run tests"
+	@echo "  make lint               - run golangci-lint"
+	@echo "  make generate           - generate deepcopy code for API types"
+	@echo "  make manifests          - generate CRD manifests"
+	@echo "  make install            - apply deployment/base/maas-controller/default (CRDs, RBAC, deployment)"
+	@echo "  make uninstall          - delete deployment/base/maas-controller/default resources"
+	@echo "  make verify-codegen     - run generate + manifests and fail if files changed (CI check)"
+	@echo "  make build-image        - build container image; override with REPO=... TAG=..."
+	@echo "  make build-image-konflux - build container image using Dockerfile.konflux"
+	@echo "  make push-image         - push container image to registry"
+	@echo ""
+	@echo "FIPS options:"
+	@echo "  make build GO_STRICTFIPS=true  - build with FIPS strict runtime"
+
+BINARY_NAME := manager
+BUILD_DIR := $(PROJECT_DIR)/bin
+
+GOOS   ?= $(shell go env GOOS)
+GOARCH ?= $(shell go env GOARCH)
+GO_STRICTFIPS ?= false
+
+CGO_ENABLED  ?= 1
+
+ifeq ($(GO_STRICTFIPS),true)
+  GOEXPERIMENT ?= strictfipsruntime
+endif
+
+GO_ENV := GOOS=$(GOOS) GOARCH=$(GOARCH)
+ifdef GOEXPERIMENT
+  GO_ENV += GOEXPERIMENT=$(GOEXPERIMENT)
+endif
+ifdef CGO_ENABLED
+  GO_ENV += CGO_ENABLED=$(CGO_ENABLED)
+endif
 
 CONTROLLER_GEN_VERSION ?= v0.16.4
 CONTROLLER_GEN = $(BUILD_DIR)/controller-gen
 
-BINARY_NAME := manager
-BUILD_DIR := bin
-
-# Container build: use podman, buildah, or docker (default: podman if available, else buildah, else docker)
-CONTAINER_RUNTIME := $(shell command -v podman 1>/dev/null 2>&1 && echo podman || (command -v buildah 1>/dev/null 2>&1 && echo buildah || echo docker))
-# Default image
-IMAGE ?= quay.io/opendatahub/maas-controller
-IMAGE_TAG ?= latest
-FULL_IMAGE := $(IMAGE):$(IMAGE_TAG)
+## Container image
+include container.mk
 
 build: tidy $(BUILD_DIR)
-	go build -o $(BUILD_DIR)/$(BINARY_NAME) ./cmd/manager
+	$(GO_ENV) go build -o $(BUILD_DIR)/$(BINARY_NAME) ./cmd/manager
 
 $(BUILD_DIR):
 	mkdir -p $(BUILD_DIR)
 
 run: build
-	./$(BUILD_DIR)/$(BINARY_NAME)
+	$(BUILD_DIR)/$(BINARY_NAME)
 
 test: tidy
 	go test ./...
@@ -90,18 +110,3 @@ install:
 
 uninstall:
 	kubectl delete -k ../deployment/base/maas-controller/default --ignore-not-found
-
-# Build container image (podman, buildah, or docker)
-# buildah uses "bud" (build-using-dockerfile) instead of "build"
-BUILD_CMD := $(if $(filter buildah,$(CONTAINER_RUNTIME)),bud,build)
-image-build:
-	$(CONTAINER_RUNTIME) $(BUILD_CMD) -t $(FULL_IMAGE) --platform=linux/amd64 -f Dockerfile .
-	@echo "Built $(FULL_IMAGE) with $(CONTAINER_RUNTIME)"
-
-# Alias for image-build (backward compatibility)
-docker-build: image-build
-
-# Push image to registry (must be logged in, e.g. podman login quay.io)
-image-push: image-build
-	$(CONTAINER_RUNTIME) push $(FULL_IMAGE)
-	@echo "Pushed $(FULL_IMAGE)"

--- a/maas-controller/container.mk
+++ b/maas-controller/container.mk
@@ -1,0 +1,32 @@
+## Container image configuration and targets
+
+CONTAINER_ENGINE ?= podman
+REPO ?= quay.io/opendatahub/maas-controller
+TAG ?= latest
+FULL_IMAGE ?= $(REPO):$(TAG)
+
+DOCKER_BUILD_ARGS := --build-arg CGO_ENABLED=$(CGO_ENABLED)
+ifdef GOEXPERIMENT
+  DOCKER_BUILD_ARGS += --build-arg GOEXPERIMENT=$(GOEXPERIMENT)
+endif
+
+.PHONY: build-image
+build-image: ## Build container image (use REPO= and TAG= to specify image)
+	@echo "Building container image $(FULL_IMAGE)..."
+	$(CONTAINER_ENGINE) build $(DOCKER_BUILD_ARGS) $(CONTAINER_ENGINE_EXTRA_FLAGS) -t "$(FULL_IMAGE)" .
+	@echo "Container image $(FULL_IMAGE) built successfully"
+
+.PHONY: build-image-konflux
+build-image-konflux: ## Build container image with Dockerfile.konflux
+	@echo "Building container image $(FULL_IMAGE) using Dockerfile.konflux..."
+	$(CONTAINER_ENGINE) build $(DOCKER_BUILD_ARGS) $(CONTAINER_ENGINE_EXTRA_FLAGS) -f Dockerfile.konflux -t "$(FULL_IMAGE)" .
+	@echo "Container image $(FULL_IMAGE) built successfully"
+
+.PHONY: push-image
+push-image: ## Push container image (use REPO= and TAG= to specify image)
+	@echo "Pushing container image $(FULL_IMAGE)..."
+	@$(CONTAINER_ENGINE) push "$(FULL_IMAGE)"
+	@echo "Container image $(FULL_IMAGE) pushed successfully"
+
+.PHONY: build-push-image
+build-push-image: build-image push-image ## Build and push container image


### PR DESCRIPTION
## Summary
Enable FIPS compliance in `maas-controller`.

## Description
- Set `CGO_ENABLED=1` and `GOEXPERIMENT=strictfipsruntime` in Dockerfile.
- Add FIPS-aware build env and `GO_STRICTFIPS` toggle to Makefile.
- Extract container targets into `container.mk` with FIPS build-arg passthrough.

## How it was tested
- Verified `make build`, `make build-image`, `make build-image-konflux`, and `make build-push-image TAG=<my-repo>` locally.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Refactored build system configuration and container image handling for improved flexibility
  * Reorganized Makefile structure with new automated build targets and enhanced build configuration variables
  * Updated Docker configurations to support configurable build parameters and multiple build variants
<!-- end of auto-generated comment: release notes by coderabbit.ai -->