### PR TITLE
feat: add external model reconciler for Istio-based egress routing

### DIFF
--- a/deployment/base/maas-controller/rbac/clusterrole.yaml
+++ b/deployment/base/maas-controller/rbac/clusterrole.yaml
@@ -30,3 +30,10 @@ rules:
 - apiGroups: [""]
   resources: ["namespaces"]
   verbs: ["create", "get", "list", "watch"]
+# ExternalModel reconciler: create/manage Istio egress resources
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+- apiGroups: ["networking.istio.io"]
+  resources: ["serviceentries", "destinationrules"]
+  verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]

--- a/maas-controller/cmd/manager/main.go
+++ b/maas-controller/cmd/manager/main.go
@@ -45,6 +45,7 @@ import (
 
 	maasv1alpha1 "github.com/opendatahub-io/models-as-a-service/maas-controller/api/maas/v1alpha1"
 	"github.com/opendatahub-io/models-as-a-service/maas-controller/pkg/controller/maas"
+	"github.com/opendatahub-io/models-as-a-service/maas-controller/pkg/reconciler/externalmodel"
 )
 
 var (
@@ -227,6 +228,17 @@ func main() {
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "MaaSSubscription")
+		os.Exit(1)
+	}
+
+	if err := (&externalmodel.Reconciler{
+		Client:           mgr.GetClient(),
+		Scheme:           mgr.GetScheme(),
+		Log:              ctrl.Log.WithName("controllers").WithName("ExternalModel"),
+		GatewayName:      gatewayName,
+		GatewayNamespace: gatewayNamespace,
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "ExternalModel")
 		os.Exit(1)
 	}
 

