### PR TITLE
feat(payload-processing): add apikey-injection plugin

### DIFF
--- a/payload-processing/pkg/plugins/apikey-injection/plugin.go
+++ b/payload-processing/pkg/plugins/apikey-injection/plugin.go
@@ -1,0 +1,167 @@
+/*
+Copyright 2026 The opendatahub.io Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apikey_injection
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/bbr/framework"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/plugin"
+
+	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/common/provider"
+	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/common/state"
+)
+
+const (
+	// APIKeyInjectionPluginType is the registered name for this plugin in the BBR registry.
+	APIKeyInjectionPluginType = "apikey-injection"
+
+	// managedLabel selects Secrets managed by the apikey-injection plugin.
+	// Only Secrets carrying this label are watched by the reconciler.
+	managedLabel = "inference.networking.k8s.io/bbr-managed"
+)
+
+// compile-time interface check
+var _ framework.RequestProcessor = &ApiKeyInjectionPlugin{}
+
+// apiKeyGenerator generates a single auth header from an API key.
+// headerName is the HTTP header (e.g. "Authorization", "x-api-key").
+// headerValuePrefix is prepended to the key (e.g. "Bearer "); use "" for raw keys.
+type apiKeyGenerator struct {
+	headerName        string
+	headerValuePrefix string
+}
+
+// generateHeader returns the header name and formatted value for the given API key.
+func (inj *apiKeyGenerator) generateHeader(apiKey string) (string, string) {
+	return inj.headerName, inj.headerValuePrefix + apiKey
+}
+
+// defaultApiKeyGenerators returns the built-in provider-to-generator registry.
+func defaultApiKeyGenerators() map[string]*apiKeyGenerator {
+	return map[string]*apiKeyGenerator{
+		provider.OpenAI:      {headerName: "Authorization", headerValuePrefix: "Bearer "},
+		provider.Anthropic:   {headerName: "x-api-key"},
+		provider.AzureOpenAI: {headerName: "api-key"},
+		provider.Vertex:      {headerName: "Authorization", headerValuePrefix: "Bearer "},
+	}
+}
+
+// APIKeyInjectionFactory creates a new apiKeyInjectionPlugin from CLI parameters and
+// registers its Secret reconciler via the Handle.
+// It matches the framework.FactoryFunc signature.
+func APIKeyInjectionFactory(name string, _ json.RawMessage, handle framework.Handle) (framework.BBRPlugin, error) {
+	plugin, err := NewAPIKeyInjectionPlugin(handle.ReconcilerBuilder, handle.ClientReader())
+	if err != nil {
+		return nil, fmt.Errorf("failed to create plugin '%s' - %w", APIKeyInjectionPluginType, err)
+	}
+
+	return plugin.WithName(name), nil
+}
+
+func NewAPIKeyInjectionPlugin(reconcilerBuilder func() *builder.Builder, clientReader client.Reader) (*ApiKeyInjectionPlugin, error) {
+	store := newSecretStore()
+	reconciler := &secretReconciler{
+		Reader: clientReader,
+		store:  store,
+	}
+
+	labelPredicate, err := predicate.LabelSelectorPredicate(metav1.LabelSelector{
+		MatchLabels: map[string]string{managedLabel: "true"},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to build label predicate for plugin '%s' - %w", APIKeyInjectionPluginType, err)
+	}
+
+	if err := reconcilerBuilder().For(&corev1.Secret{}).WithEventFilter(labelPredicate).Complete(reconciler); err != nil {
+		return nil, fmt.Errorf("failed to register Secret reconciler for plugin '%s' - %w", APIKeyInjectionPluginType, err)
+	}
+
+	return (&ApiKeyInjectionPlugin{
+		typedName: plugin.TypedName{
+			Type: APIKeyInjectionPluginType,
+			Name: APIKeyInjectionPluginType,
+		},
+		apikeyGenerators: defaultApiKeyGenerators(),
+		store:            store,
+	}), nil
+}
+
+// ApiKeyInjectionPlugin injects an API key from a Kubernetes Secret
+// into the request headers. The Secret is identified by its namespaced
+// name from CycleState. The provider (openai, anthropic) determines
+// which header name and value format are used.
+type ApiKeyInjectionPlugin struct {
+	typedName        plugin.TypedName
+	apikeyGenerators map[string]*apiKeyGenerator
+	store            *secretStore
+}
+
+// TypedName returns the type and name tuple of this plugin instance.
+func (p *ApiKeyInjectionPlugin) TypedName() plugin.TypedName {
+	return p.typedName
+}
+
+// WithName sets the name of this plugin instance.
+func (p *ApiKeyInjectionPlugin) WithName(name string) *ApiKeyInjectionPlugin {
+	p.typedName.Name = name
+	return p
+}
+
+// ProcessRequest reads the credential Secret reference and provider from
+// CycleState (written by provider-resolver), looks up the API key in the
+// store, and injects provider-specific auth headers into the request.
+func (p *ApiKeyInjectionPlugin) ProcessRequest(ctx context.Context, cycleState *framework.CycleState, request *framework.InferenceRequest) error {
+	if request == nil || request.Headers == nil {
+		return fmt.Errorf("request or headers is nil")
+	}
+
+	credsName, err := framework.ReadCycleStateKey[string](cycleState, state.CredsRefName)
+	if err != nil || credsName == "" {
+		return fmt.Errorf("missing credentials reference name in CycleState")
+	}
+	credsNamespace, err := framework.ReadCycleStateKey[string](cycleState, state.CredsRefNamespace)
+	if err != nil || credsNamespace == "" {
+		return fmt.Errorf("missing credentials reference namespace in CycleState")
+	}
+
+	secretKey := fmt.Sprintf("%s/%s", credsNamespace, credsName)
+	apiKey, found := p.store.get(secretKey)
+	if !found {
+		return fmt.Errorf("no secret found for ref '%s'", secretKey)
+	}
+
+	providerName, _ := framework.ReadCycleStateKey[string](cycleState, state.ProviderKey)
+	generator, ok := p.apikeyGenerators[providerName]
+	if !ok {
+		generator = p.apikeyGenerators[provider.OpenAI]
+	}
+
+	headerName, headerValue := generator.generateHeader(apiKey)
+	request.SetHeader(headerName, headerValue) // inject the generated header
+
+	log.FromContext(ctx).Info("API key injected", "secretRef", secretKey, "provider", providerName)
+	return nil
+}

--- a/payload-processing/pkg/plugins/apikey-injection/plugin_test.go
+++ b/payload-processing/pkg/plugins/apikey-injection/plugin_test.go
@@ -1,0 +1,249 @@
+/*
+Copyright 2026 The opendatahub.io Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apikey_injection
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/bbr/framework"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/plugin"
+
+	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/common/provider"
+	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/common/state"
+)
+
+// newTestPlugin creates an apiKeyInjectionPlugin for unit tests, bypassing the
+// Handle-based Factory (which requires a real manager).
+func newTestPlugin(store *secretStore) *ApiKeyInjectionPlugin {
+	return &ApiKeyInjectionPlugin{
+		typedName:        plugin.TypedName{Type: APIKeyInjectionPluginType, Name: APIKeyInjectionPluginType},
+		apikeyGenerators: defaultApiKeyGenerators(),
+		store:            store,
+	}
+}
+
+// newTestRequest builds an InferenceRequest pre-populated with the given headers.
+func newTestRequest(headers map[string]string) *framework.InferenceRequest {
+	req := framework.NewInferenceRequest()
+	for k, v := range headers {
+		req.Headers[k] = v
+	}
+	return req
+}
+
+// newCycleState builds a CycleState with credential ref and optional provider.
+func newCycleState(namespace, name, providerName string) *framework.CycleState {
+	cs := framework.NewCycleState()
+	cs.Write(state.CredsRefName, name)
+	cs.Write(state.CredsRefNamespace, namespace)
+	if providerName != "" {
+		cs.Write(state.ProviderKey, providerName)
+	}
+	return cs
+}
+
+func TestProcessRequest(t *testing.T) {
+	tests := []struct {
+		name        string
+		secrets     []*corev1.Secret
+		cycleState  *framework.CycleState
+		wantHeaders map[string]string
+	}{
+		{
+			name:       "OpenAI provider — injects Authorization: Bearer",
+			secrets:    []*corev1.Secret{testSecret("default", "openai-key", "sk-test-key")},
+			cycleState: newCycleState("default", "openai-key", provider.OpenAI),
+			wantHeaders: map[string]string{
+				"Authorization": "Bearer sk-test-key",
+			},
+		},
+		{
+			name:       "Anthropic provider — injects x-api-key with raw value",
+			secrets:    []*corev1.Secret{testSecret("default", "anthropic-key", "ant-key-123")},
+			cycleState: newCycleState("default", "anthropic-key", provider.Anthropic),
+			wantHeaders: map[string]string{
+				"x-api-key": "ant-key-123",
+			},
+		},
+		{
+			name:       "Vertex provider — injects Authorization: Bearer (same as OpenAI)",
+			secrets:    []*corev1.Secret{testSecret("default", "vertex-key", "vtx-key-456")},
+			cycleState: newCycleState("default", "vertex-key", provider.Vertex),
+			wantHeaders: map[string]string{
+				"Authorization": "Bearer vtx-key-456",
+			},
+		},
+		{
+			name:       "default provider when CycleState has no provider — uses OpenAI Bearer",
+			secrets:    []*corev1.Secret{testSecret("default", "no-provider", "sk-key")},
+			cycleState: newCycleState("default", "no-provider", ""),
+			wantHeaders: map[string]string{
+				"Authorization": "Bearer sk-key",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := seedStore(tt.secrets...)
+			p := newTestPlugin(store)
+			req := newTestRequest(nil)
+
+			err := p.ProcessRequest(context.Background(), tt.cycleState, req)
+			require.NoError(t, err)
+			for k, v := range tt.wantHeaders {
+				assert.Equal(t, v, req.Headers[k])
+			}
+		})
+	}
+}
+
+func TestProcessRequestMissingCredsRef(t *testing.T) {
+	store := seedStore(testSecret("default", "key", "sk-key"))
+	p := newTestPlugin(store)
+	req := newTestRequest(nil)
+	cs := framework.NewCycleState()
+
+	err := p.ProcessRequest(context.Background(), cs, req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing credentials reference")
+}
+
+func TestProcessRequestSecretNotFound(t *testing.T) {
+	store := newSecretStore()
+	p := newTestPlugin(store)
+	req := newTestRequest(nil)
+	cs := newCycleState("default", "unknown", provider.OpenAI)
+
+	err := p.ProcessRequest(context.Background(), cs, req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no secret found for ref")
+}
+
+func TestProcessRequestUnknownProviderFallback(t *testing.T) {
+	store := seedStore(testSecret("default", "some-key", "key-789"))
+	p := newTestPlugin(store)
+	req := newTestRequest(nil)
+	cs := newCycleState("default", "some-key", "unknown-provider")
+
+	err := p.ProcessRequest(context.Background(), cs, req)
+	require.NoError(t, err)
+	assert.Equal(t, "Bearer key-789", req.Headers["Authorization"])
+}
+
+func TestProcessRequestNilRequest(t *testing.T) {
+	store := newSecretStore()
+	p := newTestPlugin(store)
+
+	err := p.ProcessRequest(context.Background(), nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "request or headers is nil")
+}
+
+func TestProcessRequestMutationTracking(t *testing.T) {
+	store := seedStore(testSecret("default", "key", "sk-key"))
+	p := newTestPlugin(store)
+	req := newTestRequest(nil)
+	cs := newCycleState("default", "key", provider.OpenAI)
+
+	err := p.ProcessRequest(context.Background(), cs, req)
+	require.NoError(t, err)
+
+	mutated := req.MutatedHeaders()
+	assert.Equal(t, "Bearer sk-key", mutated["Authorization"],
+		"SetHeader should register the injected header in MutatedHeaders()")
+}
+
+func TestTypedName(t *testing.T) {
+	p := newTestPlugin(nil)
+	assert.Equal(t, APIKeyInjectionPluginType, p.TypedName().Type)
+	assert.Equal(t, APIKeyInjectionPluginType, p.TypedName().Name)
+}
+
+func TestDefaultInjectors(t *testing.T) {
+	injectors := defaultApiKeyGenerators()
+
+	require.Contains(t, injectors, provider.OpenAI)
+	assert.Equal(t, "Authorization", injectors[provider.OpenAI].headerName)
+	assert.Equal(t, "Bearer ", injectors[provider.OpenAI].headerValuePrefix)
+
+	require.Contains(t, injectors, provider.Anthropic)
+	assert.Equal(t, "x-api-key", injectors[provider.Anthropic].headerName)
+	assert.Empty(t, injectors[provider.Anthropic].headerValuePrefix)
+
+	require.Contains(t, injectors, provider.AzureOpenAI)
+	assert.Equal(t, "api-key", injectors[provider.AzureOpenAI].headerName)
+	assert.Empty(t, injectors[provider.AzureOpenAI].headerValuePrefix)
+
+	require.Contains(t, injectors, provider.Vertex)
+	assert.Equal(t, "Authorization", injectors[provider.Vertex].headerName)
+	assert.Equal(t, "Bearer ", injectors[provider.Vertex].headerValuePrefix)
+
+	assert.Len(t, injectors, 4)
+}
+
+func TestAPIKeyInjector(t *testing.T) {
+	tests := []struct {
+		name            string
+		headerName      string
+		headerPrefix    string
+		apiKey          string
+		wantHeaderName  string
+		wantHeaderValue string
+	}{
+		{
+			name:            "Bearer prefix (OpenAI style)",
+			headerName:      "Authorization",
+			headerPrefix:    "Bearer ",
+			apiKey:          "sk-test-key",
+			wantHeaderName:  "Authorization",
+			wantHeaderValue: "Bearer sk-test-key",
+		},
+		{
+			name:            "raw key without prefix (Anthropic style)",
+			headerName:      "x-api-key",
+			apiKey:          "ant-key-123",
+			wantHeaderName:  "x-api-key",
+			wantHeaderValue: "ant-key-123",
+		},
+		{
+			name:            "custom header name",
+			headerName:      "api-key",
+			apiKey:          "some-key-456",
+			wantHeaderName:  "api-key",
+			wantHeaderValue: "some-key-456",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			injector := &apiKeyGenerator{
+				headerName:        tt.headerName,
+				headerValuePrefix: tt.headerPrefix,
+			}
+
+			gotName, gotValue := injector.generateHeader(tt.apiKey)
+
+			assert.Equal(t, tt.wantHeaderName, gotName)
+			assert.Equal(t, tt.wantHeaderValue, gotValue)
+		})
+	}
+}

--- a/payload-processing/pkg/plugins/apikey-injection/reconciler.go
+++ b/payload-processing/pkg/plugins/apikey-injection/reconciler.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2026 The opendatahub.io Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apikey_injection
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// secretReconciler watches Secrets and updates the secretStore.
+type secretReconciler struct {
+	client.Reader
+	store *secretStore
+}
+
+// Reconcile handles create/update/delete events for Secrets.
+func (r *secretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+	key := req.String()
+	logger.Info("Reconciling Secret", "key", key)
+
+	secret := &corev1.Secret{}
+	err := r.Get(ctx, req.NamespacedName, secret)
+	if err != nil && !errors.IsNotFound(err) {
+		return ctrl.Result{}, fmt.Errorf("unable to get Secret: %w", err)
+	}
+
+	if errors.IsNotFound(err) || !secret.DeletionTimestamp.IsZero() {
+		r.store.delete(key)
+		return ctrl.Result{}, nil
+	}
+
+	if err := r.store.addOrUpdate(key, secret); err != nil {
+		return ctrl.Result{}, fmt.Errorf("unable to add or update Secret %s: %w", key, err)
+	}
+
+	return ctrl.Result{}, nil
+}

--- a/payload-processing/pkg/plugins/apikey-injection/reconciler_test.go
+++ b/payload-processing/pkg/plugins/apikey-injection/reconciler_test.go
@@ -1,0 +1,150 @@
+/*
+Copyright 2026 The opendatahub.io Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apikey_injection
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestReconcile(t *testing.T) {
+	tests := []struct {
+		name       string
+		secret     *corev1.Secret
+		preSeed    []*corev1.Secret
+		wantKey    string
+		wantAPIKey string
+		wantFound  bool
+		wantErr    bool
+		secretName string
+	}{
+		{
+			name:       "stores API key from Secret",
+			secret:     testSecret("default", "openai-key", "sk-live-xxx"),
+			wantKey:    "default/openai-key",
+			wantAPIKey: "sk-live-xxx",
+			wantFound:  true,
+		},
+		{
+			name:       "updates existing entry on Secret change",
+			secret:     testSecret("default", "openai-key", "sk-new-key"),
+			preSeed:    []*corev1.Secret{testSecret("default", "openai-key", "sk-old-key")},
+			wantKey:    "default/openai-key",
+			wantAPIKey: "sk-new-key",
+			wantFound:  true,
+		},
+		{
+			name:       "Secret not found — cleans store",
+			secret:     nil,
+			secretName: "gone",
+			preSeed:    []*corev1.Secret{testSecret("default", "gone", "sk-key")},
+			wantKey:    "default/gone",
+			wantFound:  false,
+		},
+		{
+			name: "Secret missing api-key data — returns error",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "no-data",
+					Namespace: "default",
+				},
+				Data: map[string][]byte{},
+			},
+			wantKey:   "default/no-data",
+			wantFound: false,
+			wantErr:   true,
+		},
+		{
+			name: "Secret marked for deletion — removes from store",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "deleting",
+					Namespace:         "default",
+					DeletionTimestamp: &metav1.Time{Time: time.Now()},
+					Finalizers:        []string{"test-finalizer"},
+				},
+				Data: map[string][]byte{
+					secretDataKey: []byte("sk-key"),
+				},
+			},
+			preSeed:   []*corev1.Secret{testSecret("default", "deleting", "sk-key")},
+			wantKey:   "default/deleting",
+			wantFound: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := seedStore(tt.preSeed...)
+
+			builder := fake.NewClientBuilder()
+			if tt.secret != nil {
+				builder = builder.WithObjects(tt.secret)
+			}
+			fakeClient := builder.Build()
+
+			reconciler := &secretReconciler{
+				Reader: fakeClient,
+				store:  store,
+			}
+
+			name := tt.secretName
+			if name == "" && tt.secret != nil {
+				name = tt.secret.Name
+			}
+			if name == "" {
+				name = "test-secret"
+			}
+
+			ns := "default"
+			if tt.secret != nil {
+				ns = tt.secret.Namespace
+			}
+
+			_, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      name,
+					Namespace: ns,
+				},
+			})
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+
+			if tt.wantKey != "" {
+				apiKey, found := store.get(tt.wantKey)
+				assert.Equal(t, tt.wantFound, found)
+				if tt.wantFound {
+					assert.Equal(t, tt.wantAPIKey, apiKey)
+				}
+			}
+		})
+	}
+}

--- a/payload-processing/pkg/plugins/apikey-injection/store.go
+++ b/payload-processing/pkg/plugins/apikey-injection/store.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2026 The opendatahub.io Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apikey_injection
+
+import (
+	"fmt"
+	"sync"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// secretDataKey is the key within Secret.Data that holds the API key value.
+const secretDataKey = "api-key"
+
+// secretStore is a thread-safe in-memory store that maps a Secret's
+// namespaced name ("namespace/name") to its API key value.
+// The secretReconciler writes to it; the apiKeyInjectionPlugin reads from it.
+type secretStore struct {
+	mu   sync.RWMutex
+	data map[string]string
+}
+
+// newSecretStore creates an empty secretStore.
+func newSecretStore() *secretStore {
+	return &secretStore{
+		data: make(map[string]string),
+	}
+}
+
+// addOrUpdate extracts the API key from the Secret's data field and stores
+// it under the given key.
+// Returns an error if the Secret is missing the required api-key data field.
+func (s *secretStore) addOrUpdate(key string, secret *corev1.Secret) error {
+	apiKeyBytes, ok := secret.Data[secretDataKey]
+	if !ok || len(apiKeyBytes) == 0 {
+		return fmt.Errorf("secret %q missing %q data field", key, secretDataKey)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.data[key] = string(apiKeyBytes)
+	return nil
+}
+
+// delete removes the entry for the given Secret namespaced name.
+func (s *secretStore) delete(secretKey string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.data, secretKey)
+}
+
+// get returns the API key for the given namespaced name and whether it was found.
+func (s *secretStore) get(secretKey string) (string, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	apiKey, ok := s.data[secretKey]
+	return apiKey, ok
+}

--- a/payload-processing/pkg/plugins/apikey-injection/store_test.go
+++ b/payload-processing/pkg/plugins/apikey-injection/store_test.go
@@ -1,0 +1,228 @@
+/*
+Copyright 2026 The opendatahub.io Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apikey_injection
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// testSecret builds a corev1.Secret for test seeding.
+func testSecret(namespace, name, apiKey string) *corev1.Secret {
+	if namespace == "" {
+		namespace = "default"
+	}
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Data: map[string][]byte{
+			secretDataKey: []byte(apiKey),
+		},
+	}
+}
+
+// seedStore is a convenience for tests that need a pre-populated secretStore.
+func seedStore(secrets ...*corev1.Secret) *secretStore {
+	s := newSecretStore()
+	for _, sec := range secrets {
+		_ = s.addOrUpdate(fmt.Sprintf("%s/%s", sec.Namespace, sec.Name), sec)
+	}
+	return s
+}
+
+func TestSecretStore(t *testing.T) {
+	tests := []struct {
+		name          string
+		initStoreFunc func(t *testing.T, s *secretStore)
+	}{
+		{
+			name: "AddOrUpdate and Get returns stored API key",
+			initStoreFunc: func(t *testing.T, s *secretStore) {
+				sec := testSecret("default", "openai-key", "sk-key-1")
+				require.NoError(t, s.addOrUpdate("default/openai-key", sec))
+
+				apiKey, found := s.get("default/openai-key")
+				assert.True(t, found)
+				assert.Equal(t, "sk-key-1", apiKey)
+			},
+		},
+		{
+			name: "get nonexistent key returns not found",
+			initStoreFunc: func(t *testing.T, s *secretStore) {
+				_, found := s.get("default/nonexistent")
+				assert.False(t, found)
+			},
+		},
+		{
+			name: "AddOrUpdate overwrites existing entry",
+			initStoreFunc: func(t *testing.T, s *secretStore) {
+				_ = s.addOrUpdate("default/key", testSecret("default", "key", "old-key"))
+				_ = s.addOrUpdate("default/key", testSecret("default", "key", "new-key"))
+
+				apiKey, found := s.get("default/key")
+				assert.True(t, found)
+				assert.Equal(t, "new-key", apiKey)
+			},
+		},
+		{
+			name: "delete removes entry",
+			initStoreFunc: func(t *testing.T, s *secretStore) {
+				_ = s.addOrUpdate("default/key", testSecret("default", "key", "sk-key-1"))
+				s.delete("default/key")
+
+				_, found := s.get("default/key")
+				assert.False(t, found)
+			},
+		},
+		{
+			name: "delete nonexistent key is a no-op",
+			initStoreFunc: func(t *testing.T, s *secretStore) {
+				s.delete("default/nonexistent")
+			},
+		},
+		{
+			name: "multiple secrets are independent",
+			initStoreFunc: func(t *testing.T, s *secretStore) {
+				_ = s.addOrUpdate("default/key-a", testSecret("default", "key-a", "value-1"))
+				_ = s.addOrUpdate("default/key-b", testSecret("default", "key-b", "value-2"))
+
+				v1, f1 := s.get("default/key-a")
+				v2, f2 := s.get("default/key-b")
+				assert.True(t, f1)
+				assert.True(t, f2)
+				assert.Equal(t, "value-1", v1)
+				assert.Equal(t, "value-2", v2)
+
+				s.delete("default/key-a")
+				_, f1 = s.get("default/key-a")
+				_, f2 = s.get("default/key-b")
+				assert.False(t, f1)
+				assert.True(t, f2)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := newSecretStore()
+			tt.initStoreFunc(t, s)
+		})
+	}
+}
+
+func TestAddOrUpdate(t *testing.T) {
+	tests := []struct {
+		name       string
+		secret     *corev1.Secret
+		wantKey    string
+		wantAPIKey string
+		wantErr    bool
+	}{
+		{
+			name:       "stores API key from Secret data",
+			secret:     testSecret("default", "openai-key", "sk-live-xxx"),
+			wantKey:    "default/openai-key",
+			wantAPIKey: "sk-live-xxx",
+		},
+		{
+			name: "returns error when api-key data is missing",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "no-data",
+					Namespace: "default",
+				},
+				Data: map[string][]byte{},
+			},
+			wantKey: "default/no-data",
+			wantErr: true,
+		},
+		{
+			name: "returns error when api-key data is empty",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "empty-key",
+					Namespace: "default",
+				},
+				Data: map[string][]byte{secretDataKey: []byte("")},
+			},
+			wantKey: "default/empty-key",
+			wantErr: true,
+		},
+		{
+			name: "overwrites existing entry on update",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "key",
+					Namespace: "default",
+				},
+				Data: map[string][]byte{secretDataKey: []byte("new-key")},
+			},
+			wantKey:    "default/key",
+			wantAPIKey: "new-key",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := newSecretStore()
+			if tt.name == "overwrites existing entry on update" {
+				_ = s.addOrUpdate("default/key", testSecret("default", "key", "old-key"))
+			}
+
+			err := s.addOrUpdate(tt.wantKey, tt.secret)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				_, found := s.get(tt.wantKey)
+				assert.False(t, found, "store should not contain entry when AddOrUpdate fails")
+				return
+			}
+
+			require.NoError(t, err)
+			apiKey, found := s.get(tt.wantKey)
+			assert.True(t, found)
+			assert.Equal(t, tt.wantAPIKey, apiKey)
+		})
+	}
+}
+
+func TestSecretStoreConcurrentAccess(t *testing.T) {
+	s := newSecretStore()
+	var wg sync.WaitGroup
+	goroutines := 100
+
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			key := fmt.Sprintf("default/secret-%d", n)
+			sec := testSecret("default", fmt.Sprintf("secret-%d", n), "key")
+			_ = s.addOrUpdate(key, sec)
+			s.get(key)
+			s.delete(key)
+		}(i)
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
## Description

Add the `apikey-injection` ExtProc plugin to `payload-processing/pkg/plugins/`. This plugin injects API keys into outbound requests based on the resolved model provider. Includes the plugin implementation, a credential store, a reconciler for syncing Kubernetes secrets, and full unit tests.

## How Has This Been Tested?

Unit tests included for all components:
- `plugin_test.go` — request/response handling and header injection
- `store_test.go` — credential store operations
- `reconciler_test.go` — Kubernetes secret reconciliation

## Merge criteria:

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added API key injection plugin that automatically injects authentication headers into AI provider requests.
  * Supports OpenAI, Anthropic, Vertex AI, and Azure OpenAI providers with proper header formatting for each.

* **Tests**
  * Added comprehensive test coverage for plugin functionality, error handling, and concurrent operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->