### PR TITLE
fix: use MaaS API key for validate-deployment.sh

### DIFF
--- a/scripts/validate-deployment.sh
+++ b/scripts/validate-deployment.sh
@@ -448,7 +448,7 @@ else
         if [ "$API_KEY_HTTP_CODE" = "201" ]; then
             TOKEN=$(echo "$API_KEY_BODY" | jq -r '.key // empty' 2>/dev/null)
             API_KEY_ID=$(echo "$API_KEY_BODY" | jq -r '.id // empty' 2>/dev/null)
-            if [ -n "$TOKEN" ] && [ -n "$API_KEY_ID" ]; then
+            if [ -n "$TOKEN" ] && [ "$TOKEN" != "null" ] && [ -n "$API_KEY_ID" ] && [ "$API_KEY_ID" != "null" ]; then
                 print_success "MaaS API key created (name: $API_KEY_NAME)"
                 # Set up cleanup trap to delete the API key on exit
                 cleanup_api_key() {
@@ -483,7 +483,7 @@ else
             fi
         else
             print_fail "Failed to create MaaS API key (HTTP $API_KEY_HTTP_CODE)" \
-                "Response: $(echo $API_KEY_BODY | head -c 200)" \
+                "Response: $(echo "$API_KEY_BODY" | head -c 200)" \
                 "Check MaaS API key endpoint: ${HOST}/maas-api/v1/api-keys"
             TOKEN=""
         fi


### PR DESCRIPTION
## Summary
- The `validate-deployment.sh` script was using the raw OpenShift identity token (`oc whoami -t`) directly for API calls to the models endpoint
- The models endpoint requires a MaaS API key for proper authentication, which caused the models list to return empty results
- Updated the script to create a temporary API key via `POST /maas-api/v1/api-keys` (matching the approach in `verify-models-and-limits.sh`) and clean it up on exit

## Test plan
- [x] Ran `validate-deployment.sh` against a live cluster — all 13 checks pass, models endpoint now returns models correctly
- [ ] Verify API key cleanup on script exit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Deployment validation now obtains temporary API keys for test authentication using available cluster identity, and ensures they are automatically cleaned up on exit or interruption.
  * Improved error reporting and guidance when authentication or required CLI tooling/token sources are missing or when key creation fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->