--- a/maas-controller/go.mod
+++ b/maas-controller/go.mod
@@ -5,6 +5,7 @@ go 1.25
 require (
 	github.com/go-logr/logr v1.4.3
 	github.com/kserve/kserve v0.15.0
+	github.com/stretchr/testify v1.11.1
 	k8s.io/api v0.33.1
 	k8s.io/apimachinery v0.33.1
 	k8s.io/client-go v0.33.1
@@ -64,6 +65,7 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_golang v1.22.0 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.64.0 // indirect

--- a/maas-controller/pkg/controller/maas/providers_external.go
+++ b/maas-controller/pkg/controller/maas/providers_external.go
@@ -28,6 +28,7 @@ import (
 	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	maasv1alpha1 "github.com/opendatahub-io/models-as-a-service/maas-controller/api/maas/v1alpha1"
+	"github.com/opendatahub-io/models-as-a-service/maas-controller/pkg/reconciler/externalmodel"
 )
 
 // routeConditionProgrammed is the "Programmed" condition type for route parent status.
@@ -40,9 +41,9 @@ type externalModelHandler struct {
 	r *MaaSModelRefReconciler
 }
 
-// ReconcileRoute validates the user-supplied HTTPRoute for an external model and populates status.
-// Users supply the HTTPRoute (the controller does not create it). The HTTPRoute naming convention
-// is "maas-model-<model.Name>" in the model's namespace.
+// ReconcileRoute validates the HTTPRoute for an external model and populates status.
+// The ExternalModel reconciler creates the "maas-model-<model.Name>" HTTPRoute in the
+// model's namespace. This method validates that it exists and is accepted by the gateway.
 func (h *externalModelHandler) ReconcileRoute(ctx context.Context, log logr.Logger, model *maasv1alpha1.MaaSModelRef) error {
 	// Fetch the referenced ExternalModel CR to get provider configuration
 	externalModel := &maasv1alpha1.ExternalModel{}
@@ -57,14 +58,14 @@ func (h *externalModelHandler) ReconcileRoute(ctx context.Context, log logr.Logg
 		return fmt.Errorf("failed to get ExternalModel %s: %w", model.Spec.ModelRef.Name, err)
 	}
 
-	routeName := fmt.Sprintf("maas-model-%s", model.Name)
+	routeName := externalmodel.ModelRouteName(model.Name)
 	routeNS := model.Namespace
 
 	route := &gatewayapiv1.HTTPRoute{}
 	key := client.ObjectKey{Name: routeName, Namespace: routeNS}
 	if err := h.r.Get(ctx, key, route); err != nil {
 		if apierrors.IsNotFound(err) {
-			log.Info("HTTPRoute not found for ExternalModel, waiting for user to create it",
+			log.Info("HTTPRoute not found for ExternalModel, waiting for ExternalModel reconciler to create it",
 				"routeName", routeName, "namespace", routeNS, "model", model.Name)
 			// Clear stale route status so the model stays NotReady without requeue hot-looping
 			model.Status.Endpoint = ""
@@ -217,7 +218,7 @@ func (h *externalModelHandler) GetModelEndpoint(ctx context.Context, log logr.Lo
 }
 
 // CleanupOnDelete is called when the MaaSModelRef is deleted.
-// ExternalModel: the HTTPRoute is user-supplied, so the controller does not delete it.
+// ExternalModel: the ExternalModel reconciler handles cleanup of all resources via finalizer.
 func (h *externalModelHandler) CleanupOnDelete(ctx context.Context, log logr.Logger, model *maasv1alpha1.MaaSModelRef) error {
 	return nil
 }
@@ -227,7 +228,7 @@ func (h *externalModelHandler) CleanupOnDelete(ctx context.Context, log logr.Log
 type externalModelRouteResolver struct{}
 
 func (externalModelRouteResolver) HTTPRouteForModel(ctx context.Context, c client.Reader, model *maasv1alpha1.MaaSModelRef) (routeName, routeNamespace string, err error) {
-	routeName = fmt.Sprintf("maas-model-%s", model.Name)
+	routeName = externalmodel.ModelRouteName(model.Name)
 	routeNamespace = model.Namespace
 	return routeName, routeNamespace, nil
 }

--- a/maas-controller/pkg/reconciler/externalmodel/README.md
+++ b/maas-controller/pkg/reconciler/externalmodel/README.md
@@ -1,0 +1,101 @@
+# External Model Reconciler
+
+Watches `MaaSModelRef` CRs with `kind: ExternalModel` and creates the Istio
+resources required to route traffic from the MaaS gateway to an external AI
+model provider.
+
+## What It Creates
+
+For each `ExternalModel` MaaSModelRef, the reconciler creates:
+
+| # | Resource | Purpose |
+|---|----------|---------|
+| 1 | ExternalName Service | DNS bridge so HTTPRoute backendRef can reference the external host |
+| 2 | ServiceEntry | Registers the external FQDN in the Istio mesh (required for REGISTRY_ONLY) |
+| 3 | DestinationRule | TLS origination (skipped when `tls: false`) |
+| 4 | HTTPRoute | Routes `/external/<provider>/*` to the provider, sets Host header |
+
+Resources are created in the gateway namespace (`openshift-ingress`), which is
+cross-namespace from the MaaSModelRef. Since Kubernetes garbage collection does
+not follow cross-namespace OwnerReferences, the reconciler uses a **finalizer**
+to explicitly delete all managed resources when the CR is removed.
+
+## MaaSModelRef Spec
+
+Until the CRD is enriched with external model fields (tracked separately), the
+reconciler reads configuration from annotations:
+
+```yaml
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: MaaSModelRef
+metadata:
+  name: gpt-4o-mini
+  namespace: opendatahub
+  annotations:
+    maas.opendatahub.io/provider: "openai"
+    maas.opendatahub.io/endpoint: "api.openai.com"
+    maas.opendatahub.io/port: "443"                         # default
+    maas.opendatahub.io/tls: "true"                         # default
+    maas.opendatahub.io/path-prefix: "/external/openai/"    # default: /external/<provider>/
+    maas.opendatahub.io/extra-headers: "anthropic-version=2023-06-01"  # optional
+spec:
+  modelRef:
+    kind: ExternalModel
+    name: gpt-4o-mini
+```
+
+When the CRD is updated, the reconciler will read from `spec` fields instead.
+
+## Annotation Reference
+
+| Annotation | Required | Default | Example |
+|------------|----------|---------|---------|
+| `maas.opendatahub.io/endpoint` | Yes | - | `api.openai.com` |
+| `maas.opendatahub.io/provider` | No | `spec.modelRef.name` | `openai` |
+| `maas.opendatahub.io/port` | No | `443` | `8000` |
+| `maas.opendatahub.io/tls` | No | `true` | `false` |
+| `maas.opendatahub.io/path-prefix` | No | `/external/<provider>/` | `/v1/` |
+| `maas.opendatahub.io/extra-headers` | No | - | `anthropic-version=2023-06-01` |
+
+## Provider Examples
+
+### OpenAI
+
+```yaml
+annotations:
+  maas.opendatahub.io/provider: "openai"
+  maas.opendatahub.io/endpoint: "api.openai.com"
+```
+
+### Anthropic
+
+```yaml
+annotations:
+  maas.opendatahub.io/provider: "anthropic"
+  maas.opendatahub.io/endpoint: "api.anthropic.com"
+  maas.opendatahub.io/extra-headers: "anthropic-version=2023-06-01"
+```
+
+### Self-hosted vLLM (no TLS)
+
+```yaml
+annotations:
+  maas.opendatahub.io/provider: "vllm"
+  maas.opendatahub.io/endpoint: "vllm.example.com"
+  maas.opendatahub.io/port: "8000"
+  maas.opendatahub.io/tls: "false"
+```
+
+## Moving to MaaS
+
+This reconciler is designed to be portable to the MaaS controller repo. To
+integrate with the existing MaaS provider pattern:
+
+1. Implement `BackendHandler` interface in `providers_external.go`
+2. Call `BuildExternalNameService`, `BuildServiceEntry`, `BuildDestinationRule`,
+   `BuildHTTPRoute` from `ReconcileRoute`
+3. Set status endpoint and phase from `Status`
+4. Finalizer handles cleanup in `CleanupOnDelete`
+
+The resource builder functions in `resources.go` are stateless and can be
+copied directly into the MaaS controller.

--- a/maas-controller/pkg/reconciler/externalmodel/reconciler.go
+++ b/maas-controller/pkg/reconciler/externalmodel/reconciler.go
@@ -1,0 +1,360 @@
+package externalmodel
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	maasv1alpha1 "github.com/opendatahub-io/models-as-a-service/maas-controller/api/maas/v1alpha1"
+)
+
+const (
+	// AnnExtraHeaders allows setting additional headers on the HTTPRoute.
+	// Format: "key1=value1,key2=value2"
+	AnnExtraHeaders = "maas.opendatahub.io/extra-headers"
+
+	// AnnPort overrides the default port (443).
+	AnnPort = "maas.opendatahub.io/port"
+
+	// AnnTLS controls TLS origination (default "true").
+	AnnTLS = "maas.opendatahub.io/tls"
+
+	// AnnPathPrefix overrides the default path prefix (/external/<provider>/).
+	AnnPathPrefix = "maas.opendatahub.io/path-prefix"
+
+	// Default gateway (matches MaaS controller defaults)
+	defaultGatewayName      = "maas-default-gateway"
+	defaultGatewayNamespace = "openshift-ingress"
+)
+
+// Reconciler watches MaaSModelRef CRs with kind=ExternalModel and creates
+// the Istio resources needed to route to the external provider.
+//
+// All resources are created in the model's namespace (same as the MaaSModelRef).
+// OwnerReferences on each resource ensure Kubernetes garbage collection handles
+// cleanup when the MaaSModelRef is deleted — no finalizer needed.
+type Reconciler struct {
+	client.Client
+	Scheme           *runtime.Scheme
+	Log              logr.Logger
+	GatewayName      string
+	GatewayNamespace string
+}
+
+func (r *Reconciler) gatewayName() string {
+	if r.GatewayName != "" {
+		return r.GatewayName
+	}
+	return defaultGatewayName
+}
+
+func (r *Reconciler) gatewayNamespace() string {
+	if r.GatewayNamespace != "" {
+		return r.GatewayNamespace
+	}
+	return defaultGatewayNamespace
+}
+
+// Reconcile handles create/update/delete of MaaSModelRef CRs with kind=ExternalModel.
+// The ExternalModel kind filter is handled by the predicate in SetupWithManager.
+func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := r.Log.WithValues("maasmodelref", req.NamespacedName)
+
+	model := &maasv1alpha1.MaaSModelRef{}
+	if err := r.Get(ctx, req.NamespacedName, model); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
+	// Nothing to do on deletion — OwnerReferences handle cleanup
+	if !model.GetDeletionTimestamp().IsZero() {
+		return ctrl.Result{}, nil
+	}
+
+	// Fetch the referenced ExternalModel CR to get provider configuration
+	extModel := &maasv1alpha1.ExternalModel{}
+	extModelKey := types.NamespacedName{
+		Name:      model.Spec.ModelRef.Name,
+		Namespace: model.Namespace,
+	}
+	if err := r.Get(ctx, extModelKey, extModel); err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Info("ExternalModel CR not found, waiting", "name", model.Spec.ModelRef.Name)
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, fmt.Errorf("failed to get ExternalModel %s: %w", model.Spec.ModelRef.Name, err)
+	}
+
+	spec, err := specFromExternalModel(extModel, model)
+	if err != nil {
+		log.Error(err, "Failed to parse ExternalModel spec")
+		return ctrl.Result{}, fmt.Errorf("invalid ExternalModel spec: %w", err)
+	}
+
+	log.Info("Reconciling ExternalModel",
+		"provider", spec.Provider,
+		"endpoint", spec.Endpoint,
+		"tls", spec.TLS,
+	)
+
+	ns := model.Namespace
+	gwName := r.gatewayName()
+	gwNamespace := r.gatewayNamespace()
+	labels := commonLabels(model.GetName())
+
+	// 1. ExternalName Service (backend for HTTPRoute)
+	svc := BuildService(spec, model.Name, ns, labels)
+	if err := controllerutil.SetControllerReference(model, svc, r.Scheme); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to set owner on Service: %w", err)
+	}
+	if err := r.applyService(ctx, log, svc); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to create Service: %w", err)
+	}
+
+	// 2. ServiceEntry (registers external host in mesh)
+	se := BuildServiceEntry(spec, model.Name, ns, labels)
+	if err := r.setUnstructuredOwner(model, se); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to set owner on ServiceEntry: %w", err)
+	}
+	if err := r.applyUnstructured(ctx, log, se); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to create ServiceEntry: %w", err)
+	}
+
+	// 3. DestinationRule (only if TLS; delete stale DR when TLS is disabled)
+	drName := ModelDestinationRuleName(model.Name)
+	if spec.TLS {
+		dr := BuildDestinationRule(spec, model.Name, ns, labels)
+		if err := r.setUnstructuredOwner(model, dr); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to set owner on DestinationRule: %w", err)
+		}
+		if err := r.applyUnstructured(ctx, log, dr); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to create DestinationRule: %w", err)
+		}
+	} else {
+		if err := r.deleteIfExists(ctx, log, "DestinationRule", drName, ns, schema.GroupVersionKind{
+			Group: "networking.istio.io", Version: "v1", Kind: "DestinationRule",
+		}); err != nil {
+			log.Error(err, "Failed to delete stale DestinationRule", "name", drName)
+		}
+	}
+
+	// 4. HTTPRoute (routes requests to external provider via gateway)
+	hr := BuildHTTPRoute(spec, model.Name, ns, gwName, gwNamespace, labels)
+	if err := controllerutil.SetControllerReference(model, hr, r.Scheme); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to set owner on HTTPRoute: %w", err)
+	}
+	if err := r.applyHTTPRoute(ctx, log, hr); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to create HTTPRoute: %w", err)
+	}
+
+	log.Info("ExternalModel resources reconciled successfully",
+		"service", svc.Name,
+		"serviceEntry", se.GetName(),
+		"httpRoute", hr.Name,
+		"namespace", ns,
+	)
+
+	return ctrl.Result{}, nil
+}
+
+// setUnstructuredOwner sets the controller OwnerReference on an unstructured resource.
+func (r *Reconciler) setUnstructuredOwner(owner *maasv1alpha1.MaaSModelRef, obj *unstructured.Unstructured) error {
+	isController := true
+	blockDeletion := true
+	obj.SetOwnerReferences([]metav1.OwnerReference{
+		{
+			APIVersion:         owner.APIVersion,
+			Kind:               owner.Kind,
+			Name:               owner.Name,
+			UID:                owner.UID,
+			Controller:         &isController,
+			BlockOwnerDeletion: &blockDeletion,
+		},
+	})
+	return nil
+}
+
+// deleteIfExists deletes an unstructured resource if it exists.
+func (r *Reconciler) deleteIfExists(ctx context.Context, log logr.Logger, kind, name, namespace string, gvk schema.GroupVersionKind) error {
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(gvk)
+	if err := r.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, obj); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to get %s %s/%s: %w", kind, namespace, name, err)
+	}
+	log.Info("Deleting resource", "kind", kind, "name", name)
+	if err := r.Delete(ctx, obj); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("failed to delete %s %s/%s: %w", kind, namespace, name, err)
+	}
+	return nil
+}
+
+// applyService creates or updates a Service.
+func (r *Reconciler) applyService(ctx context.Context, log logr.Logger, desired *corev1.Service) error {
+	existing := &corev1.Service{}
+	err := r.Get(ctx, types.NamespacedName{Name: desired.Name, Namespace: desired.Namespace}, existing)
+	if apierrors.IsNotFound(err) {
+		log.Info("Creating Service", "name", desired.Name)
+		return r.Create(ctx, desired)
+	}
+	if err != nil {
+		return err
+	}
+	if !equality.Semantic.DeepEqual(existing.Spec, desired.Spec) {
+		existing.Spec = desired.Spec
+		existing.Labels = desired.Labels
+		existing.OwnerReferences = desired.OwnerReferences
+		log.Info("Updating Service", "name", desired.Name)
+		return r.Update(ctx, existing)
+	}
+	return nil
+}
+
+// applyUnstructured creates or updates an unstructured resource (ServiceEntry, DestinationRule).
+func (r *Reconciler) applyUnstructured(ctx context.Context, log logr.Logger, desired *unstructured.Unstructured) error {
+	existing := &unstructured.Unstructured{}
+	existing.SetGroupVersionKind(desired.GroupVersionKind())
+	err := r.Get(ctx, types.NamespacedName{Name: desired.GetName(), Namespace: desired.GetNamespace()}, existing)
+	if apierrors.IsNotFound(err) {
+		log.Info("Creating resource", "kind", desired.GetKind(), "name", desired.GetName())
+		return r.Create(ctx, desired)
+	}
+	if err != nil {
+		return err
+	}
+	desired.SetResourceVersion(existing.GetResourceVersion())
+	log.Info("Updating resource", "kind", desired.GetKind(), "name", desired.GetName())
+	return r.Update(ctx, desired)
+}
+
+// applyHTTPRoute creates or updates an HTTPRoute.
+func (r *Reconciler) applyHTTPRoute(ctx context.Context, log logr.Logger, desired *gatewayapiv1.HTTPRoute) error {
+	existing := &gatewayapiv1.HTTPRoute{}
+	err := r.Get(ctx, types.NamespacedName{Name: desired.Name, Namespace: desired.Namespace}, existing)
+	if apierrors.IsNotFound(err) {
+		log.Info("Creating HTTPRoute", "name", desired.Name)
+		return r.Create(ctx, desired)
+	}
+	if err != nil {
+		return err
+	}
+	existing.Spec = desired.Spec
+	existing.Labels = desired.Labels
+	existing.OwnerReferences = desired.OwnerReferences
+	log.Info("Updating HTTPRoute", "name", desired.Name)
+	return r.Update(ctx, existing)
+}
+
+// specFromExternalModel reads ExternalModelSpec from the ExternalModel CR and
+// optional annotation overrides from the MaaSModelRef.
+// Provider and endpoint come from the ExternalModel CR (PR #586).
+// Port, TLS, path-prefix, and extra-headers are optional annotation overrides on the MaaSModelRef.
+func specFromExternalModel(extModel *maasv1alpha1.ExternalModel, model *maasv1alpha1.MaaSModelRef) (ExternalModelSpec, error) {
+	ann := model.GetAnnotations()
+	if ann == nil {
+		ann = map[string]string{}
+	}
+
+	spec := ExternalModelSpec{
+		Provider:   extModel.Spec.Provider,
+		Endpoint:   extModel.Spec.Endpoint,
+		PathPrefix: ann[AnnPathPrefix],
+		TLS:        true,
+		Port:       443,
+		// TLSInsecureSkipVerify: extModel.Spec.TLSInsecureSkipVerify, // requires issue #627 CRD change
+	}
+
+	if spec.Provider == "" {
+		return spec, fmt.Errorf("provider is required on ExternalModel %s", extModel.Name)
+	}
+	if spec.Endpoint == "" {
+		return spec, fmt.Errorf("endpoint is required on ExternalModel %s", extModel.Name)
+	}
+
+	if portStr, ok := ann[AnnPort]; ok {
+		p, err := strconv.ParseInt(portStr, 10, 32)
+		if err != nil {
+			return spec, fmt.Errorf("invalid port %q: %v", portStr, err)
+		}
+		if p < 1 || p > 65535 {
+			return spec, fmt.Errorf("port %d out of range (1-65535)", p)
+		}
+		spec.Port = int32(p)
+	}
+
+	if tlsStr, ok := ann[AnnTLS]; ok {
+		parsed, err := strconv.ParseBool(tlsStr)
+		if err != nil {
+			return spec, fmt.Errorf("invalid tls value %q: %v", tlsStr, err)
+		}
+		spec.TLS = parsed
+	}
+
+	if extraStr, ok := ann[AnnExtraHeaders]; ok && extraStr != "" {
+		spec.ExtraHeaders = map[string]string{}
+		for _, pair := range strings.Split(extraStr, ",") {
+			kv := strings.SplitN(pair, "=", 2)
+			if len(kv) == 2 {
+				spec.ExtraHeaders[strings.TrimSpace(kv[0])] = strings.TrimSpace(kv[1])
+			}
+		}
+	}
+
+	return spec, nil
+}
+
+// externalModelPredicate filters MaaSModelRef events to only ExternalModel kind.
+func externalModelPredicate() predicate.Predicate {
+	isExternalModel := func(obj client.Object) bool {
+		model, ok := obj.(*maasv1alpha1.MaaSModelRef)
+		if !ok {
+			return false
+		}
+		return model.Spec.ModelRef.Kind == "ExternalModel"
+	}
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			return isExternalModel(e.Object)
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return isExternalModel(e.ObjectOld) || isExternalModel(e.ObjectNew)
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return isExternalModel(e.Object)
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return isExternalModel(e.Object)
+		},
+	}
+}
+
+// SetupWithManager registers the reconciler to watch MaaSModelRef CRs
+// with kind=ExternalModel only (filtered by predicate).
+func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&maasv1alpha1.MaaSModelRef{}).
+		WithEventFilter(externalModelPredicate()).
+		Named("external-model-reconciler").
+		Complete(r)
+}

