### PR TITLE
feat: implement HMAC-SHA256 for API key hashing

### DIFF
--- a/maas-api/internal/api_keys/keygen.go
+++ b/maas-api/internal/api_keys/keygen.go
@@ -1,8 +1,10 @@
 package api_keys
 
 import (
+	"crypto/hmac"
 	"crypto/rand"
 	"crypto/sha256"
+	"crypto/subtle"
 	"encoding/hex"
 	"fmt"
 	"math/big"
@@ -21,6 +23,22 @@ const (
 	// displayPrefixLength is the number of chars to show in the display prefix (after sk-oai-).
 	displayPrefixLength = 12
 )
+
+// hmacKey is the secret key used for HMAC-SHA256 hashing.
+// This is set at startup via SetHMACKey() from configuration.
+// HMAC-SHA256 is FIPS 198-1 approved.
+var hmacKey []byte
+
+// SetHMACKey sets the secret key used for HMAC-SHA256 hashing.
+// Must be called before any hash operations. Key must be at least 32 bytes.
+func SetHMACKey(key []byte) error {
+	if len(key) < 32 {
+		return fmt.Errorf("HMAC key must be at least 32 bytes, got %d", len(key))
+	}
+	hmacKey = make([]byte, len(key))
+	copy(hmacKey, key)
+	return nil
+}
 
 // GenerateAPIKey creates a new API key with format: sk-oai-{base62_encoded_256bit_random}
 // Returns: (plaintext_key, sha256_hash, display_prefix, error)
@@ -58,11 +76,37 @@ func GenerateAPIKey() (plaintext, hash, prefix string, err error) {
 	return plaintext, hash, prefix, nil
 }
 
-// HashAPIKey computes SHA-256 hash of an API key (for validation and storage)
-// This is the canonical hashing function - used by both key creation and validation.
+// HashAPIKey computes HMAC-SHA256 hash of an API key using the configured secret key.
+// HMAC-SHA256 is FIPS 198-1 approved as a keyed-hash message authentication code.
+// Returns the hash as a 64-character hex string.
+// The HMAC key must be set via SetHMACKey() before calling this function.
 func HashAPIKey(key string) string {
-	h := sha256.Sum256([]byte(key))
-	return hex.EncodeToString(h[:])
+	mac := hmac.New(sha256.New, hmacKey)
+	mac.Write([]byte(key))
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+// ValidateAPIKeyHash validates an API key against its stored hash.
+// Uses HMAC-SHA256 with constant-time comparison to prevent timing attacks.
+func ValidateAPIKeyHash(key, storedHash string) bool {
+	// Validate hash length (32 bytes = 64 hex chars)
+	if len(storedHash) != 64 {
+		return false
+	}
+
+	// Decode expected hash from hex
+	expectedHash, err := hex.DecodeString(storedHash)
+	if err != nil {
+		return false
+	}
+
+	// Compute HMAC-SHA256
+	mac := hmac.New(sha256.New, hmacKey)
+	mac.Write([]byte(key))
+	computedHash := mac.Sum(nil)
+
+	// Compare hashes using constant-time comparison to prevent timing attacks
+	return subtle.ConstantTimeCompare(expectedHash, computedHash) == 1
 }
 
 // IsValidKeyFormat checks if a key has the correct sk-oai-* prefix and valid base62 body.

--- a/maas-api/internal/api_keys/keygen_test.go
+++ b/maas-api/internal/api_keys/keygen_test.go
@@ -7,7 +7,18 @@ import (
 	"github.com/opendatahub-io/models-as-a-service/maas-api/internal/api_keys"
 )
 
+// testHMACKey is a test HMAC key (at least 32 bytes).
+var testHMACKey = []byte("test-hmac-secret-key-that-is-at-least-32-bytes-long")
+
+func setupTestHMACKey(tb testing.TB) {
+	tb.Helper()
+	if err := api_keys.SetHMACKey(testHMACKey); err != nil {
+		tb.Fatalf("failed to set test HMAC key: %v", err)
+	}
+}
+
 func TestGenerateAPIKey(t *testing.T) {
+	setupTestHMACKey(t)
 	plaintext, hash, prefix, err := api_keys.GenerateAPIKey()
 
 	if err != nil {
@@ -50,6 +61,7 @@ func TestGenerateAPIKey(t *testing.T) {
 }
 
 func TestGenerateAPIKey_Uniqueness(t *testing.T) {
+	setupTestHMACKey(t)
 	// Generate multiple keys and ensure they're unique
 	keys := make(map[string]bool)
 	hashes := make(map[string]bool)
@@ -73,6 +85,7 @@ func TestGenerateAPIKey_Uniqueness(t *testing.T) {
 }
 
 func TestHashAPIKey(t *testing.T) {
+	setupTestHMACKey(t)
 	// Compute the hash for the test key
 	testKey := "sk-oai-test123"
 	hash := api_keys.HashAPIKey(testKey)
@@ -95,6 +108,43 @@ func TestHashAPIKey(t *testing.T) {
 	}
 }
 
+func TestValidateAPIKeyHash(t *testing.T) {
+	setupTestHMACKey(t)
+	testKey := "sk-oai-test123"
+
+	t.Run("ValidateHash", func(t *testing.T) {
+		// Create hash using HMAC-SHA256
+		hash := api_keys.HashAPIKey(testKey)
+
+		// Should validate successfully
+		if !api_keys.ValidateAPIKeyHash(testKey, hash) {
+			t.Error("ValidateAPIKeyHash() should validate correct hash")
+		}
+
+		// Should fail with wrong key
+		if api_keys.ValidateAPIKeyHash("sk-oai-wrong", hash) {
+			t.Error("ValidateAPIKeyHash() should reject wrong key")
+		}
+	})
+
+	t.Run("RejectInvalidFormats", func(t *testing.T) {
+		testCases := []string{
+			"invalid-hash",
+			"short",
+			"not-a-valid-hex-string-that-is-64-characters-long-xxxxxxxxxx",
+			// Wrong length (not 64 hex chars)
+			"abc123",
+			"0123456789abcdef0123456789abcdef", // 32 chars, not 64
+		}
+
+		for _, invalidHash := range testCases {
+			if api_keys.ValidateAPIKeyHash(testKey, invalidHash) {
+				t.Errorf("ValidateAPIKeyHash() should reject invalid format: %q", invalidHash)
+			}
+		}
+	})
+}
+
 func TestIsValidKeyFormat(t *testing.T) {
 	t.Run("ValidKey", func(t *testing.T) {
 		if !api_keys.IsValidKeyFormat("sk-oai-ABC123xyz") {
@@ -110,15 +160,29 @@ func TestIsValidKeyFormat(t *testing.T) {
 }
 
 func BenchmarkGenerateAPIKey(b *testing.B) {
+	setupTestHMACKey(b)
 	for b.Loop() {
 		_, _, _, _ = api_keys.GenerateAPIKey()
 	}
 }
 
 func BenchmarkHashAPIKey(b *testing.B) {
+	setupTestHMACKey(b)
 	key := "sk-oai-0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefgh"
 
+	b.ResetTimer()
 	for b.Loop() {
 		_ = api_keys.HashAPIKey(key)
+	}
+}
+
+func BenchmarkValidateAPIKeyHash(b *testing.B) {
+	setupTestHMACKey(b)
+	key := "sk-oai-0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefgh"
+	hash := api_keys.HashAPIKey(key)
+
+	b.ResetTimer()
+	for b.Loop() {
+		_ = api_keys.ValidateAPIKeyHash(key, hash)
 	}
 }

--- a/maas-api/internal/config/config.go
+++ b/maas-api/internal/config/config.go
@@ -46,6 +46,11 @@ type Config struct {
 	// Default: 30 days. Minimum: 1 day.
 	APIKeyMaxExpirationDays int
 
+	// APIKeyHMACSecret is the secret key used for HMAC-SHA256 hashing of API keys.
+	// HMAC-SHA256 is FIPS 198-1 approved. Must be at least 32 bytes.
+	// Loaded from K8s secret.
+	APIKeyHMACSecret string
+
 	// Deprecated flag (backward compatibility with pre-TLS version)
 	deprecatedHTTPPort string
 }
@@ -141,6 +146,11 @@ func (c *Config) Validate() error {
 		return errors.New("API_KEY_MAX_EXPIRATION_DAYS must be at least 1")
 	}
 
+	// Validate API key HMAC secret (must be at least 32 bytes for HMAC-SHA256)
+	if len(c.APIKeyHMACSecret) < 32 {
+		return errors.New("API_KEY_HMAC_SECRET must be at least 32 characters")
+	}
+
 	return nil
 }
 
@@ -189,5 +199,34 @@ func (c *Config) LoadDatabaseURL(ctx context.Context, clientset *kubernetes.Clie
 	}
 
 	c.DBConnectionURL = string(dbURL)
+	return nil
+}
+
+// LoadAPIKeyHMACSecret reads the API key HMAC secret from the Kubernetes secret.
+// HMAC-SHA256 is FIPS 198-1 approved as a keyed-hash message authentication code.
+//
+// Secret: maas-api-keys-config (in the same namespace as the pod)
+// Key: API_KEY_HMAC_SECRET
+//
+// Returns an error if the secret is missing or the key is not found.
+func (c *Config) LoadAPIKeyHMACSecret(ctx context.Context, clientset *kubernetes.Clientset) error {
+	const (
+		//nolint:gosec // These are secret/key names, not hardcoded credentials.
+		secretName = "maas-api-keys-config"
+		//nolint:gosec // This is the key name within the secret, not a credential.
+		secretKey = "API_KEY_HMAC_SECRET"
+	)
+
+	secret, err := clientset.CoreV1().Secrets(c.Namespace).Get(ctx, secretName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to read secret %s/%s: %w (ensure the secret exists before starting maas-api)", c.Namespace, secretName, err)
+	}
+
+	hmacSecret, ok := secret.Data[secretKey]
+	if !ok || len(hmacSecret) == 0 {
+		return fmt.Errorf("key %q not found or empty in secret %s/%s", secretKey, c.Namespace, secretName)
+	}
+
+	c.APIKeyHMACSecret = string(hmacSecret)
 	return nil
 }

--- a/maas-api/internal/config/config_test.go
+++ b/maas-api/internal/config/config_test.go
@@ -48,6 +48,7 @@ func TestConfig_Validate_APIKeyMaxExpirationDays(t *testing.T) {
 				DBConnectionURL:           "postgresql://test:test@localhost/test",
 				MaaSSubscriptionNamespace: "maas-subscription-namespace",
 				APIKeyMaxExpirationDays:   tt.maxDays,
+				APIKeyHMACSecret:          "test-hmac-secret-that-is-at-least-32-bytes-long",
 			}
 
 			err := c.Validate()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Replace plain SHA-256 with HMAC-SHA256 (FIPS 198-1 approved) for API key hashing. This provides a keyed-hash mechanism that is the proper cryptographic primitive for this use case.

**Changes:**
- Add SetHMACKey() to configure the HMAC secret at startup
- Update HashAPIKey() to use HMAC-SHA256
- Add ValidateAPIKeyHash() with constant-time comparison
- Add APIKeyHMACSecret config field loaded from K8s secret
- Add tests for HMAC-based hashing and validation

The HMAC secret must be configured via K8s secret `maas-api-keys-config` with key `API_KEY_HMAC_SECRET` (minimum 32 bytes).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
