### PR TITLE
[Feat]: Add Azure OpenAI API translation plugin

### DIFF
--- a/payload-processing/pkg/plugins/azureopenai/azureopenai.go
+++ b/payload-processing/pkg/plugins/azureopenai/azureopenai.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2026 The opendatahub.io Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package azureopenai
+
+import (
+	"fmt"
+	"regexp"
+)
+
+const (
+	// defaultAPIVersion is the default Azure OpenAI API version.
+	// Reference: https://learn.microsoft.com/en-us/azure/ai-services/openai/reference
+	defaultAPIVersion = "2024-10-21"
+
+	// Azure OpenAI endpoint path template.
+	// The deployment ID typically matches the deployed model name.
+	// Reference: https://learn.microsoft.com/en-us/azure/ai-foundry/openai/reference#chat-completions
+	azurePathTemplate = "/openai/deployments/%s/chat/completions?api-version=%s"
+)
+
+// compile-time interface check
+// var _ translator.Translator = &AzureOpenAITranslator{}
+
+func NewAzureOpenAITranslator() *AzureOpenAITranslator {
+	return &AzureOpenAITranslator{
+		apiVersion:          defaultAPIVersion,
+		deploymentIDPattern: regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]*$`), // deploymentIDPattern validates Azure deployment IDs to prevent path/query injection.
+	}
+}
+
+// AzureOpenAITranslator translates between OpenAI Chat Completions format and
+// Azure OpenAI Service format. Azure OpenAI uses the same request/response schema
+// as OpenAI, so translation is limited to path rewriting and header adjustments.
+type AzureOpenAITranslator struct {
+	apiVersion          string
+	deploymentIDPattern *regexp.Regexp
+}
+
+// TranslateRequest rewrites the path and headers for Azure OpenAI.
+// The request body is not mutated since Azure OpenAI accepts the same schema as OpenAI.
+// Azure ignores the model field in the body and uses the deployment ID from the URI path.
+func (t *AzureOpenAITranslator) TranslateRequest(body map[string]any) (map[string]any, map[string]string, []string, error) {
+	model, _ := body["model"].(string)
+	if model == "" {
+		return nil, nil, nil, fmt.Errorf("model field is required")
+	}
+	if !t.deploymentIDPattern.MatchString(model) {
+		return nil, nil, nil, fmt.Errorf("model contains invalid characters for Azure deployment ID")
+	}
+
+	headers := map[string]string{
+		":path":        fmt.Sprintf(azurePathTemplate, model, t.apiVersion),
+		"content-type": "application/json",
+	}
+
+	// Return nil body — no body mutation is needed, Azure accepts the OpenAI request format as-is.
+	return nil, headers, nil, nil
+}
+
+// TranslateResponse is a no-op since Azure OpenAI returns responses in OpenAI format.
+func (t *AzureOpenAITranslator) TranslateResponse(body map[string]any, model string) (map[string]any, error) {
+	return nil, nil
+}

--- a/payload-processing/pkg/plugins/azureopenai/azureopenai_test.go
+++ b/payload-processing/pkg/plugins/azureopenai/azureopenai_test.go
@@ -1,0 +1,269 @@
+/*
+Copyright 2026 The opendatahub.io Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package azureopenai
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTranslateRequest_BasicChat(t *testing.T) {
+	body := map[string]any{
+		"model": "gpt-4o",
+		"messages": []any{
+			map[string]any{"role": "user", "content": "What is 2+2?"},
+		},
+	}
+
+	translatedBody, headers, headersToRemove, err := NewAzureOpenAITranslator().TranslateRequest(body)
+	require.NoError(t, err)
+
+	assert.Nil(t, translatedBody, "body should not be mutated for Azure OpenAI")
+
+	expectedPath := fmt.Sprintf("/openai/deployments/gpt-4o/chat/completions?api-version=%s", defaultAPIVersion)
+	assert.Equal(t, expectedPath, headers[":path"])
+	assert.Equal(t, "application/json", headers["content-type"])
+
+	assert.Empty(t, headersToRemove)
+}
+
+func TestTranslateRequest_ModelUsedAsDeploymentID(t *testing.T) {
+	tests := []struct {
+		name  string
+		model string
+	}{
+		{"gpt-4o model", "gpt-4o"},
+		{"gpt-4o-mini model", "gpt-4o-mini"},
+		{"custom deployment name", "my-custom-deployment"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := map[string]any{
+				"model":    tt.model,
+				"messages": []any{map[string]any{"role": "user", "content": "Hi"}},
+			}
+
+			_, headers, _, err := NewAzureOpenAITranslator().TranslateRequest(body)
+			require.NoError(t, err)
+
+			expectedPath := fmt.Sprintf("/openai/deployments/%s/chat/completions?api-version=%s", tt.model, defaultAPIVersion)
+			assert.Equal(t, expectedPath, headers[":path"])
+		})
+	}
+}
+
+func TestTranslateRequest_MissingModel(t *testing.T) {
+	body := map[string]any{
+		"messages": []any{map[string]any{"role": "user", "content": "Hi"}},
+	}
+
+	_, _, _, err := NewAzureOpenAITranslator().TranslateRequest(body)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "model")
+}
+
+func TestTranslateRequest_EmptyModel(t *testing.T) {
+	body := map[string]any{
+		"model":    "",
+		"messages": []any{map[string]any{"role": "user", "content": "Hi"}},
+	}
+
+	_, _, _, err := NewAzureOpenAITranslator().TranslateRequest(body)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "model")
+}
+
+func TestTranslateRequest_InvalidModelCharacters(t *testing.T) {
+	tests := []struct {
+		name  string
+		model string
+	}{
+		{"query injection", "gpt-4o?api-version=hijacked&x="},
+		{"path traversal", "../../../etc/passwd"},
+		{"slash in model", "org/model-name"},
+		{"space in model", "gpt 4o"},
+		{"starts with hyphen", "-gpt-4o"},
+		{"starts with dot", ".hidden"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := map[string]any{
+				"model":    tt.model,
+				"messages": []any{map[string]any{"role": "user", "content": "Hi"}},
+			}
+
+			_, _, _, err := NewAzureOpenAITranslator().TranslateRequest(body)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "invalid characters")
+		})
+	}
+}
+
+func TestTranslateRequest_ValidModelCharacters(t *testing.T) {
+	tests := []struct {
+		name  string
+		model string
+	}{
+		{"simple model", "gpt-4o"},
+		{"with dots", "gpt-4o.2025"},
+		{"with underscore", "my_deployment"},
+		{"alphanumeric", "model123"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := map[string]any{
+				"model":    tt.model,
+				"messages": []any{map[string]any{"role": "user", "content": "Hi"}},
+			}
+
+			_, _, _, err := NewAzureOpenAITranslator().TranslateRequest(body)
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestTranslateRequest_defaultAPIVersion(t *testing.T) {
+	p := NewAzureOpenAITranslator()
+	assert.Equal(t, defaultAPIVersion, p.apiVersion)
+}
+
+func TestTranslateRequest_BodyPassthrough(t *testing.T) {
+	body := map[string]any{
+		"model": "gpt-4o",
+		"messages": []any{
+			map[string]any{"role": "system", "content": "You are helpful."},
+			map[string]any{"role": "user", "content": "Hello"},
+		},
+		"temperature":       0.7,
+		"top_p":             0.9,
+		"max_tokens":        float64(1000),
+		"stream":            true,
+		"stop":              []any{"END"},
+		"n":                 float64(1),
+		"presence_penalty":  0.5,
+		"frequency_penalty": 0.3,
+	}
+
+	translatedBody, _, _, err := NewAzureOpenAITranslator().TranslateRequest(body)
+	require.NoError(t, err)
+
+	assert.Nil(t, translatedBody, "Azure OpenAI should not mutate the request body")
+}
+
+func TestTranslateRequest_HeadersSet(t *testing.T) {
+	body := map[string]any{
+		"model":    "gpt-4o",
+		"messages": []any{map[string]any{"role": "user", "content": "Hi"}},
+	}
+
+	_, headers, _, err := NewAzureOpenAITranslator().TranslateRequest(body)
+	require.NoError(t, err)
+
+	assert.Len(t, headers, 2)
+	assert.Contains(t, headers, ":path")
+	assert.Contains(t, headers, "content-type")
+}
+
+func TestTranslateRequest_HeadersRemoved(t *testing.T) {
+	body := map[string]any{
+		"model":    "gpt-4o",
+		"messages": []any{map[string]any{"role": "user", "content": "Hi"}},
+	}
+
+	_, _, headersToRemove, err := NewAzureOpenAITranslator().TranslateRequest(body)
+	require.NoError(t, err)
+
+	assert.Empty(t, headersToRemove)
+}
+
+func TestTranslateResponse_Passthrough(t *testing.T) {
+	body := map[string]any{
+		"id":      "chatcmpl-abc123",
+		"object":  "chat.completion",
+		"created": float64(1700000000),
+		"model":   "gpt-4o",
+		"choices": []any{
+			map[string]any{
+				"index": float64(0),
+				"message": map[string]any{
+					"role":    "assistant",
+					"content": "The answer is 4.",
+				},
+				"finish_reason": "stop",
+			},
+		},
+		"usage": map[string]any{
+			"prompt_tokens":     float64(10),
+			"completion_tokens": float64(5),
+			"total_tokens":      float64(15),
+		},
+	}
+
+	translatedBody, err := NewAzureOpenAITranslator().TranslateResponse(body, "gpt-4o")
+	require.NoError(t, err)
+	assert.Nil(t, translatedBody, "Azure OpenAI response should not be mutated — already in OpenAI format")
+}
+
+func TestTranslateResponse_EmptyBody(t *testing.T) {
+	body := map[string]any{}
+
+	translatedBody, err := NewAzureOpenAITranslator().TranslateResponse(body, "gpt-4o")
+	require.NoError(t, err)
+	assert.Nil(t, translatedBody)
+}
+
+func TestTranslateResponse_ErrorPassthrough(t *testing.T) {
+	body := map[string]any{
+		"error": map[string]any{
+			"message": "The API deployment for this resource does not exist.",
+			"type":    "invalid_request_error",
+			"code":    "DeploymentNotFound",
+		},
+	}
+
+	translatedBody, err := NewAzureOpenAITranslator().TranslateResponse(body, "gpt-4o")
+	require.NoError(t, err)
+	assert.Nil(t, translatedBody, "Azure error responses are already in OpenAI format")
+}
+
+func TestTranslateResponse_StreamingChunkPassthrough(t *testing.T) {
+	body := map[string]any{
+		"id":      "chatcmpl-abc123",
+		"object":  "chat.completion.chunk",
+		"created": float64(1700000000),
+		"model":   "gpt-4o",
+		"choices": []any{
+			map[string]any{
+				"index": float64(0),
+				"delta": map[string]any{
+					"content": "Hello",
+				},
+				"finish_reason": nil,
+			},
+		},
+	}
+
+	translatedBody, err := NewAzureOpenAITranslator().TranslateResponse(body, "gpt-4o")
+	require.NoError(t, err)
+	assert.Nil(t, translatedBody)
+}


### PR DESCRIPTION
## Description

Add Azure OpenAI API translation plugin under `payload-processing/pkg/plugins/api-translation/`.

This introduces:
- The `Translator` interface (`translator/translator.go`) that defines the contract for provider-specific request/response translation.
- The `azureopenai` translator implementation that handles path rewriting and header adjustments for Azure OpenAI endpoints. Azure OpenAI uses the same request/response schema as OpenAI, so no body mutation is needed — translation is limited to rewriting the `:path` header to `/openai/deployments/{model}/chat/completions?api-version=...` and setting appropriate headers.
- Comprehensive test coverage including deployment ID validation, path injection prevention, header verification, and response passthrough.

## How Has This Been Tested?

- Unit tests pass: `go test ./pkg/plugins/api-translation/...`
- Tests cover: basic chat translation, model-as-deployment-ID mapping, missing/empty model validation, invalid character rejection (path traversal, query injection), header mutation, body passthrough, and response passthrough (including streaming chunks and error responses).

## Merge criteria:

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Azure OpenAI support: validates model/deployment identifiers, rewrites requests to the Azure chat-completions endpoint using a default API version, sets appropriate request headers, and leaves request bodies unchanged.

* **Tests**
  * Added tests covering identifier validation, endpoint/header rewriting, API version behavior, error cases for invalid models, and response passthrough behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->