### PR TITLE
fix: include username in api key search query results

### DIFF
--- a/maas-api/internal/api_keys/store_postgres.go
+++ b/maas-api/internal/api_keys/store_postgres.go
@@ -241,7 +241,7 @@ func (s *PostgresStore) Search(
 
 	//nolint:gosec // Dynamic ORDER BY is safe - sort.By/Order validated against allowlist in handler
 	query := fmt.Sprintf(`
-		SELECT id, name, description, created_at, expires_at, status, last_used_at, ephemeral
+		SELECT id, name, description, username, created_at, expires_at, status, last_used_at, ephemeral
 		FROM api_keys
 		%s
 		%s
@@ -267,6 +267,7 @@ func (s *PostgresStore) Search(
 			&key.ID,
 			&key.Name,
 			&description,
+			&key.Username,
 			&createdAt,
 			&expiresAt,
 			&key.Status,


### PR DESCRIPTION
## Summary
Fix missing `username` field in API key search response by adding it to the postgres search query.

[RHOAIENG-54410](https://redhat.atlassian.net/browse/RHOAIENG-54410) 

## Description
- The postgres `Search` query was missing `username` in its `SELECT` clause and `rows.Scan` call.
- Since the `ApiKey` struct tags `username` with `json:"username,omitempty"`, the field was silently omitted from the JSON response rather than producing an error.

## How it was tested
- Built and deployed the patched image (`quay.io/chkulkar/maas-api:test-api-key-username`) to a live cluster.
- Verified `POST /v1/api-keys/search` now returns the `username` field for each record.
- All existing unit tests pass (`go test ./internal/api_keys/...`).
- output:
```
{
  "object": "list",
  "data": [
    {
      "id": "21053ea1-bd57-4598-a13c-f6e7a344b343",
      "name": "validation-key",
      "description": "Key for validation",
      "username": "kube:admin",
      "creationDate": "2026-03-20T22:25:29Z",
      "expirationDate": "2026-03-20T23:25:29Z",
      "status": "active",
      "ephemeral": false
    },
    {
      "id": "133f1ce9-d3b5-4725-89cb-0abaae5cdb9e",
      "name": "validation-key",
      "description": "Key for validation",
      "username": "kube:admin",
      "creationDate": "2026-03-20T22:23:52Z",
      "expirationDate": "2026-03-20T23:23:52Z",
      "status": "active",
      "ephemeral": false
    },
    {
      "id": "da041095-e2cb-4fda-88f4-5a38726c2f20",
      "name": "validation-key",
      "description": "Key for validation",
      "username": "kube:admin",
      "creationDate": "2026-03-20T22:22:37Z",
      "expirationDate": "2026-03-20T23:22:37Z",
      "status": "active",
      "ephemeral": false
    }
  ],
  "has_more": false
}
```


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed API key search to properly populate and return username information in results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->