### PR TITLE
feat(payload-processing): add AWS Bedrock OpenAI chat completions sup…

### DIFF
--- a/payload-processing/pkg/plugins/api-translation/plugin.go
+++ b/payload-processing/pkg/plugins/api-translation/plugin.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/api-translation/translator"
 	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/api-translation/translator/anthropic"
+	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/api-translation/translator/awsbedrock"
 	// "github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/api-translation/translator/azureopenai"
 	// "github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/api-translation/translator/vertex"
 	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/common/provider"
@@ -53,7 +54,8 @@ func NewAPITranslationPlugin() *APITranslationPlugin {
 			Name: APITranslationPluginType,
 		},
 		providers: map[string]translator.Translator{
-			provider.Anthropic: anthropic.NewAnthropicTranslator(),
+			provider.Anthropic:        anthropic.NewAnthropicTranslator(),
+			provider.AWSBedrockOpenAI: awsbedrock.NewBedrockTranslator(),
 			// provider.AzureOpenAI: azureopenai.NewAzureOpenAITranslator(),
 			// provider.Vertex:      vertex.NewVertexTranslator(),
 		},

--- a/payload-processing/pkg/plugins/api-translation/translator/awsbedrock/awsbedrock.go
+++ b/payload-processing/pkg/plugins/api-translation/translator/awsbedrock/awsbedrock.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2026 The opendatahub.io Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package awsbedrock
+
+import (
+	"fmt"
+	"os"
+)
+
+const (
+	// AWS environment variables
+	awsRegionEnv     = "AWS_REGION"
+	awsDefaultRegion = "us-east-1"
+
+	// Bedrock OpenAI-compatible endpoint path
+	bedrockOpenAIPath = "/v1/chat/completions"
+)
+
+// BedrockTranslator translates OpenAI Chat Completions to AWS Bedrock's OpenAI-compatible API
+// This is a simple path rewriter since Bedrock's OpenAI-compatible endpoint uses the same format
+type BedrockTranslator struct {
+	region string
+}
+
+// NewBedrockTranslator creates a new AWS Bedrock translator instance
+func NewBedrockTranslator() *BedrockTranslator {
+	region := os.Getenv(awsRegionEnv)
+	if region == "" {
+		region = awsDefaultRegion
+	}
+
+	return &BedrockTranslator{
+		region: region,
+	}
+}
+
+// NewBedrockTranslatorWithRegion creates a translator with explicit region
+func NewBedrockTranslatorWithRegion(region string) *BedrockTranslator {
+	if region == "" {
+		region = awsDefaultRegion
+	}
+
+	return &BedrockTranslator{
+		region: region,
+	}
+}
+
+// TranslateRequest translates an OpenAI request to AWS Bedrock Converse API format
+// Returns the translated body, headers to set, headers to remove, and any error
+// TranslateRequest rewrites the path to target Bedrock's OpenAI-compatible endpoint.
+// The request body is not mutated since Bedrock's OpenAI-compatible API accepts the same schema as OpenAI.
+func (t *BedrockTranslator) TranslateRequest(body map[string]any) (
+	translatedBody map[string]any,
+	headersToMutate map[string]string,
+	headersToRemove []string,
+	err error,
+) {
+	// Validate required fields
+	model, ok := body["model"].(string)
+	if !ok || model == "" {
+		return nil, nil, nil, fmt.Errorf("model field is required")
+	}
+
+	// Validate this is a Chat Completions request
+	if _, hasMessages := body["messages"]; !hasMessages {
+		return nil, nil, nil, fmt.Errorf("only Chat Completions API is supported - 'messages' field required")
+	}
+
+	// Build headers for Bedrock OpenAI-compatible endpoint
+	headersToMutate = map[string]string{
+		":path":        bedrockOpenAIPath,
+		"content-type": "application/json",
+		"host":         fmt.Sprintf("bedrock-runtime.%s.amazonaws.com", t.region),
+	}
+
+	// Return nil body — no body mutation needed, Bedrock accepts OpenAI request format as-is
+	return nil, headersToMutate, nil, nil
+}
+
+// TranslateResponse is a no-op since Bedrock's OpenAI-compatible API returns responses in OpenAI format
+func (t *BedrockTranslator) TranslateResponse(body map[string]any, model string) (
+	translatedBody map[string]any,
+	err error,
+) {
+	// No translation needed - Bedrock's OpenAI-compatible endpoint returns OpenAI format
+	return nil, nil
+}
+
+// GetRegion returns the AWS region configured for this translator
+func (t *BedrockTranslator) GetRegion() string {
+	return t.region
+}

