### PR TITLE
fix: patch params.env for custom image injection in kustomize mode

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -555,44 +555,6 @@ main() {
     log_info "  Subscription controller ready."
     log_info "  Create MaaSModelRef, MaaSAuthPolicy, and MaaSSubscription to enable per-model auth and rate limiting."
 
-    # When using a custom controller image, annotate deployment to prevent operator reconciliation
-    # and patch the deployment with the custom image
-    if [[ -n "${MAAS_CONTROLLER_IMAGE:-}" ]]; then
-      # Log the current image before patching
-      local actual_image
-      actual_image=$(kubectl get deployment/maas-controller -n "$NAMESPACE" -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null || echo "")
-      log_info "  Controller image before patch: $actual_image"
-      log_info "  Expected image: $MAAS_CONTROLLER_IMAGE"
-      
-      # Step 1: Annotate to prevent operator from reverting our changes
-      log_info "  Annotating maas-controller deployment to prevent operator reconciliation..."
-      kubectl annotate deployment/maas-controller -n "$NAMESPACE" \
-        opendatahub.io/managed="false" --overwrite 2>/dev/null || true
-      
-      # Step 2: Patch the deployment with the custom image
-      if [[ "$actual_image" != "$MAAS_CONTROLLER_IMAGE" ]]; then
-        log_info "  Patching maas-controller with custom image: $MAAS_CONTROLLER_IMAGE"
-        kubectl set image deployment/maas-controller -n "$NAMESPACE" \
-          manager="$MAAS_CONTROLLER_IMAGE"
-        
-        # Wait for rollout to complete
-        log_info "  Waiting for controller rollout..."
-        if ! kubectl rollout status deployment/maas-controller -n "$NAMESPACE" --timeout="${ROLLOUT_TIMEOUT}s"; then
-          log_warn "  Controller rollout did not complete in time (timeout: ${ROLLOUT_TIMEOUT}s)"
-        fi
-      fi
-      
-      # Step 3: Verify the controller is running the expected image
-      actual_image=$(kubectl get deployment/maas-controller -n "$NAMESPACE" -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null || echo "")
-      if [[ "$actual_image" == "$MAAS_CONTROLLER_IMAGE" ]]; then
-        log_info "  ✓ Controller image verified: $actual_image"
-      else
-        log_warn "  WARNING: Controller may not be running the expected image!"
-        log_warn "    Expected: $MAAS_CONTROLLER_IMAGE"
-        log_warn "    Actual:   $actual_image"
-      fi
-    fi
-
     # Patch controller with correct audience for HyperShift/ROSA clusters.
     # The controller creates AuthPolicies with kubernetesTokenReview.audiences;
     # on non-standard clusters the default audience (https://kubernetes.default.svc)
@@ -609,8 +571,15 @@ main() {
     fi
   fi
 
+  log_info "MaaS API and MaaS Controller deployment completed successfully!"
+  local deployed_api_image deployed_ctrl_image
+  deployed_api_image=$(kubectl get deployment/maas-api -n "$NAMESPACE" -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null || echo "unknown")
+  deployed_ctrl_image=$(kubectl get deployment/maas-controller -n "$NAMESPACE" -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null || echo "unknown")
+  log_info "  maas-api image:        $deployed_api_image"
+  log_info "  maas-controller image: $deployed_ctrl_image"
+
   log_info "==================================================="
-  log_info "  Deployment completed successfully!"
+  log_info "  Models-as-a-Service Deployment completed successfully!"
   log_info "==================================================="
 }
 

--- a/scripts/deployment-helpers.sh
+++ b/scripts/deployment-helpers.sh
@@ -739,6 +739,29 @@ find_project_root() {
   fi
 }
 
+# _patch_params_env key value project_root
+#   Patches a key=value line in params.env. Creates a backup on first call.
+_patch_params_env() {
+  local key="$1" value="$2" project_root="$3"
+  export _MAAS_PARAMS_ENV="$project_root/deployment/overlays/odh/params.env"
+  [ -f "$_MAAS_PARAMS_ENV" ] || return 0
+  export _MAAS_PARAMS_ENV_BACKUP="${_MAAS_PARAMS_ENV}.backup"
+  if [ ! -f "$_MAAS_PARAMS_ENV_BACKUP" ]; then
+    cp "$_MAAS_PARAMS_ENV" "$_MAAS_PARAMS_ENV_BACKUP"
+  fi
+  local sed_cmd="sed"
+  [[ "$(uname -s)" == "Darwin" ]] && sed_cmd="gsed"
+  $sed_cmd -i "s|^${key}=.*|${key}=${value}|" "$_MAAS_PARAMS_ENV"
+}
+
+# _cleanup_params_env
+#   Restores params.env from backup. Safe to call multiple times.
+_cleanup_params_env() {
+  if [ -n "${_MAAS_PARAMS_ENV_BACKUP:-}" ] && [ -f "$_MAAS_PARAMS_ENV_BACKUP" ]; then
+    mv -f "$_MAAS_PARAMS_ENV_BACKUP" "$_MAAS_PARAMS_ENV" 2>/dev/null || true
+  fi
+}
+
 # set_maas_api_image
 #   Sets the MaaS API container image in base kustomization using MAAS_API_IMAGE env var.
 #   If MAAS_API_IMAGE is not set, does nothing.
@@ -774,15 +797,20 @@ set_maas_api_image() {
     mv -f "$_MAAS_API_BACKUP" "$_MAAS_API_KUSTOMIZATION" 2>/dev/null || true
     return 1
   }
+
+  # Patch params.env — kustomize replacements in shared-patches read from this
+  # file and override the base images: transformer set above.
+  _patch_params_env "maas-api-image" "$MAAS_API_IMAGE" "$project_root"
 }
 
 # cleanup_maas_api_image
