### PR TITLE
fix: remove reference to removed apiKeyValidation.subscription field

### DIFF
--- a/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
@@ -215,7 +215,7 @@ func (r *MaaSAuthPolicyReconciler) reconcileModelAuthPolicies(ctx context.Contex
 							"expression": fmt.Sprintf(`{
   "groups": auth.metadata.apiKeyValidation.valid == true ? auth.metadata.apiKeyValidation.groups : auth.identity.user.groups,
   "username": auth.metadata.apiKeyValidation.valid == true ? auth.metadata.apiKeyValidation.username : auth.identity.user.username,
-  "requestedSubscription": auth.metadata.apiKeyValidation.valid == true ? auth.metadata.apiKeyValidation.subscription : ("x-maas-subscription" in request.headers ? request.headers["x-maas-subscription"] : ""),
+  "requestedSubscription": "x-maas-subscription" in request.headers ? request.headers["x-maas-subscription"] : "",
   "requestedModel": "%s/%s"
 }`, ref.Namespace, ref.Name),
 						},
@@ -226,7 +226,7 @@ func (r *MaaSAuthPolicyReconciler) reconcileModelAuthPolicies(ctx context.Contex
 					// Groups are joined with commas to create a stable string representation.
 					"cache": map[string]interface{}{
 						"key": map[string]interface{}{
-							"selector": fmt.Sprintf(`(auth.metadata.apiKeyValidation.valid == true ? auth.metadata.apiKeyValidation.username : auth.identity.user.username) + "|" + (auth.metadata.apiKeyValidation.valid == true ? auth.metadata.apiKeyValidation.groups : auth.identity.user.groups).join(",") + "|" + (auth.metadata.apiKeyValidation.valid == true ? auth.metadata.apiKeyValidation.subscription : ("x-maas-subscription" in request.headers ? request.headers["x-maas-subscription"] : "")) + "|%s/%s"`, ref.Namespace, ref.Name),
+							"selector": fmt.Sprintf(`(auth.metadata.apiKeyValidation.valid == true ? auth.metadata.apiKeyValidation.username : auth.identity.user.username) + "|" + (auth.metadata.apiKeyValidation.valid == true ? auth.metadata.apiKeyValidation.groups : auth.identity.user.groups).join(",") + "|" + ("x-maas-subscription" in request.headers ? request.headers["x-maas-subscription"] : "") + "|%s/%s"`, ref.Namespace, ref.Name),
 						},
 						"ttl": int64(60),
 					},
@@ -388,11 +388,10 @@ allow {
 						"metrics":  false,
 						"priority": int64(0),
 					},
-					// Subscription bound to API key (only for API keys)
-					// For K8s tokens, this header is not injected (empty string)
+					// Selected subscription name resolved by Authorino via subscription-select
 					"X-MaaS-Subscription": map[string]interface{}{
 						"plain": map[string]interface{}{
-							"expression": `auth.metadata.apiKeyValidation.valid == true ? auth.metadata.apiKeyValidation.subscription : ""`,
+							"expression": `has(auth.metadata["subscription-info"].name) ? auth.metadata["subscription-info"].name : ""`,
 						},
 						"metrics":  false,
 						"priority": int64(0),


### PR DESCRIPTION
## Summary

PR #584 removed the `subscription` field from the maas-api `/internal/v1/api-keys/validate` response, but the auth policy controller still references `auth.metadata.apiKeyValidation.subscription` in CEL expressions. This breaks all inference requests with 403.

## Changes

Replaced `auth.metadata.apiKeyValidation.subscription` with the request header fallback in 3 places in `maasauthpolicy_controller.go`:

1. `subscription-info` metadata body expression
2. `subscription-info` cache key selector  
3. `X-MaaS-Subscription` response header expression

## Test plan

- [x] Verified on RHOAI cluster: all 5 models return 200 after the fix
- [x] Invalid API key returns 401
- [x] Auth policies regenerated correctly

Fixes #615

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Subscription selection now consistently uses the incoming subscription request header instead of previously used validation data.
  * Subscription cache keys are derived from the request header to ensure consistent lookup behavior.
  * Response headers now reflect the resolved subscription selection metadata rather than prior validation-specific values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->