### PR TITLE
chore: update smoke.sh to use API Keys

### DIFF
--- a/test/e2e/smoke.sh
+++ b/test/e2e/smoke.sh
@@ -106,6 +106,13 @@ mint_api_key() {
   local token="${2:-${BOOTSTRAP_TOKEN}}"
   local response
   local api_key
+  
+  # Pre-flight check for jq
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "[smoke] ERROR: jq is required to mint API keys" | tee -a "${LOG}" >&2
+    return 1
+  fi
+  
   echo "[smoke] Minting API key '${key_name}' via ${MAAS_API_BASE_URL}/v1/api-keys..." | tee -a "${LOG}" >&2
   
   if ! response=$(curl -skS --max-time 30 -X POST \
@@ -121,7 +128,7 @@ mint_api_key() {
   
   if [[ -z "${api_key}" || "${api_key}" == "null" ]]; then
     echo "[smoke] ERROR: Failed to mint API key" | tee -a "${LOG}" >&2
-    echo "[smoke] Response: ${response:0:500}" | tee -a "${LOG}" >&2
+    echo "[smoke] Response from /v1/api-keys was not parseable (may contain sensitive data)" | tee -a "${LOG}" >&2
     return 1
   fi
   
@@ -138,6 +145,9 @@ export TOKEN
 
 # Admin token setup - add to odh-admins, then mint admin API key
 setup_admin_token() {
+  # Clear any stale inherited value to prevent false positive admin tests
+  unset ADMIN_OC_TOKEN
+  
   echo "[smoke] Setting up admin token for admin tests..."
   
   local current_user


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Switch smoke tests to use minted MaaS API keys instead of raw oc whoami -t cluster tokens.

[RHOAIENG-51553](https://redhat.atlassian.net/browse/RHOAIENG-51553)

## How Has This Been Tested?
* Manual testing against cluster with MaaS API deployed
* To test locally:
```
cd test/e2e
./smoke.sh
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * End-to-end tests now obtain short-lived API keys via the cluster bootstrap flow instead of using direct user tokens.
  * Test setup fails fast if minting the required test API key isn't possible; admin tests automatically mint admin credentials and are skipped when unavailable.
  * Logging reduced token exposure by recording only token/key lengths, not their contents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->