### PR TITLE
chore: add MaaS component metadata for operator prefetched manifests

### DIFF
--- a/deployment/component_metadata.yaml
+++ b/deployment/component_metadata.yaml
@@ -1,0 +1,4 @@
+releases:
+  - name: ModelsAsService
+    version: v0.1.1
+    repoUrl: https://github.com/opendatahub-io/models-as-a-service/


### PR DESCRIPTION
## Summary
Add `component_metadata.yaml` under `deployment/` for the MaaS component, aligning with the pattern used by other components (KServe, DSP, TrustyAI, etc.).

## Context
The operator's `get_all_manifests.sh` pulls the `deployment/` folder into `opt/manifests/maas/` at build time. This file will be available for the operator's releases status action when it's enabled for MaaS.

**Note:** The releases action in `modelsasservice_controller.go` is currently commented out (TODO). When enabled, it will need `WithMetadataFilePath` pointing to the `maas` ContextDir since the default lookup uses lowercase Kind (`modelsasservice`).

## Test plan
- [x] File follows the same format as other components (KServe, DSP, etc.)
- [x] No runtime behavior change (releases action not yet enabled)

Ref: [RHOAIENG-57776](https://redhat.atlassian.net/browse/RHOAIENG-57776)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added deployment metadata registering a component release (name and version plus repository reference) to centralize component information. Improves deployment organization, release tracking, and visibility of component versions across environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->