--- a/maas-controller/pkg/reconciler/externalmodel/resources.go
+++ b/maas-controller/pkg/reconciler/externalmodel/resources.go
@@ -1,0 +1,238 @@
+package externalmodel
+
+import (
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+// BuildService creates a Kubernetes ExternalName Service that maps an in-cluster
+// DNS name to the external FQDN. This allows HTTPRoute backendRefs to reference
+// external hosts via standard k8s Service names.
+func BuildService(spec ExternalModelSpec, modelName, namespace string, labels map[string]string) *corev1.Service {
+	svcName := ModelBackendServiceName(modelName)
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      svcName,
+			Namespace: namespace,
+			Labels:    labels,
+		},
+		Spec: corev1.ServiceSpec{
+			Type:         corev1.ServiceTypeExternalName,
+			ExternalName: spec.Endpoint,
+			Ports: []corev1.ServicePort{
+				{
+					Port:       spec.Port,
+					TargetPort: intstr.FromInt32(spec.Port),
+				},
+			},
+		},
+	}
+}
+
+// BuildServiceEntry creates an Istio ServiceEntry that registers the external
+// FQDN in the mesh service registry. Required when outboundTrafficPolicy is
+// REGISTRY_ONLY.
+func BuildServiceEntry(spec ExternalModelSpec, modelName, namespace string, labels map[string]string) *unstructured.Unstructured {
+	seName := ModelServiceEntryName(modelName)
+
+	protocol := "HTTPS"
+	portName := "https"
+	if !spec.TLS {
+		protocol = "HTTP"
+		portName = "http"
+	}
+
+	se := &unstructured.Unstructured{}
+	se.SetAPIVersion("networking.istio.io/v1")
+	se.SetKind("ServiceEntry")
+	se.SetName(seName)
+	se.SetNamespace(namespace)
+	se.SetLabels(labels)
+
+	se.Object["spec"] = map[string]interface{}{
+		"hosts":      []interface{}{spec.Endpoint},
+		"location":   "MESH_EXTERNAL",
+		"resolution": "DNS",
+		"ports": []interface{}{
+			map[string]interface{}{
+				"number":   int64(spec.Port),
+				"name":     portName,
+				"protocol": protocol,
+			},
+		},
+	}
+	return se
+}
+
+// BuildDestinationRule creates an Istio DestinationRule that configures TLS
+// origination for the external host. Skipped when TLS is false.
+func BuildDestinationRule(spec ExternalModelSpec, modelName, namespace string, labels map[string]string) *unstructured.Unstructured {
+	drName := ModelDestinationRuleName(modelName)
+
+	dr := &unstructured.Unstructured{}
+	dr.SetAPIVersion("networking.istio.io/v1")
+	dr.SetKind("DestinationRule")
+	dr.SetName(drName)
+	dr.SetNamespace(namespace)
+	dr.SetLabels(labels)
+
+	tlsConfig := map[string]interface{}{
+		"mode": "SIMPLE",
+	}
+	if spec.TLSInsecureSkipVerify {
+		tlsConfig["insecureSkipVerify"] = true
+	}
+
+	dr.Object["spec"] = map[string]interface{}{
+		"host": spec.Endpoint,
+		"trafficPolicy": map[string]interface{}{
+			"tls": tlsConfig,
+		},
+	}
+	return dr
+}
+
+// BuildHTTPRoute creates the maas-model-<name> HTTPRoute in the model's namespace.
+// This route is used by the MaaS auth and subscription controllers to attach
+// AuthPolicy and TokenRateLimitPolicy.
+//
+// It contains two match rules:
+//  1. Path-based match (PathPrefix: /<modelName>) — required for the Kuadrant Wasm plugin
+//     which runs before BBR in the Envoy filter chain. Without a path predicate, auth +
+//     rate limiting are bypassed.
+//  2. Header-based match (X-Gateway-Model-Name: <modelName>) — required for BBR's
+//     ClearRouteCache flow. After BBR extracts the model name from the request body,
+//     it sets this header and Envoy re-matches to this route.
+//
+// Both rules route to the backend ExternalName Service in the same namespace and apply
+// a URLRewrite filter to strip the path prefix before forwarding to the external provider.
+func BuildHTTPRoute(spec ExternalModelSpec, modelName, namespace, gatewayName, gatewayNamespace string, labels map[string]string) *gatewayapiv1.HTTPRoute {
+	routeName := ModelRouteName(modelName)
+	backendSvcName := ModelBackendServiceName(modelName)
+
+	gwNamespace := gatewayapiv1.Namespace(gatewayNamespace)
+	pathType := gatewayapiv1.PathMatchPathPrefix
+	pathPrefix := "/" + modelName
+	headerType := gatewayapiv1.HeaderMatchExact
+	port := gatewayapiv1.PortNumber(spec.Port)
+	timeout := gatewayapiv1.Duration("300s")
+
+	backendRefs := []gatewayapiv1.HTTPBackendRef{
+		{
+			BackendRef: gatewayapiv1.BackendRef{
+				BackendObjectReference: gatewayapiv1.BackendObjectReference{
+					Name: gatewayapiv1.ObjectName(backendSvcName),
+					Port: &port,
+				},
+			},
+		},
+	}
+
+	// Build header modifiers (Host + any extra headers)
+	headers := []gatewayapiv1.HTTPHeader{
+		{
+			Name:  "Host",
+			Value: spec.Endpoint,
+		},
+	}
+	for k, v := range spec.ExtraHeaders {
+		headers = append(headers, gatewayapiv1.HTTPHeader{
+			Name:  gatewayapiv1.HTTPHeaderName(k),
+			Value: v,
+		})
+	}
+
+	// Filters shared by both rules: rewrite path prefix and set Host header
+	filters := []gatewayapiv1.HTTPRouteFilter{
+		{
+			Type: gatewayapiv1.HTTPRouteFilterURLRewrite,
+			URLRewrite: &gatewayapiv1.HTTPURLRewriteFilter{
+				Path: &gatewayapiv1.HTTPPathModifier{
+					Type:               gatewayapiv1.PrefixMatchHTTPPathModifier,
+					ReplacePrefixMatch: strPtr("/"),
+				},
+			},
+		},
+		{
+			Type: gatewayapiv1.HTTPRouteFilterRequestHeaderModifier,
+			RequestHeaderModifier: &gatewayapiv1.HTTPHeaderFilter{
+				Set: headers,
+			},
+		},
+	}
+
+	return &gatewayapiv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      routeName,
+			Namespace: namespace,
+			Labels:    labels,
+		},
+		Spec: gatewayapiv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayapiv1.CommonRouteSpec{
+				ParentRefs: []gatewayapiv1.ParentReference{
+					{
+						Name:      gatewayapiv1.ObjectName(gatewayName),
+						Namespace: &gwNamespace,
+					},
+				},
+			},
+			Rules: []gatewayapiv1.HTTPRouteRule{
+				// Rule 1: Path-based match — Kuadrant Wasm plugin needs this
+				{
+					Matches: []gatewayapiv1.HTTPRouteMatch{
+						{
+							Path: &gatewayapiv1.HTTPPathMatch{
+								Type:  &pathType,
+								Value: &pathPrefix,
+							},
+						},
+					},
+					BackendRefs: backendRefs,
+					Filters:     filters,
+					Timeouts:    &gatewayapiv1.HTTPRouteTimeouts{Request: &timeout},
+				},
+				// Rule 2: Header-based match — BBR ClearRouteCache sets this header
+				{
+					Matches: []gatewayapiv1.HTTPRouteMatch{
+						{
+							Headers: []gatewayapiv1.HTTPHeaderMatch{
+								{
+									Name:  "X-Gateway-Model-Name",
+									Type:  &headerType,
+									Value: modelName,
+								},
+							},
+						},
+					},
+					BackendRefs: backendRefs,
+					Filters:     filters,
+					Timeouts:    &gatewayapiv1.HTTPRouteTimeouts{Request: &timeout},
+				},
+			},
+		},
+	}
+}
+
+func sanitize(s string) string {
+	// Convert to lowercase and replace non-alphanumeric characters with dashes
+	// for RFC 1123 DNS label compatibility.
+	var result []byte
+	for _, c := range []byte(strings.ToLower(s)) {
+		if (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') {
+			result = append(result, c)
+		} else {
+			result = append(result, '-')
+		}
+	}
+	// Trim leading/trailing dashes
+	return strings.Trim(string(result), "-")
+}
+
+func strPtr(s string) *string {
+	return &s
+}

