### PR TITLE
feat(maas-api): enable TLS certificate validation for internal gateway calls

### DIFF
--- a/maas-api/internal/models/discovery.go
+++ b/maas-api/internal/models/discovery.go
@@ -75,7 +75,7 @@ func NewManager(log *logger.Logger, accessCheckTimeoutSeconds int, gatewayIntern
 		timeout = time.Duration(accessCheckTimeoutSeconds) * time.Second
 	}
 
-	tlsConfig, err := buildClusterTLSConfig(log)
+	tlsConfig, err := BuildClusterTLSConfig(log)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build TLS config: %w", err)
 	}
@@ -111,26 +111,32 @@ func NewManager(log *logger.Logger, accessCheckTimeoutSeconds int, gatewayIntern
 	}, nil
 }
 
-// buildClusterTLSConfig creates a TLS config for cluster-internal communication.
-// It uses the Kubernetes service account CA when running in-cluster, or falls back
-// to system root CAs when running locally (e.g., during development).
-func buildClusterTLSConfig(log *logger.Logger) (*tls.Config, error) {
+// BuildClusterTLSConfig creates a TLS config for cluster-internal communication.
+// It starts with the system root CAs and appends the Kubernetes service account CA
+// when running in-cluster. This ensures both public CAs and cluster CAs are trusted,
+// supporting endpoints with publicly-trusted certificates as well as cluster-internal services.
+func BuildClusterTLSConfig(log *logger.Logger) (*tls.Config, error) {
+	caCertPool, err := x509.SystemCertPool()
+	if err != nil {
+		log.Debug("Failed to load system cert pool, creating empty pool", "error", err)
+		caCertPool = x509.NewCertPool()
+	}
+
 	caCert, err := os.ReadFile(kubeServiceAccountCAPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			log.Debug("Kubernetes service account CA not found, using system root CAs",
+			log.Debug("Kubernetes service account CA not found, using system root CAs only",
 				"path", kubeServiceAccountCAPath)
-			return &tls.Config{MinVersion: tls.VersionTLS12}, nil
+			return &tls.Config{MinVersion: tls.VersionTLS12, RootCAs: caCertPool}, nil
 		}
 		return nil, fmt.Errorf("failed to read CA certificate: %w", err)
 	}
 
-	caCertPool := x509.NewCertPool()
 	if !caCertPool.AppendCertsFromPEM(caCert) {
 		return nil, errors.New("failed to parse Kubernetes service account CA certificate")
 	}
 
-	log.Debug("Using Kubernetes service account CA for TLS validation",
+	log.Debug("Using system root CAs with Kubernetes service account CA appended",
 		"path", kubeServiceAccountCAPath)
 
 	return &tls.Config{

--- a/maas-api/internal/models/discovery.go
+++ b/maas-api/internal/models/discovery.go
@@ -3,6 +3,7 @@ package models
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -10,6 +11,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"sync"
 	"time"
 
@@ -44,6 +46,10 @@ const (
 	defaultAccessCheckTimeout = 15 * time.Second
 )
 
+// kubeServiceAccountCAPath is the path to the Kubernetes service account CA certificate.
+// This CA is used to validate TLS certificates for cluster-internal services.
+const kubeServiceAccountCAPath = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+
 // Manager runs access validation (probe model endpoints) for models listed from MaaSModelRef.
 type Manager struct {
 	logger              *logger.Logger
@@ -52,8 +58,9 @@ type Manager struct {
 	gatewayInternalHost string
 }
 
-// NewManager creates a Manager for filtering models by access. The client uses InsecureSkipVerify
-// for cluster-internal probes; auth is enforced by the gateway/model server.
+// NewManager creates a Manager for filtering models by access.
+// The client uses proper TLS certificate validation via the Kubernetes service account CA
+// (when running in-cluster) or system root CAs (when running locally).
 // accessCheckTimeoutSeconds controls the total duration bound for access validation;
 // if <= 0, the default of 15 seconds is used.
 // gatewayInternalHost, when non-empty, routes all probe TCP connections to this
@@ -68,8 +75,16 @@ func NewManager(log *logger.Logger, accessCheckTimeoutSeconds int, gatewayIntern
 		timeout = time.Duration(accessCheckTimeoutSeconds) * time.Second
 	}
 
+	tlsConfig, err := buildClusterTLSConfig(log)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build TLS config: %w", err)
+	}
+
+	// No per-client Timeout — each request inherits the accessCheckTimeout
+	// deadline via its context. This ensures that configuring a longer
+	// ACCESS_CHECK_TIMEOUT_SECONDS actually allows slower backends to respond.
 	transport := &http.Transport{
-		TLSClientConfig:     &tls.Config{InsecureSkipVerify: true, MinVersion: tls.VersionTLS12}, //nolint:gosec // cluster-internal only
+		TLSClientConfig:     tlsConfig,
 		MaxIdleConns:        httpMaxIdleConns,
 		MaxIdleConnsPerHost: maxDiscoveryConcurrency,
 		IdleConnTimeout:     httpIdleConnTimeout,
@@ -93,6 +108,34 @@ func NewManager(log *logger.Logger, accessCheckTimeoutSeconds int, gatewayIntern
 		httpClient: &http.Client{
 			Transport: transport,
 		},
+	}, nil
+}
+
+// buildClusterTLSConfig creates a TLS config for cluster-internal communication.
+// It uses the Kubernetes service account CA when running in-cluster, or falls back
+// to system root CAs when running locally (e.g., during development).
+func buildClusterTLSConfig(log *logger.Logger) (*tls.Config, error) {
+	caCert, err := os.ReadFile(kubeServiceAccountCAPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			log.Debug("Kubernetes service account CA not found, using system root CAs",
+				"path", kubeServiceAccountCAPath)
+			return &tls.Config{MinVersion: tls.VersionTLS12}, nil
+		}
+		return nil, fmt.Errorf("failed to read CA certificate: %w", err)
+	}
+
+	caCertPool := x509.NewCertPool()
+	if !caCertPool.AppendCertsFromPEM(caCert) {
+		return nil, errors.New("failed to parse Kubernetes service account CA certificate")
+	}
+
+	log.Debug("Using Kubernetes service account CA for TLS validation",
+		"path", kubeServiceAccountCAPath)
+
+	return &tls.Config{
+		RootCAs:    caCertPool,
+		MinVersion: tls.VersionTLS12,
 	}, nil
 }
 

--- a/maas-api/internal/models/discovery.go
+++ b/maas-api/internal/models/discovery.go
@@ -75,7 +75,7 @@ func NewManager(log *logger.Logger, accessCheckTimeoutSeconds int, gatewayIntern
 		timeout = time.Duration(accessCheckTimeoutSeconds) * time.Second
 	}
 
-	tlsConfig, err := BuildClusterTLSConfig(log)
+	tlsConfig, err := BuildClusterTLSConfigFromPath(log, kubeServiceAccountCAPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build TLS config: %w", err)
 	}
@@ -111,22 +111,35 @@ func NewManager(log *logger.Logger, accessCheckTimeoutSeconds int, gatewayIntern
 	}, nil
 }
 
-// BuildClusterTLSConfig creates a TLS config for cluster-internal communication.
-// It starts with the system root CAs and appends the Kubernetes service account CA
-// when running in-cluster. This ensures both public CAs and cluster CAs are trusted,
-// supporting endpoints with publicly-trusted certificates as well as cluster-internal services.
+// BuildClusterTLSConfig creates a TLS config for cluster-internal communication using
+// the default Kubernetes service account CA path. It is a convenience wrapper around
+// BuildClusterTLSConfigFromPath.
 func BuildClusterTLSConfig(log *logger.Logger) (*tls.Config, error) {
-	caCertPool, err := x509.SystemCertPool()
-	if err != nil {
-		log.Debug("Failed to load system cert pool, creating empty pool", "error", err)
-		caCertPool = x509.NewCertPool()
+	return BuildClusterTLSConfigFromPath(log, kubeServiceAccountCAPath)
+}
+
+// BuildClusterTLSConfigFromPath creates a TLS config for cluster-internal communication.
+// It starts with the system root CAs and appends the CA certificate at caPath when present.
+// This ensures both public CAs and cluster CAs are trusted, supporting endpoints with
+// publicly-trusted certificates as well as cluster-internal services.
+//
+// If caPath does not exist, system root CAs are used alone (development/out-of-cluster mode).
+// If caPath exists but cannot be read or parsed, an error is returned to prevent insecure fallback.
+func BuildClusterTLSConfigFromPath(log *logger.Logger, caPath string) (*tls.Config, error) {
+	if log == nil {
+		return nil, errors.New("log is required")
 	}
 
-	caCert, err := os.ReadFile(kubeServiceAccountCAPath)
+	caCertPool, err := x509.SystemCertPool()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load system certificate pool: %w", err)
+	}
+
+	caCert, err := os.ReadFile(caPath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			log.Debug("Kubernetes service account CA not found, using system root CAs only",
-				"path", kubeServiceAccountCAPath)
+				"path", caPath)
 			return &tls.Config{MinVersion: tls.VersionTLS12, RootCAs: caCertPool}, nil
 		}
 		return nil, fmt.Errorf("failed to read CA certificate: %w", err)
@@ -137,7 +150,7 @@ func BuildClusterTLSConfig(log *logger.Logger) (*tls.Config, error) {
 	}
 
 	log.Debug("Using system root CAs with Kubernetes service account CA appended",
-		"path", kubeServiceAccountCAPath)
+		"path", caPath)
 
 	return &tls.Config{
 		RootCAs:    caCertPool,

--- a/maas-api/internal/models/discovery_test.go
+++ b/maas-api/internal/models/discovery_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestNewManager(t *testing.T) {
 	t.Run("returns error when logger is nil", func(t *testing.T) {
-		manager, err := models.NewManager(nil)
+		manager, err := models.NewManager(nil, 15)
 		require.Error(t, err)
 		assert.Nil(t, manager)
 		assert.Contains(t, err.Error(), "log is required")
@@ -22,7 +22,7 @@ func TestNewManager(t *testing.T) {
 	t.Run("creates manager successfully with valid logger", func(t *testing.T) {
 		log := logger.New(true)
 
-		manager, err := models.NewManager(log)
+		manager, err := models.NewManager(log, 15)
 		require.NoError(t, err)
 		assert.NotNil(t, manager)
 	})

--- a/maas-api/internal/models/discovery_test.go
+++ b/maas-api/internal/models/discovery_test.go
@@ -1,8 +1,17 @@
 package models_test
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
 	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -13,7 +22,7 @@ import (
 
 func TestNewManager(t *testing.T) {
 	t.Run("returns error when logger is nil", func(t *testing.T) {
-		manager, err := models.NewManager(nil, 15)
+		manager, err := models.NewManager(nil, 15, "")
 		require.Error(t, err)
 		assert.Nil(t, manager)
 		assert.Contains(t, err.Error(), "log is required")
@@ -22,14 +31,21 @@ func TestNewManager(t *testing.T) {
 	t.Run("creates manager successfully with valid logger", func(t *testing.T) {
 		log := logger.New(true)
 
-		manager, err := models.NewManager(log, 15)
+		manager, err := models.NewManager(log, 15, "")
 		require.NoError(t, err)
 		assert.NotNil(t, manager)
 	})
 }
 
 func TestBuildClusterTLSConfig(t *testing.T) {
-	t.Run("returns secure TLS config", func(t *testing.T) {
+	t.Run("returns error when logger is nil", func(t *testing.T) {
+		tlsConfig, err := models.BuildClusterTLSConfig(nil)
+		require.Error(t, err)
+		assert.Nil(t, tlsConfig)
+		assert.Contains(t, err.Error(), "log is required")
+	})
+
+	t.Run("returns secure TLS config without InsecureSkipVerify", func(t *testing.T) {
 		log := logger.New(true)
 
 		tlsConfig, err := models.BuildClusterTLSConfig(log)
@@ -43,4 +59,92 @@ func TestBuildClusterTLSConfig(t *testing.T) {
 		assert.NotNil(t, tlsConfig.RootCAs,
 			"RootCAs must be populated with system CAs (and cluster CA when in-cluster)")
 	})
+}
+
+func TestBuildClusterTLSConfigFromPath(t *testing.T) {
+	t.Run("returns error when logger is nil", func(t *testing.T) {
+		tlsConfig, err := models.BuildClusterTLSConfigFromPath(nil, "/nonexistent")
+		require.Error(t, err)
+		assert.Nil(t, tlsConfig)
+	})
+
+	t.Run("uses system root CAs when CA file is absent", func(t *testing.T) {
+		log := logger.New(true)
+
+		tlsConfig, err := models.BuildClusterTLSConfigFromPath(log, "/nonexistent/ca.crt")
+		require.NoError(t, err)
+		require.NotNil(t, tlsConfig)
+
+		assert.False(t, tlsConfig.InsecureSkipVerify)
+		assert.Equal(t, uint16(tls.VersionTLS12), tlsConfig.MinVersion)
+		assert.NotNil(t, tlsConfig.RootCAs)
+	})
+
+	t.Run("returns error when CA file exists but contains invalid PEM", func(t *testing.T) {
+		log := logger.New(true)
+
+		f, err := os.CreateTemp(t.TempDir(), "ca-*.crt")
+		require.NoError(t, err)
+		_, err = f.WriteString("NOT VALID PEM CONTENT")
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
+
+		tlsConfig, err := models.BuildClusterTLSConfigFromPath(log, f.Name())
+		require.Error(t, err)
+		assert.Nil(t, tlsConfig)
+		assert.Contains(t, err.Error(), "failed to parse")
+	})
+
+	t.Run("returns error when CA file exists but is unreadable", func(t *testing.T) {
+		log := logger.New(true)
+
+		dir := t.TempDir()
+		caPath := filepath.Join(dir, "ca.crt")
+		require.NoError(t, os.WriteFile(caPath, []byte("placeholder"), 0o000))
+		t.Cleanup(func() { _ = os.Chmod(caPath, 0o644) })
+
+		tlsConfig, err := models.BuildClusterTLSConfigFromPath(log, caPath)
+		require.Error(t, err)
+		assert.Nil(t, tlsConfig)
+	})
+
+	t.Run("appends valid CA cert to system pool", func(t *testing.T) {
+		log := logger.New(true)
+
+		certPEM := selfSignedCertPEM(t)
+		f, err := os.CreateTemp(t.TempDir(), "ca-*.crt")
+		require.NoError(t, err)
+		_, err = f.Write(certPEM)
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
+
+		tlsConfig, err := models.BuildClusterTLSConfigFromPath(log, f.Name())
+		require.NoError(t, err)
+		require.NotNil(t, tlsConfig)
+
+		assert.False(t, tlsConfig.InsecureSkipVerify)
+		assert.Equal(t, uint16(tls.VersionTLS12), tlsConfig.MinVersion)
+		assert.NotNil(t, tlsConfig.RootCAs)
+	})
+}
+
+// selfSignedCertPEM generates a minimal self-signed CA certificate in PEM format for use in tests.
+func selfSignedCertPEM(t *testing.T) []byte {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+	}
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
 }

--- a/maas-api/internal/models/discovery_test.go
+++ b/maas-api/internal/models/discovery_test.go
@@ -1,6 +1,7 @@
 package models_test
 
 import (
+	"crypto/tls"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -18,64 +19,28 @@ func TestNewManager(t *testing.T) {
 		assert.Contains(t, err.Error(), "log is required")
 	})
 
-	t.Run("creates manager with valid logger", func(t *testing.T) {
+	t.Run("creates manager successfully with valid logger", func(t *testing.T) {
 		log := logger.New(true)
 
 		manager, err := models.NewManager(log)
 		require.NoError(t, err)
-		assert.NotNil(t, manager)
-	})
-
-	t.Run("manager uses proper TLS configuration", func(t *testing.T) {
-		log := logger.New(true)
-
-		manager, err := models.NewManager(log)
-		require.NoError(t, err)
-		assert.NotNil(t, manager)
-
-		// The manager should be created successfully even when running outside a K8s pod
-		// (falls back to system root CAs). This validates the TLS config doesn't use
-		// InsecureSkipVerify and has proper FIPS-compliant settings.
-	})
-}
-
-func TestManagerHTTPClientTLSConfig(t *testing.T) {
-	t.Run("HTTP client uses TLS 1.2 minimum for FIPS compliance", func(t *testing.T) {
-		log := logger.New(true)
-
-		manager, err := models.NewManager(log)
-		require.NoError(t, err)
-
-		// Access the HTTP client through reflection or exported method
-		// Since httpClient is unexported, we verify through the Manager's behavior
-		// The fact that NewManager succeeds without InsecureSkipVerify proves
-		// the TLS config is properly set up
 		assert.NotNil(t, manager)
 	})
 }
 
-// TestTLSConfigNotInsecure verifies the fix for FIPS-001:
-// TLS Certificate Verification should NOT be disabled.
-func TestTLSConfigNotInsecure(t *testing.T) {
-	t.Run("NewManager does not use InsecureSkipVerify", func(t *testing.T) {
+func TestBuildClusterTLSConfig(t *testing.T) {
+	t.Run("returns secure TLS config", func(t *testing.T) {
 		log := logger.New(true)
 
-		// This test documents the security fix:
-		// Before: tls.Config{InsecureSkipVerify: true} - INSECURE
-		// After:  tls.Config{MinVersion: tls.VersionTLS12, RootCAs: <K8s CA or system>}
-		//
-		// The fix ensures:
-		// 1. TLS certificate validation is enabled (InsecureSkipVerify: false)
-		// 2. Uses Kubernetes service account CA when in-cluster
-		// 3. Falls back to system root CAs when running locally
-		// 4. Minimum TLS version 1.2 for FIPS compliance
-
-		manager, err := models.NewManager(log)
+		tlsConfig, err := models.BuildClusterTLSConfig(log)
 		require.NoError(t, err)
-		assert.NotNil(t, manager)
+		require.NotNil(t, tlsConfig)
 
-		// If InsecureSkipVerify was true, connections to services with
-		// self-signed certs would succeed without proper CA validation.
-		// With the fix, the Kubernetes service account CA is used for validation.
+		assert.False(t, tlsConfig.InsecureSkipVerify,
+			"InsecureSkipVerify must be false for FIPS compliance")
+		assert.Equal(t, uint16(tls.VersionTLS12), tlsConfig.MinVersion,
+			"MinVersion must be TLS 1.2 for FIPS compliance")
+		assert.NotNil(t, tlsConfig.RootCAs,
+			"RootCAs must be populated with system CAs (and cluster CA when in-cluster)")
 	})
 }

--- a/maas-api/internal/models/discovery_test.go
+++ b/maas-api/internal/models/discovery_test.go
@@ -1,0 +1,81 @@
+package models_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/opendatahub-io/models-as-a-service/maas-api/internal/logger"
+	"github.com/opendatahub-io/models-as-a-service/maas-api/internal/models"
+)
+
+func TestNewManager(t *testing.T) {
+	t.Run("returns error when logger is nil", func(t *testing.T) {
+		manager, err := models.NewManager(nil)
+		require.Error(t, err)
+		assert.Nil(t, manager)
+		assert.Contains(t, err.Error(), "log is required")
+	})
+
+	t.Run("creates manager with valid logger", func(t *testing.T) {
+		log := logger.New(true)
+
+		manager, err := models.NewManager(log)
+		require.NoError(t, err)
+		assert.NotNil(t, manager)
+	})
+
+	t.Run("manager uses proper TLS configuration", func(t *testing.T) {
+		log := logger.New(true)
+
+		manager, err := models.NewManager(log)
+		require.NoError(t, err)
+		assert.NotNil(t, manager)
+
+		// The manager should be created successfully even when running outside a K8s pod
+		// (falls back to system root CAs). This validates the TLS config doesn't use
+		// InsecureSkipVerify and has proper FIPS-compliant settings.
+	})
+}
+
+func TestManagerHTTPClientTLSConfig(t *testing.T) {
+	t.Run("HTTP client uses TLS 1.2 minimum for FIPS compliance", func(t *testing.T) {
+		log := logger.New(true)
+
+		manager, err := models.NewManager(log)
+		require.NoError(t, err)
+
+		// Access the HTTP client through reflection or exported method
+		// Since httpClient is unexported, we verify through the Manager's behavior
+		// The fact that NewManager succeeds without InsecureSkipVerify proves
+		// the TLS config is properly set up
+		assert.NotNil(t, manager)
+	})
+}
+
+// TestTLSConfigNotInsecure verifies the fix for FIPS-001:
+// TLS Certificate Verification should NOT be disabled.
+func TestTLSConfigNotInsecure(t *testing.T) {
+	t.Run("NewManager does not use InsecureSkipVerify", func(t *testing.T) {
+		log := logger.New(true)
+
+		// This test documents the security fix:
+		// Before: tls.Config{InsecureSkipVerify: true} - INSECURE
+		// After:  tls.Config{MinVersion: tls.VersionTLS12, RootCAs: <K8s CA or system>}
+		//
+		// The fix ensures:
+		// 1. TLS certificate validation is enabled (InsecureSkipVerify: false)
+		// 2. Uses Kubernetes service account CA when in-cluster
+		// 3. Falls back to system root CAs when running locally
+		// 4. Minimum TLS version 1.2 for FIPS compliance
+
+		manager, err := models.NewManager(log)
+		require.NoError(t, err)
+		assert.NotNil(t, manager)
+
+		// If InsecureSkipVerify was true, connections to services with
+		// self-signed certs would succeed without proper CA validation.
+		// With the fix, the Kubernetes service account CA is used for validation.
+	})
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR fixes the TLS certificate validation issue in the maas-api service where InsecureSkipVerify: true was used for internal gateway calls, bypassing FIPS-certified certificate validation.

**Issue:** The HTTP client used for model discovery/access validation (probing model endpoints to check user access) had TLS certificate verification disabled. This was flagged as [FIPS-001](https://redhat.atlassian.net/browse/FIPS-001) violation during security scanning.

**Before:**
```
TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // cluster-internal only
```
**After:**
```
TLSClientConfig: tlsConfig, // Uses K8s service account CA or system root CAs
```

https://redhat.atlassian.net/browse/RHOAIENG-47769

## How Has This Been Tested?
* Unit Tests 
* Manual Cluster Testing:
  * Built and pushed test image: quay.io/isequeir/maas-api:tls-fix-amd64
  * Deployed to OpenShift cluster in opendatahub namespace
  * Verified pod starts successfully with debug logging enabled
  * Made authenticated requests to /v1/models endpoint
  * Verified HTTPS connections to model endpoints complete successfully (received HTTP 403 auth response, not TLS errors)

  * Confirmed TLS CA loading via log message:
```
  Using Kubernetes service account CA for TLS validation {"path": "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"}
```
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced secure TLS for cluster probes: removed insecure defaults, require TLS 1.2+, prefer the in-cluster service account CA when available, fall back to system roots, and fail initialization if a present cluster CA cannot be parsed. Added debug logging indicating which CA pool was used.

* **Tests**
  * Added tests covering manager initialization and TLS configuration behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->