### PR TITLE
feat(payload-processing): add model-provider-resolver and api-translation plugins

### DIFF
--- a/payload-processing/cmd/main.go
+++ b/payload-processing/cmd/main.go
@@ -27,6 +27,11 @@ import (
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/gateway-api-inference-extension/cmd/bbr/runner"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/bbr/framework"
+
+	api_translation "github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/api-translation"
+	provider_resolver "github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/model-provider-resolver"
+	// apikey_injection "github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/apikey-injection"
 )
 
 func main() {
@@ -41,8 +46,7 @@ func main() {
 }
 
 func registerPlugins() {
-	// TODO uncomment after all code moves
-	// framework.Register(provider_resolver.ModelProviderResolverPluginType, provider_resolver.ModelProviderResolverFactory)
-	// framework.Register(api_translation.APITranslationPluginType, api_translation.APITranslationFactory)
+	framework.Register(provider_resolver.ModelProviderResolverPluginType, provider_resolver.ModelProviderResolverFactory)
+	framework.Register(api_translation.APITranslationPluginType, api_translation.APITranslationFactory)
 	// framework.Register(apikey_injection.APIKeyInjectionPluginType, apikey_injection.APIKeyInjectionFactory)
 }

--- a/payload-processing/go.mod
+++ b/payload-processing/go.mod
@@ -4,7 +4,6 @@ go 1.25.0
 
 require (
 	github.com/stretchr/testify v1.11.1
-	k8s.io/api v0.35.2
 	k8s.io/apimachinery v0.35.2
 	sigs.k8s.io/controller-runtime v0.23.3
 	sigs.k8s.io/gateway-api-inference-extension v0.0.0-20260318135032-876ac9d909d0
@@ -94,6 +93,7 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	k8s.io/api v0.35.2 // indirect
 	k8s.io/apiextensions-apiserver v0.35.2 // indirect
 	k8s.io/apiserver v0.35.2 // indirect
 	k8s.io/client-go v0.35.2 // indirect

--- a/payload-processing/pkg/plugins/api-translation/plugin.go
+++ b/payload-processing/pkg/plugins/api-translation/plugin.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2026 The opendatahub.io Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api_translation
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/bbr/framework"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/plugin"
+
+	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/api-translation/translator"
+	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/api-translation/translator/anthropic"
+	// "github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/api-translation/translator/azureopenai"
+	// "github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/api-translation/translator/vertex"
+	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/common/provider"
+	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/common/state"
+)
+
+const (
+	APITranslationPluginType = "api-translation"
+)
+
+// compile-time type validation
+var _ framework.RequestProcessor = &APITranslationPlugin{}
+var _ framework.ResponseProcessor = &APITranslationPlugin{}
+
+// APITranslationFactory defines the factory function for APITranslationPlugin.
+func APITranslationFactory(name string, _ json.RawMessage, _ framework.Handle) (framework.BBRPlugin, error) {
+	return NewAPITranslationPlugin().WithName(name), nil
+}
+
+// NewAPITranslationPlugin creates a new plugin instance with all registered providers.
+func NewAPITranslationPlugin() *APITranslationPlugin {
+	return &APITranslationPlugin{
+		typedName: plugin.TypedName{
+			Type: APITranslationPluginType,
+			Name: APITranslationPluginType,
+		},
+		providers: map[string]translator.Translator{
+			provider.Anthropic: anthropic.NewAnthropicTranslator(),
+			// provider.AzureOpenAI: azureopenai.NewAzureOpenAITranslator(),
+			// provider.Vertex:      vertex.NewVertexTranslator(),
+		},
+	}
+}
+
+// APITranslationPlugin translates inference API requests and responses between
+// OpenAI Chat Completions format and provider-native formats (e.g., Anthropic Messages API).
+type APITranslationPlugin struct {
+	typedName plugin.TypedName
+	providers map[string]translator.Translator // map from provider name to translator interface
+}
+
+// TypedName returns the type and name tuple of this plugin instance.
+func (p *APITranslationPlugin) TypedName() plugin.TypedName {
+	return p.typedName
+}
+
+// WithName sets the name of the plugin instance.
+func (p *APITranslationPlugin) WithName(name string) *APITranslationPlugin {
+	p.typedName.Name = name
+	return p
+}
+
+// ProcessRequest reads the provider from CycleState (set by an upstream plugin) and translates
+// the request body from OpenAI format to the provider's native format if needed.
+func (p *APITranslationPlugin) ProcessRequest(ctx context.Context, cycleState *framework.CycleState, request *framework.InferenceRequest) error {
+	if request == nil || request.Headers == nil || request.Body == nil {
+		return fmt.Errorf("invalid inference request: request/headers/body must be non-nil")
+	}
+
+	providerName, err := framework.ReadCycleStateKey[string](cycleState, state.ProviderKey) // err if not found
+	if err != nil || providerName == "" || providerName == "openai" {                       // empty provider means no translation needed
+		return nil
+	}
+
+	translator, ok := p.providers[providerName]
+	if !ok {
+		return fmt.Errorf("unsupported provider - '%s'", providerName)
+	}
+
+	translatedBody, headersToMutate, headersToRemove, err := translator.TranslateRequest(request.Body)
+	if err != nil {
+		return fmt.Errorf("request translation failed for provider '%s' - %w", providerName, err)
+	}
+
+	if translatedBody != nil {
+		request.SetBody(translatedBody)
+	}
+
+	for key, value := range headersToMutate {
+		request.SetHeader(key, value)
+	}
+	for _, key := range headersToRemove {
+		request.RemoveHeader(key)
+	}
+
+	// authorization is a special header removed by the plugin, no matter which provider is used.
+	// The api-key is expected to be set by the the api-key injection plugin.
+	request.RemoveHeader("authorization")
+
+	// content-length is another special header that will be set automatically by the pluggable framework when the body is mutated.
+
+	return nil
+}
+
+// ProcessResponse reads the provider from CycleState and translates the response
+// back to OpenAI Chat Completions format if needed.
+func (p *APITranslationPlugin) ProcessResponse(ctx context.Context, cycleState *framework.CycleState, response *framework.InferenceResponse) error {
+	if response == nil || response.Headers == nil || response.Body == nil {
+		return fmt.Errorf("invalid inference response: response/headers/body must be non-nil")
+	}
+
+	providerName, err := framework.ReadCycleStateKey[string](cycleState, state.ProviderKey) // err if not found
+	if err != nil || providerName == "" || providerName == "openai" {                       // empty provider means no translation needed
+		return nil
+	}
+
+	translator, ok := p.providers[providerName]
+	if !ok {
+		return fmt.Errorf("unsupported provider - '%s'", providerName)
+	}
+
+	model, _ := framework.ReadCycleStateKey[string](cycleState, state.ModelKey)
+
+	translatedBody, err := translator.TranslateResponse(response.Body, model)
+	if err != nil {
+		return fmt.Errorf("response translation failed for provider '%s' - %w", providerName, err)
+	}
+
+	if translatedBody != nil {
+		response.SetBody(translatedBody)
+	}
+
+	return nil
+}

--- a/payload-processing/pkg/plugins/api-translation/plugin_test.go
+++ b/payload-processing/pkg/plugins/api-translation/plugin_test.go
@@ -1,0 +1,267 @@
+/*
+Copyright 2026 The opendatahub.io Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api_translation
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/bbr/framework"
+
+	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/common/state"
+)
+
+func newCycleStateWithProvider(providerName string) *framework.CycleState {
+	cs := framework.NewCycleState()
+	cs.Write(state.ProviderKey, providerName)
+	return cs
+}
+
+func TestProcessRequest_NoProvider(t *testing.T) {
+	p := NewAPITranslationPlugin()
+
+	req := framework.NewInferenceRequest()
+	req.Body["model"] = "gpt-4o"
+	req.Body["messages"] = []any{map[string]any{"role": "user", "content": "Hi"}}
+
+	err := p.ProcessRequest(context.Background(), framework.NewCycleState(), req)
+	assert.NoError(t, err)
+	assert.False(t, req.BodyMutated())
+}
+
+func TestProcessRequest_OpenAIProvider(t *testing.T) {
+	p := NewAPITranslationPlugin()
+
+	cs := newCycleStateWithProvider("openai")
+	req := framework.NewInferenceRequest()
+	req.Body["model"] = "gpt-4o"
+	req.Body["messages"] = []any{map[string]any{"role": "user", "content": "Hi"}}
+
+	err := p.ProcessRequest(context.Background(), cs, req)
+	assert.NoError(t, err)
+	assert.False(t, req.BodyMutated())
+}
+
+func TestProcessRequest_AnthropicProvider(t *testing.T) {
+	p := NewAPITranslationPlugin()
+
+	cs := newCycleStateWithProvider("anthropic")
+	req := framework.NewInferenceRequest()
+	req.Headers["authorization"] = "Bearer sk-test"
+	req.Headers["content-length"] = "123"
+	req.Body["model"] = "claude-sonnet-4-20250514"
+	req.Body["messages"] = []any{
+		map[string]any{"role": "system", "content": "Be concise"},
+		map[string]any{"role": "user", "content": "What is 2+2?"},
+	}
+	req.Body["max_tokens"] = float64(100)
+
+	err := p.ProcessRequest(context.Background(), cs, req)
+	require.NoError(t, err)
+
+	assert.True(t, req.BodyMutated())
+
+	assert.Equal(t, "Be concise", req.Body["system"])
+	assert.Equal(t, 100, req.Body["max_tokens"])
+
+	msgs, ok := req.Body["messages"].([]map[string]any)
+	require.True(t, ok)
+	require.Len(t, msgs, 1)
+	assert.Equal(t, "user", msgs[0]["role"])
+
+	mutated := req.MutatedHeaders()
+	assert.Equal(t, "2023-06-01", mutated["anthropic-version"])
+	assert.Equal(t, "/v1/messages", mutated[":path"])
+	assert.Equal(t, "application/json", mutated["content-type"])
+
+	removed := req.RemovedHeaders()
+	assert.Contains(t, removed, "authorization")
+	assert.NotContains(t, removed, "content-length")
+}
+
+// Azure OpenAI and Vertex tests are commented out until their translators are moved to this repo.
+// See: TestProcessRequest_AzureOpenAIProvider, TestProcessResponse_AzureOpenAI
+
+func TestProcessRequest_UnknownProvider(t *testing.T) {
+	p := NewAPITranslationPlugin()
+
+	cs := newCycleStateWithProvider("unknown")
+	req := framework.NewInferenceRequest()
+	req.Body["model"] = "some-model"
+	req.Body["messages"] = []any{map[string]any{"role": "user", "content": "Hi"}}
+
+	err := p.ProcessRequest(context.Background(), cs, req)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported provider")
+	assert.Contains(t, err.Error(), "unknown")
+}
+
+func TestProcessRequest_NilRequest(t *testing.T) {
+	p := NewAPITranslationPlugin()
+
+	err := p.ProcessRequest(context.Background(), framework.NewCycleState(), nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "non-nil")
+}
+
+func TestProcessResponse_NilResponse(t *testing.T) {
+	p := NewAPITranslationPlugin()
+
+	err := p.ProcessResponse(context.Background(), framework.NewCycleState(), nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "non-nil")
+}
+
+func TestProcessResponse_Anthropic(t *testing.T) {
+	p := NewAPITranslationPlugin()
+
+	cs := newCycleStateWithProvider("anthropic")
+	cs.Write(state.ModelKey, "claude-sonnet-4-20250514")
+
+	resp := framework.NewInferenceResponse()
+	resp.Body["id"] = "msg_123"
+	resp.Body["type"] = "message"
+	resp.Body["content"] = []any{
+		map[string]any{"type": "text", "text": "The answer is 4."},
+	}
+	resp.Body["stop_reason"] = "end_turn"
+	resp.Body["usage"] = map[string]any{
+		"input_tokens":  float64(10),
+		"output_tokens": float64(5),
+	}
+
+	err := p.ProcessResponse(context.Background(), cs, resp)
+	require.NoError(t, err)
+
+	assert.True(t, resp.BodyMutated())
+	assert.Equal(t, "chat.completion", resp.Body["object"])
+	assert.Equal(t, "claude-sonnet-4-20250514", resp.Body["model"])
+
+	choices := resp.Body["choices"].([]any)
+	choice := choices[0].(map[string]any)
+	msg := choice["message"].(map[string]any)
+	assert.Equal(t, "assistant", msg["role"])
+	assert.Equal(t, "The answer is 4.", msg["content"])
+	assert.Equal(t, "stop", choice["finish_reason"])
+
+	usage := resp.Body["usage"].(map[string]any)
+	assert.Equal(t, 10, usage["prompt_tokens"])
+	assert.Equal(t, 5, usage["completion_tokens"])
+	assert.Equal(t, 15, usage["total_tokens"])
+}
+
+func TestProcessResponse_AnthropicError(t *testing.T) {
+	p := NewAPITranslationPlugin()
+
+	cs := newCycleStateWithProvider("anthropic")
+
+	resp := framework.NewInferenceResponse()
+	resp.Body["type"] = "error"
+	resp.Body["error"] = map[string]any{
+		"type":    "invalid_request_error",
+		"message": "max_tokens must be positive",
+	}
+
+	err := p.ProcessResponse(context.Background(), cs, resp)
+	require.NoError(t, err)
+
+	assert.True(t, resp.BodyMutated())
+	errObj := resp.Body["error"].(map[string]any)
+	assert.Equal(t, "invalid_request_error", errObj["type"])
+}
+
+func TestProcessResponse_AnthropicToolUse(t *testing.T) {
+	p := NewAPITranslationPlugin()
+
+	cs := newCycleStateWithProvider("anthropic")
+	cs.Write(state.ModelKey, "claude-sonnet-4-20250514")
+
+	resp := framework.NewInferenceResponse()
+	resp.Body["id"] = "msg_456"
+	resp.Body["type"] = "message"
+	resp.Body["content"] = []any{
+		map[string]any{"type": "text", "text": "Let me check."},
+		map[string]any{
+			"type":  "tool_use",
+			"id":    "toolu_abc",
+			"name":  "get_weather",
+			"input": map[string]any{"location": "Paris"},
+		},
+	}
+	resp.Body["stop_reason"] = "tool_use"
+	resp.Body["usage"] = map[string]any{
+		"input_tokens":  float64(20),
+		"output_tokens": float64(10),
+	}
+
+	err := p.ProcessResponse(context.Background(), cs, resp)
+	require.NoError(t, err)
+
+	assert.True(t, resp.BodyMutated())
+
+	choices := resp.Body["choices"].([]any)
+	choice := choices[0].(map[string]any)
+	assert.Equal(t, "tool_calls", choice["finish_reason"])
+
+	msg := choice["message"].(map[string]any)
+	toolCalls := msg["tool_calls"].([]any)
+	require.Len(t, toolCalls, 1)
+
+	tc := toolCalls[0].(map[string]any)
+	assert.Equal(t, "toolu_abc", tc["id"])
+	assert.Equal(t, 0, tc["index"])
+}
+
+// Vertex tests are commented out until the Vertex translator is moved to this repo.
+// See: TestProcessRequest_VertexProvider, TestProcessResponse_Vertex,
+//      TestProcessResponse_VertexError, TestProcessResponse_VertexToolCall
+
+func TestProcessResponse_NoProviderPassthrough(t *testing.T) {
+	p := NewAPITranslationPlugin()
+
+	resp := framework.NewInferenceResponse()
+	resp.Body["object"] = "chat.completion"
+	resp.Body["choices"] = []any{
+		map[string]any{"message": map[string]any{"content": "hi"}},
+	}
+
+	err := p.ProcessResponse(context.Background(), framework.NewCycleState(), resp)
+	assert.NoError(t, err)
+	assert.False(t, resp.BodyMutated())
+}
+
+func TestProcessResponse_OpenAIPassthrough(t *testing.T) {
+	p := NewAPITranslationPlugin()
+
+	cs := newCycleStateWithProvider("openai")
+
+	resp := framework.NewInferenceResponse()
+	resp.Body["object"] = "chat.completion"
+
+	err := p.ProcessResponse(context.Background(), cs, resp)
+	assert.NoError(t, err)
+	assert.False(t, resp.BodyMutated())
+}
+
+func TestFactory_Success(t *testing.T) {
+	p, err := APITranslationFactory("test-instance", nil, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "test-instance", p.TypedName().Name)
+	assert.Equal(t, APITranslationPluginType, p.TypedName().Type)
+}

--- a/payload-processing/pkg/plugins/api-translation/translator/anthropic/anthropic.go
+++ b/payload-processing/pkg/plugins/api-translation/translator/anthropic/anthropic.go
@@ -1,0 +1,455 @@
+/*
+Copyright 2026 The opendatahub.io Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package anthropic
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/api-translation/translator"
+)
+
+const (
+	anthropicAPIVersion = "2023-06-01"
+	anthropicPath       = "/v1/messages"
+	defaultMaxTokens    = 4096
+)
+
+// compile-time interface check
+var _ translator.Translator = &AnthropicTranslator{}
+
+func NewAnthropicTranslator() *AnthropicTranslator {
+	return &AnthropicTranslator{}
+}
+
+// AnthropicTranslator translates between OpenAI Chat Completions format and
+// Anthropic Messages API format. Works with generic map[string]any bodies.
+type AnthropicTranslator struct{}
+
+// TranslateRequest translates an OpenAI Chat Completions request body to Anthropic Messages API format.
+func (t *AnthropicTranslator) TranslateRequest(body map[string]any) (map[string]any, map[string]string, []string, error) {
+	model, _ := body["model"].(string)
+	if model == "" {
+		return nil, nil, nil, fmt.Errorf("model field is required")
+	}
+
+	messages, err := extractMessages(body)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to extract messages: %w", err)
+	}
+
+	systemPrompt, anthropicMessages, err := separateSystemMessages(messages)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	if len(anthropicMessages) == 0 {
+		return nil, nil, nil, fmt.Errorf("at least one non-system message is required")
+	}
+
+	maxTokens := resolveMaxTokens(body)
+
+	translated := map[string]any{
+		"model":      model,
+		"messages":   anthropicMessages,
+		"max_tokens": maxTokens,
+	}
+
+	if systemPrompt != "" {
+		translated["system"] = systemPrompt
+	}
+
+	if temp, ok := getFloat(body, "temperature"); ok {
+		translated["temperature"] = temp
+	}
+	if topP, ok := getFloat(body, "top_p"); ok {
+		translated["top_p"] = topP
+	}
+	if stop := extractStopSequences(body); len(stop) > 0 {
+		translated["stop_sequences"] = stop
+	}
+
+	headers := map[string]string{
+		"anthropic-version": anthropicAPIVersion,
+		"content-type":      "application/json",
+		":path":             anthropicPath,
+	}
+
+	return translated, headers, nil, nil
+}
+
+// TranslateResponse translates an Anthropic Messages API response to OpenAI Chat Completions format.
+// Handles both success responses (type: "message") and error responses (type: "error").
+func (t *AnthropicTranslator) TranslateResponse(body map[string]any, model string) (map[string]any, error) {
+	bodyType, _ := body["type"].(string)
+
+	// Handle Anthropic error responses
+	if bodyType == "error" {
+		return translateAnthropicError(body), nil
+	}
+
+	content := extractAnthropicContent(body)
+	finishReason := mapStopReason(body)
+	usage := mapAnthropicUsage(body)
+
+	id, _ := body["id"].(string)
+	if model == "" {
+		model, _ = body["model"].(string)
+	}
+
+	message := map[string]any{
+		"role":    "assistant",
+		"content": content,
+	}
+
+	// Extract tool_use blocks if stop_reason is tool_use
+	if finishReason == "tool_calls" {
+		toolCalls, err := extractAnthropicToolCalls(body)
+		if err != nil {
+			return nil, fmt.Errorf("failed to extract tool calls: %w", err)
+		}
+		if len(toolCalls) > 0 {
+			message["tool_calls"] = toolCalls
+		}
+	}
+
+	translated := map[string]any{
+		"id":      id,
+		"object":  "chat.completion",
+		"created": time.Now().Unix(),
+		"model":   model,
+		"choices": []any{
+			map[string]any{
+				"index":         0,
+				"message":       message,
+				"finish_reason": finishReason,
+			},
+		},
+		"usage": usage,
+	}
+
+	return translated, nil
+}
+
+// translateAnthropicError converts an Anthropic error response to OpenAI error format.
+func translateAnthropicError(body map[string]any) map[string]any {
+	errObj, _ := body["error"].(map[string]any)
+	errType, _ := errObj["type"].(string)
+	errMessage, _ := errObj["message"].(string)
+
+	return map[string]any{
+		"error": map[string]any{
+			"message": errMessage,
+			"type":    errType,
+			"param":   nil,
+			"code":    errType,
+		},
+	}
+}
+
+// separateSystemMessages extracts the system prompt and returns non-system messages
+// in Anthropic format (with role and content fields).
+// Maps OpenAI "developer" role to Anthropic system prompt (concatenated with "system").
+// Returns an error for unsupported roles like "tool" or "function".
+func separateSystemMessages(messages []map[string]any) (string, []map[string]any, error) {
+	var systemParts []string
+	var anthropicMessages []map[string]any
+
+	for i, msg := range messages {
+		role, _ := msg["role"].(string)
+		content := extractContentString(msg)
+
+		switch role {
+		case "system", "developer":
+			systemParts = append(systemParts, content)
+		case "user":
+			anthropicMessages = append(anthropicMessages, map[string]any{
+				"role":    "user",
+				"content": content,
+			})
+		case "assistant":
+			anthropicMessages = append(anthropicMessages, map[string]any{
+				"role":    "assistant",
+				"content": content,
+			})
+		case "tool", "function":
+			return "", nil, fmt.Errorf("message at index %d has role '%s' which is not supported for Anthropic translation", i, role)
+		default:
+			return "", nil, fmt.Errorf("message at index %d has unknown role '%s'", i, role)
+		}
+	}
+
+	return joinStrings(systemParts, "\n"), anthropicMessages, nil
+}
+
+// extractMessages extracts the messages array from the request body.
+func extractMessages(body map[string]any) ([]map[string]any, error) {
+	rawMessages, ok := body["messages"]
+	if !ok {
+		return nil, fmt.Errorf("messages field is required")
+	}
+
+	messagesSlice, ok := rawMessages.([]any)
+	if !ok {
+		return nil, fmt.Errorf("messages must be an array")
+	}
+
+	var messages []map[string]any
+	for i, raw := range messagesSlice {
+		msg, ok := raw.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("message at index %d is not an object", i)
+		}
+		messages = append(messages, msg)
+	}
+
+	return messages, nil
+}
+
+// extractContentString extracts text content from a message, handling both
+// string content and array-of-content-parts formats.
+// Only text content is extracted; non-text blocks (image_url, audio, etc.) are skipped.
+// Returns empty string if no text content is found.
+func extractContentString(msg map[string]any) string {
+	content, ok := msg["content"]
+	if !ok {
+		return ""
+	}
+
+	// Simple string content
+	if s, ok := content.(string); ok {
+		return s
+	}
+
+	// Array of content parts (e.g., [{type: "text", text: "hello"}])
+	if parts, ok := content.([]any); ok {
+		var texts []string
+		for _, part := range parts {
+			if partMap, ok := part.(map[string]any); ok {
+				if text, ok := partMap["text"].(string); ok {
+					texts = append(texts, text)
+				}
+			}
+		}
+		return joinStrings(texts, " ")
+	}
+
+	return ""
+}
+
+// resolveMaxTokens extracts max tokens from the request body, checking
+// max_completion_tokens first, then max_tokens, defaulting to 4096.
+func resolveMaxTokens(body map[string]any) int {
+	if v, ok := getInt(body, "max_completion_tokens"); ok && v > 0 {
+		return v
+	}
+	if v, ok := getInt(body, "max_tokens"); ok && v > 0 {
+		return v
+	}
+	return defaultMaxTokens
+}
+
+// extractStopSequences extracts stop sequences from the request body,
+// handling both string and array formats.
+func extractStopSequences(body map[string]any) []string {
+	stop, ok := body["stop"]
+	if !ok {
+		return nil
+	}
+
+	if s, ok := stop.(string); ok && s != "" {
+		return []string{s}
+	}
+
+	if arr, ok := stop.([]any); ok {
+		var sequences []string
+		for _, v := range arr {
+			if s, ok := v.(string); ok {
+				sequences = append(sequences, s)
+			}
+		}
+		return sequences
+	}
+
+	return nil
+}
+
+// extractAnthropicContent extracts text from Anthropic response content blocks.
+func extractAnthropicContent(body map[string]any) string {
+	contentBlocks, ok := body["content"].([]any)
+	if !ok {
+		return ""
+	}
+
+	var texts []string
+	for _, block := range contentBlocks {
+		if blockMap, ok := block.(map[string]any); ok {
+			if blockType, _ := blockMap["type"].(string); blockType == "text" {
+				if text, ok := blockMap["text"].(string); ok {
+					texts = append(texts, text)
+				}
+			}
+		}
+	}
+
+	return joinStrings(texts, "")
+}
+
+// extractAnthropicToolCalls extracts tool_use blocks from an Anthropic response
+// and converts them to OpenAI tool_calls format.
+func extractAnthropicToolCalls(body map[string]any) ([]any, error) {
+	contentBlocks, ok := body["content"].([]any)
+	if !ok {
+		return nil, nil
+	}
+
+	var toolCalls []any
+	toolIndex := 0
+	for _, block := range contentBlocks {
+		blockMap, ok := block.(map[string]any)
+		if !ok {
+			continue
+		}
+		if blockType, _ := blockMap["type"].(string); blockType == "tool_use" {
+			id, _ := blockMap["id"].(string)
+			name, _ := blockMap["name"].(string)
+			input := blockMap["input"]
+
+			args, err := toJSONString(input)
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal tool call arguments for '%s' - %w", name, err)
+			}
+
+			toolCall := map[string]any{
+				"id":    id,
+				"index": toolIndex,
+				"type":  "function",
+				"function": map[string]any{
+					"name":      name,
+					"arguments": args,
+				},
+			}
+			toolCalls = append(toolCalls, toolCall)
+			toolIndex++
+		}
+	}
+
+	return toolCalls, nil
+}
+
+// mapStopReason maps Anthropic stop_reason to OpenAI finish_reason.
+func mapStopReason(body map[string]any) string {
+	reason, _ := body["stop_reason"].(string)
+	switch reason {
+	case "max_tokens":
+		return "length"
+	case "tool_use":
+		return "tool_calls"
+	default:
+		return "stop"
+	}
+}
+
+// mapAnthropicUsage maps Anthropic usage fields to OpenAI format.
+func mapAnthropicUsage(body map[string]any) map[string]any {
+	usage, ok := body["usage"].(map[string]any)
+	if !ok {
+		return map[string]any{
+			"prompt_tokens":     0,
+			"completion_tokens": 0,
+			"total_tokens":      0,
+		}
+	}
+
+	inputTokens := toInt(usage["input_tokens"])
+	outputTokens := toInt(usage["output_tokens"])
+
+	return map[string]any{
+		"prompt_tokens":     inputTokens,
+		"completion_tokens": outputTokens,
+		"total_tokens":      inputTokens + outputTokens,
+	}
+}
+
+// Helper functions for type-safe extraction from map[string]any
+
+func getFloat(body map[string]any, key string) (float64, bool) {
+	v, ok := body[key]
+	if !ok {
+		return 0, false
+	}
+	switch f := v.(type) {
+	case float64:
+		return f, true
+	case int:
+		return float64(f), true
+	case int64:
+		return float64(f), true
+	default:
+		return 0, false
+	}
+}
+
+func getInt(body map[string]any, key string) (int, bool) {
+	v, ok := body[key]
+	if !ok {
+		return 0, false
+	}
+	switch n := v.(type) {
+	case float64:
+		return int(n), true
+	case int:
+		return n, true
+	case int64:
+		return int(n), true
+	default:
+		return 0, false
+	}
+}
+
+func toInt(v any) int {
+	switch n := v.(type) {
+	case float64:
+		return int(n)
+	case int:
+		return n
+	case int64:
+		return int(n)
+	default:
+		return 0
+	}
+}
+
+func toJSONString(v any) (string, error) {
+	if v == nil {
+		return "{}", nil
+	}
+	if s, ok := v.(string); ok {
+		return s, nil
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal to JSON: %w", err)
+	}
+	return string(b), nil
+}
+
+func joinStrings(parts []string, sep string) string {
+	return strings.Join(parts, sep)
+}

--- a/payload-processing/pkg/plugins/api-translation/translator/anthropic/anthropic_test.go
+++ b/payload-processing/pkg/plugins/api-translation/translator/anthropic/anthropic_test.go
@@ -1,0 +1,477 @@
+/*
+Copyright 2026 The opendatahub.io Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package anthropic
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTranslateRequest_BasicChat(t *testing.T) {
+	body := map[string]any{
+		"model": "claude-sonnet-4-20250514",
+		"messages": []any{
+			map[string]any{"role": "user", "content": "What is 2+2?"},
+		},
+	}
+
+	translated, headers, headersToRemove, err := NewAnthropicTranslator().TranslateRequest(body)
+	require.NoError(t, err)
+
+	assert.Equal(t, "claude-sonnet-4-20250514", translated["model"])
+	assert.Equal(t, defaultMaxTokens, translated["max_tokens"])
+
+	msgs := translated["messages"].([]map[string]any)
+	require.Len(t, msgs, 1)
+	assert.Equal(t, "user", msgs[0]["role"])
+	assert.Equal(t, "What is 2+2?", msgs[0]["content"])
+
+	assert.Nil(t, translated["system"])
+
+	assert.Equal(t, anthropicAPIVersion, headers["anthropic-version"])
+	assert.Equal(t, "application/json", headers["content-type"])
+	assert.Equal(t, anthropicPath, headers[":path"])
+
+	assert.Empty(t, headersToRemove)
+}
+
+func TestTranslateRequest_SystemMessage(t *testing.T) {
+	body := map[string]any{
+		"model": "claude-sonnet-4-20250514",
+		"messages": []any{
+			map[string]any{"role": "system", "content": "You are a helpful assistant."},
+			map[string]any{"role": "user", "content": "Hello"},
+		},
+	}
+
+	translated, _, _, err := NewAnthropicTranslator().TranslateRequest(body)
+	require.NoError(t, err)
+
+	assert.Equal(t, "You are a helpful assistant.", translated["system"])
+
+	msgs := translated["messages"].([]map[string]any)
+	require.Len(t, msgs, 1)
+	assert.Equal(t, "user", msgs[0]["role"])
+}
+
+func TestTranslateRequest_MultipleMessages(t *testing.T) {
+	body := map[string]any{
+		"model": "claude-sonnet-4-20250514",
+		"messages": []any{
+			map[string]any{"role": "user", "content": "Hi"},
+			map[string]any{"role": "assistant", "content": "Hello!"},
+			map[string]any{"role": "user", "content": "How are you?"},
+		},
+	}
+
+	translated, _, _, err := NewAnthropicTranslator().TranslateRequest(body)
+	require.NoError(t, err)
+
+	msgs := translated["messages"].([]map[string]any)
+	require.Len(t, msgs, 3)
+	assert.Equal(t, "user", msgs[0]["role"])
+	assert.Equal(t, "assistant", msgs[1]["role"])
+	assert.Equal(t, "user", msgs[2]["role"])
+}
+
+func TestTranslateRequest_MaxTokens(t *testing.T) {
+	tests := []struct {
+		name     string
+		body     map[string]any
+		expected int
+	}{
+		{
+			name: "max_completion_tokens takes priority",
+			body: map[string]any{
+				"model":                 "claude-sonnet-4-20250514",
+				"messages":              []any{map[string]any{"role": "user", "content": "Hi"}},
+				"max_completion_tokens": float64(200),
+				"max_tokens":            float64(100),
+			},
+			expected: 200,
+		},
+		{
+			name: "max_tokens fallback",
+			body: map[string]any{
+				"model":      "claude-sonnet-4-20250514",
+				"messages":   []any{map[string]any{"role": "user", "content": "Hi"}},
+				"max_tokens": float64(500),
+			},
+			expected: 500,
+		},
+		{
+			name: "default when neither set",
+			body: map[string]any{
+				"model":    "claude-sonnet-4-20250514",
+				"messages": []any{map[string]any{"role": "user", "content": "Hi"}},
+			},
+			expected: defaultMaxTokens,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			translated, _, _, err := NewAnthropicTranslator().TranslateRequest(tt.body)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, translated["max_tokens"])
+		})
+	}
+}
+
+func TestTranslateRequest_OptionalParams(t *testing.T) {
+	body := map[string]any{
+		"model":       "claude-sonnet-4-20250514",
+		"messages":    []any{map[string]any{"role": "user", "content": "Hi"}},
+		"temperature": 0.7,
+		"top_p":       0.9,
+		"stop":        []any{"END", "STOP"},
+	}
+
+	translated, _, _, err := NewAnthropicTranslator().TranslateRequest(body)
+	require.NoError(t, err)
+
+	assert.Equal(t, 0.7, translated["temperature"])
+	assert.Equal(t, 0.9, translated["top_p"])
+	assert.Equal(t, []string{"END", "STOP"}, translated["stop_sequences"])
+}
+
+func TestTranslateRequest_StopString(t *testing.T) {
+	body := map[string]any{
+		"model":    "claude-sonnet-4-20250514",
+		"messages": []any{map[string]any{"role": "user", "content": "Hi"}},
+		"stop":     "END",
+	}
+
+	translated, _, _, err := NewAnthropicTranslator().TranslateRequest(body)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"END"}, translated["stop_sequences"])
+}
+
+func TestTranslateRequest_MissingModel(t *testing.T) {
+	body := map[string]any{
+		"messages": []any{map[string]any{"role": "user", "content": "Hi"}},
+	}
+
+	_, _, _, err := NewAnthropicTranslator().TranslateRequest(body)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "model")
+}
+
+func TestTranslateRequest_MissingMessages(t *testing.T) {
+	body := map[string]any{
+		"model": "claude-sonnet-4-20250514",
+	}
+
+	_, _, _, err := NewAnthropicTranslator().TranslateRequest(body)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "messages")
+}
+
+func TestTranslateRequest_OnlySystemMessage(t *testing.T) {
+	body := map[string]any{
+		"model": "claude-sonnet-4-20250514",
+		"messages": []any{
+			map[string]any{"role": "system", "content": "You are helpful"},
+		},
+	}
+
+	_, _, _, err := NewAnthropicTranslator().TranslateRequest(body)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "non-system message")
+}
+
+func TestTranslateRequest_ContentParts(t *testing.T) {
+	body := map[string]any{
+		"model": "claude-sonnet-4-20250514",
+		"messages": []any{
+			map[string]any{
+				"role": "user",
+				"content": []any{
+					map[string]any{"type": "text", "text": "Hello"},
+					map[string]any{"type": "text", "text": "World"},
+				},
+			},
+		},
+	}
+
+	translated, _, _, err := NewAnthropicTranslator().TranslateRequest(body)
+	require.NoError(t, err)
+
+	msgs := translated["messages"].([]map[string]any)
+	assert.Equal(t, "Hello World", msgs[0]["content"])
+}
+
+func TestTranslateResponse_BasicCompletion(t *testing.T) {
+	body := map[string]any{
+		"id":    "msg_123",
+		"type":  "message",
+		"model": "claude-sonnet-4-20250514",
+		"content": []any{
+			map[string]any{"type": "text", "text": "The answer is 4."},
+		},
+		"stop_reason": "end_turn",
+		"usage": map[string]any{
+			"input_tokens":  float64(10),
+			"output_tokens": float64(5),
+		},
+	}
+
+	translated, err := NewAnthropicTranslator().TranslateResponse(body, "claude-sonnet-4-20250514")
+	require.NoError(t, err)
+
+	assert.Equal(t, "msg_123", translated["id"])
+	assert.Equal(t, "chat.completion", translated["object"])
+	assert.Equal(t, "claude-sonnet-4-20250514", translated["model"])
+
+	choices := translated["choices"].([]any)
+	require.Len(t, choices, 1)
+
+	choice := choices[0].(map[string]any)
+	assert.Equal(t, 0, choice["index"])
+	assert.Equal(t, "stop", choice["finish_reason"])
+
+	msg := choice["message"].(map[string]any)
+	assert.Equal(t, "assistant", msg["role"])
+	assert.Equal(t, "The answer is 4.", msg["content"])
+
+	usage := translated["usage"].(map[string]any)
+	assert.Equal(t, 10, usage["prompt_tokens"])
+	assert.Equal(t, 5, usage["completion_tokens"])
+	assert.Equal(t, 15, usage["total_tokens"])
+}
+
+func TestTranslateResponse_StopReasons(t *testing.T) {
+	tests := []struct {
+		anthropicReason string
+		openaiReason    string
+	}{
+		{"end_turn", "stop"},
+		{"max_tokens", "length"},
+		{"tool_use", "tool_calls"},
+		{"", "stop"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.anthropicReason, func(t *testing.T) {
+			body := map[string]any{
+				"type":        "message",
+				"content":     []any{map[string]any{"type": "text", "text": "hi"}},
+				"stop_reason": tt.anthropicReason,
+				"usage":       map[string]any{"input_tokens": float64(1), "output_tokens": float64(1)},
+			}
+
+			translated, err := NewAnthropicTranslator().TranslateResponse(body, "test")
+			require.NoError(t, err)
+
+			choices := translated["choices"].([]any)
+			choice := choices[0].(map[string]any)
+			assert.Equal(t, tt.openaiReason, choice["finish_reason"])
+		})
+	}
+}
+
+func TestTranslateResponse_MultipleContentBlocks(t *testing.T) {
+	body := map[string]any{
+		"type": "message",
+		"content": []any{
+			map[string]any{"type": "text", "text": "Hello "},
+			map[string]any{"type": "text", "text": "World"},
+		},
+		"stop_reason": "end_turn",
+		"usage":       map[string]any{"input_tokens": float64(1), "output_tokens": float64(2)},
+	}
+
+	translated, err := NewAnthropicTranslator().TranslateResponse(body, "test")
+	require.NoError(t, err)
+
+	choices := translated["choices"].([]any)
+	msg := choices[0].(map[string]any)["message"].(map[string]any)
+	assert.Equal(t, "Hello World", msg["content"])
+}
+
+func TestTranslateResponse_ModelFromBody(t *testing.T) {
+	body := map[string]any{
+		"type":        "message",
+		"model":       "claude-sonnet-4-20250514",
+		"content":     []any{map[string]any{"type": "text", "text": "hi"}},
+		"stop_reason": "end_turn",
+		"usage":       map[string]any{"input_tokens": float64(1), "output_tokens": float64(1)},
+	}
+
+	translated, err := NewAnthropicTranslator().TranslateResponse(body, "")
+	require.NoError(t, err)
+	assert.Equal(t, "claude-sonnet-4-20250514", translated["model"])
+}
+
+func TestTranslateResponse_MissingUsage(t *testing.T) {
+	body := map[string]any{
+		"type":        "message",
+		"content":     []any{map[string]any{"type": "text", "text": "hi"}},
+		"stop_reason": "end_turn",
+	}
+
+	translated, err := NewAnthropicTranslator().TranslateResponse(body, "test")
+	require.NoError(t, err)
+
+	usage := translated["usage"].(map[string]any)
+	assert.Equal(t, 0, usage["prompt_tokens"])
+	assert.Equal(t, 0, usage["completion_tokens"])
+	assert.Equal(t, 0, usage["total_tokens"])
+}
+
+func TestTranslateResponse_AnthropicError(t *testing.T) {
+	body := map[string]any{
+		"type": "error",
+		"error": map[string]any{
+			"type":    "invalid_request_error",
+			"message": "max_tokens must be a positive integer",
+		},
+	}
+
+	translated, err := NewAnthropicTranslator().TranslateResponse(body, "claude-sonnet-4-20250514")
+	require.NoError(t, err)
+
+	errObj := translated["error"].(map[string]any)
+	assert.Equal(t, "invalid_request_error", errObj["type"])
+	assert.Equal(t, "max_tokens must be a positive integer", errObj["message"])
+	assert.Equal(t, "invalid_request_error", errObj["code"])
+}
+
+func TestTranslateResponse_ToolUse(t *testing.T) {
+	body := map[string]any{
+		"id":   "msg_123",
+		"type": "message",
+		"content": []any{
+			map[string]any{"type": "text", "text": "I'll check the weather."},
+			map[string]any{
+				"type":  "tool_use",
+				"id":    "toolu_abc",
+				"name":  "get_weather",
+				"input": map[string]any{"location": "San Francisco"},
+			},
+		},
+		"stop_reason": "tool_use",
+		"usage":       map[string]any{"input_tokens": float64(20), "output_tokens": float64(15)},
+	}
+
+	translated, err := NewAnthropicTranslator().TranslateResponse(body, "claude-sonnet-4-20250514")
+	require.NoError(t, err)
+
+	choices := translated["choices"].([]any)
+	choice := choices[0].(map[string]any)
+	assert.Equal(t, "tool_calls", choice["finish_reason"])
+
+	msg := choice["message"].(map[string]any)
+	assert.Equal(t, "I'll check the weather.", msg["content"])
+
+	toolCalls := msg["tool_calls"].([]any)
+	require.Len(t, toolCalls, 1)
+
+	tc := toolCalls[0].(map[string]any)
+	assert.Equal(t, "toolu_abc", tc["id"])
+	assert.Equal(t, "function", tc["type"])
+
+	fn := tc["function"].(map[string]any)
+	assert.Equal(t, "get_weather", fn["name"])
+}
+
+func TestTranslateRequest_DeveloperRole(t *testing.T) {
+	body := map[string]any{
+		"model": "claude-sonnet-4-20250514",
+		"messages": []any{
+			map[string]any{"role": "developer", "content": "You are a coding assistant."},
+			map[string]any{"role": "user", "content": "Hello"},
+		},
+	}
+
+	translated, _, _, err := NewAnthropicTranslator().TranslateRequest(body)
+	require.NoError(t, err)
+
+	assert.Equal(t, "You are a coding assistant.", translated["system"])
+
+	msgs := translated["messages"].([]map[string]any)
+	require.Len(t, msgs, 1)
+	assert.Equal(t, "user", msgs[0]["role"])
+}
+
+func TestTranslateRequest_SystemAndDeveloperConcatenated(t *testing.T) {
+	body := map[string]any{
+		"model": "claude-sonnet-4-20250514",
+		"messages": []any{
+			map[string]any{"role": "system", "content": "Be concise."},
+			map[string]any{"role": "developer", "content": "Use markdown."},
+			map[string]any{"role": "user", "content": "Hello"},
+		},
+	}
+
+	translated, _, _, err := NewAnthropicTranslator().TranslateRequest(body)
+	require.NoError(t, err)
+
+	assert.Equal(t, "Be concise.\nUse markdown.", translated["system"])
+}
+
+func TestTranslateRequest_ToolRoleRejected(t *testing.T) {
+	body := map[string]any{
+		"model": "claude-sonnet-4-20250514",
+		"messages": []any{
+			map[string]any{"role": "user", "content": "Hi"},
+			map[string]any{"role": "tool", "content": "result", "tool_call_id": "abc"},
+		},
+	}
+
+	_, _, _, err := NewAnthropicTranslator().TranslateRequest(body)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "tool")
+	assert.Contains(t, err.Error(), "not supported")
+}
+
+func TestTranslateRequest_UnknownRoleRejected(t *testing.T) {
+	body := map[string]any{
+		"model": "claude-sonnet-4-20250514",
+		"messages": []any{
+			map[string]any{"role": "narrator", "content": "Once upon a time"},
+		},
+	}
+
+	_, _, _, err := NewAnthropicTranslator().TranslateRequest(body)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown role")
+}
+
+func TestTranslateRequest_NonTextContentSkipped(t *testing.T) {
+	body := map[string]any{
+		"model": "claude-sonnet-4-20250514",
+		"messages": []any{
+			map[string]any{
+				"role": "user",
+				"content": []any{
+					map[string]any{"type": "text", "text": "Describe this"},
+					map[string]any{"type": "image_url", "image_url": map[string]any{"url": "https://example.com/img.png"}},
+				},
+			},
+		},
+	}
+
+	translated, _, _, err := NewAnthropicTranslator().TranslateRequest(body)
+	require.NoError(t, err)
+
+	msgs := translated["messages"].([]map[string]any)
+	assert.Equal(t, "Describe this", msgs[0]["content"])
+}

--- a/payload-processing/pkg/plugins/api-translation/translator/translator.go
+++ b/payload-processing/pkg/plugins/api-translation/translator/translator.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2026 The opendatahub.io Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package translator
+
+// Translator translates between OpenAI Chat Completions format and a specific
+// provider's native API format. Implementations handle both request and response
+// translation using generic map[string]any bodies (pre-parsed JSON from the BBR framework).
+type Translator interface {
+	// TranslateRequest translates an OpenAI-format request body to the provider's native format.
+	// Returns the translated body, headers to set, headers to remove, and any error.
+	// A nil translatedBody means no body mutation is needed.
+	TranslateRequest(body map[string]any) (translatedBody map[string]any, headersToMutate map[string]string, headersToRemove []string, err error)
+
+	// TranslateResponse translates a provider-native response body back to OpenAI Chat Completions format.
+	// The model parameter is used to populate the model field in the OpenAI response.
+	// A nil translatedBody means no body mutation is needed.
+	TranslateResponse(body map[string]any, model string) (translatedBody map[string]any, err error)
+}

--- a/payload-processing/pkg/plugins/model-provider-resolver/model_store.go
+++ b/payload-processing/pkg/plugins/model-provider-resolver/model_store.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2026 The opendatahub.io Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package model_provider_resolver
+
+import (
+	"sync"
+
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// ModelInfo holds the provider and credential reference for an external model.
+type ModelInfo struct {
+	provider               string
+	credentialRefName      string
+	credentialRefNamespace string
+}
+
+// modelInfoStore is a thread-safe in-memory store that maps model names to their provider info.
+// The reconciler writes to it; the plugin reads from it during request processing.
+type modelInfoStore struct {
+	models map[string]ModelInfo
+	// modelRefKeyToModel tracks which MaaSModelRef resource added each model entry,
+	// so we can clean up when the resource is deleted.
+	modelRefKeyToModel map[types.NamespacedName]string
+	lock               sync.RWMutex
+}
+
+func newModelInfoStore() *modelInfoStore {
+	return &modelInfoStore{
+		models:             make(map[string]ModelInfo),
+		modelRefKeyToModel: make(map[types.NamespacedName]string),
+	}
+}
+
+// getModelInfo returns the ModelInfo for a model name, or empty if not found.
+func (s *modelInfoStore) getModelInfo(modelName string) (ModelInfo, bool) {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+	info, ok := s.models[modelName]
+	return info, ok
+}
+
+// setModelInfo stores the model→provider mapping and records which resource it came from.
+func (s *modelInfoStore) setModelInfo(modelName string, info ModelInfo, modelRefKey types.NamespacedName) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	s.models[modelName] = info
+	s.modelRefKeyToModel[modelRefKey] = modelName
+}
+
+// deleteByResource removes the model entry that was added by the given MaaSModelRef resource.
+func (s *modelInfoStore) deleteByResource(modelRefKey types.NamespacedName) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	modelName, ok := s.modelRefKeyToModel[modelRefKey]
+	if !ok {
+		return // no model info was stored for this modelRef
+	}
+
+	delete(s.models, modelName)
+	delete(s.modelRefKeyToModel, modelRefKey)
+}

--- a/payload-processing/pkg/plugins/model-provider-resolver/model_store_test.go
+++ b/payload-processing/pkg/plugins/model-provider-resolver/model_store_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2026 The opendatahub.io Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package model_provider_resolver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/common/provider"
+)
+
+func TestModelStore_SetAndGet(t *testing.T) {
+	store := newModelInfoStore()
+	key := types.NamespacedName{Name: "test", Namespace: "ns"}
+
+	store.setModelInfo("model-a", ModelInfo{provider: provider.Anthropic}, key)
+
+	info, found := store.getModelInfo("model-a")
+	assert.True(t, found)
+	assert.Equal(t, provider.Anthropic, info.provider)
+}
+
+func TestModelStore_DeleteByResource(t *testing.T) {
+	store := newModelInfoStore()
+	key := types.NamespacedName{Name: "test", Namespace: "ns"}
+
+	store.setModelInfo("model-a", ModelInfo{provider: provider.Anthropic}, key)
+	store.deleteByResource(key)
+
+	_, found := store.getModelInfo("model-a")
+	assert.False(t, found)
+}
+
+func TestModelStore_DeleteNonExistent(t *testing.T) {
+	store := newModelInfoStore()
+	// should not panic
+	store.deleteByResource(types.NamespacedName{Name: "nonexistent", Namespace: "ns"})
+}

--- a/payload-processing/pkg/plugins/model-provider-resolver/plugin.go
+++ b/payload-processing/pkg/plugins/model-provider-resolver/plugin.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2026 The opendatahub.io Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package model_provider_resolver
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/bbr/framework"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/plugin"
+
+	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/common/state"
+)
+
+const (
+	ModelProviderResolverPluginType = "model-provider-resolver"
+)
+
+// maasModelRefGVK is the GroupVersionKind for MaaSModelRef CRD.
+var maasModelRefGVK = schema.GroupVersionKind{
+	Group:   "maas.opendatahub.io",
+	Version: "v1alpha1",
+	Kind:    "MaaSModelRef",
+}
+
+// compile-time type validation
+var _ framework.RequestProcessor = &ModelProviderResolverPlugin{}
+
+// ModelProviderResolverFactory defines the factory function for ModelProviderResolverPlugin
+func ModelProviderResolverFactory(name string, _ json.RawMessage, handle framework.Handle) (framework.BBRPlugin, error) {
+	plugin, err := NewModelProviderResolver(handle.ReconcilerBuilder, handle.ClientReader())
+	if err != nil {
+		return nil, fmt.Errorf("failed to create plugin '%s' - %w", ModelProviderResolverPluginType, err)
+	}
+
+	return plugin.WithName(name), nil
+}
+
+func NewModelProviderResolver(reconcilerBuilder func() *builder.Builder, clientReader client.Reader) (*ModelProviderResolverPlugin, error) {
+	modelInfoStore := newModelInfoStore()
+	reconciler := &maasModelRefReconciler{
+		Reader: clientReader,
+		store:  modelInfoStore,
+	}
+
+	// Watch MaaSModelRef CRDs using unstructured client (no MaaS type dependency)
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(maasModelRefGVK)
+
+	if err := reconcilerBuilder().For(obj).Complete(reconciler); err != nil {
+		return nil, fmt.Errorf("failed to register MaaSModelRef reconciler for plugin '%s' - %w", ModelProviderResolverPluginType, err)
+	}
+
+	return &ModelProviderResolverPlugin{
+		typedName:      plugin.TypedName{Type: ModelProviderResolverPluginType, Name: ModelProviderResolverPluginType},
+		modelInfoStore: modelInfoStore,
+	}, nil
+}
+
+// ModelProviderResolverPlugin resolves model names to provider info by watching MaaSModelRef CRDs.
+// It writes the model, provider and credential reference to CycleState for downstream plugins
+// (api-translation, api-key-injection).
+type ModelProviderResolverPlugin struct {
+	typedName      plugin.TypedName
+	modelInfoStore *modelInfoStore
+}
+
+// TypedName returns the type and name tuple of this plugin instance.
+func (p *ModelProviderResolverPlugin) TypedName() plugin.TypedName {
+	return p.typedName
+}
+
+// WithName sets the name of the plugin instance.
+func (p *ModelProviderResolverPlugin) WithName(name string) *ModelProviderResolverPlugin {
+	p.typedName.Name = name
+	return p
+}
+
+// ProcessRequest reads the model name from the request body, resolves the provider
+// from the modelInfoStore (populated by MaaSModelRef reconciler), and writes model, provider
+// and credential reference info to CycleState.
+func (p *ModelProviderResolverPlugin) ProcessRequest(ctx context.Context, cycleState *framework.CycleState, request *framework.InferenceRequest) error {
+	if request == nil || request.Headers == nil || request.Body == nil {
+		return fmt.Errorf("invalid inference request: request/headers/body must be non-nil")
+	}
+
+	model, ok := request.Body["model"].(string)
+	if !ok || model == "" {
+		return errors.New("failed to read 'model' from request body")
+	}
+
+	info, found := p.modelInfoStore.getModelInfo(model)
+	if !found { // info is stored only for external models
+		return nil // this is not considered an error, we just need to skip if it's internal model
+	}
+
+	// info of external model written to cycle state for next plugins
+	cycleState.Write(state.ModelKey, model)
+	cycleState.Write(state.ProviderKey, info.provider)
+	if info.credentialRefName != "" {
+		cycleState.Write(state.CredsRefName, info.credentialRefName)
+	}
+	if info.credentialRefNamespace != "" {
+		cycleState.Write(state.CredsRefNamespace, info.credentialRefNamespace)
+	}
+
+	return nil
+}

--- a/payload-processing/pkg/plugins/model-provider-resolver/plugin_test.go
+++ b/payload-processing/pkg/plugins/model-provider-resolver/plugin_test.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2026 The opendatahub.io Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package model_provider_resolver
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/bbr/framework"
+
+	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/common/provider"
+	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/common/state"
+)
+
+func TestProcessRequest_ModelResolved(t *testing.T) {
+	store := newModelInfoStore()
+	model := "claude-sonnet"
+	credentialRefName := "anthropic-key"
+	credentialRefNamespace := "llm"
+	store.setModelInfo(model, ModelInfo{
+		provider:               provider.Anthropic,
+		credentialRefName:      credentialRefName,
+		credentialRefNamespace: credentialRefNamespace,
+	}, types.NamespacedName{Name: "claude-sonnet", Namespace: "llm"})
+
+	plugin := &ModelProviderResolverPlugin{modelInfoStore: store}
+	cs := framework.NewCycleState()
+	req := framework.NewInferenceRequest()
+	req.Body["model"] = model
+
+	err := plugin.ProcessRequest(context.Background(), cs, req)
+	require.NoError(t, err)
+
+	actualModel, err := framework.ReadCycleStateKey[string](cs, state.ModelKey)
+	assert.NoError(t, err)
+	assert.Equal(t, model, actualModel)
+
+	actualProvider, err := framework.ReadCycleStateKey[string](cs, state.ProviderKey)
+	assert.NoError(t, err)
+	assert.Equal(t, provider.Anthropic, actualProvider)
+
+	actualCredsName, err := framework.ReadCycleStateKey[string](cs, state.CredsRefName)
+	assert.NoError(t, err)
+	assert.Equal(t, credentialRefName, actualCredsName)
+
+	actualCredsNamespace, err := framework.ReadCycleStateKey[string](cs, state.CredsRefNamespace)
+	assert.NoError(t, err)
+	assert.Equal(t, credentialRefNamespace, actualCredsNamespace)
+}
+
+func TestProcessRequest_ModelNotFound(t *testing.T) {
+	store := newModelInfoStore()
+	p := &ModelProviderResolverPlugin{modelInfoStore: store}
+	cs := framework.NewCycleState()
+	req := framework.NewInferenceRequest()
+	req.Body["model"] = "unknown-model"
+
+	err := p.ProcessRequest(context.Background(), cs, req)
+	assert.NoError(t, err)
+
+	_, provErr := framework.ReadCycleStateKey[string](cs, state.ProviderKey)
+	assert.Error(t, provErr) // not found in CycleState
+}
+
+func TestProcessRequest_NoModel(t *testing.T) {
+	store := newModelInfoStore()
+	p := &ModelProviderResolverPlugin{modelInfoStore: store}
+
+	err := p.ProcessRequest(context.Background(), framework.NewCycleState(), framework.NewInferenceRequest())
+	assert.Error(t, err)
+}
+
+func TestProcessRequest_NilRequest(t *testing.T) {
+	store := newModelInfoStore()
+	p := &ModelProviderResolverPlugin{modelInfoStore: store}
+
+	err := p.ProcessRequest(context.Background(), framework.NewCycleState(), nil)
+	assert.Error(t, err)
+}
+
+func TestProcessRequest_NoCredentialRef(t *testing.T) {
+	store := newModelInfoStore()
+	store.setModelInfo("gpt-4o", ModelInfo{
+		provider: provider.OpenAI,
+		// no credential ref
+	}, types.NamespacedName{Name: "gpt-4o", Namespace: "llm"})
+
+	p := &ModelProviderResolverPlugin{modelInfoStore: store}
+	cs := framework.NewCycleState()
+	req := framework.NewInferenceRequest()
+	req.Body["model"] = "gpt-4o"
+
+	err := p.ProcessRequest(context.Background(), cs, req)
+	require.NoError(t, err)
+
+	actualProvider, _ := framework.ReadCycleStateKey[string](cs, state.ProviderKey)
+	assert.Equal(t, provider.OpenAI, actualProvider)
+
+	_, credErr := framework.ReadCycleStateKey[string](cs, state.CredsRefName)
+	assert.Error(t, credErr)
+}

--- a/payload-processing/pkg/plugins/model-provider-resolver/reconciler.go
+++ b/payload-processing/pkg/plugins/model-provider-resolver/reconciler.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2026 The opendatahub.io Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package model_provider_resolver
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// maasModelRefReconciler watches MaaSModelRef CRDs (via unstructured client)
+// and updates the model store with provider and credential information.
+type maasModelRefReconciler struct {
+	client.Reader
+	store *modelInfoStore
+}
+
+// Reconcile handles create/update/delete events for MaaSModelRef resources.
+func (r *maasModelRefReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+	logger.Info("Reconciling MaaSModelRef", "name", req.Name, "namespace", req.Namespace)
+
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(maasModelRefGVK)
+
+	err := r.Get(ctx, req.NamespacedName, obj)
+	if errors.IsNotFound(err) {
+		r.store.deleteByResource(req.NamespacedName)
+		logger.Info("MaaSModelRef deleted, cleaned store", "name", req.Name)
+		return ctrl.Result{}, nil
+	}
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("unable to get MaaSModelRef: %w", err)
+	}
+
+	if !obj.GetDeletionTimestamp().IsZero() {
+		r.store.deleteByResource(req.NamespacedName)
+		return ctrl.Result{}, nil
+	}
+
+	// Extract spec.modelRef fields
+	kind, _, _ := unstructured.NestedString(obj.Object, "spec", "modelRef", "kind")
+	if kind != "ExternalModel" {
+		return ctrl.Result{}, nil
+	}
+
+	modelName, _, _ := unstructured.NestedString(obj.Object, "spec", "modelRef", "name")
+	provider, _, _ := unstructured.NestedString(obj.Object, "spec", "modelRef", "provider")
+	if provider == "" {
+		logger.Info("MaaSModelRef ExternalModel missing provider, skipping", "name", req.Name)
+		return ctrl.Result{}, nil
+	}
+
+	info := ModelInfo{
+		provider: provider,
+	}
+
+	// Extract spec.credentialRef if present
+	credName, _, _ := unstructured.NestedString(obj.Object, "spec", "credentialRef", "name")
+	credNS, _, _ := unstructured.NestedString(obj.Object, "spec", "credentialRef", "namespace")
+	if credName != "" {
+		info.credentialRefName = credName
+		info.credentialRefNamespace = credNS
+		if info.credentialRefNamespace == "" {
+			info.credentialRefNamespace = obj.GetNamespace()
+		}
+	}
+
+	r.store.setModelInfo(modelName, info, req.NamespacedName)
+	logger.Info("Updated model store", "model", modelName, "provider", provider)
+
+	return ctrl.Result{}, nil
+}


### PR DESCRIPTION
## Description

  Move the `model-provider-resolver` and `api-translation` plugins to `payload-processing/pkg/plugins/`.

  **model-provider-resolver** watches MaaSModelRef CRDs and resolves model names to providers, writing the result (provider, credentialRef) to CycleState for downstream plugins.

  **api-translation** translates inference API requests and responses between OpenAI Chat Completions format and provider-native formats. Currently includes the Anthropic Messages API
  translator. Vertex AI and Azure OpenAI translators are commented out pending their own move PRs by their respective contributors.

  Also uncomments the plugin registrations in `cmd/main.go` for these two plugins.

  ## How Has This Been Tested?

  Unit tests included for all components:
  - `model-provider-resolver/plugin_test.go` — request processing and CycleState population
  - `model-provider-resolver/model_store_test.go` — thread-safe model store operations
  - `api-translation/plugin_test.go` — request/response translation with CycleState
  - `api-translation/translator/anthropic/anthropic_test.go` — Anthropic Messages API translation

  ## Merge criteria:

  - [ ] The commits are squashed in a cohesive manner and have meaningful messages.
  - [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
  - [ ] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Activated API translation plugin enabling automatic format conversion between OpenAI and Anthropic APIs.
  * Activated model provider resolver plugin for dynamic model-to-provider mapping resolution from resource definitions.
  * Added Anthropic API request and response translation support.

* **Tests**
  * Added comprehensive test coverage for API translation and model provider resolver functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->