-#   Restores the original kustomization.yaml from backup.
+#   Restores the original kustomization.yaml and params.env from backup.
 #   Safe to call even if set_maas_api_image was not called or MAAS_API_IMAGE was not set.
 cleanup_maas_api_image() {
   if [ -n "${_MAAS_API_BACKUP:-}" ] && [ -f "$_MAAS_API_BACKUP" ]; then
     mv -f "$_MAAS_API_BACKUP" "$_MAAS_API_KUSTOMIZATION" 2>/dev/null || true
   fi
+  _cleanup_params_env
 }
 
 # set_maas_controller_image
@@ -817,15 +845,20 @@ set_maas_controller_image() {
     mv -f "$_MAAS_CONTROLLER_BACKUP" "$_MAAS_CONTROLLER_KUSTOMIZATION" 2>/dev/null || true
     return 1
   }
+
+  # Patch params.env — kustomize replacements in shared-patches read from this
+  # file and override the base images: transformer set above.
+  _patch_params_env "maas-controller-image" "$MAAS_CONTROLLER_IMAGE" "$project_root"
 }
 
 # cleanup_maas_controller_image
-#   Restores the original controller kustomization.yaml from backup.
+#   Restores the original controller kustomization.yaml and params.env from backup.
 #   Safe to call even if set_maas_controller_image was not called or MAAS_CONTROLLER_IMAGE was not set.
 cleanup_maas_controller_image() {
   if [ -n "${_MAAS_CONTROLLER_BACKUP:-}" ] && [ -f "$_MAAS_CONTROLLER_BACKUP" ]; then
     mv -f "$_MAAS_CONTROLLER_BACKUP" "$_MAAS_CONTROLLER_KUSTOMIZATION" 2>/dev/null || true
   fi
+  _cleanup_params_env
 }
 
 # set_overlay_namespace overlay_dir namespace


### PR DESCRIPTION
## Summary

Fix `MAAS_API_IMAGE` and `MAAS_CONTROLLER_IMAGE` env vars being silently ignored during kustomize-mode deployments, causing CI to always deploy `latest` instead of PR images.

## Description

### Problem

When deploying MaaS via kustomize mode (used by Konflux CI and `prow_run_smoke_test.sh`), the `MAAS_API_IMAGE` environment variable was silently overridden. The deploy script logged the correct PR image, but the pod always ended up running `latest`:

```
# Logs showed correct image:
Using custom MaaS API image: quay.io/opendatahub/maas-api:odh-pr-721

# But the pod had:
image: quay.io/opendatahub/maas-api:latest
```

### Root Cause

The `shared-patches` kustomize component uses `replacements:` to set container images from `params.env`. But `set_maas_api_image()` and `set_maas_controller_image()` were only patching the base `images:` transformer in `kustomization.yaml`.

Kustomize processes `images:` transformers **before** `replacements:`, so `params.env` (hardcoded to `latest`) always overwrote the custom image. This regression was introduced when the `shared-patches` component was added to centralize overlay configuration.

The maas-controller was not visibly affected because `deploy.sh` had a post-apply `kubectl set image` workaround that corrected the image after kustomize had already applied it with the wrong tag. maas-api had no such workaround.

### Fix

- Add `_patch_params_env` helper to patch `params.env` with custom image values before `kustomize build`, so replacements pick up the correct image.
- Call `_patch_params_env` from both `set_maas_api_image` and `set_maas_controller_image` after the existing base kustomization patching.
- Add `_cleanup_params_env` to restore `params.env` from backup after build.
- Remove the post-apply `kubectl set image` workaround for maas-controller in `deploy.sh` since `params.env` now carries the correct image through the kustomize build pipeline.
- Log deployed maas-api and maas-controller images at end of deployment for easier verification.

## How it was tested

- Verified locally that `kustomize build` with the old approach (patching base `images:` transformer) still produces `latest` — confirming the bug.
- Verified locally that `kustomize build` with the fix (patching `params.env`) produces the correct custom image.
- Tested both `tls-backend` and `http-backend` overlays — both produce correct images.
- Verified operator mode is unaffected (base `images:` transformer still works for direct base builds).
- Verified default behavior (no env var set) still produces `latest`.
- Verified `params.env` is restored from backup after deployment (no leftover `.backup` file).
- Deployed on a live cluster with `MAAS_API_IMAGE` and `MAAS_CONTROLLER_IMAGE` set — both pods running correct PR images.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Deployment now always logs the live container images for key services to help verification and troubleshooting, with safe fallbacks when data is missing.
  * Image update operations also persistently update deployment configuration so chosen images remain synchronized across tools and are cleanly restored during cleanup.
  * Final completion message changed to “Models-as-a-Service Deployment completed successfully!” to reflect branding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->