### PR TITLE
feat(ci): add multi-arch image builds for maas

### DIFF
--- a/.tekton/odh-maas-api-pull-request.yaml
+++ b/.tekton/odh-maas-api-pull-request.yaml
@@ -29,6 +29,12 @@ spec:
     value: maas-api/Dockerfile
   - name: path-context
     value: maas-api
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux/arm64
+    - linux/ppc64le
+    - linux/s390x
   - name: additional-tags
     value:
     - 'odh-pr-{{revision}}'

--- a/.tekton/odh-maas-api-push.yaml
+++ b/.tekton/odh-maas-api-push.yaml
@@ -28,6 +28,12 @@ spec:
     value: maas-api/Dockerfile
   - name: path-context
     value: maas-api
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux/arm64
+    - linux/ppc64le
+    - linux/s390x
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-maas-controller-pull-request.yaml
+++ b/.tekton/odh-maas-controller-pull-request.yaml
@@ -34,6 +34,12 @@ spec:
     - 'odh-pr-{{revision}}'
   - name: pipeline-type
     value: pull-request
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux/arm64
+    - linux/ppc64le
+    - linux/s390x
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-maas-controller-push.yaml
+++ b/.tekton/odh-maas-controller-push.yaml
@@ -28,6 +28,12 @@ spec:
     value: Dockerfile
   - name: path-context
     value: maas-controller
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux/arm64
+    - linux/ppc64le
+    - linux/s390x
   pipelineRef:
     resolver: git
     params:


### PR DESCRIPTION
Enable multi-architecture container image builds for both maas-api and maas-controller components by adding build-platforms parameter to support x86_64, arm64, ppc64le, and s390x architectures.

 ## Summary                                                                                                                                                                                                                                                                                                                                                                         
  Add multi-architecture build support to models-as-a-service components (maas-api and maas-controller).                                                                                                                                      
                                                                                                                                                                                                                                              
  ## Changes
  - Added `build-platforms` parameter to all maas pipeline runs (push and pull-request)                                                                                                                                                       
  - Enabled builds for: 
    - `linux/x86_64` (existing)                                                                                                                                                                                                                   
    - `linux/arm64` (aarch64)                                                                                                                                                                                                                     
    - `linux/ppc64le` (IBM Power)                                                                                                                                                                                                                 
    - `linux/s390x` (IBM Z) 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Verified on Konflux and quay repo that the builds are made and pushed to repo. 
<img width="376" height="240" alt="image" src="https://github.com/user-attachments/assets/b20b47bd-268d-4e5a-8f26-2ee023656be9" />
quay - https://quay.io/repository/opendatahub/maas-controller/manifest/sha256:78da17de0901c3b60ef345f01c3910218cb3f492b0bde69068ae54eba8927eef 

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added multi-architecture build support across build pipelines, targeting x86_64, arm64, ppc64le and s390x platforms to enable producing and testing images for these architectures. This updates pipeline run parameters so builds will include the listed target architectures consistently across CI runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->