### PR TITLE
fix: assert single-subscription precondition before auto-select test

### DIFF
--- a/test/e2e/tests/test_subscription.py
+++ b/test/e2e/tests/test_subscription.py
@@ -1902,6 +1902,25 @@ class TestE2ESubscriptionFlow:
             _create_test_subscription(subscription_name, MODEL_REF, users=[sa_user])
             _wait_reconcile()
 
+            # Assert precondition: user must see exactly one subscription for auto-select to work.
+            # On clusters with extra system:authenticated subscriptions this would fail with an
+            # opaque 403 timeout instead of a clear message (see RHOAIENG-57377).
+            subs_r = requests.get(
+                f"{_maas_api_url()}/v1/subscriptions",
+                headers={"Authorization": f"Bearer {oc_token}"},
+                timeout=TIMEOUT,
+                verify=TLS_VERIFY,
+            )
+            assert subs_r.status_code == 200, (
+                f"Failed to list subscriptions: {subs_r.status_code} {subs_r.text[:200]}"
+            )
+            subs = subs_r.json().get("data", [])
+            assert len(subs) == 1, (
+                f"Test requires exactly 1 subscription for auto-select, "
+                f"found {len(subs)}: {[s.get('name') for s in subs]}. "
+                f"Other subscriptions on the cluster may grant system:authenticated access."
+            )
+
             # Exactly one subscription for this user → mint can auto-bind it without explicit name
             api_key = _create_api_key(oc_token, name=f"{sa_name}-key")
 

--- a/test/e2e/tests/test_subscription.py
+++ b/test/e2e/tests/test_subscription.py
@@ -1914,7 +1914,7 @@ class TestE2ESubscriptionFlow:
             assert subs_r.status_code == 200, (
                 f"Failed to list subscriptions: {subs_r.status_code} {subs_r.text[:200]}"
             )
-            subs = subs_r.json().get("data", [])
+            subs = subs_r.json()
             assert len(subs) == 1, (
                 f"Test requires exactly 1 subscription for auto-select, "
                 f"found {len(subs)}: {[s.get('name') for s in subs]}. "


### PR DESCRIPTION
## Summary
- `test_e2e_single_subscription_auto_selects` deletes `simulator-subscription` to ensure the test SA has exactly one subscription, but never verified this assumption
- On clusters with additional `system:authenticated` subscriptions (e.g. deployed by upstream pipelines), auto-bind picks the wrong one and the test fails with an opaque `403` after 90s of polling
- Adds an explicit precondition assertion via `GET /v1/subscriptions` that surfaces the root cause immediately with a descriptive message listing unexpected subscriptions

Ref: [RHOAIENG-57377](https://redhat.atlassian.net/browse/RHOAIENG-57377)

## Test plan
- [x] Run `test_e2e_single_subscription_auto_selects` on a clean cluster — should pass as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end subscription test: adds an explicit pre-check that confirms exactly one subscription is returned before proceeding, and asserts a successful listing response. This makes the test fail earlier and more clearly when extra subscriptions exist, improving reliability and clarity of test outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->