### PR TITLE
feat: [RHOAIRFE-496] add publicPaths to MaaSAuthPolicy for unauthenticated access to docs endpoints

### DIFF
--- a/deployment/base/maas-controller/crd/bases/maas.opendatahub.io_maasauthpolicies.yaml
+++ b/deployment/base/maas-controller/crd/bases/maas.opendatahub.io_maasauthpolicies.yaml
@@ -89,6 +89,22 @@ spec:
                   type: object
                 minItems: 1
                 type: array
+              publicPaths:
+                description: |-
+                  PublicPaths is a list of well-known documentation endpoints that should be
+                  accessible without authentication. Values are restricted to a curated allowlist
+                  of safe, read-only paths. The generated gateway AuthPolicy will include an anonymous
+                  authentication rule using exact-path matching for these endpoints.
+                  Inference and other endpoints remain fully authenticated.
+                items:
+                  description: PublicPath is a well-known documentation endpoint that
+                    can be exposed without authentication.
+                  enum:
+                  - /docs
+                  - /openapi.json
+                  type: string
+                maxItems: 10
+                type: array
               subjects:
                 description: Subjects defines who has access (OR logic - any match
                   grants access)

--- a/maas-controller/api/maas/v1alpha1/maasauthpolicy_types.go
+++ b/maas-controller/api/maas/v1alpha1/maasauthpolicy_types.go
@@ -30,10 +30,28 @@ type MaaSAuthPolicySpec struct {
 	// +kubebuilder:validation:XValidation:rule="size(self.groups) > 0 || size(self.users) > 0",message="at least one group or user must be specified in subjects"
 	Subjects SubjectSpec `json:"subjects"`
 
+	// PublicPaths is a list of well-known documentation endpoints that should be
+	// accessible without authentication. Values are restricted to a curated allowlist
+	// of safe, read-only paths. The generated gateway AuthPolicy will include an anonymous
+	// authentication rule using exact-path matching for these endpoints.
+	// Inference and other endpoints remain fully authenticated.
+	// +optional
+	// +kubebuilder:validation:MaxItems=10
+	PublicPaths []PublicPath `json:"publicPaths,omitempty"`
+
 	// MeteringMetadata contains billing and tracking information
 	// +optional
 	MeteringMetadata *MeteringMetadata `json:"meteringMetadata,omitempty"`
 }
