### PR TITLE
feat: enable group testing for MaaS components

### DIFF
--- a/.tekton/maas-group-test.yaml
+++ b/.tekton/maas-group-test.yaml
@@ -1,0 +1,49 @@
+---
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/models-as-a-service?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "group-test"
+    pipelinesascode.tekton.dev/on-comment: "^/group-test"
+  name: maas-group-test
+  namespace: open-data-hub-tenant
+  labels:
+    appstudio.openshift.io/application: group-testing
+    appstudio.openshift.io/component: maas-group
+    pipelines.appstudio.openshift.io/type: test
+spec:
+  params:
+  - name: group-components
+    value: '{ "odh-maas-api-ci": "opendatahub/maas-api", "odh-maas-controller-ci": "opendatahub/maas-controller" }'
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/opendatahub-io/odh-konflux-central.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: integration-tests/models-as-a-service/pr-group-testing-pipeline.yaml
+  taskRunTemplate:
+    podTemplate:
+      nodeSelector:
+        konflux-ci.dev/workload: konflux-tenants
+      tolerations:
+      - effect: NoSchedule
+        key: konflux-ci.dev/workload
+        operator: Equal
+        value: konflux-tenants
+    serviceAccountName: konflux-integration-runner
+  timeouts:
+    pipeline: 4h0m0s
+    tasks: 3h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/.tekton/odh-maas-api-pull-request.yaml
+++ b/.tekton/odh-maas-api-pull-request.yaml
@@ -36,6 +36,8 @@ spec:
     - 'odh-pr-{{revision}}'
   - name: pipeline-type
     value: pull-request
+  - name: enable-group-testing
+    value: "true"
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-maas-controller-pull-request.yaml
+++ b/.tekton/odh-maas-controller-pull-request.yaml
@@ -36,6 +36,8 @@ spec:
     - 'odh-pr-{{revision}}'
   - name: pipeline-type
     value: pull-request
+  - name: enable-group-testing
+    value: "true"
   pipelineRef:
     resolver: git
     params:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,7 +70,7 @@ This project uses two CI systems: **Konflux** (Tekton-based) for container image
 
 ### Konflux / Tekton pipelines
 