--- a/maas-controller/pkg/reconciler/externalmodel/resources_test.go
+++ b/maas-controller/pkg/reconciler/externalmodel/resources_test.go
@@ -1,0 +1,227 @@
+package externalmodel
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSanitize(t *testing.T) {
+	assert.Equal(t, "api-openai-com", sanitize("api.openai.com"))
+	assert.Equal(t, "vllm-internal", sanitize("vllm.internal"))
+	assert.Equal(t, "simple", sanitize("simple"))
+	assert.Equal(t, "api-openai-com", sanitize("API.OpenAI.com")) // uppercase
+	assert.Equal(t, "host-8000", sanitize("host:8000"))           // colon
+	assert.Equal(t, "my-host", sanitize("my_host"))               // underscore
+}
+
+func TestModelNameHelpers(t *testing.T) {
+	// Normal names
+	assert.Equal(t, "maas-model-my-gpt4", ModelRouteName("my-gpt4"))
+	assert.Equal(t, "maas-model-my-gpt4-backend", ModelBackendServiceName("my-gpt4"))
+	assert.Equal(t, "maas-model-my-gpt4-se", ModelServiceEntryName("my-gpt4"))
+	assert.Equal(t, "maas-model-my-gpt4-dr", ModelDestinationRuleName("my-gpt4"))
+
+	// Names with dots (e.g., model names like "gpt-4o.v2")
+	assert.Equal(t, "maas-model-gpt-4o-v2", ModelRouteName("gpt-4o.v2"))
+	assert.Equal(t, "maas-model-gpt-4o-v2-backend", ModelBackendServiceName("gpt-4o.v2"))
+
+	// Long names get truncated to 63 chars
+	longName := "this-is-a-very-long-model-name-that-exceeds-sixty-three-characters-limit"
+	assert.LessOrEqual(t, len(ModelRouteName(longName)), 63)
+	assert.LessOrEqual(t, len(ModelBackendServiceName(longName)), 63)
+	assert.LessOrEqual(t, len(ModelServiceEntryName(longName)), 63)
+	assert.LessOrEqual(t, len(ModelDestinationRuleName(longName)), 63)
+}
+
+func TestBuildService(t *testing.T) {
+	spec := ExternalModelSpec{
+		Provider: "openai",
+		Endpoint: "api.openai.com",
+		Port:     443,
+		TLS:      true,
+	}
+	labels := commonLabels("my-gpt4")
+
+	svc := BuildService(spec, "my-gpt4", "llm", labels)
+
+	assert.Equal(t, ModelBackendServiceName("my-gpt4"), svc.Name)
+	assert.Equal(t, "llm", svc.Namespace)
+	assert.Equal(t, "api.openai.com", svc.Spec.ExternalName)
+	assert.Equal(t, int32(443), svc.Spec.Ports[0].Port)
+	assert.Contains(t, svc.Labels, "maas.opendatahub.io/external-model")
+}
+
+func TestBuildServiceEntry(t *testing.T) {
+	spec := ExternalModelSpec{
+		Provider: "openai",
+		Endpoint: "api.openai.com",
+		Port:     443,
+		TLS:      true,
+	}
+	labels := commonLabels("my-gpt4")
+
+	se := BuildServiceEntry(spec, "my-gpt4", "llm", labels)
+
+	assert.Equal(t, "ServiceEntry", se.GetKind())
+	assert.Equal(t, "networking.istio.io/v1", se.GetAPIVersion())
+	assert.Equal(t, ModelServiceEntryName("my-gpt4"), se.GetName())
+	assert.Equal(t, "llm", se.GetNamespace())
+
+	hosts := se.Object["spec"].(map[string]interface{})["hosts"].([]interface{})
+	assert.Equal(t, "api.openai.com", hosts[0])
+
+	ports := se.Object["spec"].(map[string]interface{})["ports"].([]interface{})
+	port := ports[0].(map[string]interface{})
+	assert.Equal(t, "https", port["name"])
+	assert.Equal(t, "HTTPS", port["protocol"])
+}
+
+func TestBuildServiceEntryNoTLS(t *testing.T) {
+	spec := ExternalModelSpec{
+		Provider: "vllm",
+		Endpoint: "vllm.internal",
+		Port:     8000,
+		TLS:      false,
+	}
+	labels := commonLabels("test-model")
+
+	se := BuildServiceEntry(spec, "test-model", "llm", labels)
+	seSpec := se.Object["spec"].(map[string]interface{})
+	ports := seSpec["ports"].([]interface{})
+	port := ports[0].(map[string]interface{})
+	assert.Equal(t, "HTTP", port["protocol"])
+	assert.Equal(t, "http", port["name"])
+}
+
+func TestBuildDestinationRule(t *testing.T) {
+	spec := ExternalModelSpec{
+		Provider: "openai",
+		Endpoint: "api.openai.com",
+		Port:     443,
+		TLS:      true,
+	}
+	labels := commonLabels("my-gpt4")
+
+	dr := BuildDestinationRule(spec, "my-gpt4", "llm", labels)
+
+	assert.Equal(t, "DestinationRule", dr.GetKind())
+	assert.Equal(t, "networking.istio.io/v1", dr.GetAPIVersion())
+	assert.Equal(t, ModelDestinationRuleName("my-gpt4"), dr.GetName())
+	assert.Equal(t, "llm", dr.GetNamespace())
+
+	drSpec := dr.Object["spec"].(map[string]interface{})
+	assert.Equal(t, "api.openai.com", drSpec["host"])
+
+	// Default: no insecureSkipVerify key
+	tlsCfg := drSpec["trafficPolicy"].(map[string]interface{})["tls"].(map[string]interface{})
+	assert.Equal(t, "SIMPLE", tlsCfg["mode"])
+	_, hasInsecure := tlsCfg["insecureSkipVerify"]
+	assert.False(t, hasInsecure, "insecureSkipVerify should not be set by default")
+}
+
+func TestBuildDestinationRuleInsecureSkipVerify(t *testing.T) {
+	spec := ExternalModelSpec{
+		Provider:              "openai",
+		Endpoint:              "3.150.113.9",
+		Port:                  443,
+		TLS:                   true,
+		TLSInsecureSkipVerify: true,
+	}
+	labels := commonLabels("simulator-model")
+
+	dr := BuildDestinationRule(spec, "simulator-model", "llm", labels)
+
+	drSpec := dr.Object["spec"].(map[string]interface{})
+	assert.Equal(t, "3.150.113.9", drSpec["host"])
+
+	tlsCfg := drSpec["trafficPolicy"].(map[string]interface{})["tls"].(map[string]interface{})
+	assert.Equal(t, "SIMPLE", tlsCfg["mode"])
+	assert.Equal(t, true, tlsCfg["insecureSkipVerify"], "insecureSkipVerify must be true when opted in")
+}
+
+func TestBuildHTTPRoute(t *testing.T) {
+	spec := ExternalModelSpec{
+		Provider:     "openai",
+		Endpoint:     "api.openai.com",
+		Port:         443,
+		TLS:          true,
+		ExtraHeaders: map[string]string{},
+	}
+	labels := commonLabels("my-gpt4")
+
+	hr := BuildHTTPRoute(spec, "my-gpt4", "llm", "maas-default-gateway", "openshift-ingress", labels)
+
+	assert.Equal(t, ModelRouteName("my-gpt4"), hr.Name)
+	assert.Equal(t, "llm", hr.Namespace)
+	assert.Len(t, hr.Spec.ParentRefs, 1)
+	assert.Equal(t, "maas-default-gateway", string(hr.Spec.ParentRefs[0].Name))
+
+	// Must have 2 rules: path-based and header-based
+	assert.Len(t, hr.Spec.Rules, 2, "must have path-based and header-based rules")
+
+	// Rule 1: path-based match
+	rule1 := hr.Spec.Rules[0]
+	assert.Len(t, rule1.Matches, 1)
+	assert.NotNil(t, rule1.Matches[0].Path)
+	assert.Equal(t, "/my-gpt4", *rule1.Matches[0].Path.Value)
+	assert.Equal(t, ModelBackendServiceName("my-gpt4"), string(rule1.BackendRefs[0].Name))
+
+	// Rule 2: header-based match
+	rule2 := hr.Spec.Rules[1]
+	assert.Len(t, rule2.Matches, 1)
+	assert.Len(t, rule2.Matches[0].Headers, 1)
+	assert.Equal(t, "X-Gateway-Model-Name", string(rule2.Matches[0].Headers[0].Name))
+	assert.Equal(t, "my-gpt4", rule2.Matches[0].Headers[0].Value)
+	assert.Equal(t, ModelBackendServiceName("my-gpt4"), string(rule2.BackendRefs[0].Name))
+
+	// Both rules should have URLRewrite filter
+	for i, rule := range hr.Spec.Rules {
+		foundRewrite := false
+		for _, f := range rule.Filters {
+			if f.URLRewrite != nil {
+				foundRewrite = true
+				assert.Equal(t, "/", *f.URLRewrite.Path.ReplacePrefixMatch,
+					"rule %d: URLRewrite should strip prefix to /", i)
+			}
+		}
+		assert.True(t, foundRewrite, "rule %d: must have URLRewrite filter", i)
+	}
+}
+
+func TestBuildHTTPRouteWithExtraHeaders(t *testing.T) {
+	spec := ExternalModelSpec{
+		Provider: "anthropic",
+		Endpoint: "api.anthropic.com",
+		Port:     443,
+		TLS:      true,
+		ExtraHeaders: map[string]string{
+			"anthropic-version": "2023-06-01",
+		},
+	}
+	labels := commonLabels("my-claude")
+
+	hr := BuildHTTPRoute(spec, "my-claude", "llm", "maas-default-gateway", "openshift-ingress", labels)
+
+	// Check both rules have the extra header
+	for _, rule := range hr.Spec.Rules {
+		for _, f := range rule.Filters {
+			if f.RequestHeaderModifier != nil {
+				foundHost := false
+				foundExtra := false
+				for _, h := range f.RequestHeaderModifier.Set {
+					if string(h.Name) == "Host" {
+						foundHost = true
+						assert.Equal(t, "api.anthropic.com", h.Value)
+					}
+					if string(h.Name) == "anthropic-version" {
+						foundExtra = true
+						assert.Equal(t, "2023-06-01", h.Value)
+					}
+				}
+				assert.True(t, foundHost, "must set Host header")
+				assert.True(t, foundExtra, "must set anthropic-version header")
+			}
+		}
+	}
+}