+
+// PublicPath is a well-known documentation endpoint that can be exposed without authentication.
+// +kubebuilder:validation:Enum="/docs";"/openapi.json"
+type PublicPath string
+
+const (
+	PublicPathDocs    PublicPath = "/docs"
+	PublicPathOpenAPI PublicPath = "/openapi.json"
+)
 
 // ModelRef references a MaaSModelRef by name and namespace.
 type ModelRef struct {

--- a/maas-controller/api/maas/v1alpha1/zz_generated.deepcopy.go
+++ b/maas-controller/api/maas/v1alpha1/zz_generated.deepcopy.go
@@ -486,6 +486,11 @@ func (in *MaaSAuthPolicySpec) DeepCopyInto(out *MaaSAuthPolicySpec) {
 		copy(*out, *in)
 	}
 	in.Subjects.DeepCopyInto(&out.Subjects)
+	if in.PublicPaths != nil {
+		in, out := &in.PublicPaths, &out.PublicPaths
+		*out = make([]PublicPath, len(*in))
+		copy(*out, *in)
+	}
 	if in.MeteringMetadata != nil {
 		in, out := &in.MeteringMetadata, &out.MeteringMetadata
 		*out = new(MeteringMetadata)

--- a/maas-controller/api/maas/v1alpha1/zz_generated.deepcopy.go
+++ b/maas-controller/api/maas/v1alpha1/zz_generated.deepcopy.go
@@ -491,6 +491,11 @@ func (in *MaaSAuthPolicySpec) DeepCopyInto(out *MaaSAuthPolicySpec) {
 		copy(*out, *in)
 	}
 	in.Subjects.DeepCopyInto(&out.Subjects)
+	if in.PublicPaths != nil {
+		in, out := &in.PublicPaths, &out.PublicPaths
+		*out = make([]PublicPath, len(*in))
+		copy(*out, *in)
+	}
 	if in.MeteringMetadata != nil {
 		in, out := &in.MeteringMetadata, &out.MeteringMetadata
 		*out = new(MeteringMetadata)

--- a/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -341,6 +342,60 @@ func subscriptionGatewayCacheKeySelector() string {
 	)
 }
 
+// applyPublicPathsCELToRules appends a CEL "when" predicate to every evaluator in the
+// given rule map so that public-path requests skip those evaluators entirely.
+func applyPublicPathsCELToRules(rules map[string]any, celPredicate string) {
+	for name, evaluator := range rules {
+		eval, ok := evaluator.(map[string]any)
+		if !ok {
+			continue
+		}
+		when, _ := eval["when"].([]any)
+		eval["when"] = append(when, map[string]any{
+			"predicate": celPredicate,
+		})
+		rules[name] = eval
+	}
+}
+
+// buildPublicPathsRegex constructs a regex that matches exact public-path URLs across all
+// models in the allowlist. Each model's route prefix is /{namespace}/{name} per the
+// HTTPRoute convention, so /docs on model default/llm becomes ^/default/llm/docs$.
+func buildPublicPathsRegex(allowlists map[string]modelSubjectAllowlist) string {
+	var parts []string
+	for modelKey, entry := range allowlists {
+		if len(entry.PublicPaths) == 0 {
+			continue
+		}
+		for _, p := range entry.PublicPaths {
+			full := "/" + modelKey + p
+			parts = append(parts, fmt.Sprintf("^%s$", regexp.QuoteMeta(full)))
+		}
+	}
+	sort.Strings(parts)
+	return strings.Join(parts, "|")
+}
+
+// buildPublicPathsCELPredicate constructs a CEL predicate that evaluates to true for
+// requests that are NOT targeting public paths. Attach as a "when" predicate on metadata
+// and authorization evaluators so they are skipped for unauthenticated doc endpoints.
+func buildPublicPathsCELPredicate(allowlists map[string]modelSubjectAllowlist) string {
+	var parts []string
+	for modelKey, entry := range allowlists {
+		if len(entry.PublicPaths) == 0 {
+			continue
+		}
+		for _, p := range entry.PublicPaths {
+			full := "/" + modelKey + p
+			escaped := strings.ReplaceAll(full, `\`, `\\`)
+			escaped = strings.ReplaceAll(escaped, `"`, `\"`)
+			parts = append(parts, fmt.Sprintf(`request.path != "%s"`, escaped))
+		}
+	}
+	sort.Strings(parts)
+	return strings.Join(parts, " && ")
+}
+
 //+kubebuilder:rbac:groups=maas.opendatahub.io,resources=maasauthpolicies,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=maas.opendatahub.io,resources=maasauthpolicies/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=maas.opendatahub.io,resources=maasauthpolicies/finalizers,verbs=update
@@ -447,7 +502,7 @@ func (r *MaaSAuthPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		return ctrl.Result{}, nil
 	}
 
-	if err := r.reconcileGatewayAuthPolicy(ctx, log, string(modelAllowlistsJSON), oidc, tenantID, gatewayNs, gatewayName); err != nil {
+	if err := r.reconcileGatewayAuthPolicy(ctx, log, string(modelAllowlistsJSON), oidc, tenantID, gatewayNs, gatewayName, modelAllowlists); err != nil {
 		log.Error(err, "failed to reconcile gateway AuthPolicy")
 		r.updateStatus(ctx, policy, maasv1alpha1.PhaseFailed, fmt.Sprintf("Failed to reconcile gateway AuthPolicy: %v", err), statusSnapshot)
 		return ctrl.Result{}, err
@@ -571,14 +626,20 @@ type authPolicyRef struct {
 }
 
 type modelSubjectAllowlist struct {
-	Users  []string `json:"users"`
-	Groups []string `json:"groups"`
+	Users       []string `json:"users"`
+	Groups      []string `json:"groups"`
+	PublicPaths []string `json:"publicPaths,omitempty"`
 }
 
 // buildGatewayAuthPolicySpec returns the Authorino AuthPolicy spec for the singleton
 // Gateway-level policy. Model identity is resolved dynamically via CEL on every request
 // rather than being baked in per-model, so this spec is the same for all MaaSAuthPolicy CRs.
-func (r *MaaSAuthPolicyReconciler) buildGatewayAuthPolicySpec(modelAccessJSON string, oidc *oidcConfig, tenantID, tenantName, gatewayNamespace, gatewayName string) map[string]any {
+// The allowlists map is used to derive public-path rules (anonymous auth + evaluator skip).
+func (r *MaaSAuthPolicyReconciler) buildGatewayAuthPolicySpec(
+	modelAccessJSON string, oidc *oidcConfig,
+	tenantID, tenantName, gatewayNamespace, gatewayName string,
+	allowlists map[string]modelSubjectAllowlist,
+) map[string]any {
 	// Construct tenant-specific maas-api service name using TenantIdentifier
 	// Default tenant (tenantID="") uses "maas-api", others use "maas-api-{tenantID}"
 	maasAPIServiceName := "maas-api"
@@ -639,6 +700,25 @@ func (r *MaaSAuthPolicyReconciler) buildGatewayAuthPolicySpec(modelAccessJSON st
 			},
 			"metrics":  false,
 			"priority": int64(1),
+		}
+	}
+
+	// If any model has publicPaths configured, add an anonymous authentication rule scoped
+	// to those exact paths so documentation endpoints can be accessed without credentials.
+	publicPathsRegex := buildPublicPathsRegex(allowlists)
+	publicPathsCEL := buildPublicPathsCELPredicate(allowlists)
+	if publicPathsRegex != "" {
+		authenticationRules["anonymous-public-paths"] = map[string]any{
+			"anonymous": map[string]any{},
+			"when": []any{
+				map[string]any{
+					"selector": "request.url_path",
+					"operator": "matches",
+					"value":    publicPathsRegex,
+				},
+			},
+			"metrics":  false,
+			"priority": int64(0),
 		}
 	}
 
@@ -1004,6 +1084,18 @@ allow {
 		},
 	}
 
+	// If any model has publicPaths, append CEL skip predicates to metadata and authorization
+	// evaluators so that API-key validation, subscription checks, and group-membership
+	// checks are not triggered for unauthenticated documentation requests.
+	if publicPathsCEL != "" {
+		if md, ok := defaultsRules["metadata"].(map[string]any); ok {
+			applyPublicPathsCELToRules(md, publicPathsCEL)
+		}
+		if az, ok := defaultsRules["authorization"].(map[string]any); ok {
+			applyPublicPathsCELToRules(az, publicPathsCEL)
+		}
+	}
+
 	return map[string]any{
 		"targetRef": map[string]any{
 			"group":     "gateway.networking.k8s.io",
@@ -1029,7 +1121,10 @@ allow {
 
 // reconcileGatewayAuthPolicy creates or updates the singleton Gateway-level AuthPolicy in
 // the gateway namespace. All MaaSAuthPolicy reconciliations converge on this one resource.
-func (r *MaaSAuthPolicyReconciler) reconcileGatewayAuthPolicy(ctx context.Context, log logr.Logger, modelAccessJSON string, oidc *oidcConfig, tenantID, gatewayNamespace, gatewayName string) error {
+func (r *MaaSAuthPolicyReconciler) reconcileGatewayAuthPolicy(
+	ctx context.Context, log logr.Logger, modelAccessJSON string, oidc *oidcConfig,
+	tenantID, gatewayNamespace, gatewayName string, allowlists map[string]modelSubjectAllowlist,
+) error {
 	log.Info("reconcileGatewayAuthPolicy entered", "gatewayNamespace", gatewayNamespace, "gatewayName", gatewayName, "tenantID", tenantID)
 
 	// Calculate tenantName from tenantID
@@ -1039,7 +1134,7 @@ func (r *MaaSAuthPolicyReconciler) reconcileGatewayAuthPolicy(ctx context.Contex
 		tenantName = tenantID
 	}
 
-	spec := r.buildGatewayAuthPolicySpec(modelAccessJSON, oidc, tenantID, tenantName, gatewayNamespace, gatewayName)
+	spec := r.buildGatewayAuthPolicySpec(modelAccessJSON, oidc, tenantID, tenantName, gatewayNamespace, gatewayName, allowlists)
 
 	// Use legacy name for default gateway (backward compatibility), dynamic name for tenant gateways
 	authPolicyName := maasGatewayAuthPolicyName
@@ -1177,8 +1272,12 @@ func (r *MaaSAuthPolicyReconciler) aggregateModelSubjectAllowlists(ctx context.C
 				}
 				entry.Users = append(entry.Users, user)
 			}
+			for _, pp := range p.Spec.PublicPaths {
+				entry.PublicPaths = append(entry.PublicPaths, string(pp))
+			}
 			entry.Groups = deduplicateAndSort(entry.Groups)
 			entry.Users = deduplicateAndSort(entry.Users)
+			entry.PublicPaths = deduplicateAndSort(entry.PublicPaths)
 			aggregate[key] = entry
 		}
 	}

--- a/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -464,6 +465,60 @@ func subscriptionGatewayCacheKeySelector() string {
 	)
 }
 
+// applyPublicPathsCELToRules appends a CEL "when" predicate to every evaluator in the
+// given rule map so that public-path requests skip those evaluators entirely.
+func applyPublicPathsCELToRules(rules map[string]any, celPredicate string) {
+	for name, evaluator := range rules {
+		eval, ok := evaluator.(map[string]any)
+		if !ok {
+			continue
+		}
+		when, _ := eval["when"].([]any)
+		eval["when"] = append(when, map[string]any{
+			"predicate": celPredicate,
+		})
+		rules[name] = eval
+	}
+}
+
+// buildPublicPathsRegex constructs a regex that matches exact public-path URLs across all
+// models in the allowlist. Each model's route prefix is /{namespace}/{name} per the
+// HTTPRoute convention, so /docs on model default/llm becomes ^/default/llm/docs$.
+func buildPublicPathsRegex(allowlists map[string]modelSubjectAllowlist) string {
+	var parts []string
+	for modelKey, entry := range allowlists {
+		if len(entry.PublicPaths) == 0 {
+			continue
+		}
+		for _, p := range entry.PublicPaths {
+			full := "/" + modelKey + p
+			parts = append(parts, fmt.Sprintf("^%s$", regexp.QuoteMeta(full)))
+		}
+	}
+	sort.Strings(parts)
+	return strings.Join(parts, "|")
+}
+
+// buildPublicPathsCELPredicate constructs a CEL predicate that evaluates to true for
+// requests that are NOT targeting public paths. Attach as a "when" predicate on metadata
+// and authorization evaluators so they are skipped for unauthenticated doc endpoints.
+func buildPublicPathsCELPredicate(allowlists map[string]modelSubjectAllowlist) string {
+	var parts []string
+	for modelKey, entry := range allowlists {
+		if len(entry.PublicPaths) == 0 {
+			continue
+		}
+		for _, p := range entry.PublicPaths {
+			full := "/" + modelKey + p
+			escaped := strings.ReplaceAll(full, `\`, `\\`)
+			escaped = strings.ReplaceAll(escaped, `"`, `\"`)
+			parts = append(parts, fmt.Sprintf(`request.path != "%s"`, escaped))
+		}
+	}
+	sort.Strings(parts)
+	return strings.Join(parts, " && ")
+}
+
 //+kubebuilder:rbac:groups=maas.opendatahub.io,resources=maasauthpolicies,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=maas.opendatahub.io,resources=maasauthpolicies/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=maas.opendatahub.io,resources=maasauthpolicies/finalizers,verbs=update
@@ -604,7 +659,7 @@ func (r *MaaSAuthPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		}
 	}
 
-	gwChanged, reconcileErr := r.reconcileGatewayAuthPolicy(ctx, log, string(modelAllowlistsJSON), oidc, xAPIKeyEnabled, tenantID, gatewayNs, gatewayName)
+	gwChanged, reconcileErr := r.reconcileGatewayAuthPolicy(ctx, log, string(modelAllowlistsJSON), oidc, xAPIKeyEnabled, tenantID, gatewayNs, gatewayName, modelAllowlists)
 	if reconcileErr != nil {
 		log.Error(reconcileErr, "failed to reconcile gateway AuthPolicy")
 		r.updateStatus(ctx, policy, maasv1alpha1.PhaseFailed, fmt.Sprintf("Failed to reconcile gateway AuthPolicy: %v", reconcileErr), statusSnapshot)
@@ -748,14 +803,20 @@ type authPolicyRef struct {
 }
 
 type modelSubjectAllowlist struct {
-	Users  []string `json:"users"`
-	Groups []string `json:"groups"`
+	Users       []string `json:"users"`
+	Groups      []string `json:"groups"`
+	PublicPaths []string `json:"publicPaths,omitempty"`
 }
 
 // buildGatewayAuthPolicySpec returns the Authorino AuthPolicy spec for the singleton
 // Gateway-level policy. Model identity is resolved dynamically via CEL on every request
 // rather than being baked in per-model, so this spec is the same for all MaaSAuthPolicy CRs.
-func (r *MaaSAuthPolicyReconciler) buildGatewayAuthPolicySpec(modelAccessJSON string, oidc *oidcConfig, xAPIKeyEnabled bool, tenantID, tenantName, gatewayNamespace, gatewayName string) map[string]any {
+// The allowlists map is used to derive public-path rules (anonymous auth + evaluator skip).
+func (r *MaaSAuthPolicyReconciler) buildGatewayAuthPolicySpec(
+	modelAccessJSON string, oidc *oidcConfig, xAPIKeyEnabled bool,
+	tenantID, tenantName, gatewayNamespace, gatewayName string,
+	allowlists map[string]modelSubjectAllowlist,
+) map[string]any {
 	// Construct tenant-specific maas-api service name using TenantIdentifier
 	// Default tenant (tenantID="") uses "maas-api", others use "maas-api-{tenantID}"
 	maasAPIServiceName := "maas-api"
@@ -833,6 +894,25 @@ func (r *MaaSAuthPolicyReconciler) buildGatewayAuthPolicySpec(modelAccessJSON st
 			},
 			"metrics":  false,
 			"priority": int64(1),
+		}
+	}
+
+	// If any model has publicPaths configured, add an anonymous authentication rule scoped
+	// to those exact paths so documentation endpoints can be accessed without credentials.
+	publicPathsRegex := buildPublicPathsRegex(allowlists)
+	publicPathsCEL := buildPublicPathsCELPredicate(allowlists)
+	if publicPathsRegex != "" {
+		authenticationRules["anonymous-public-paths"] = map[string]any{
+			"anonymous": map[string]any{},
+			"when": []any{
+				map[string]any{
+					"selector": "request.url_path",
+					"operator": "matches",
+					"value":    publicPathsRegex,
+				},
+			},
+			"metrics":  false,
+			"priority": int64(0),
 		}
 	}
 
@@ -1213,6 +1293,18 @@ allow {
 		},
 	}
 
+	// If any model has publicPaths, append CEL skip predicates to metadata and authorization
+	// evaluators so that API-key validation, subscription checks, and group-membership
+	// checks are not triggered for unauthenticated documentation requests.
+	if publicPathsCEL != "" {
+		if md, ok := defaultsRules["metadata"].(map[string]any); ok {
+			applyPublicPathsCELToRules(md, publicPathsCEL)
+		}
+		if az, ok := defaultsRules["authorization"].(map[string]any); ok {
+			applyPublicPathsCELToRules(az, publicPathsCEL)
+		}
+	}
+
 	return map[string]any{
 		"targetRef": map[string]any{
 			"group": "gateway.networking.k8s.io",
@@ -1353,6 +1445,7 @@ func stripExtraFieldsSlice(current, desired []any) {
 func (r *MaaSAuthPolicyReconciler) reconcileGatewayAuthPolicy(
 	ctx context.Context, log logr.Logger, modelAccessJSON string,
 	oidc *oidcConfig, xAPIKeyEnabled bool, tenantID, gatewayNamespace, gatewayName string,
+	allowlists map[string]modelSubjectAllowlist,
 ) (bool, error) {
 	log.Info("reconcileGatewayAuthPolicy entered", "gatewayNamespace", gatewayNamespace, "gatewayName", gatewayName, "tenantID", tenantID, "xAPIKeyEnabled", xAPIKeyEnabled)
 
@@ -1363,7 +1456,7 @@ func (r *MaaSAuthPolicyReconciler) reconcileGatewayAuthPolicy(
 		tenantName = tenantID
 	}
 
-	spec := r.buildGatewayAuthPolicySpec(modelAccessJSON, oidc, xAPIKeyEnabled, tenantID, tenantName, gatewayNamespace, gatewayName)
+	spec := r.buildGatewayAuthPolicySpec(modelAccessJSON, oidc, xAPIKeyEnabled, tenantID, tenantName, gatewayNamespace, gatewayName, allowlists)
 	authPolicyName := r.gatewayAuthPolicyName(gatewayNamespace, gatewayName)
 	isTenantGateway := gatewayNamespace != r.GatewayNamespace || gatewayName != r.GatewayName
 
@@ -1537,8 +1630,12 @@ func (r *MaaSAuthPolicyReconciler) aggregateModelSubjectAllowlists(ctx context.C
 				}
 				entry.Users = append(entry.Users, user)
 			}
+			for _, pp := range p.Spec.PublicPaths {
+				entry.PublicPaths = append(entry.PublicPaths, string(pp))
+			}
 			entry.Groups = deduplicateAndSort(entry.Groups)
 			entry.Users = deduplicateAndSort(entry.Users)
+			entry.PublicPaths = deduplicateAndSort(entry.PublicPaths)
 			aggregate[key] = entry
 
 			for _, altKey := range r.resolveHeaderModelKeys(ctx, ref) {

--- a/maas-controller/pkg/controller/maas/maasauthpolicy_controller_test.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_controller_test.go
@@ -1231,7 +1231,7 @@ func TestBuildGatewayAuthPolicySpec_K8sAndOIDCAuth(t *testing.T) {
 	}
 
 	t.Run("without OIDC", func(t *testing.T) {
-		spec := r.buildGatewayAuthPolicySpec("{}", nil, "", "models-as-a-service", "test-gateway-ns", "test-gateway")
+		spec := r.buildGatewayAuthPolicySpec("{}", nil, "", "models-as-a-service", "test-gateway-ns", "test-gateway", map[string]modelSubjectAllowlist{})
 		obj := gwSpecToUnstructured(t, spec)
 
 		auth, found, err := unstructured.NestedMap(obj.Object, "spec", "defaults", "rules", "authentication")
@@ -1254,7 +1254,7 @@ func TestBuildGatewayAuthPolicySpec_K8sAndOIDCAuth(t *testing.T) {
 			IssuerURL: "https://keycloak.example.com/realms/test",
 			ClientID:  "maas-client",
 		}
-		spec := r.buildGatewayAuthPolicySpec("{}", oidc, "", "models-as-a-service", "test-gateway-ns", "test-gateway")
+		spec := r.buildGatewayAuthPolicySpec("{}", oidc, "", "models-as-a-service", "test-gateway-ns", "test-gateway", map[string]modelSubjectAllowlist{})
 		obj := gwSpecToUnstructured(t, spec)
 
 		auth, found, err := unstructured.NestedMap(obj.Object, "spec", "defaults", "rules", "authentication")
@@ -1274,7 +1274,7 @@ func TestBuildGatewayAuthPolicySpec_K8sAndOIDCAuth(t *testing.T) {
 	})
 
 	t.Run("subscription-info has path-scoped when condition", func(t *testing.T) {
-		spec := r.buildGatewayAuthPolicySpec("{}", nil, "", "models-as-a-service", "test-gateway-ns", "test-gateway")
+		spec := r.buildGatewayAuthPolicySpec("{}", nil, "", "models-as-a-service", "test-gateway-ns", "test-gateway", map[string]modelSubjectAllowlist{})
 		obj := gwSpecToUnstructured(t, spec)
 
 		when, found, err := unstructured.NestedSlice(obj.Object, "spec", "defaults", "rules", "metadata", "subscription-info", "when")
@@ -1295,7 +1295,7 @@ func TestBuildGatewayAuthPolicySpec_K8sAndOIDCAuth(t *testing.T) {
 	})
 
 	t.Run("subscription-valid has path-scoped when condition", func(t *testing.T) {
-		spec := r.buildGatewayAuthPolicySpec("{}", nil, "", "models-as-a-service", "test-gateway-ns", "test-gateway")
+		spec := r.buildGatewayAuthPolicySpec("{}", nil, "", "models-as-a-service", "test-gateway-ns", "test-gateway", map[string]modelSubjectAllowlist{})
 		obj := gwSpecToUnstructured(t, spec)
 
 		when, found, err := unstructured.NestedSlice(obj.Object, "spec", "defaults", "rules", "authorization", "subscription-valid", "when")
@@ -1316,7 +1316,7 @@ func TestBuildGatewayAuthPolicySpec_K8sAndOIDCAuth(t *testing.T) {
 	})
 
 	t.Run("auth-valid supports non-API-key tokens", func(t *testing.T) {
-		spec := r.buildGatewayAuthPolicySpec("{}", nil, "", "models-as-a-service", "test-gateway-ns", "test-gateway")
+		spec := r.buildGatewayAuthPolicySpec("{}", nil, "", "models-as-a-service", "test-gateway-ns", "test-gateway", map[string]modelSubjectAllowlist{})
 		obj := gwSpecToUnstructured(t, spec)
 
 		rego, found, err := unstructured.NestedString(obj.Object, "spec", "defaults", "rules", "authorization", "auth-valid", "opa", "rego")
@@ -1357,6 +1357,365 @@ func contains(s, substr string) bool {
 			}
 			return false
 		}())
+}
+
+func TestBuildPublicPathsRegex(t *testing.T) {
+	tests := []struct {
+		name       string
+		allowlists map[string]modelSubjectAllowlist
+		want       string
+	}{
+		{
+			name:       "empty allowlists",
+			allowlists: map[string]modelSubjectAllowlist{},
+			want:       "",
+		},
+		{
+			name: "no public paths configured",
+			allowlists: map[string]modelSubjectAllowlist{
+				"default/llm": {Users: []string{"alice"}, Groups: []string{"devs"}},
+			},
+			want: "",
+		},
+		{
+			name: "single model single path",
+			allowlists: map[string]modelSubjectAllowlist{
+				"default/llm": {PublicPaths: []string{"/docs"}},
+			},
+			want: `^/default/llm/docs$`,
+		},
+		{
+			name: "single model multiple paths",
+			allowlists: map[string]modelSubjectAllowlist{
+				"default/llm": {PublicPaths: []string{"/docs", "/openapi.json"}},
+			},
+			want: `^/default/llm/docs$|^/default/llm/openapi\.json$`,
+		},
+		{
+			name: "multiple models with paths",
+			allowlists: map[string]modelSubjectAllowlist{
+				"default/llm":  {PublicPaths: []string{"/docs"}},
+				"prod/gpt":     {PublicPaths: []string{"/openapi.json"}},
+				"staging/bert": {Users: []string{"bob"}},
+			},
+			want: `^/default/llm/docs$|^/prod/gpt/openapi\.json$`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildPublicPathsRegex(tt.allowlists)
+			if got != tt.want {
+				t.Errorf("buildPublicPathsRegex() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildPublicPathsCELPredicate(t *testing.T) {
+	tests := []struct {
+		name       string
+		allowlists map[string]modelSubjectAllowlist
+		want       string
+	}{
+		{
+			name:       "empty allowlists",
+			allowlists: map[string]modelSubjectAllowlist{},
+			want:       "",
+		},
+		{
+			name: "single model single path",
+			allowlists: map[string]modelSubjectAllowlist{
+				"default/llm": {PublicPaths: []string{"/docs"}},
+			},
+			want: `request.path != "/default/llm/docs"`,
+		},
+		{
+			name: "single model multiple paths",
+			allowlists: map[string]modelSubjectAllowlist{
+				"default/llm": {PublicPaths: []string{"/docs", "/openapi.json"}},
+			},
+			want: `request.path != "/default/llm/docs" && request.path != "/default/llm/openapi.json"`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildPublicPathsCELPredicate(tt.allowlists)
+			if got != tt.want {
+				t.Errorf("buildPublicPathsCELPredicate() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestApplyPublicPathsCELToRules(t *testing.T) {
+	rules := map[string]any{
+		"apiKeyValidation": map[string]any{
+			"when": []any{
+				map[string]any{"selector": "request.headers.authorization"},
+			},
+			"metrics": false,
+		},
+		"subscription-info": map[string]any{
+			"metrics": false,
+		},
+	}
+	applyPublicPathsCELToRules(rules, `request.path != "/default/llm/docs"`)
+
+	for name, evaluator := range rules {
+		eval, ok := evaluator.(map[string]any)
+		if !ok {
+			t.Fatalf("evaluator %q: expected map[string]any", name)
+		}
+		when, ok := eval["when"].([]any)
+		if !ok {
+			t.Fatalf("evaluator %q: when should be []any", name)
+		}
+		lastWhen, ok := when[len(when)-1].(map[string]any)
+		if !ok {
+			t.Fatalf("evaluator %q: last when entry should be map[string]any", name)
+		}
+		pred, ok := lastWhen["predicate"].(string)
+		if !ok || pred != `request.path != "/default/llm/docs"` {
+			t.Errorf("evaluator %q: last when predicate = %v, want %q", name, lastWhen, `request.path != "/default/llm/docs"`)
+		}
+	}
+}
+
+func TestBuildGatewayAuthPolicySpec_PublicPaths(t *testing.T) {
+	r := &MaaSAuthPolicyReconciler{
+		MaaSAPINamespace: "maas-system",
+		GatewayName:      "maas-default-gateway",
+		GatewayNamespace: "gateway-ns",
+		ClusterAudience:  "https://kubernetes.default.svc",
+		MetadataCacheTTL: 60,
+		AuthzCacheTTL:    60,
+	}
+
+	gwSpecToUnstructured := func(t *testing.T, spec map[string]any) *unstructured.Unstructured {
+		t.Helper()
+		return &unstructured.Unstructured{Object: map[string]any{"spec": spec}}
+	}
+
+	t.Run("without public paths no anonymous auth rule", func(t *testing.T) {
+		allowlists := map[string]modelSubjectAllowlist{
+			"default/llm": {Users: []string{"alice"}, Groups: []string{"devs"}},
+		}
+		spec := r.buildGatewayAuthPolicySpec("{}", nil, "", "models-as-a-service", "test-gateway-ns", "test-gateway", allowlists)
+		obj := gwSpecToUnstructured(t, spec)
+
+		auth, found, err := unstructured.NestedMap(obj.Object, "spec", "defaults", "rules", "authentication")
+		if err != nil || !found {
+			t.Fatalf("authentication block missing: found=%v err=%v", found, err)
+		}
+		if _, exists := auth["anonymous-public-paths"]; exists {
+			t.Error("anonymous-public-paths should NOT be present when no model has publicPaths")
+		}
+	})
+
+	t.Run("with public paths adds anonymous auth rule", func(t *testing.T) {
+		allowlists := map[string]modelSubjectAllowlist{
+			"default/llm": {
+				Users:       []string{"alice"},
+				Groups:      []string{"devs"},
+				PublicPaths: []string{"/docs"},
+			},
+		}
+		spec := r.buildGatewayAuthPolicySpec("{}", nil, "", "models-as-a-service", "test-gateway-ns", "test-gateway", allowlists)
+		obj := gwSpecToUnstructured(t, spec)
+
+		auth, found, err := unstructured.NestedMap(obj.Object, "spec", "defaults", "rules", "authentication")
+		if err != nil || !found {
+			t.Fatalf("authentication block missing: found=%v err=%v", found, err)
+		}
+		anonRule, exists := auth["anonymous-public-paths"]
+		if !exists {
+			t.Fatal("anonymous-public-paths should be present when a model has publicPaths")
+		}
+		anonMap, ok := anonRule.(map[string]any)
+		if !ok {
+			t.Fatal("anonymous-public-paths should be a map")
+		}
+		if _, hasAnon := anonMap["anonymous"]; !hasAnon {
+			t.Error("anonymous-public-paths should have an 'anonymous' key")
+		}
+	})
+
+	t.Run("public paths adds CEL skip predicates to metadata evaluators", func(t *testing.T) {
+		allowlists := map[string]modelSubjectAllowlist{
+			"default/llm": {
+				PublicPaths: []string{"/docs"},
+			},
+		}
+		spec := r.buildGatewayAuthPolicySpec("{}", nil, "", "models-as-a-service", "test-gateway-ns", "test-gateway", allowlists)
+		obj := gwSpecToUnstructured(t, spec)
+
+		metadata, found, err := unstructured.NestedMap(obj.Object, "spec", "defaults", "rules", "metadata")
+		if err != nil || !found {
+			t.Fatalf("metadata block missing: found=%v err=%v", found, err)
+		}
+		for evalName, evaluator := range metadata {
+			eval, ok := evaluator.(map[string]any)
+			if !ok {
+				continue
+			}
+			when, ok := eval["when"].([]any)
+			if !ok || len(when) == 0 {
+				t.Errorf("metadata evaluator %q should have when predicates", evalName)
+				continue
+			}
+			lastWhen, ok := when[len(when)-1].(map[string]any)
+			if !ok {
+				t.Errorf("metadata evaluator %q: last when entry should be a map", evalName)
+				continue
+			}
+			pred, ok := lastWhen["predicate"].(string)
+			if !ok || !strings.Contains(pred, `request.path != "/default/llm/docs"`) {
+				t.Errorf("metadata evaluator %q: last when predicate should contain public path skip, got %v", evalName, lastWhen)
+			}
+		}
+	})
+
+	t.Run("public paths adds CEL skip predicates to authorization evaluators", func(t *testing.T) {
+		allowlists := map[string]modelSubjectAllowlist{
+			"default/llm": {
+				PublicPaths: []string{"/docs"},
+			},
+		}
+		spec := r.buildGatewayAuthPolicySpec("{}", nil, "", "models-as-a-service", "test-gateway-ns", "test-gateway", allowlists)
+		obj := gwSpecToUnstructured(t, spec)
+
+		authz, found, err := unstructured.NestedMap(obj.Object, "spec", "defaults", "rules", "authorization")
+		if err != nil || !found {
+			t.Fatalf("authorization block missing: found=%v err=%v", found, err)
+		}
+		for evalName, evaluator := range authz {
+			eval, ok := evaluator.(map[string]any)
+			if !ok {
+				continue
+			}
+			when, ok := eval["when"].([]any)
+			if !ok || len(when) == 0 {
+				t.Errorf("authorization evaluator %q should have when predicates", evalName)
+				continue
+			}
+			lastWhen, ok := when[len(when)-1].(map[string]any)
+			if !ok {
+				t.Errorf("authorization evaluator %q: last when entry should be a map", evalName)
+				continue
+			}
+			pred, ok := lastWhen["predicate"].(string)
+			if !ok || !strings.Contains(pred, `request.path != "/default/llm/docs"`) {
+				t.Errorf("authorization evaluator %q: last when predicate should contain public path skip, got %v", evalName, lastWhen)
+			}
+		}
+	})
+}
+
+func TestMaaSAuthPolicyReconciler_PublicPaths(t *testing.T) {
+	const (
+		modelName      = "llm"
+		namespace      = "default"
+		gatewayNS      = "gateway-ns"
+		httpRouteName  = modelName
+		maasPolicyName = "policy-public"
+	)
+
+	model := newMaaSModelRef(modelName, namespace, "ExternalModel", modelName)
+	route := newHTTPRoute(httpRouteName, namespace)
+	maasPolicy := &maasv1alpha1.MaaSAuthPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: maasPolicyName, Namespace: namespace},
+		Spec: maasv1alpha1.MaaSAuthPolicySpec{
+			ModelRefs:   []maasv1alpha1.ModelRef{{Name: modelName, Namespace: namespace}},
+			Subjects:    maasv1alpha1.SubjectSpec{Groups: []maasv1alpha1.GroupReference{{Name: "team-a"}}},
+			PublicPaths: []maasv1alpha1.PublicPath{maasv1alpha1.PublicPathDocs, maasv1alpha1.PublicPathOpenAPI},
+		},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithRESTMapper(testRESTMapper()).
+		WithObjects(model, route, maasPolicy).
+		WithStatusSubresource(&maasv1alpha1.MaaSAuthPolicy{}).
+		Build()
+
+	r := &MaaSAuthPolicyReconciler{
+		Client:           c,
+		Scheme:           scheme,
+		MaaSAPINamespace: "maas-system",
+		GatewayName:      "maas-default-gateway",
+		GatewayNamespace: gatewayNS,
+		MetadataCacheTTL: 60,
+		AuthzCacheTTL:    60,
+	}
+
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: maasPolicyName, Namespace: namespace}}
+	if _, err := r.Reconcile(context.Background(), req); err != nil {
+		t.Fatalf("Reconcile: unexpected error: %v", err)
+	}
+
+	gwPolicy := &unstructured.Unstructured{}
+	gwPolicy.SetGroupVersionKind(schema.GroupVersionKind{Group: "kuadrant.io", Version: "v1", Kind: "AuthPolicy"})
+	if err := c.Get(context.Background(), types.NamespacedName{Name: maasGatewayAuthPolicyName, Namespace: gatewayNS}, gwPolicy); err != nil {
+		t.Fatalf("Get gateway AuthPolicy: %v", err)
+	}
+
+	auth, found, err := unstructured.NestedMap(gwPolicy.Object, "spec", "defaults", "rules", "authentication")
+	if err != nil || !found {
+		t.Fatalf("authentication block missing: found=%v err=%v", found, err)
+	}
+	if _, exists := auth["anonymous-public-paths"]; !exists {
+		t.Error("gateway AuthPolicy should contain anonymous-public-paths authentication rule")
+	}
+}
+
+func TestMaaSAuthPolicyReconciler_NoPublicPaths(t *testing.T) {
+	const (
+		modelName      = "llm"
+		namespace      = "default"
+		gatewayNS      = "gateway-ns"
+		httpRouteName  = modelName
+		maasPolicyName = "policy-no-public"
+	)
+
+	model := newMaaSModelRef(modelName, namespace, "ExternalModel", modelName)
+	route := newHTTPRoute(httpRouteName, namespace)
+	maasPolicy := newMaaSAuthPolicy(maasPolicyName, namespace, "team-a", maasv1alpha1.ModelRef{Name: modelName, Namespace: namespace})
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithRESTMapper(testRESTMapper()).
+		WithObjects(model, route, maasPolicy).
+		WithStatusSubresource(&maasv1alpha1.MaaSAuthPolicy{}).
+		Build()
+
+	r := &MaaSAuthPolicyReconciler{
+		Client:           c,
+		Scheme:           scheme,
+		MaaSAPINamespace: "maas-system",
+		GatewayName:      "maas-default-gateway",
+		GatewayNamespace: gatewayNS,
+		MetadataCacheTTL: 60,
+		AuthzCacheTTL:    60,
+	}
+
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: maasPolicyName, Namespace: namespace}}
+	if _, err := r.Reconcile(context.Background(), req); err != nil {
+		t.Fatalf("Reconcile: unexpected error: %v", err)
+	}
+
+	gwPolicy := &unstructured.Unstructured{}
+	gwPolicy.SetGroupVersionKind(schema.GroupVersionKind{Group: "kuadrant.io", Version: "v1", Kind: "AuthPolicy"})
+	if err := c.Get(context.Background(), types.NamespacedName{Name: maasGatewayAuthPolicyName, Namespace: gatewayNS}, gwPolicy); err != nil {
+		t.Fatalf("Get gateway AuthPolicy: %v", err)
+	}
+
+	auth, found, err := unstructured.NestedMap(gwPolicy.Object, "spec", "defaults", "rules", "authentication")
+	if err != nil || !found {
+		t.Fatalf("authentication block missing: found=%v err=%v", found, err)
+	}
+	if _, exists := auth["anonymous-public-paths"]; exists {
+		t.Error("gateway AuthPolicy should NOT contain anonymous-public-paths when no publicPaths are set")
+	}
 }
 
 // TestMaaSAuthPolicyReconciler_MissingModelRef_FailedPhase verifies that an auth policy

--- a/maas-controller/pkg/controller/maas/maasauthpolicy_controller_test.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_controller_test.go
@@ -1733,7 +1733,7 @@ func gatewayAuthPolicySpecTestObject(t *testing.T, oidc *oidcConfig) *unstructur
 		MetadataCacheTTL: 60,
 		AuthzCacheTTL:    60,
 	}
-	spec := r.buildGatewayAuthPolicySpec("{}", oidc, false, "", "models-as-a-service", "test-gateway-ns", "test-gateway")
+	spec := r.buildGatewayAuthPolicySpec("{}", oidc, false, "", "models-as-a-service", "test-gateway-ns", "test-gateway", map[string]modelSubjectAllowlist{})
 	return &unstructured.Unstructured{Object: map[string]any{"spec": spec}}
 }
 
@@ -1872,7 +1872,7 @@ func TestBuildGatewayAuthPolicySpec_XAPIKeyEnabled(t *testing.T) {
 		AuthzCacheTTL:    60,
 	}
 
-	spec := r.buildGatewayAuthPolicySpec("{}", nil, true, "", "models-as-a-service", "gateway-ns", "maas-default-gateway")
+	spec := r.buildGatewayAuthPolicySpec("{}", nil, true, "", "models-as-a-service", "gateway-ns", "maas-default-gateway", map[string]modelSubjectAllowlist{})
 	obj := &unstructured.Unstructured{Object: map[string]any{"spec": spec}}
 
 	auth, found, err := unstructured.NestedMap(obj.Object, "spec", "defaults", "rules", "authentication")
@@ -1961,7 +1961,7 @@ func TestBuildGatewayAuthPolicySpec_OIDCJWKsTTL(t *testing.T) {
 				ClientID:  "maas-client",
 				TTL:       tc.ttl,
 			}
-			spec := r.buildGatewayAuthPolicySpec("{}", oidc, false, "", "models-as-a-service", "test-gateway-ns", "test-gateway")
+			spec := r.buildGatewayAuthPolicySpec("{}", oidc, false, "", "models-as-a-service", "test-gateway-ns", "test-gateway", map[string]modelSubjectAllowlist{})
 			obj := &unstructured.Unstructured{Object: map[string]any{"spec": spec}}
 
 			gotTTL, found, err := unstructured.NestedInt64(obj.Object, "spec", "defaults", "rules", "authentication", "oidc-identities", "jwt", "ttl")
@@ -2110,6 +2110,365 @@ func contains(s, substr string) bool {
 			}
 			return false
 		}())
+}
+
+func TestBuildPublicPathsRegex(t *testing.T) {
+	tests := []struct {
+		name       string
+		allowlists map[string]modelSubjectAllowlist
+		want       string
+	}{
+		{
+			name:       "empty allowlists",
+			allowlists: map[string]modelSubjectAllowlist{},
+			want:       "",
+		},
+		{
+			name: "no public paths configured",
+			allowlists: map[string]modelSubjectAllowlist{
+				"default/llm": {Users: []string{"alice"}, Groups: []string{"devs"}},
+			},
+			want: "",
+		},
+		{
+			name: "single model single path",
+			allowlists: map[string]modelSubjectAllowlist{
+				"default/llm": {PublicPaths: []string{"/docs"}},
+			},
+			want: `^/default/llm/docs$`,
+		},
+		{
+			name: "single model multiple paths",
+			allowlists: map[string]modelSubjectAllowlist{
+				"default/llm": {PublicPaths: []string{"/docs", "/openapi.json"}},
+			},
+			want: `^/default/llm/docs$|^/default/llm/openapi\.json$`,
+		},
+		{
+			name: "multiple models with paths",
+			allowlists: map[string]modelSubjectAllowlist{
+				"default/llm":  {PublicPaths: []string{"/docs"}},
+				"prod/gpt":     {PublicPaths: []string{"/openapi.json"}},
+				"staging/bert": {Users: []string{"bob"}},
+			},
+			want: `^/default/llm/docs$|^/prod/gpt/openapi\.json$`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildPublicPathsRegex(tt.allowlists)
+			if got != tt.want {
+				t.Errorf("buildPublicPathsRegex() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildPublicPathsCELPredicate(t *testing.T) {
+	tests := []struct {
+		name       string
+		allowlists map[string]modelSubjectAllowlist
+		want       string
+	}{
+		{
+			name:       "empty allowlists",
+			allowlists: map[string]modelSubjectAllowlist{},
+			want:       "",
+		},
+		{
+			name: "single model single path",
+			allowlists: map[string]modelSubjectAllowlist{
+				"default/llm": {PublicPaths: []string{"/docs"}},
+			},
+			want: `request.path != "/default/llm/docs"`,
+		},
+		{
+			name: "single model multiple paths",
+			allowlists: map[string]modelSubjectAllowlist{
+				"default/llm": {PublicPaths: []string{"/docs", "/openapi.json"}},
+			},
+			want: `request.path != "/default/llm/docs" && request.path != "/default/llm/openapi.json"`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildPublicPathsCELPredicate(tt.allowlists)
+			if got != tt.want {
+				t.Errorf("buildPublicPathsCELPredicate() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestApplyPublicPathsCELToRules(t *testing.T) {
+	rules := map[string]any{
+		"apiKeyValidation": map[string]any{
+			"when": []any{
+				map[string]any{"selector": "request.headers.authorization"},
+			},
+			"metrics": false,
+		},
+		"subscription-info": map[string]any{
+			"metrics": false,
+		},
+	}
+	applyPublicPathsCELToRules(rules, `request.path != "/default/llm/docs"`)
+
+	for name, evaluator := range rules {
+		eval, ok := evaluator.(map[string]any)
+		if !ok {
+			t.Fatalf("evaluator %q: expected map[string]any", name)
+		}
+		when, ok := eval["when"].([]any)
+		if !ok {
+			t.Fatalf("evaluator %q: when should be []any", name)
+		}
+		lastWhen, ok := when[len(when)-1].(map[string]any)
+		if !ok {
+			t.Fatalf("evaluator %q: last when entry should be map[string]any", name)
+		}
+		pred, ok := lastWhen["predicate"].(string)
+		if !ok || pred != `request.path != "/default/llm/docs"` {
+			t.Errorf("evaluator %q: last when predicate = %v, want %q", name, lastWhen, `request.path != "/default/llm/docs"`)
+		}
+	}
+}
+
+func TestBuildGatewayAuthPolicySpec_PublicPaths(t *testing.T) {
+	r := &MaaSAuthPolicyReconciler{
+		InfraNamespace:   "maas-system",
+		GatewayName:      "maas-default-gateway",
+		GatewayNamespace: "gateway-ns",
+		ClusterAudience:  "https://kubernetes.default.svc",
+		MetadataCacheTTL: 60,
+		AuthzCacheTTL:    60,
+	}
+
+	gwSpecToUnstructured := func(t *testing.T, spec map[string]any) *unstructured.Unstructured {
+		t.Helper()
+		return &unstructured.Unstructured{Object: map[string]any{"spec": spec}}
+	}
+
+	t.Run("without public paths no anonymous auth rule", func(t *testing.T) {
+		allowlists := map[string]modelSubjectAllowlist{
+			"default/llm": {Users: []string{"alice"}, Groups: []string{"devs"}},
+		}
+		spec := r.buildGatewayAuthPolicySpec("{}", nil, false, "", "models-as-a-service", "test-gateway-ns", "test-gateway", allowlists)
+		obj := gwSpecToUnstructured(t, spec)
+
+		auth, found, err := unstructured.NestedMap(obj.Object, "spec", "defaults", "rules", "authentication")
+		if err != nil || !found {
+			t.Fatalf("authentication block missing: found=%v err=%v", found, err)
+		}
+		if _, exists := auth["anonymous-public-paths"]; exists {
+			t.Error("anonymous-public-paths should NOT be present when no model has publicPaths")
+		}
+	})
+
+	t.Run("with public paths adds anonymous auth rule", func(t *testing.T) {
+		allowlists := map[string]modelSubjectAllowlist{
+			"default/llm": {
+				Users:       []string{"alice"},
+				Groups:      []string{"devs"},
+				PublicPaths: []string{"/docs"},
+			},
+		}
+		spec := r.buildGatewayAuthPolicySpec("{}", nil, false, "", "models-as-a-service", "test-gateway-ns", "test-gateway", allowlists)
+		obj := gwSpecToUnstructured(t, spec)
+
+		auth, found, err := unstructured.NestedMap(obj.Object, "spec", "defaults", "rules", "authentication")
+		if err != nil || !found {
+			t.Fatalf("authentication block missing: found=%v err=%v", found, err)
+		}
+		anonRule, exists := auth["anonymous-public-paths"]
+		if !exists {
+			t.Fatal("anonymous-public-paths should be present when a model has publicPaths")
+		}
+		anonMap, ok := anonRule.(map[string]any)
+		if !ok {
+			t.Fatal("anonymous-public-paths should be a map")
+		}
+		if _, hasAnon := anonMap["anonymous"]; !hasAnon {
+			t.Error("anonymous-public-paths should have an 'anonymous' key")
+		}
+	})
+
+	t.Run("public paths adds CEL skip predicates to metadata evaluators", func(t *testing.T) {
+		allowlists := map[string]modelSubjectAllowlist{
+			"default/llm": {
+				PublicPaths: []string{"/docs"},
+			},
+		}
+		spec := r.buildGatewayAuthPolicySpec("{}", nil, false, "", "models-as-a-service", "test-gateway-ns", "test-gateway", allowlists)
+		obj := gwSpecToUnstructured(t, spec)
+
+		metadata, found, err := unstructured.NestedMap(obj.Object, "spec", "defaults", "rules", "metadata")
+		if err != nil || !found {
+			t.Fatalf("metadata block missing: found=%v err=%v", found, err)
+		}
+		for evalName, evaluator := range metadata {
+			eval, ok := evaluator.(map[string]any)
+			if !ok {
+				continue
+			}
+			when, ok := eval["when"].([]any)
+			if !ok || len(when) == 0 {
+				t.Errorf("metadata evaluator %q should have when predicates", evalName)
+				continue
+			}
+			lastWhen, ok := when[len(when)-1].(map[string]any)
+			if !ok {
+				t.Errorf("metadata evaluator %q: last when entry should be a map", evalName)
+				continue
+			}
+			pred, ok := lastWhen["predicate"].(string)
+			if !ok || !strings.Contains(pred, `request.path != "/default/llm/docs"`) {
+				t.Errorf("metadata evaluator %q: last when predicate should contain public path skip, got %v", evalName, lastWhen)
+			}
+		}
+	})
+
+	t.Run("public paths adds CEL skip predicates to authorization evaluators", func(t *testing.T) {
+		allowlists := map[string]modelSubjectAllowlist{
+			"default/llm": {
+				PublicPaths: []string{"/docs"},
+			},
+		}
+		spec := r.buildGatewayAuthPolicySpec("{}", nil, false, "", "models-as-a-service", "test-gateway-ns", "test-gateway", allowlists)
+		obj := gwSpecToUnstructured(t, spec)
+
+		authz, found, err := unstructured.NestedMap(obj.Object, "spec", "defaults", "rules", "authorization")
+		if err != nil || !found {
+			t.Fatalf("authorization block missing: found=%v err=%v", found, err)
+		}
+		for evalName, evaluator := range authz {
+			eval, ok := evaluator.(map[string]any)
+			if !ok {
+				continue
+			}
+			when, ok := eval["when"].([]any)
+			if !ok || len(when) == 0 {
+				t.Errorf("authorization evaluator %q should have when predicates", evalName)
+				continue
+			}
+			lastWhen, ok := when[len(when)-1].(map[string]any)
+			if !ok {
+				t.Errorf("authorization evaluator %q: last when entry should be a map", evalName)
+				continue
+			}
+			pred, ok := lastWhen["predicate"].(string)
+			if !ok || !strings.Contains(pred, `request.path != "/default/llm/docs"`) {
+				t.Errorf("authorization evaluator %q: last when predicate should contain public path skip, got %v", evalName, lastWhen)
+			}
+		}
+	})
+}
+
+func TestMaaSAuthPolicyReconciler_PublicPaths(t *testing.T) {
+	const (
+		modelName      = "llm"
+		namespace      = "default"
+		gatewayNS      = "gateway-ns"
+		httpRouteName  = modelName
+		maasPolicyName = "policy-public"
+	)
+
+	model := newMaaSModelRef(modelName, namespace, "ExternalModel", modelName)
+	route := newHTTPRoute(httpRouteName, namespace)
+	maasPolicy := &maasv1alpha1.MaaSAuthPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: maasPolicyName, Namespace: namespace},
+		Spec: maasv1alpha1.MaaSAuthPolicySpec{
+			ModelRefs:   []maasv1alpha1.ModelRef{{Name: modelName, Namespace: namespace}},
+			Subjects:    maasv1alpha1.SubjectSpec{Groups: []maasv1alpha1.GroupReference{{Name: "team-a"}}},
+			PublicPaths: []maasv1alpha1.PublicPath{maasv1alpha1.PublicPathDocs, maasv1alpha1.PublicPathOpenAPI},
+		},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithRESTMapper(testRESTMapper()).
+		WithObjects(model, route, maasPolicy).
+		WithStatusSubresource(&maasv1alpha1.MaaSAuthPolicy{}).
+		Build()
+
+	r := &MaaSAuthPolicyReconciler{
+		Client:           c,
+		Scheme:           scheme,
+		InfraNamespace:   "maas-system",
+		GatewayName:      "maas-default-gateway",
+		GatewayNamespace: gatewayNS,
+		MetadataCacheTTL: 60,
+		AuthzCacheTTL:    60,
+	}
+
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: maasPolicyName, Namespace: namespace}}
+	if _, err := r.Reconcile(context.Background(), req); err != nil {
+		t.Fatalf("Reconcile: unexpected error: %v", err)
+	}
+
+	gwPolicy := &unstructured.Unstructured{}
+	gwPolicy.SetGroupVersionKind(schema.GroupVersionKind{Group: "kuadrant.io", Version: "v1", Kind: "AuthPolicy"})
+	if err := c.Get(context.Background(), types.NamespacedName{Name: maasGatewayAuthPolicyName, Namespace: gatewayNS}, gwPolicy); err != nil {
+		t.Fatalf("Get gateway AuthPolicy: %v", err)
+	}
+
+	auth, found, err := unstructured.NestedMap(gwPolicy.Object, "spec", "defaults", "rules", "authentication")
+	if err != nil || !found {
+		t.Fatalf("authentication block missing: found=%v err=%v", found, err)
+	}
+	if _, exists := auth["anonymous-public-paths"]; !exists {
+		t.Error("gateway AuthPolicy should contain anonymous-public-paths authentication rule")
+	}
+}
+
+func TestMaaSAuthPolicyReconciler_NoPublicPaths(t *testing.T) {
+	const (
+		modelName      = "llm"
+		namespace      = "default"
+		gatewayNS      = "gateway-ns"
+		httpRouteName  = modelName
+		maasPolicyName = "policy-no-public"
+	)
+
+	model := newMaaSModelRef(modelName, namespace, "ExternalModel", modelName)
+	route := newHTTPRoute(httpRouteName, namespace)
+	maasPolicy := newMaaSAuthPolicy(maasPolicyName, namespace, "team-a", maasv1alpha1.ModelRef{Name: modelName, Namespace: namespace})
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithRESTMapper(testRESTMapper()).
+		WithObjects(model, route, maasPolicy).
+		WithStatusSubresource(&maasv1alpha1.MaaSAuthPolicy{}).
+		Build()
+
+	r := &MaaSAuthPolicyReconciler{
+		Client:           c,
+		Scheme:           scheme,
+		InfraNamespace:   "maas-system",
+		GatewayName:      "maas-default-gateway",
+		GatewayNamespace: gatewayNS,
+		MetadataCacheTTL: 60,
+		AuthzCacheTTL:    60,
+	}
+
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: maasPolicyName, Namespace: namespace}}
+	if _, err := r.Reconcile(context.Background(), req); err != nil {
+		t.Fatalf("Reconcile: unexpected error: %v", err)
+	}
+
+	gwPolicy := &unstructured.Unstructured{}
+	gwPolicy.SetGroupVersionKind(schema.GroupVersionKind{Group: "kuadrant.io", Version: "v1", Kind: "AuthPolicy"})
+	if err := c.Get(context.Background(), types.NamespacedName{Name: maasGatewayAuthPolicyName, Namespace: gatewayNS}, gwPolicy); err != nil {
+		t.Fatalf("Get gateway AuthPolicy: %v", err)
+	}
+
+	auth, found, err := unstructured.NestedMap(gwPolicy.Object, "spec", "defaults", "rules", "authentication")
+	if err != nil || !found {
+		t.Fatalf("authentication block missing: found=%v err=%v", found, err)
+	}
+	if _, exists := auth["anonymous-public-paths"]; exists {
+		t.Error("gateway AuthPolicy should NOT contain anonymous-public-paths when no publicPaths are set")
+	}
 }
 
 // TestMaaSAuthPolicyReconciler_MissingModelRef_FailedPhase verifies that an auth policy

--- a/maas-controller/pkg/controller/maas/maasauthpolicy_gateway_aggregate_test.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_gateway_aggregate_test.go
@@ -83,7 +83,7 @@ func TestAggregateModelSubjectAllowlistsAndGatewaySpec(t *testing.T) {
 		t.Fatalf("json.Marshal(allowlists) returned error: %v", err)
 	}
 
-	spec := r.buildGatewayAuthPolicySpec(string(allowlistsJSON), nil, "", "models-as-a-service", "test-gateway-ns", "test-gateway")
+	spec := r.buildGatewayAuthPolicySpec(string(allowlistsJSON), nil, "", "models-as-a-service", "test-gateway-ns", "test-gateway", allowlists)
 	defaults, ok := spec["defaults"].(map[string]any)
 	if !ok {
 		t.Fatalf("gateway spec missing defaults block")

--- a/maas-controller/pkg/controller/maas/maasauthpolicy_gateway_aggregate_test.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_gateway_aggregate_test.go
@@ -84,7 +84,7 @@ func TestAggregateModelSubjectAllowlistsAndGatewaySpec(t *testing.T) {
 		t.Fatalf("json.Marshal(allowlists) returned error: %v", err)
 	}
 
-	spec := r.buildGatewayAuthPolicySpec(string(allowlistsJSON), nil, false, "", "models-as-a-service", "test-gateway-ns", "test-gateway")
+	spec := r.buildGatewayAuthPolicySpec(string(allowlistsJSON), nil, false, "", "models-as-a-service", "test-gateway-ns", "test-gateway", allowlists)
 	defaults, ok := spec["defaults"].(map[string]any)
 	if !ok {
 		t.Fatalf("gateway spec missing defaults block")


### PR DESCRIPTION
## Summary

Adds a `publicPaths` field to `MaaSAuthPolicySpec` that allows administrators to specify URL path suffixes (e.g., `/docs`, `/openapi.json`) that should be accessible **without authentication**. This enables users to browse model Swagger/OpenAPI documentation directly in a browser without needing a token, while keeping inference and all other endpoints fully authenticated.

**Motivation:** vLLM and other serving runtimes expose a `/docs` (Swagger UI) and `/openapi.json` endpoint, but the current MaaS authentication setup blocks unauthenticated access to all paths. There is no way to selectively expose documentation endpoints without bypassing auth entirely.

## Changes

- **CRD (`maasauthpolicy_types.go`):** Add `PublicPaths []string` field to `MaaSAuthPolicySpec` with `+optional`, max 10 items validation
- **Deepcopy (`zz_generated.deepcopy.go`):** Updated to handle the new `PublicPaths` slice
- **CRD manifest (`maas.opendatahub.io_maasauthpolicies.yaml`):** Regenerated via `controller-gen`
- **Reconciler (`maasauthpolicy_controller.go`):**
  - Added `buildPublicPathsRegex()` — generates a `request.url_path` regex pattern for Authorino
  - Added `buildPublicPathsCELPredicate()` — generates CEL `when` predicates to skip auth/metadata for public paths
  - Injects an `anonymous-public-paths` authentication rule into the generated AuthPolicy, scoped to matching paths
  - Adds `when` predicates to `apiKeyValidation`, `subscription-info` metadata evaluators and `auth-valid`, `subscription-valid`, `require-group-membership` authorization rules to skip them for public paths
- **Gateway default-deny TRLP (`gateway-default-deny.yaml`):** Updated predicate to exclude `/docs` and `/openapi.json` from the zero-rate-limit deny rule
- **Unit tests (`maasauthpolicy_controller_test.go`):** Added comprehensive tests for helper functions and reconciler behavior with and without `publicPaths`

## Usage

```yaml
apiVersion: maas.opendatahub.io/v1alpha1
kind: MaaSAuthPolicy
metadata:
  name: my-model-policy
spec:
  modelRefs:
    - name: my-model
      namespace: my-namespace
  subjects:
    groups:
      - system:authenticated
  publicPaths:
    - "/docs"
    - "/openapi.json"
```

## What changes, what stays the same

- `/docs` and `/openapi.json` → accessible without auth (anonymous)
- `/v1/completions`, `/v1/chat/completions`, etc. → still require full authentication (API key or token)
- Models without `publicPaths` → no behavior change at all (backward compatible)

## Test plan

- [x] Unit tests for `buildPublicPathsRegex` and `buildPublicPathsCELPredicate` helpers
- [x] Unit test: reconciler generates `anonymous-public-paths` auth rule when `publicPaths` is set
- [x] Unit test: reconciler adds `when` predicates to metadata/authorization evaluators
- [x] Unit test: reconciler produces unchanged AuthPolicy when `publicPaths` is empty
- [x] `make -C maas-controller test` — all tests pass
- [x] `make -C maas-controller verify-codegen` — generated files in sync
- [x] `./scripts/ci/validate-manifests.sh` — all kustomize manifests validate
- [ ] E2E: deploy with custom controller image, apply MaaSAuthPolicy with `publicPaths`, verify `/docs` returns 200 without auth and inference endpoints still require auth




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional public paths configuration for authentication policies. Specified paths now bypass authentication requirements while maintaining security on inference endpoints. Supports up to 10 public paths per policy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->