-Konflux builds multi-arch container images (x86_64, arm64, ppc64le, s390x) for both `maas-api` and `maas-controller` on every PR and push to `main`. Pipeline definitions live in `.tekton/` and reference a shared pipeline from [odh-konflux-central](https://github.com/opendatahub-io/odh-konflux-central) (`pipeline/multi-arch-container-build.yaml`). For a full overview of the ODH Konflux CI infrastructure (builds, integration test scenarios, group testing, must-gather), see the [ODH Konflux ITS Infrastructure](https://docs.google.com/document/d/11DcaZSOlg2sdcfE_P_VZVx_gOnNkJJyugPYrY8hpKbk/edit?tab=t.0) document.
+Konflux builds multi-arch container images (x86_64, arm64, ppc64le, s390x) for both `maas-api` and `maas-controller` on every PR and push to `main`. Pipeline definitions live in `.tekton/` and reference a shared pipeline from [odh-konflux-central](https://github.com/opendatahub-io/odh-konflux-central) (`pipeline/multi-arch-container-build.yaml`).
 
 | Pipeline | Trigger | Output image |
 |----------|---------|--------------|
@@ -80,8 +80,6 @@ Konflux builds multi-arch container images (x86_64, arm64, ppc64le, s390x) for b
 | `odh-maas-controller-on-push` | Push to `main` | `quay.io/opendatahub/maas-controller:odh-stable` |
 
 **Integration tests (e2e):** When a PR build completes, Konflux runs an integration test that provisions an ephemeral OpenShift cluster (HyperShift on AWS), deploys the ODH stack with the newly built images, and runs `test/e2e/scripts/prow_run_smoke_test.sh`. This is defined in `odh-konflux-central` under `integration-tests/models-as-a-service/`.
-
-**Group testing:** Because both `maas-api` and `maas-controller` are built from this mono-repo, group testing ensures e2e tests run with both images built from the same PR commit. After all component builds complete, a `/group-test` comment is automatically posted on the PR, triggering a combined test run.
 
 **Docs-only skip:** PRs that only touch documentation files (`docs/**` or `**/*.md`) skip the Konflux build pipelines and integration tests entirely. This is controlled via a CEL expression in the `.tekton/` pipeline definitions.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,7 +70,7 @@ This project uses two CI systems: **Konflux** (Tekton-based) for container image
 
 ### Konflux / Tekton pipelines
 
-Konflux builds multi-arch container images (x86_64, arm64, ppc64le, s390x) for both `maas-api` and `maas-controller` on every PR and push to `main`. Pipeline definitions live in `.tekton/` and reference a shared pipeline from [odh-konflux-central](https://github.com/opendatahub-io/odh-konflux-central) (`pipeline/multi-arch-container-build.yaml`).
+Konflux builds multi-arch container images (x86_64, arm64, ppc64le, s390x) for both `maas-api` and `maas-controller` on every PR and push to `main`. Pipeline definitions live in `.tekton/` and reference a shared pipeline from [odh-konflux-central](https://github.com/opendatahub-io/odh-konflux-central) (`pipeline/multi-arch-container-build.yaml`). For a full overview of the ODH Konflux CI infrastructure (builds, integration test scenarios, group testing, must-gather), see the [ODH Konflux ITS Infrastructure](https://docs.google.com/document/d/11DcaZSOlg2sdcfE_P_VZVx_gOnNkJJyugPYrY8hpKbk/edit?tab=t.0) document.
 
 | Pipeline | Trigger | Output image |
 |----------|---------|--------------|
@@ -80,6 +80,8 @@ Konflux builds multi-arch container images (x86_64, arm64, ppc64le, s390x) for b
 | `odh-maas-controller-on-push` | Push to `main` | `quay.io/opendatahub/maas-controller:odh-stable` |
 
 **Integration tests (e2e):** When a PR build completes, Konflux runs an integration test that provisions an ephemeral OpenShift cluster (HyperShift on AWS), deploys the ODH stack with the newly built images, and runs `test/e2e/scripts/prow_run_smoke_test.sh`. This is defined in `odh-konflux-central` under `integration-tests/models-as-a-service/`.
+
+**Group testing:** Because both `maas-api` and `maas-controller` are built from this mono-repo, group testing ensures e2e tests run with both images built from the same PR commit. After all component builds complete, a `/group-test` comment is automatically posted on the PR, triggering a combined test run.
 
 **Docs-only skip:** PRs that only touch documentation files (`docs/**` or `**/*.md`) skip the Konflux build pipelines and integration tests entirely. This is controlled via a CEL expression in the `.tekton/` pipeline definitions.
 


### PR DESCRIPTION
## Summary
- Enable group testing so that e2e tests run with both `maas-api` and `maas-controller` images built from the same PR commit
- Previously, per-component Konflux snapshots meant each integration test had one image from the PR and the other from the main branch

## Changes
- **`.tekton/odh-maas-api-pull-request.yaml`** — add `enable-group-testing: "true"`
- **`.tekton/odh-maas-controller-pull-request.yaml`** — add `enable-group-testing: "true"`
- **`.tekton/maas-group-test.yaml`** (new) — group test PipelineRun triggered by `/group-test` comment after all builds complete

## How it works
1. PR opened on `models-as-a-service` → both component builds triggered
2. Each build's `trigger-group-testing` finally task checks if all other Konflux checks are completed
3. The last build to complete posts `/group-test` comment on the PR
4. PAC matches the comment and triggers the `maas-group-test` PipelineRun
5. `generate-snapshot-for-group-testing` creates a composite snapshot with both PR-built images (using `odh-pr-{PR_NUMBER}` tags)
6. e2e tests run with correct `MAAS_API_IMAGE` and `MAAS_CONTROLLER_IMAGE` from the same commit

## Dependencies
- Requires opendatahub-io/odh-konflux-central#241 to be merged first (registers `maas-group` Component and the group testing Pipeline)

## Test plan
- [ ] Merge opendatahub-io/odh-konflux-central#241 first
- [ ] Wait for gitops sync (maas-group Component lands in Konflux)
- [ ] Merge this PR
- [ ] Open a test PR on this repo
- [ ] Verify both builds complete and `/group-test` comment is posted automatically
- [ ] Verify `maas-group-test` PipelineRun is created and e2e tests pass with both correct images

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added new group testing pipeline for comprehensive validation of models-as-a-service component groups
  * Enabled group testing parameter in pull request workflows for API and controller services
  * Implemented dedicated integration testing infrastructure to support component group validation scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->