--- a/maas-controller/pkg/reconciler/externalmodel/types.go
+++ b/maas-controller/pkg/reconciler/externalmodel/types.go
@@ -1,0 +1,82 @@
+// Package externalmodel implements a reconciler that watches MaaSModelRef CRs
+// with kind=ExternalModel and creates the Istio resources required to route
+// traffic to an external AI model provider:
+//
+//  1. ExternalName Service   - DNS bridge for HTTPRoute backendRef
+//  2. ServiceEntry           - Registers external host in Istio mesh
+//  3. DestinationRule        - TLS origination (HTTP -> HTTPS)
+//  4. HTTPRoute              - Routes requests and sets Host header
+//
+// All resources are created in the model's namespace (same as the MaaSModelRef).
+// OwnerReferences on each resource ensure Kubernetes garbage collection handles
+// cleanup when the MaaSModelRef is deleted.
+package externalmodel
+
+import (
+	"strings"
+)
+
+// ExternalModelSpec holds the configuration for routing to an external model.
+// Provider and endpoint are read from the referenced ExternalModel CR (PR #586).
+// Port, TLS, path-prefix, and extra-headers are optional annotation overrides on the MaaSModelRef.
+type ExternalModelSpec struct {
+	// Provider identifies the API format (e.g. "openai", "anthropic", "vllm")
+	Provider string
+	// Endpoint is the external FQDN (e.g. "api.openai.com")
+	Endpoint string
+	// ExtraHeaders are additional headers to set (e.g. "anthropic-version=2023-06-01")
+	ExtraHeaders map[string]string
+	// Port is the external service port (default 443)
+	Port int32
+	// TLS indicates whether TLS origination is needed (default true)
+	TLS bool
+	// PathPrefix is the path prefix to match (default "/external/<provider>/")
+	PathPrefix string
+	// TLSInsecureSkipVerify disables certificate verification (testing only)
+	TLSInsecureSkipVerify bool
+}
+
+// truncateName ensures base + suffix fits within 63 characters.
+func truncateName(base, suffix string) string {
+	const maxLen = 63
+	max := maxLen - len(suffix)
+	if max < 1 {
+		max = 1
+	}
+	if len(base) == 0 {
+		base = "model"
+	}
+	if len(base) > max {
+		base = base[:max]
+		base = strings.TrimRight(base, "-")
+	}
+	return base + suffix
+}
+
+// ModelRouteName returns the sanitized, length-safe name for the maas-model-* HTTPRoute.
+func ModelRouteName(modelName string) string {
+	return truncateName("maas-model-"+sanitize(modelName), "")
+}
+
+// ModelBackendServiceName returns the sanitized, length-safe name for the backend Service.
+func ModelBackendServiceName(modelName string) string {
+	return truncateName("maas-model-"+sanitize(modelName), "-backend")
+}
+
+// ModelServiceEntryName returns the sanitized, length-safe name for the ServiceEntry.
+func ModelServiceEntryName(modelName string) string {
+	return truncateName("maas-model-"+sanitize(modelName), "-se")
+}
+
+// ModelDestinationRuleName returns the sanitized, length-safe name for the DestinationRule.
+func ModelDestinationRuleName(modelName string) string {
+	return truncateName("maas-model-"+sanitize(modelName), "-dr")
+}
+
+// commonLabels returns labels applied to all managed resources.
+func commonLabels(modelName string) map[string]string {
+	return map[string]string{
+		"app.kubernetes.io/managed-by":       "maas-external-model-reconciler",
+		"maas.opendatahub.io/external-model": modelName,
+	}
+}