--- a/payload-processing/pkg/plugins/api-translation/translator/awsbedrock/awsbedrock_test.go
+++ b/payload-processing/pkg/plugins/api-translation/translator/awsbedrock/awsbedrock_test.go
@@ -1,0 +1,227 @@
+/*
+Copyright 2026 The opendatahub.io Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package awsbedrock
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/common/provider"
+)
+
+func createTestTranslator() *BedrockTranslator {
+	return NewBedrockTranslator()
+}
+
+func TestTranslateRequest_BasicChat(t *testing.T) {
+	body := map[string]any{
+		"model": "nvidia.nemotron-nano-12b-v2",
+		"messages": []any{
+			map[string]any{"role": "user", "content": "What is 2+2?"},
+		},
+	}
+
+	translatedBody, headers, headersToRemove, err := createTestTranslator().TranslateRequest(body)
+	require.NoError(t, err)
+
+	assert.Nil(t, translatedBody, "body should not be mutated for Bedrock OpenAI-compatible API")
+	assert.Equal(t, "/v1/chat/completions", headers[":path"])
+	assert.Equal(t, "application/json", headers["content-type"])
+	assert.Equal(t, "bedrock-runtime.us-east-1.amazonaws.com", headers["host"])
+	assert.Empty(t, headersToRemove)
+}
+
+func TestTranslateRequest_WithRegion(t *testing.T) {
+	translator := NewBedrockTranslatorWithRegion("us-west-2")
+	
+	body := map[string]any{
+		"model": "nvidia.nemotron-nano-12b-v2",
+		"messages": []any{
+			map[string]any{"role": "user", "content": "Hello"},
+		},
+	}
+
+	_, headers, _, err := translator.TranslateRequest(body)
+	require.NoError(t, err)
+
+	assert.Equal(t, "bedrock-runtime.us-west-2.amazonaws.com", headers["host"])
+}
+
+func TestTranslateRequest_PassthroughAllChatParams(t *testing.T) {
+	body := map[string]any{
+		"model": "nvidia.nemotron-nano-12b-v2",
+		"messages": []any{
+			map[string]any{"role": "system", "content": "You are helpful."},
+			map[string]any{"role": "user", "content": "Hello"},
+		},
+		"temperature":       0.7,
+		"top_p":             0.9,
+		"max_tokens":        1000,
+		"stream":            true,
+		"stop":              []any{"END"},
+		"n":                 1,
+		"presence_penalty":  0.5,
+		"frequency_penalty": 0.3,
+	}
+
+	translatedBody, _, _, err := createTestTranslator().TranslateRequest(body)
+	require.NoError(t, err)
+
+	assert.Nil(t, translatedBody, "Bedrock OpenAI-compatible API should not mutate the request body")
+}
+
+func TestTranslateRequest_MissingModel(t *testing.T) {
+	body := map[string]any{
+		"messages": []any{map[string]any{"role": "user", "content": "Hi"}},
+	}
+
+	_, _, _, err := createTestTranslator().TranslateRequest(body)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "model field is required")
+}
+
+func TestTranslateRequest_EmptyModel(t *testing.T) {
+	body := map[string]any{
+		"model":    "",
+		"messages": []any{map[string]any{"role": "user", "content": "Hi"}},
+	}
+
+	_, _, _, err := createTestTranslator().TranslateRequest(body)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "model field is required")
+}
+
+func TestTranslateRequest_MissingMessages(t *testing.T) {
+	body := map[string]any{
+		"model": "nvidia.nemotron-nano-12b-v2",
+	}
+
+	_, _, _, err := createTestTranslator().TranslateRequest(body)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "only Chat Completions API is supported")
+}
+
+func TestTranslateRequest_LegacyCompletionsNotSupported(t *testing.T) {
+	body := map[string]any{
+		"model":  "nvidia.nemotron-nano-12b-v2",
+		"prompt": "Complete this sentence: The weather today is",
+	}
+
+	_, _, _, err := createTestTranslator().TranslateRequest(body)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "only Chat Completions API is supported")
+}
+
+func TestTranslateRequest_HeadersSet(t *testing.T) {
+	body := map[string]any{
+		"model":    "nvidia.nemotron-nano-12b-v2",
+		"messages": []any{map[string]any{"role": "user", "content": "Hi"}},
+	}
+
+	_, headers, _, err := createTestTranslator().TranslateRequest(body)
+	require.NoError(t, err)
+
+	assert.Len(t, headers, 3)
+	assert.Contains(t, headers, ":path")
+	assert.Contains(t, headers, "content-type")
+	assert.Contains(t, headers, "host")
+}
+
+func TestTranslateResponse_Passthrough(t *testing.T) {
+	body := map[string]any{
+		"id":      "chatcmpl-abc123",
+		"object":  "chat.completion",
+		"created": 1700000000,
+		"model":   "nvidia.nemotron-nano-12b-v2",
+		"choices": []any{
+			map[string]any{
+				"index": 0,
+				"message": map[string]any{
+					"role":    "assistant",
+					"content": "The answer is 4.",
+				},
+				"finish_reason": "stop",
+			},
+		},
+		"usage": map[string]any{
+			"prompt_tokens":     10,
+			"completion_tokens": 5,
+			"total_tokens":      15,
+		},
+	}
+
+	translatedBody, err := createTestTranslator().TranslateResponse(body, "nvidia.nemotron-nano-12b-v2")
+	require.NoError(t, err)
+	assert.Nil(t, translatedBody, "Bedrock OpenAI-compatible response should not be mutated")
+}
+
+func TestTranslateResponse_StreamingChunk(t *testing.T) {
+	body := map[string]any{
+		"id":      "chatcmpl-abc123",
+		"object":  "chat.completion.chunk",
+		"created": 1700000000,
+		"model":   "nvidia.nemotron-nano-12b-v2",
+		"choices": []any{
+			map[string]any{
+				"index": 0,
+				"delta": map[string]any{
+					"content": "Hello",
+				},
+				"finish_reason": nil,
+			},
+		},
+	}
+
+	translatedBody, err := createTestTranslator().TranslateResponse(body, "nvidia.nemotron-nano-12b-v2")
+	require.NoError(t, err)
+	assert.Nil(t, translatedBody)
+}
+
+func TestTranslateResponse_Error(t *testing.T) {
+	body := map[string]any{
+		"error": map[string]any{
+			"message": "Model not found",
+			"type":    "invalid_request_error",
+			"code":    "model_not_found",
+		},
+	}
+
+	translatedBody, err := createTestTranslator().TranslateResponse(body, "invalid-model")
+	require.NoError(t, err)
+	assert.Nil(t, translatedBody, "Error responses should pass through unchanged")
+}
+
+func TestProviderName(t *testing.T) {
+	assert.Equal(t, "awsbedrock-openai", provider.AWSBedrockOpenAI)
+}
+
+func TestNewBedrockTranslator(t *testing.T) {
+	translator := NewBedrockTranslator()
+	assert.NotNil(t, translator)
+	assert.Equal(t, "us-east-1", translator.GetRegion()) // Default region
+}
+
+func TestGetRegion(t *testing.T) {
+	translator := NewBedrockTranslatorWithRegion("eu-west-1")
+	assert.Equal(t, "eu-west-1", translator.GetRegion())
+}
+
+func TestNewBedrockTranslatorWithRegion_EmptyRegion(t *testing.T) {
+	translator := NewBedrockTranslatorWithRegion("")
+	assert.Equal(t, "us-east-1", translator.GetRegion()) // Should default
+}

--- a/payload-processing/pkg/plugins/apikey-injection/plugin.go
+++ b/payload-processing/pkg/plugins/apikey-injection/plugin.go
@@ -62,10 +62,11 @@ func (inj *apiKeyGenerator) generateHeader(apiKey string) (string, string) {
 // defaultApiKeyGenerators returns the built-in provider-to-generator registry.
 func defaultApiKeyGenerators() map[string]*apiKeyGenerator {
 	return map[string]*apiKeyGenerator{
-		provider.OpenAI:      {headerName: "Authorization", headerValuePrefix: "Bearer "},
-		provider.Anthropic:   {headerName: "x-api-key"},
-		provider.AzureOpenAI: {headerName: "api-key"},
-		provider.Vertex:      {headerName: "Authorization", headerValuePrefix: "Bearer "},
+		provider.OpenAI:            {headerName: "Authorization", headerValuePrefix: "Bearer "},
+		provider.Anthropic:         {headerName: "x-api-key"},
+		provider.AzureOpenAI:       {headerName: "api-key"},
+		provider.Vertex:            {headerName: "Authorization", headerValuePrefix: "Bearer "},
+		provider.AWSBedrockOpenAI:  {headerName: "Authorization", headerValuePrefix: "Bearer "},
 	}
 }
 

--- a/payload-processing/pkg/plugins/apikey-injection/plugin_test.go
+++ b/payload-processing/pkg/plugins/apikey-injection/plugin_test.go
@@ -197,7 +197,11 @@ func TestDefaultInjectors(t *testing.T) {
 	assert.Equal(t, "Authorization", injectors[provider.Vertex].headerName)
 	assert.Equal(t, "Bearer ", injectors[provider.Vertex].headerValuePrefix)
 
-	assert.Len(t, injectors, 4)
+	require.Contains(t, injectors, provider.AWSBedrockOpenAI)
+	assert.Equal(t, "Authorization", injectors[provider.AWSBedrockOpenAI].headerName)
+	assert.Equal(t, "Bearer ", injectors[provider.AWSBedrockOpenAI].headerValuePrefix)
+
+	assert.Len(t, injectors, 5)
 }
 
 func TestAPIKeyInjector(t *testing.T) {

--- a/payload-processing/pkg/plugins/common/provider/provider.go
+++ b/payload-processing/pkg/plugins/common/provider/provider.go
@@ -17,8 +17,9 @@ limitations under the License.
 package provider
 
 const (
-	OpenAI      = "openai"
-	Anthropic   = "anthropic"
-	AzureOpenAI = "azure-openai"
-	Vertex      = "vertex"
+	OpenAI            = "openai"
+	Anthropic         = "anthropic"
+	AzureOpenAI       = "azure-openai"
+	Vertex            = "vertex"
+	AWSBedrockOpenAI  = "awsbedrock-openai"
 )


### PR DESCRIPTION
…port

## Description
- Add AWSBedrockOpenAI provider constant
- Implement Bedrock translator for OpenAI-compatible API
- Support configurable AWS regions (defaults to us-east-1)
- Add API key injection with Bearer token format
- Include comprehensive test suite (15 test cases)
- Maintain full compatibility with existing providers
Note: The goal here is not to support the Bedrock Converse or Invoke APIs, not the openai responses api. Limiting this PR to just the direct OpenAI endpoint within Bedrock and only the chat completions api for a simple initial implementation. More api translation and interworking combinations can be added in future.

## How Has This Been Tested?

All Unit tests pass. Additional e2e/ manual testing to be performed for full verification.

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
