### PR TITLE
fix: address review feedback from ExternalModel CRD https://github.com/opendatahub-io/models-as-a-service/pull/586

### DIFF
--- a/deployment/base/maas-controller/crd/bases/maas.opendatahub.io_externalmodels.yaml
+++ b/deployment/base/maas-controller/crd/bases/maas.opendatahub.io_externalmodels.yaml
@@ -65,11 +65,6 @@ spec:
                     maxLength: 253
                     minLength: 1
                     type: string
-                  namespace:
-                    description: Namespace is the namespace of the Secret. Defaults
-                      to the ExternalModel namespace if omitted.
-                    maxLength: 253
-                    type: string
                 required:
                 - name
                 type: object

--- a/deployment/base/maas-controller/crd/bases/maas.opendatahub.io_maasmodelrefs.yaml
+++ b/deployment/base/maas-controller/crd/bases/maas.opendatahub.io_maasmodelrefs.yaml
@@ -79,6 +79,7 @@ spec:
                       For LLMInferenceService, this is the InferenceService name.
                       For ExternalModel, this is the ExternalModel CR name.
                     maxLength: 253
+                    minLength: 1
                     type: string
                 required:
                 - kind

--- a/docs/content/reference/crds/external-model.md
+++ b/docs/content/reference/crds/external-model.md
@@ -14,8 +14,7 @@ Defines an external AI/ML model hosted outside the cluster (e.g., OpenAI, Anthro
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| name | string | Yes | Name of the Secret containing the credentials. Max length: 253 characters. |
-| namespace | string | No | Namespace of the Secret. Defaults to the ExternalModel's namespace if not specified. |
+| name | string | Yes | Name of the Secret containing the credentials. Must be in the same namespace as the ExternalModel. Max length: 253 characters. |
 
 ## ExternalModelStatus
 

--- a/maas-controller/api/maas/v1alpha1/maasmodelref_types.go
+++ b/maas-controller/api/maas/v1alpha1/maasmodelref_types.go
@@ -32,15 +32,12 @@ type MaaSModelSpec struct {
 }
 
 // CredentialReference references a Kubernetes Secret with provider API credentials.
+// The Secret must be in the same namespace as the ExternalModel.
 type CredentialReference struct {
 	// Name is the name of the Secret
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=253
 	Name string `json:"name"`
-	// Namespace is the namespace of the Secret. Defaults to the ExternalModel namespace if omitted.
-	// +kubebuilder:validation:MaxLength=253
-	// +optional
-	Namespace string `json:"namespace,omitempty"`
 }
 
 // ModelReference references a model endpoint in the same namespace.
@@ -55,6 +52,7 @@ type ModelReference struct {
 	// Name is the name of the model resource.
 	// For LLMInferenceService, this is the InferenceService name.
 	// For ExternalModel, this is the ExternalModel CR name.
+	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=253
 	Name string `json:"name"`
 }

--- a/maas-controller/pkg/controller/maas/providers_external_test.go
+++ b/maas-controller/pkg/controller/maas/providers_external_test.go
@@ -288,15 +288,11 @@ func TestExternalModel_CleanupOnDelete(t *testing.T) {
 func TestExternalModel_CredentialRef(t *testing.T) {
 	externalModel := newExternalModelCR("gpt-4o", "default", "openai", "api.openai.com")
 	externalModel.Spec.CredentialRef = maasv1alpha1.CredentialReference{
-		Name:      "openai-api-key",
-		Namespace: "opendatahub",
+		Name: "openai-api-key",
 	}
 
 	if externalModel.Spec.CredentialRef.Name != "openai-api-key" {
 		t.Errorf("CredentialRef.Name = %q, want %q", externalModel.Spec.CredentialRef.Name, "openai-api-key")
-	}
-	if externalModel.Spec.CredentialRef.Namespace != "opendatahub" {
-		t.Errorf("CredentialRef.Namespace = %q, want %q", externalModel.Spec.CredentialRef.Namespace, "opendatahub")
 	}
 }
 


### PR DESCRIPTION
This PR addresses the review comments from @nirrozenbaum  on #586 that were not resolved before merge.

##Changes

1. Remove namespace field from credentialRef
  Comment: "isn't it always the same namespace? is there a use case for other namespace? I would argue that it's the same as MaaSModelRef expecting to reference ExternalModel from the same namespace.. IMO we should be consistent."
  Remove optional namespace field from ExternalModel.spec.credentialRef
  Credential Secret must now reside in the same namespace as the ExternalModel (consistent with MaaSModelRef → ExternalModel reference pattern)
2. Clarify rate-limiting model identity
Comment: "which field represents the model that MaaS is rate limiting on? is it MaaSModelRef metadata.name? model.ref.Name?"
Update documentation to clarify that rate limiting is keyed on MaaSModelRef.metadata.name
Add explanation of the relationship between MaaSModelRef and ExternalModel
3. Document single credential limitation
Comment: "this works as long as there is a single api key per external model. I'm assuming this won't be the case for long time. just as a fyi"
Add documentation note about current single-credential-per-ExternalModel limitation
(Optional) Create tracking issue for multi-credential support


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Credential references no longer support namespace override; credentials must reside in the same namespace as the `ExternalModel`.

* **Validation**
  * Name fields now require a minimum length of 1 character.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->