### PR TITLE
chore(docs): document shared HTTPRoute TRLP limitation and cross-links

### DIFF
--- a/docs/content/configuration-and-management/quota-and-access-configuration.md
+++ b/docs/content/configuration-and-management/quota-and-access-configuration.md
@@ -136,6 +136,13 @@ TRLP=$(kubectl get tokenratelimitpolicy -n ${MODEL_NS} -l maas.opendatahub.io/mo
 [[ -n "$TRLP" ]] && kubectl wait --for=condition=Enforced=true tokenratelimitpolicy/${TRLP} -n ${MODEL_NS} --timeout=120s
 ```
 
+!!! warning "Multiple model references on one HTTPRoute"
+    **This limitation affects v3.4 deployments.** More than one **MaaSModelRef** on the same route can break independent per-subscription limits—only one TokenRateLimitPolicy is fully effective while others may show **Overridden**.
+    
+    **Planning guidance:** Prefer **one HTTPRoute per model** when different subscriptions need separate limits. Tier-based route sharing does **not** help if **multiple subscriptions** each need their own limits on that **same** route.
+    
+    See [Subscription limitations and known issues](subscription-known-issues.md#token-rate-limits-when-multiple-model-references-share-one-httproute) for detection commands and workarounds.
+
 !!! note "Namespace requirements"
     Both **MaaSAuthPolicy** and **MaaSSubscription** must be installed in the `models-as-a-service` namespace. Each `modelRefs` entry must specify the `namespace` where the MaaSModelRef lives (e.g. `llm`).
 

--- a/docs/content/configuration-and-management/quota-and-access-configuration.md
+++ b/docs/content/configuration-and-management/quota-and-access-configuration.md
@@ -137,11 +137,11 @@ TRLP=$(kubectl get tokenratelimitpolicy -n ${MODEL_NS} -l maas.opendatahub.io/mo
 ```
 
 !!! warning "Multiple model references on one HTTPRoute"
-    **This limitation affects v3.4 deployments.** More than one **MaaSModelRef** on the same route can break independent per-subscription limits—only one TokenRateLimitPolicy is fully effective while others may show **Overridden**.
-    
-    **Planning guidance:** Prefer **one HTTPRoute per model** when different subscriptions need separate limits. Tier-based route sharing does **not** help if **multiple subscriptions** each need their own limits on that **same** route.
-    
-    See [Subscription limitations and known issues](subscription-known-issues.md#token-rate-limits-when-multiple-model-references-share-one-httproute) for detection commands and workarounds.
+    **This limitation affects v3.4 deployments.** More than one **MaaSModelRef** on the same route can break independent per-subscription limits—only one **TokenRateLimitPolicy** is fully effective at the gateway. For **MaaSSubscription** readiness, the controller checks each TRLP’s **`Accepted`** condition; Kuadrant may still show **`Enforced`** and **`Overridden`** (or similar **`reason`**) when policies conflict on one route.
+
+    **Planning guidance:** Prefer **one HTTPRoute per model** when different subscriptions need separate limits. Putting models on a shared route “by tier” still implies **multiple TRLPs** if **multiple** **MaaSModelRef** resources target that route—it only aligns with this limitation when **every** model on the route is meant to share **one** **MaaSSubscription** (and access policy) story.
+
+    See [Subscription limitations and known issues](subscription-known-issues.md#token-rate-limits-when-multiple-model-references-share-one-httproute) for `kubectl`/`jq` examples and workarounds.
 
 !!! note "Namespace requirements"
     Both **MaaSAuthPolicy** and **MaaSSubscription** must be installed in the `models-as-a-service` namespace. Each `modelRefs` entry must specify the `namespace` where the MaaSModelRef lives (e.g. `llm`).

--- a/docs/content/configuration-and-management/subscription-known-issues.md
+++ b/docs/content/configuration-and-management/subscription-known-issues.md
@@ -1,4 +1,4 @@
-# Subscription Known Issues
+# Subscription limitations and known issues
 
 This document describes known issues and operational considerations for the subscription-based MaaS Platform.
 
@@ -39,6 +39,41 @@ API keys store the user's groups and bound subscription name at creation time. I
 
 - Revoke and recreate API keys when users change groups
 - Use OpenShift tokens for interactive use when group membership changes frequently (tokens reflect live group membership)
+
+## Token Rate Limits when Multiple Model References Share One HTTPRoute
+
+**Impact:** High
+
+**Description:**
+
+When more than one **MaaSModelRef** resolves to the **same** **HTTPRoute**, the controller creates multiple **TokenRateLimitPolicy** resources targeting that route. Kuadrant then **enforces only one** of them in practice (others may show **Overridden**; one **Enforced**), so **per-subscription token limits may not all apply** even though CRs look valid.
+
+**Detection:**
+
+Check for multiple TRLPs targeting the same HTTPRoute:
+
+```bash
+# List TRLPs that target an HTTPRoute (namespace/name → route name)
+kubectl get tokenratelimitpolicy -A -o json | jq -r '.items[] | select(.spec.targetRef.kind=="HTTPRoute") | "\(.metadata.namespace)/\(.metadata.name) → \(.spec.targetRef.name)"' | sort
+
+# Same data plus Enforced condition (needs jq; if this fails, use kubectl describe on each TRLP)
+kubectl get tokenratelimitpolicy -A -o json | jq -r '
+  .items[] | select(.spec.targetRef.kind == "HTTPRoute")
+  | [
+      .metadata.namespace,
+      .metadata.name,
+      .spec.targetRef.name,
+      ((.status.conditions // []) | map(select(.type == "Enforced")) | .[0].status // "?")
+    ] | @tsv'
+```
+
+**How to recognize it:** Several TRLPs share the same `spec.targetRef.name`, with mixed **Overridden** / **Enforced** conditions.
+
+**Workarounds:**
+
+1. **Dedicated routes per model** — Deploy each model with its own HTTPRoute to ensure independent rate limiting
+2. **Shared subscription design** — If models must share routes, use a single subscription that covers all models on that route
+3. **Route consolidation planning** — Group models by subscription tier on shared routes (e.g., all "premium" models on one route, all "free" models on another)
 
 ## Related Documentation
 

--- a/docs/content/configuration-and-management/subscription-known-issues.md
+++ b/docs/content/configuration-and-management/subscription-known-issues.md
@@ -40,43 +40,57 @@ API keys store the user's groups and bound subscription name at creation time. I
 - Revoke and recreate API keys when users change groups
 - Use OpenShift tokens for interactive use when group membership changes frequently (tokens reflect live group membership)
 
-## Token Rate Limits when Multiple Model References Share One HTTPRoute
+## Token rate limits when multiple model references share one HTTPRoute
 
 **Impact:** High
 
 **Description:**
 
-When more than one **MaaSModelRef** resolves to the **same** **HTTPRoute**, the controller creates multiple **TokenRateLimitPolicy** resources targeting that route. Kuadrant then **enforces only one** of them in practice (others may show **Overridden**; one **Enforced**), so **per-subscription token limits may not all apply** even though CRs look valid.
+When more than one **MaaSModelRef** resolves to the **same** **HTTPRoute**, the controller creates multiple **TokenRateLimitPolicy** resources targeting that route. Kuadrant then **enforces only one** of them in practice, so **per-subscription token limits may not all apply** even though CRs look valid.
+
+The **MaaS controller** treats a TRLP as healthy for **MaaSSubscription** status using the Kuadrant **`Accepted`** condition on each `TokenRateLimitPolicy`. Kuadrant also publishes runtime conditions such as **`Enforced`**; when multiple TRLPs conflict on one route you may see **`Enforced`** = True on one policy and **`Overridden`** (or similar) on others—check **`status.conditions`** (and **`reason`** / **`message`**) on each TRLP.
 
 **Detection:**
 
-Check for multiple TRLPs targeting the same HTTPRoute:
+List TRLPs that target an HTTPRoute, then inspect **`Accepted`** (controller readiness) and **`Enforced`** (gateway application):
 
 ```bash
 # List TRLPs that target an HTTPRoute (namespace/name → route name)
 kubectl get tokenratelimitpolicy -A -o json | jq -r '.items[] | select(.spec.targetRef.kind=="HTTPRoute") | "\(.metadata.namespace)/\(.metadata.name) → \(.spec.targetRef.name)"' | sort
 
-# Same data plus Enforced condition (needs jq; if this fails, use kubectl describe on each TRLP)
+# Accepted + Enforced condition status per TRLP (needs jq; if this fails, use kubectl describe on each TRLP)
 kubectl get tokenratelimitpolicy -A -o json | jq -r '
   .items[] | select(.spec.targetRef.kind == "HTTPRoute")
+  | . as $i
+  | (($i.status.conditions // []) | map(select(.type == "Accepted")) | .[0]) as $a
+  | (($i.status.conditions // []) | map(select(.type == "Enforced")) | .[0]) as $e
   | [
-      .metadata.namespace,
-      .metadata.name,
-      .spec.targetRef.name,
-      ((.status.conditions // []) | map(select(.type == "Enforced")) | .[0].status // "?")
+      $i.metadata.namespace,
+      $i.metadata.name,
+      $i.spec.targetRef.name,
+      (($a // {}) | .status // "?"),
+      (($e // {}) | .status // "?"),
+      (($e // {}) | .reason // "")
     ] | @tsv'
 ```
 
-**How to recognize it:** Several TRLPs share the same `spec.targetRef.name`, with mixed **Overridden** / **Enforced** conditions.
+**How to recognize it:** Several TRLPs share the same `spec.targetRef.name`. Compare **`Accepted`** (what the MaaS controller uses for subscription readiness) and **`Enforced`** / **`reason`** (for example **`Overridden`**) on each policy—one route may show one TRLP fully effective and others superseded.
 
 **Workarounds:**
 
 1. **Dedicated routes per model** — Deploy each model with its own HTTPRoute to ensure independent rate limiting
-2. **Shared subscription design** — If models must share routes, use a single subscription that covers all models on that route
-3. **Route consolidation planning** — Group models by subscription tier on shared routes (e.g., all "premium" models on one route, all "free" models on another)
+2. **Shared subscription design** — If models share an **HTTPRoute**, use **one** **MaaSSubscription** that lists every **MaaSModelRef** on that route so you are not applying **different** subscription limits to the same route. The controller may still create **one TRLP per model ref**; **prefer (1)** when each subscription must enforce limits independently until **Tracking** below ships.
+3. **Route consolidation by tier** — **Yes:** if **multiple** **MaaSModelRef** resources still target the **same** **HTTPRoute**, you still get **multiple TRLPs**; grouping models by tier on shared routes does **not** change that by itself. Treat “premium” vs “free” as an operational label only. This pattern is **only** appropriate when **every** model on that shared route is meant to share **one** **MaaSSubscription** and a consistent **MaaSAuthPolicy** access story—**not** when different teams or subscriptions each register their own model refs on one route. If you need **separate** subscriptions with **separate** limits on the same route, use **dedicated routes per model** (1).
+
+**Status in v3.4:**
+
+This limitation **remains in Models-as-a-Service v3.4**. The fix requiring merge strategy support for TokenRateLimitPolicy is not included. Plan your model deployment topology accordingly.
+
+**Tracking:** [opendatahub-io/models-as-a-service#585](https://github.com/opendatahub-io/models-as-a-service/pull/585) proposes the controller change for coexisting token rate limit policies on a shared route.
 
 ## Related Documentation
 
 - [Understanding Token Management](token-management.md)
 - [Access and Quota Overview](subscription-overview.md)
 - [Quota and Access Configuration](quota-and-access-configuration.md)
+- [MaaS Controller Overview](maas-controller-overview.md)

--- a/docs/content/configuration-and-management/token-management.md
+++ b/docs/content/configuration-and-management/token-management.md
@@ -3,7 +3,7 @@
 This guide explains the authentication and credential management used to access models in the MaaS Platform.
 
 !!! tip "API keys (current)"
-    The platform uses **API keys** (`sk-oai-*`) stored in PostgreSQL for programmatic access. Create keys via `POST /v1/api-keys` (authenticate with your OpenShift token) and use them with the `Authorization: Bearer` header. Each key is bound to one MaaSSubscription at creation time (optional `subscription` in the request body; if omitted, the **highest `spec.priority`** subscription you can access is chosen). See [Quota and Access Configuration](quota-and-access-configuration.md) and [Subscription Known Issues](subscription-known-issues.md).
+    The platform uses **API keys** (`sk-oai-*`) stored in PostgreSQL for programmatic access. Create keys via `POST /v1/api-keys` (authenticate with your OpenShift token) and use them with the `Authorization: Bearer` header. Each key is bound to one MaaSSubscription at creation time (optional `subscription` in the request body; if omitted, the **highest `spec.priority`** subscription you can access is chosen). See [Quota and Access Configuration](quota-and-access-configuration.md) and [Subscription limitations and known issues](subscription-known-issues.md).
 
 !!! note "Prerequisites"
     This document assumes you have configured subscriptions (MaaSAuthPolicy, MaaSSubscription).

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -16,11 +16,13 @@ Use this platform to streamline the deployment of your models, monitor usage, an
 ### ⚙️ Configuration & Management
 
 - **[Access and Quota Overview](configuration-and-management/subscription-overview.md)** - Policies (access) and subscriptions (quota) for model access
+- **[Subscription limitations and known issues](configuration-and-management/subscription-known-issues.md)** - Rate limits on shared routes, API keys, caching, and other planning notes
 - **[Model Setup (On Cluster)](configuration-and-management/model-setup.md)** - Setting up models for MaaS
 - **[Self-Service Model Access](user-guide/self-service-model-access.md)** - Managing model access and policies
 
 ### 📋 Release Notes
 
+- **[Release notes](release-notes/index.md)** - Version highlights and known limitations by release
 
 ### 🔧 Advanced Administration
 

--- a/docs/content/install/troubleshooting.md
+++ b/docs/content/install/troubleshooting.md
@@ -44,6 +44,7 @@ This guide helps you diagnose and resolve common issues with MaaS Platform deplo
 5. **Rate limiting not working**: Verify AuthPolicy and TokenRateLimitPolicy are applied
       - [ ] Verify `gateway-rate-limits` RateLimitPolicy is applied
       - [ ] Verify TokenRateLimitPolicy is applied (e.g. gateway-default-deny or per-route policies)
+      - [ ] If **multiple** TokenRateLimitPolicies target the **same** HTTPRoute, see [Subscription limitations and known issues](../configuration-and-management/subscription-known-issues.md#token-rate-limits-when-multiple-model-references-share-one-httproute)
       - [ ] Verify the model is deployed and the `LLMInferenceService` has the `maas-default-gateway` gateway specified
       - [ ] Verify that the model is rate limited by checking the inference endpoint (see [Validation Guide - Test Rate Limiting](validation.md#6-test-rate-limiting))
       - [ ] Verify that the model is token rate limited by checking the inference endpoint (see [Validation Guide - Test Rate Limiting](validation.md#6-test-rate-limiting))

--- a/docs/content/release-notes/index.md
+++ b/docs/content/release-notes/index.md
@@ -8,6 +8,10 @@ Version 3.4.0 introduces new CRDs and API resources that are not compatible with
 
 **Migration:** See the overall migration plan for detailed upgrade instructions from previous versions.
 
+### Known limitations
+
+- **Shared HTTPRoute and token rate limits:** Multiple **MaaSModelRef** resources on the same **HTTPRoute** can yield multiple **TokenRateLimitPolicy** objects, but **only one limit set may be enforced** until the controller change in [opendatahub-io/models-as-a-service#585](https://github.com/opendatahub-io/models-as-a-service/pull/585) is in your build. See [Subscription limitations and known issues](../configuration-and-management/subscription-known-issues.md#token-rate-limits-when-multiple-model-references-share-one-httproute).
+
 ---
 
 ## v0.1.0

--- a/docs/content/release-notes/index.md
+++ b/docs/content/release-notes/index.md
@@ -10,7 +10,7 @@ Version 3.4.0 introduces new CRDs and API resources that are not compatible with
 
 ### Known limitations
 
-- **Shared HTTPRoute and token rate limits:** Multiple **MaaSModelRef** resources on the same **HTTPRoute** can yield multiple **TokenRateLimitPolicy** objects, but **only one limit set may be enforced** until the controller change in [opendatahub-io/models-as-a-service#585](https://github.com/opendatahub-io/models-as-a-service/pull/585) is in your build. See [Subscription limitations and known issues](../configuration-and-management/subscription-known-issues.md#token-rate-limits-when-multiple-model-references-share-one-httproute).
+- **Shared HTTPRoute and token rate limits:** Multiple **MaaSModelRef** resources on the same **HTTPRoute** can yield multiple **TokenRateLimitPolicy** objects, but **only one limit set may be enforced** at the gateway until the controller change in [opendatahub-io/models-as-a-service#585](https://github.com/opendatahub-io/models-as-a-service/pull/585) is in your build. See [Subscription limitations and known issues](../configuration-and-management/subscription-known-issues.md#token-rate-limits-when-multiple-model-references-share-one-httproute).
 
 ---
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -75,7 +75,7 @@ nav:
       - Quota and Access Configuration: configuration-and-management/quota-and-access-configuration.md
       - Token Management: configuration-and-management/token-management.md
       - TLS Configuration: configuration-and-management/tls-configuration.md
-      - Subscription Known Issues: configuration-and-management/subscription-known-issues.md
+      - Subscription limitations & known issues: configuration-and-management/subscription-known-issues.md
     - Models:
       - Model Setup (On Cluster): configuration-and-management/model-setup.md
       - Model Listing Flow: configuration-and-management/model-listing-flow.md


### PR DESCRIPTION
## Description
Documents the **known limitation** when multiple **MaaSModelRef** resources resolve to the **same** **HTTPRoute**: multiple **TokenRateLimitPolicy** objects can target that route, but **only one** is fully effective in practice (others may show **Overridden**), so **per-subscription token limits may not all apply**.

The fix would be merged as a fast follow in 3.5 https://github.com/opendatahub-io/models-as-a-service/pull/585
[RHOAIENG-57602](https://redhat.atlassian.net/browse/RHOAIENG-57602)

## How Has This Been Tested?
- Docs-only change

## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Documentation
* Added a warning and guidance about token rate limit behavior when multiple model references share a single route, and recommended planning to use separate routes for independent subscription limits.
* Expanded the "Subscription limitations and known issues" section with detection commands and practical workarounds.
* Added a known-limitation note to release notes and updated troubleshooting steps and navigation links for easier discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->