### PR TITLE
fix: restore /v1/models rate limiting exemption

### DIFF
--- a/maas-controller/pkg/controller/maas/cross_namespace_test.go
+++ b/maas-controller/pkg/controller/maas/cross_namespace_test.go
@@ -538,7 +538,7 @@ func TestMaaSSubscriptionReconciler_DuplicateNameIsolation(t *testing.T) {
 			if !ok {
 				t.Fatal("predicate is not string")
 			}
-			expectedPredA := `auth.identity.selected_subscription_key == "` + namespaceA + "/" + subscriptionName + "@" + modelNamespace + "/" + modelName + `"`
+			expectedPredA := `auth.identity.selected_subscription_key == "` + namespaceA + "/" + subscriptionName + "@" + modelNamespace + "/" + modelName + `" && !request.path.endsWith("/v1/models")`
 			if pred != expectedPredA {
 				t.Errorf("Tenant-a predicate = %q, want %q", pred, expectedPredA)
 			}
@@ -564,7 +564,7 @@ func TestMaaSSubscriptionReconciler_DuplicateNameIsolation(t *testing.T) {
 			if !ok {
 				t.Fatal("predicate is not string")
 			}
-			expectedPredB := `auth.identity.selected_subscription_key == "` + namespaceB + "/" + subscriptionName + "@" + modelNamespace + "/" + modelName + `"`
+			expectedPredB := `auth.identity.selected_subscription_key == "` + namespaceB + "/" + subscriptionName + "@" + modelNamespace + "/" + modelName + `" && !request.path.endsWith("/v1/models")`
 			if pred != expectedPredB {
 				t.Errorf("Tenant-b predicate = %q, want %q", pred, expectedPredB)
 			}

--- a/maas-controller/pkg/controller/maas/maassubscription_controller.go
+++ b/maas-controller/pkg/controller/maas/maassubscription_controller.go
@@ -471,7 +471,10 @@ func (r *MaaSSubscriptionReconciler) reconcileTRLPForModel(ctx context.Context, 
 			"rates": si.rates,
 			"when": []any{
 				map[string]any{
-					"predicate": fmt.Sprintf(`auth.identity.selected_subscription_key == "%s"`, modelScopedRef),
+					// Exempt /v1/models endpoint from token rate limiting.
+					// This endpoint is used for model discovery/metadata and does not consume inference tokens.
+					// Users should be able to query model capabilities even when their token quota is exhausted.
+					"predicate": fmt.Sprintf(`auth.identity.selected_subscription_key == "%s" && !request.path.endsWith("/v1/models")`, modelScopedRef),
 				},
 			},
 			"counters": []any{

--- a/maas-controller/pkg/controller/maas/maassubscription_controller_test.go
+++ b/maas-controller/pkg/controller/maas/maassubscription_controller_test.go
@@ -778,7 +778,8 @@ func TestMaaSSubscriptionReconciler_SimplifiedTRLP(t *testing.T) {
 	}
 
 	// Predicate now uses model-scoped key: namespace/name@modelNamespace/modelName
-	expected := fmt.Sprintf(`auth.identity.selected_subscription_key == "%s/%s@%s/%s"`, namespace, maasSubName, namespace, modelName)
+	// and exempts /v1/models endpoint from rate limiting
+	expected := fmt.Sprintf(`auth.identity.selected_subscription_key == "%s/%s@%s/%s" && !request.path.endsWith("/v1/models")`, namespace, maasSubName, namespace, modelName)
 	if pred != expected {
 		t.Errorf("predicate = %q, want %q", pred, expected)
 	}
@@ -866,7 +867,8 @@ func TestMaaSSubscriptionReconciler_MultipleSubscriptionsSimplified(t *testing.T
 			t.Fatalf("sub-a predicate not a string: %T", predMap["predicate"])
 		}
 		// Predicate now uses model-scoped key: namespace/name@modelNamespace/modelName
-		expected := fmt.Sprintf(`auth.identity.selected_subscription_key == "%s/sub-a@%s/%s"`, namespace, namespace, modelName)
+		// and exempts /v1/models endpoint from rate limiting
+		expected := fmt.Sprintf(`auth.identity.selected_subscription_key == "%s/sub-a@%s/%s" && !request.path.endsWith("/v1/models")`, namespace, namespace, modelName)
 		if pred != expected {
 			t.Errorf("sub-a predicate = %q, want %q", pred, expected)
 		}
@@ -901,7 +903,8 @@ func TestMaaSSubscriptionReconciler_MultipleSubscriptionsSimplified(t *testing.T
 			t.Fatalf("sub-b predicate not a string: %T", predMap["predicate"])
 		}
 		// Predicate now uses model-scoped key: namespace/name@modelNamespace/modelName
-		expected := fmt.Sprintf(`auth.identity.selected_subscription_key == "%s/sub-b@%s/%s"`, namespace, namespace, modelName)
+		// and exempts /v1/models endpoint from rate limiting
+		expected := fmt.Sprintf(`auth.identity.selected_subscription_key == "%s/sub-b@%s/%s" && !request.path.endsWith("/v1/models")`, namespace, namespace, modelName)
 		if pred != expected {
 			t.Errorf("sub-b predicate = %q, want %q", pred, expected)
 		}

--- a/scripts/deployment-helpers.sh
+++ b/scripts/deployment-helpers.sh
@@ -1488,3 +1488,125 @@ create_maas_db_config_secret() {
     kubectl label --local -f - app=maas-api --dry-run=client -o yaml | \
     kubectl apply -n "$namespace" -f -
 }
+
+# ==========================================
+# Diagnostic Helpers
+# ==========================================
+
+# dump_llmis_diagnostics <llmis_name> <namespace>
+#   Dumps comprehensive diagnostic information when an LLMInferenceService
+#   fails to become ready. Captures pod status, logs, events, and node resources
+#   to help diagnose deployment failures.
+#
+# Usage:
+#   if ! kubectl wait llminferenceservice/my-model --for=condition=Ready; then
+#       dump_llmis_diagnostics "my-model" "llm"
+#   fi
+#
+# Output:
+#   - LLMInferenceService YAML
+#   - Pod status and descriptions
+#   - ReplicaSet/Deployment status
+#   - Container logs (current and previous)
+#   - Namespace events
+#   - Node resource allocation
+dump_llmis_diagnostics() {
+    local llmis_name="$1"
+    local namespace="$2"
+
+    if [[ -z "$llmis_name" || -z "$namespace" ]]; then
+        echo "Usage: dump_llmis_diagnostics <llmis_name> <namespace>"
+        return 1
+    fi
+
+    echo ""
+    echo "=========================================="
+    echo "LLMInferenceService Diagnostics: $llmis_name"
+    echo "=========================================="
+
+    echo ""
+    echo "========== LLMInferenceService Status =========="
+    kubectl get llminferenceservice/"$llmis_name" -n "$namespace" -o yaml 2>&1 || echo "  (failed to get LLMIS)"
+
+    echo ""
+    echo "========== Pod Status =========="
+    # KServe creates resources with pattern: ${llmis_name}-kserve-*
+    # Use name-based filtering since label selectors may not match
+    if kubectl get pods -n "$namespace" 2>/dev/null | grep -q "^${llmis_name}-"; then
+        kubectl get pods -n "$namespace" 2>&1 | grep "^NAME\|^${llmis_name}-" || echo "  (no matching pods found)"
+    else
+        echo "  (no pods found matching pattern: ${llmis_name}-*)"
+    fi
+
+    echo ""
+    echo "========== Pod Descriptions =========="
+    local matching_pods
+    matching_pods=$(kubectl get pods -n "$namespace" --no-headers 2>/dev/null | grep "^${llmis_name}-" | awk '{print $1}')
+    if [[ -n "$matching_pods" ]]; then
+        for pod in $matching_pods; do
+            kubectl describe pod "$pod" -n "$namespace" 2>&1
+            echo ""
+        done
+    else
+        echo "  (no pods found matching pattern: ${llmis_name}-*)"
+    fi
+
+    echo ""
+    echo "========== ReplicaSet Status =========="
+    if kubectl get rs -n "$namespace" 2>/dev/null | grep -q "^${llmis_name}-"; then
+        kubectl get rs -n "$namespace" -o wide 2>&1 | grep "^NAME\|^${llmis_name}-" || echo "  (no matching replicasets found)"
+    else
+        echo "  (no replicasets found matching pattern: ${llmis_name}-*)"
+    fi
+
+    echo ""
+    echo "========== Deployment Status =========="
+    if kubectl get deployment -n "$namespace" 2>/dev/null | grep -q "^${llmis_name}-"; then
+        kubectl get deployment -n "$namespace" -o wide 2>&1 | grep "^NAME\|^${llmis_name}-" || echo "  (no matching deployments found)"
+    else
+        echo "  (no deployments found matching pattern: ${llmis_name}-*)"
+    fi
+
+    echo ""
+    echo "========== Container Logs =========="
+    local pods
+    pods=$(kubectl get pods -n "$namespace" --no-headers 2>/dev/null | grep "^${llmis_name}-" | awk '{print $1}')
+
+    if [[ -z "$pods" ]]; then
+        echo "  (no pods found - container logs unavailable)"
+    else
+        for pod in $pods; do
+            echo ""
+            echo "--- Pod: $pod ---"
+
+            # Try main container
+            echo "Main container (current):"
+            kubectl logs "$pod" -n "$namespace" -c main --tail=100 2>&1 || echo "  (no logs available)"
+
+            echo ""
+            echo "Main container (previous - if crashed):"
+            kubectl logs "$pod" -n "$namespace" -c main --previous --tail=100 2>&1 || echo "  (no previous logs)"
+
+            echo ""
+            echo "Storage initializer container:"
+            kubectl logs "$pod" -n "$namespace" -c storage-initializer --tail=50 2>&1 || echo "  (no logs available)"
+        done
+    fi
+
+    echo ""
+    echo "========== Namespace Events (Recent 100) =========="
+    kubectl get events -n "$namespace" --sort-by='.lastTimestamp' 2>&1 | tail -100 || echo "  (failed to get events)"
+
+    echo ""
+    echo "========== Node Status =========="
+    kubectl get nodes -o wide 2>&1 || echo "  (failed to get nodes)"
+
+    echo ""
+    echo "========== Node Resource Allocation =========="
+    kubectl describe nodes 2>&1 | grep -A 10 "Allocated resources:" || echo "  (failed to get node resources)"
+
+    echo ""
+    echo "=========================================="
+    echo "End of diagnostics for: $llmis_name"
+    echo "=========================================="
+}

--- a/scripts/deployment-helpers.sh
+++ b/scripts/deployment-helpers.sh
@@ -1504,8 +1504,8 @@ create_maas_db_config_secret() {
 #   fi
 #
 # Output:
-#   - LLMInferenceService YAML
-#   - Pod status and descriptions
+#   - LLMInferenceService status (conditions, observedGeneration)
+#   - Pod status (wide format)
 #   - ReplicaSet/Deployment status
 #   - Container logs (current and previous)
 #   - Namespace events
@@ -1526,7 +1526,10 @@ dump_llmis_diagnostics() {
 
     echo ""
     echo "========== LLMInferenceService Status =========="
-    kubectl get llminferenceservice/"$llmis_name" -n "$namespace" -o yaml 2>&1 || echo "  (failed to get LLMIS)"
+    # Only output status (not full YAML) to avoid logging potentially sensitive spec fields
+    kubectl get llminferenceservice/"$llmis_name" -n "$namespace" -o jsonpath='{.status}' 2>&1 | jq -C '.' 2>/dev/null || \
+        kubectl get llminferenceservice/"$llmis_name" -n "$namespace" -o jsonpath='{.status}' 2>&1 || \
+        echo "  (failed to get LLMIS status)"
 
     echo ""
     echo "========== Pod Status =========="
@@ -1534,19 +1537,6 @@ dump_llmis_diagnostics() {
     # Use name-based filtering since label selectors may not match
     if kubectl get pods -n "$namespace" 2>/dev/null | grep -q "^${llmis_name}-"; then
         kubectl get pods -n "$namespace" 2>&1 | grep "^NAME\|^${llmis_name}-" || echo "  (no matching pods found)"
-    else
-        echo "  (no pods found matching pattern: ${llmis_name}-*)"
-    fi
-
-    echo ""
-    echo "========== Pod Descriptions =========="
-    local matching_pods
-    matching_pods=$(kubectl get pods -n "$namespace" --no-headers 2>/dev/null | grep "^${llmis_name}-" | awk '{print $1}')
-    if [[ -n "$matching_pods" ]]; then
-        for pod in $matching_pods; do
-            kubectl describe pod "$pod" -n "$namespace" 2>&1
-            echo ""
-        done
     else
         echo "  (no pods found matching pattern: ${llmis_name}-*)"
     fi
@@ -1570,7 +1560,8 @@ dump_llmis_diagnostics() {
     echo ""
     echo "========== Container Logs =========="
     local pods
-    pods=$(kubectl get pods -n "$namespace" --no-headers 2>/dev/null | grep "^${llmis_name}-" | awk '{print $1}')
+    # Use awk alone to avoid grep exit code 1 when no matches found
+    pods=$(kubectl get pods -n "$namespace" --no-headers 2>/dev/null | awk '/^'"${llmis_name}"'-/ {print $1}')
 
     if [[ -z "$pods" ]]; then
         echo "  (no pods found - container logs unavailable)"

--- a/test/e2e/scripts/prow_run_smoke_test.sh
+++ b/test/e2e/scripts/prow_run_smoke_test.sh
@@ -275,14 +275,12 @@ deploy_models() {
     echo "Waiting for models to be ready (timeout: ${LLMIS_TIMEOUT}s)..."
     if ! oc wait llminferenceservice/facebook-opt-125m-simulated -n llm --for=condition=Ready --timeout="${LLMIS_TIMEOUT}s"; then
         echo "❌ ERROR: Timed out after ${LLMIS_TIMEOUT}s waiting for free simulator to be ready"
-        oc get llminferenceservice/facebook-opt-125m-simulated -n llm -o yaml || true
-        oc get events -n llm --sort-by='.lastTimestamp' || true
+        dump_llmis_diagnostics "facebook-opt-125m-simulated" "llm"
         exit 1
     fi
     if ! oc wait llminferenceservice/premium-simulated-simulated-premium -n llm --for=condition=Ready --timeout="${LLMIS_TIMEOUT}s"; then
         echo "❌ ERROR: Timed out after ${LLMIS_TIMEOUT}s waiting for premium simulator to be ready"
-        oc get llminferenceservice/premium-simulated-simulated-premium -n llm -o yaml || true
-        oc get events -n llm --sort-by='.lastTimestamp' || true
+        dump_llmis_diagnostics "premium-simulated-simulated-premium" "llm"
         exit 1
     fi
     echo "✅ Simulator models ready"

--- a/test/e2e/tests/test_external_models.py
+++ b/test/e2e/tests/test_external_models.py
@@ -146,6 +146,7 @@ def external_models_setup(gateway_url, headers, api_keys_base_url):
         "metadata": {"name": EXTERNAL_MODEL_NAME, "namespace": MODEL_NAMESPACE},
         "spec": {
             "provider": "openai",
+            "targetModel": "gpt-4o",  # Required: upstream model name
             "endpoint": EXTERNAL_ENDPOINT,
             "credentialRef": {
                 "name": f"{EXTERNAL_MODEL_NAME}-api-key",
@@ -190,7 +191,11 @@ def external_models_setup(gateway_url, headers, api_keys_base_url):
         "spec": {
             "owner": {"groups": [{"name": "system:authenticated"}]},
             "modelRefs": [
-                {"name": EXTERNAL_MODEL_NAME, "namespace": MODEL_NAMESPACE},
+                {
+                    "name": EXTERNAL_MODEL_NAME,
+                    "namespace": MODEL_NAMESPACE,
+                    "tokenRateLimits": [{"limit": 1000, "window": "1m"}],
+                },
             ],
         },
     })
@@ -327,6 +332,7 @@ class TestExternalModelCleanup:
             "metadata": {"name": temp_name, "namespace": MODEL_NAMESPACE},
             "spec": {
                 "provider": "openai",
+                "targetModel": "gpt-4o",  # Required: upstream model name
                 "endpoint": EXTERNAL_ENDPOINT,
                 "credentialRef": {
                     "name": f"{EXTERNAL_MODEL_NAME}-api-key",

--- a/test/e2e/tests/test_models_endpoint.py
+++ b/test/e2e/tests/test_models_endpoint.py
@@ -16,6 +16,7 @@ import logging
 import os
 import subprocess
 import time
+import uuid
 
 import pytest
 import requests
@@ -30,14 +31,17 @@ from test_subscription import (
     _delete_cr,
     _delete_sa,
     _get_auth_policies_for_model,
+    _get_cluster_token,
     _get_cr,
     _get_subscriptions_for_model,
+    _inference,
     _maas_api_url,
     _ns,
     _sa_to_user,
     _snapshot_cr,
     _wait_for_maas_auth_policy_ready,
     _wait_for_maas_subscription_ready,
+    _wait_for_token_rate_limit_policy,
     _wait_reconcile,
     DISTINCT_MODEL_ID,
     DISTINCT_MODEL_REF,
@@ -48,6 +52,7 @@ from test_subscription import (
     PREMIUM_MODEL_REF,
     PREMIUM_SIMULATOR_SUBSCRIPTION,
     UNCONFIGURED_MODEL_REF,
+    UNCONFIGURED_MODEL_PATH,
     SIMULATOR_ACCESS_POLICY,
     SIMULATOR_SUBSCRIPTION,
     TIMEOUT,
@@ -2114,3 +2119,130 @@ class TestModelsEndpoint:
             pass
 
         log.info(f"✅ Unauthenticated request → {r.status_code}")
+
+    def test_central_models_endpoint_exempt_from_rate_limiting(self):
+        """
+        Test that the central /v1/models endpoint remains accessible when token quota is exhausted.
+
+        This test validates the end-to-end flow:
+        1. User exhausts token quota with inference requests (gets 429)
+        2. Central /v1/models endpoint is exempt at gateway level (gateway-default-deny TRLP)
+        3. Central endpoint calls model-specific /v1/models endpoints for discovery
+        4. Model-specific endpoints are also exempt (per-route TRLP fix)
+        5. Central endpoint successfully aggregates and returns model list
+
+        This ensures the entire discovery chain works when quota is exhausted.
+
+        Ref: https://issues.redhat.com/browse/RHOAIENG-46770
+        """
+        # Use unconfigured model to isolate this test
+        model_ref = UNCONFIGURED_MODEL_REF
+        model_path = UNCONFIGURED_MODEL_PATH
+
+        # Create unique subscription and auth policy names
+        auth_policy_name = "e2e-central-models-exempt-auth"
+        subscription_name = "e2e-central-models-exempt-sub"
+
+        # Very low limit for fast test: 15 tokens/min with max_tokens=3 per request
+        token_limit = 15
+        window = "1m"
+        max_tokens = 3
+
+        try:
+            # 1. Create auth policy allowing system:authenticated
+            log.info(f"Creating auth policy for {model_ref}")
+            _create_test_auth_policy(
+                name=auth_policy_name,
+                model_refs=[model_ref],
+                groups=["system:authenticated"]
+            )
+            _wait_reconcile()
+
+            # 2. Create subscription with low token limit
+            log.info(f"Creating subscription with {token_limit} token limit")
+            _create_test_subscription(
+                name=subscription_name,
+                model_refs=[model_ref],
+                groups=["system:authenticated"],
+                token_limit=token_limit,
+                window=window
+            )
+            _wait_reconcile()
+
+            # Wait for TRLP to be created and enforced
+            _wait_for_token_rate_limit_policy(model_ref, model_namespace=MODEL_NAMESPACE, timeout=90)
+
+            # 3. Create API key for this subscription
+            oc_token = _get_cluster_token()
+            api_key = _create_api_key(
+                oc_token,
+                name=f"e2e-central-exempt-{uuid.uuid4().hex[:8]}",
+                subscription=subscription_name,
+            )
+
+            # 4. Exhaust the token limit
+            expected_success = token_limit // max_tokens  # 5 requests
+            success_count = 0
+
+            log.info(f"Exhausting token quota: sending {expected_success + 1} requests")
+            for i in range(expected_success + 1):
+                r = _inference(api_key, path=model_path)
+                request_num = i + 1
+                log.info(f"Request {request_num}: {r.status_code}")
+
+                if r.status_code == 200:
+                    success_count += 1
+                elif r.status_code == 429:
+                    log.info(f"Rate limit hit after {success_count} successful requests")
+                    break
+
+            # 5. Verify inference is blocked
+            log.info("Verifying inference endpoint is blocked...")
+            r_inference = _inference(api_key, path=model_path)
+            assert r_inference.status_code == 429, \
+                f"Expected 429 for inference after exhausting tokens, got {r_inference.status_code}"
+            log.info("✓ Inference endpoint correctly blocked with 429")
+
+            # 6. Verify central /v1/models endpoint still works
+            log.info("Verifying central /v1/models endpoint is still accessible...")
+            url = f"{_maas_api_url()}/v1/models"
+            headers = {"Authorization": f"Bearer {api_key}"}
+            r_models = requests.get(url, headers=headers, timeout=TIMEOUT, verify=TLS_VERIFY)
+
+            assert r_models.status_code == 200, \
+                f"Expected 200 for central /v1/models endpoint even when quota exhausted, got {r_models.status_code}. " \
+                f"The central /v1/models endpoint should be exempt from rate limiting (gateway-level) and " \
+                f"should be able to call model-specific /v1/models endpoints (per-route exemption). " \
+                f"Response: {r_models.text[:500]}"
+
+            # 7. Verify response structure and contains our model
+            try:
+                models_data = r_models.json()
+                assert "data" in models_data, \
+                    f"Expected 'data' field in response, got: {list(models_data.keys())}"
+
+                models = models_data["data"]
+                assert isinstance(models, list), "Expected 'data' to be a list"
+
+                # Should include our unconfigured model
+                model_ids = [m.get("id") for m in models]
+                log.info(f"✅ Central /v1/models returned {len(models)} models: {model_ids}")
+
+                # Verify at least one model is present (should be our unconfigured model)
+                assert len(models) >= 1, \
+                    f"Expected at least 1 model in response (our unconfigured model), got {len(models)}"
+
+            except json.JSONDecodeError as e:
+                pytest.fail(f"Central /v1/models response is not valid JSON: {e}. Response: {r_models.text[:500]}")
+
+            log.info("✅ Central /v1/models endpoint works correctly when quota exhausted")
+            log.info("   - Gateway-level exemption: ✓")
+            log.info("   - Model-specific endpoint exemption: ✓")
+            log.info("   - End-to-end discovery flow: ✓")
+
+        finally:
+            # Clean up
+            _delete_cr("maassubscription", subscription_name)
+            _delete_cr("maasauthpolicy", auth_policy_name)
+            _wait_reconcile()
+            log.info("Cleaned up central models endpoint exemption test resources")

--- a/test/e2e/tests/test_models_endpoint.py
+++ b/test/e2e/tests/test_models_endpoint.py
@@ -2237,13 +2237,25 @@ class TestModelsEndpoint:
                 models = models_data["data"]
                 assert isinstance(models, list), "Expected 'data' to be a list"
 
-                # Should include our unconfigured model
+                # Verify at least one model is tied to our test subscription
                 model_ids = [m.get("id") for m in models]
                 log.info(f"✅ Central /v1/models returned {len(models)} models: {model_ids}")
 
-                # Verify at least one model is present (should be our unconfigured model)
-                assert len(models) >= 1, \
-                    f"Expected at least 1 model in response (our unconfigured model), got {len(models)}"
+                # Check that at least one model belongs to our test subscription
+                models_in_our_subscription = []
+                for model in models:
+                    # Models have a subscriptions array with subscription info
+                    model_subs = model.get("subscriptions", [])
+                    for sub in model_subs:
+                        if sub.get("name") == subscription_name:
+                            models_in_our_subscription.append(model.get("id"))
+                            break
+
+                assert len(models_in_our_subscription) >= 1, \
+                    f"Expected at least 1 model tied to subscription '{subscription_name}', " \
+                    f"but found none. Returned models: {model_ids}, subscription: {subscription_name}"
+
+                log.info(f"✓ Found {len(models_in_our_subscription)} model(s) in our subscription: {models_in_our_subscription}")
 
             except json.JSONDecodeError as e:
                 pytest.fail(f"Central /v1/models response is not valid JSON: {e}. Response: {r_models.text[:500]}")

--- a/test/e2e/tests/test_models_endpoint.py
+++ b/test/e2e/tests/test_models_endpoint.py
@@ -2143,10 +2143,12 @@ class TestModelsEndpoint:
         auth_policy_name = "e2e-central-models-exempt-auth"
         subscription_name = "e2e-central-models-exempt-sub"
 
-        # Very low limit for fast test: 15 tokens/min with max_tokens=3 per request
-        token_limit = 15
+        # Very low limit for fast, deterministic test
+        # With 3 token limit and max_tokens=1, we're guaranteed to exhaust quota within 5 requests
+        # (each successful request consumes ≥1 token, so 5 requests > 3 token limit)
+        token_limit = 3
         window = "1m"
-        max_tokens = 3
+        max_tokens = 1
 
         try:
             # 1. Create auth policy allowing system:authenticated
@@ -2157,6 +2159,7 @@ class TestModelsEndpoint:
                 groups=["system:authenticated"]
             )
             _wait_reconcile()
+            _wait_for_maas_auth_policy_ready(auth_policy_name, timeout=90)
 
             # 2. Create subscription with low token limit
             log.info(f"Creating subscription with {token_limit} token limit")
@@ -2168,6 +2171,7 @@ class TestModelsEndpoint:
                 window=window
             )
             _wait_reconcile()
+            _wait_for_maas_subscription_ready(subscription_name, timeout=90)
 
             # Wait for TRLP to be created and enforced
             _wait_for_token_rate_limit_policy(model_ref, model_namespace=MODEL_NAMESPACE, timeout=90)
@@ -2181,11 +2185,14 @@ class TestModelsEndpoint:
             )
 
             # 4. Exhaust the token limit
-            expected_success = token_limit // max_tokens  # 5 requests
+            # With 3 token limit and 5 requests, we're guaranteed to hit the limit
+            # (each successful request consumes ≥1 token, so 5 requests > 3 token limit)
+            max_requests = 5
             success_count = 0
+            rate_limited = False
 
-            log.info(f"Exhausting token quota: sending {expected_success + 1} requests")
-            for i in range(expected_success + 1):
+            log.info(f"Exhausting token quota: sending up to {max_requests} requests")
+            for i in range(max_requests):
                 r = _inference(api_key, path=model_path)
                 request_num = i + 1
                 log.info(f"Request {request_num}: {r.status_code}")
@@ -2194,7 +2201,13 @@ class TestModelsEndpoint:
                     success_count += 1
                 elif r.status_code == 429:
                     log.info(f"Rate limit hit after {success_count} successful requests")
+                    rate_limited = True
                     break
+
+            # Verify we hit rate limit (otherwise test setup is broken)
+            assert rate_limited, \
+                f"Expected to hit rate limit within {max_requests} requests with {token_limit} token limit, " \
+                f"but got {success_count} successful requests without hitting limit"
 
             # 5. Verify inference is blocked
             log.info("Verifying inference endpoint is blocked...")

--- a/test/e2e/tests/test_namespace_scoping.py
+++ b/test/e2e/tests/test_namespace_scoping.py
@@ -27,6 +27,7 @@ import json
 import logging
 import os
 import subprocess
+import time
 import uuid
 from typing import Optional
 

--- a/test/e2e/tests/test_subscription.py
+++ b/test/e2e/tests/test_subscription.py
@@ -1234,14 +1234,12 @@ class TestSubscriptionEnforcement:
         auth_policy_name = "e2e-models-exempt-test-auth"
         subscription_name = "e2e-models-exempt-test-subscription"
 
-        # Very low limit for fast test: 15 tokens/min with max_tokens=3 per request
-        # Expected behavior:
-        #   - Requests 1-5 succeed (use 15 tokens total)
-        #   - Request 6 gets 429 (would need 18 tokens total)
-        #   - /v1/models endpoint still works (not token-based)
-        token_limit = 15
+        # Very low limit for fast, deterministic test
+        # With 3 token limit and max_tokens=1, we're guaranteed to exhaust quota within 5 requests
+        # (even if each request uses exactly 1 token: 5 requests > 3 token limit)
+        token_limit = 3
         window = "1m"
-        max_tokens = 3
+        max_tokens = 1
 
         try:
             # 1. Create auth policy allowing system:authenticated
@@ -1251,6 +1249,7 @@ class TestSubscriptionEnforcement:
                 groups=["system:authenticated"]
             )
             _wait_reconcile()
+            _wait_for_maas_auth_policy_ready(auth_policy_name, timeout=90)
 
             # 2. Create subscription with low token limit
             _create_test_subscription(
@@ -1261,6 +1260,7 @@ class TestSubscriptionEnforcement:
                 window=window
             )
             _wait_reconcile()
+            _wait_for_maas_subscription_ready(subscription_name, timeout=90)
 
             # Wait for TRLP to be created AND enforced by Kuadrant/Limitador
             _wait_for_token_rate_limit_policy(model_ref, model_namespace=MODEL_NAMESPACE, timeout=90)
@@ -1274,24 +1274,32 @@ class TestSubscriptionEnforcement:
             )
 
             # 4. Exhaust the token limit
-            # Calculate expected successful requests: token_limit / max_tokens = 15 / 3 = 5
-            expected_success = token_limit // max_tokens
+            # With 3 token limit and 5 requests, we're guaranteed to hit the limit
+            # (each successful request consumes ≥1 token, so 5 requests > 3 token limit)
+            max_requests = 5
             success_count = 0
+            rate_limited = False
 
-            log.info(f"Exhausting token quota: sending {expected_success + 1} requests to use {token_limit} tokens")
-            for i in range(expected_success + 1):
+            log.info(f"Exhausting token quota: sending up to {max_requests} requests")
+            for i in range(max_requests):
                 r = _inference(api_key, path=model_path)
                 request_num = i + 1
-                log.info(f"Exhausting quota: Request {request_num}, status {r.status_code}")
+                log.info(f"Request {request_num}: status {r.status_code}")
 
                 if r.status_code == 200:
                     success_count += 1
                 elif r.status_code == 429:
                     log.info(f"Rate limit hit after {success_count} successful requests")
+                    rate_limited = True
                     break
                 else:
                     # Unexpected status during exhaustion
                     log.warning(f"Unexpected status during quota exhaustion: {r.status_code}")
+
+            # Verify we hit rate limit (otherwise test setup is broken)
+            assert rate_limited, \
+                f"Expected to hit rate limit within {max_requests} requests with {token_limit} token limit, " \
+                f"but got {success_count} successful requests without hitting limit"
 
             # 5. Verify inference is now blocked with 429
             log.info("Verifying inference endpoint is blocked...")
@@ -1315,12 +1323,14 @@ class TestSubscriptionEnforcement:
             # Verify it returns valid model metadata (sanity check)
             try:
                 models_data = r_models.json()
+            except (json.JSONDecodeError, ValueError) as e:
+                # Non-JSON response is acceptable for some vLLM versions
+                log.info(f"✓ /v1/models endpoint accessible (200), non-JSON response: {r_models.text[:200]}")
+            else:
+                # JSON response - validate structure
                 assert "data" in models_data or "object" in models_data, \
                     f"Expected valid models response with 'data' or 'object' field, got: {models_data}"
                 log.info(f"✓ /v1/models endpoint accessible (200) despite exhausted quota. Response keys: {list(models_data.keys())}")
-            except Exception as e:
-                # Non-JSON response is also acceptable for some vLLM versions
-                log.info(f"✓ /v1/models endpoint accessible (200), response: {r_models.text[:200]}")
 
         finally:
             # Clean up

--- a/test/e2e/tests/test_subscription.py
+++ b/test/e2e/tests/test_subscription.py
@@ -1210,6 +1210,125 @@ class TestSubscriptionEnforcement:
             _wait_reconcile()
             log.info("Cleaned up rate limit test resources")
 
+    def test_models_endpoint_exempt_from_rate_limiting(self):
+        """
+        Test that /v1/models endpoint remains accessible when token quota is exhausted.
+
+        This verifies that users can discover model capabilities even when they've
+        used all their inference tokens. The /v1/models endpoint is a discovery/metadata
+        endpoint that does not consume tokens and should remain accessible.
+
+        Ref: https://issues.redhat.com/browse/RHOAIENG-46770
+
+        Test steps:
+        1. Create subscription with very low token limit (15 tokens)
+        2. Exhaust the limit with inference requests (5 requests × 3 tokens = 15)
+        3. Verify inference requests get 429 (rate limited)
+        4. Verify /v1/models endpoint still returns 200 (not rate limited)
+        """
+        # Use unconfigured model to isolate this test
+        model_ref = UNCONFIGURED_MODEL_REF
+        model_path = UNCONFIGURED_MODEL_PATH
+
+        # Create unique subscription and auth policy names
+        auth_policy_name = "e2e-models-exempt-test-auth"
+        subscription_name = "e2e-models-exempt-test-subscription"
+
+        # Very low limit for fast test: 15 tokens/min with max_tokens=3 per request
+        # Expected behavior:
+        #   - Requests 1-5 succeed (use 15 tokens total)
+        #   - Request 6 gets 429 (would need 18 tokens total)
+        #   - /v1/models endpoint still works (not token-based)
+        token_limit = 15
+        window = "1m"
+        max_tokens = 3
+
+        try:
+            # 1. Create auth policy allowing system:authenticated
+            _create_test_auth_policy(
+                name=auth_policy_name,
+                model_refs=[model_ref],
+                groups=["system:authenticated"]
+            )
+            _wait_reconcile()
+
+            # 2. Create subscription with low token limit
+            _create_test_subscription(
+                name=subscription_name,
+                model_refs=[model_ref],
+                groups=["system:authenticated"],
+                token_limit=token_limit,
+                window=window
+            )
+            _wait_reconcile()
+
+            # Wait for TRLP to be created AND enforced by Kuadrant/Limitador
+            _wait_for_token_rate_limit_policy(model_ref, model_namespace=MODEL_NAMESPACE, timeout=90)
+
+            # 3. Create API key for this subscription
+            oc_token = _get_cluster_token()
+            api_key = _create_api_key(
+                oc_token,
+                name=f"e2e-models-exempt-{uuid.uuid4().hex[:8]}",
+                subscription=subscription_name,
+            )
+
+            # 4. Exhaust the token limit
+            # Calculate expected successful requests: token_limit / max_tokens = 15 / 3 = 5
+            expected_success = token_limit // max_tokens
+            success_count = 0
+
+            log.info(f"Exhausting token quota: sending {expected_success + 1} requests to use {token_limit} tokens")
+            for i in range(expected_success + 1):
+                r = _inference(api_key, path=model_path)
+                request_num = i + 1
+                log.info(f"Exhausting quota: Request {request_num}, status {r.status_code}")
+
+                if r.status_code == 200:
+                    success_count += 1
+                elif r.status_code == 429:
+                    log.info(f"Rate limit hit after {success_count} successful requests")
+                    break
+                else:
+                    # Unexpected status during exhaustion
+                    log.warning(f"Unexpected status during quota exhaustion: {r.status_code}")
+
+            # 5. Verify inference is now blocked with 429
+            log.info("Verifying inference endpoint is blocked...")
+            r_inference = _inference(api_key, path=model_path)
+            assert r_inference.status_code == 429, \
+                f"Expected 429 for inference after exhausting tokens, got {r_inference.status_code}. " \
+                f"Response: {r_inference.text[:500]}"
+            log.info("✓ Inference endpoint correctly blocked with 429")
+
+            # 6. Verify /v1/models endpoint is still accessible with 200
+            log.info("Verifying /v1/models endpoint is still accessible...")
+            url = f"{_gateway_url()}{model_path}/v1/models"
+            headers = {"Authorization": f"Bearer {api_key}"}
+            r_models = requests.get(url, headers=headers, timeout=TIMEOUT, verify=TLS_VERIFY)
+
+            assert r_models.status_code == 200, \
+                f"Expected 200 for /v1/models endpoint even when quota exhausted, got {r_models.status_code}. " \
+                f"The /v1/models endpoint does not consume tokens and should remain accessible. " \
+                f"Response: {r_models.text[:500]}"
+
+            # Verify it returns valid model metadata (sanity check)
+            try:
+                models_data = r_models.json()
+                assert "data" in models_data or "object" in models_data, \
+                    f"Expected valid models response with 'data' or 'object' field, got: {models_data}"
+                log.info(f"✓ /v1/models endpoint accessible (200) despite exhausted quota. Response keys: {list(models_data.keys())}")
+            except Exception as e:
+                # Non-JSON response is also acceptable for some vLLM versions
+                log.info(f"✓ /v1/models endpoint accessible (200), response: {r_models.text[:200]}")
+
+        finally:
+            # Clean up
+            _delete_cr("maassubscription", subscription_name)
+            _delete_cr("maasauthpolicy", auth_policy_name)
+            _wait_reconcile()
+            log.info("Cleaned up models endpoint exemption test resources")
+
 
 class TestMultipleSubscriptionsPerModel:
     """Multiple subscriptions for one model — API key in ONE subscription should get access.


### PR DESCRIPTION
## Description

https://redhat.atlassian.net/browse/RHOAIENG-57627

The /v1/models endpoint exemption was lost during the migration from tier-based to subscription-based rate limiting. This caused model discovery endpoints to be blocked when users exhausted their token quota, even though these endpoints don't consume inference tokens.

This restores the original behavior from commit 660f4db by adding `!request.path.endsWith("/v1/models")` to the per-route TokenRateLimitPolicy predicates.

Changes:
- Add path exemption to TRLP when clause in maassubscription_controller.go
- Add E2E test for per-model /v1/models endpoints (test_subscription.py)
- Add E2E test for central /v1/models endpoint aggregation (test_models_endpoint.py)

## How Has This Been Tested?
Both tests validate that:
1. Inference requests are blocked (429) when quota exhausted
2. /v1/models endpoints remain accessible (200) when quota exhausted

This is a regression from the tier system removal. The original issue was [RHOAIENG-46770](https://redhat.atlassian.net/browse/RHOAIENG-46770) (resolved in tier-based system).


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Token-based subscription rate limiting now exempts the /v1/models endpoint so model discovery remains accessible when a subscription's token quota is exhausted.

* **Tests**
  * Added e2e tests confirming inference is blocked after quota exhaustion while GET /v1/models still returns 200 and valid listings; updated test expectations and cleanup to reflect the exemption.

* **Chores**
  * Added a diagnostics helper for LLM inference service artifacts and integrated it into smoke-test timeout diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->