### PR DESCRIPTION
Adds a reconciler that watches `MaaSModelRef` CRs with `kind=ExternalModel` and creates the Istio resources needed to route traffic from the MaaS gateway to external inf providers.

An initial PR was opened here for more details and an initial review: https://github.com/opendatahub-io/ai-gateway-payload-processing/pull/17

I made some modifications to try and align with #571. Once it merges, I'll change or open a new PR to have `specFromAnnotations()` to read provider and endpoint from `spec.modelRef` fields instead of annotations.

**Quick Summary** 

When a MaaSModelRef with kind=ExternalModel is created, the reconciler creates 4 resources in the gateway namespace: ExternalName Service (DNS bridge), ServiceEntry (mesh registration), DestinationRule (TLS origination), and HTTPRoute (routing + Host header). Resources live cross-namespace from the CR, so cleanup uses a finalizer with a stored resource key annotation rather than OwnerReferences.

Configuration is read from annotations until the CRD patch merges. The stored key (maas.opendatahub.io/last-resource-key) ensures cleanup works even if annotations are changed or removed before deletion. On update, old resources are cleaned up before new ones are created.

More details in the [here](https://github.com/opendatahub-io/ai-gateway-payload-processing/pull/17) that @jland-redhat reviewed 🙏

Ty!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an External Model Reconciler to create and manage cross-namespace routing to external AI providers (ExternalName service, mesh registry entry, optional TLS rule, and HTTPRoute) with finalizer-driven cleanup.

* **Documentation**
  * Added guide with annotation-driven configuration, provider examples, routing behavior, and cleanup semantics.

* **Tests**
  * Added unit tests for resource construction, naming/sanitization, and protocol/TLS behavior.

* **Chores**
  * Updated module dependencies and extended controller RBAC to allow managing external networking resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->