### PR TITLE
fix: sanitize Service names and namespace-prefix header match

### DIFF
--- a/maas-controller/pkg/reconciler/externalmodel/reconciler.go
+++ b/maas-controller/pkg/reconciler/externalmodel/reconciler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -61,6 +62,13 @@ func (r *Reconciler) gatewayNamespace() string {
 		return r.GatewayNamespace
 	}
 	return defaultGatewayNamespace
+}
+
+// sanitizeDNSName converts a name to DNS-1035 compatible format by replacing
+// dots with dashes. Service names must be DNS-1035 compliant while CRD names
+// (ExternalModel, MaaSModelRef) allow dots.
+func sanitizeDNSName(name string) string {
+	return strings.ReplaceAll(name, ".", "-")
 }
 
 // commonLabels returns labels applied to all managed resources.
@@ -142,12 +150,14 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	ns := extModel.Namespace
 	name := extModel.Name
+	svcName := sanitizeDNSName(name)
 	gwName := r.gatewayName()
 	gwNamespace := r.gatewayNamespace()
 	labels := commonLabels(name)
 
 	// 1. ExternalName Service (backend for HTTPRoute)
-	svc := buildService(extModel.Spec.Endpoint, name, ns, port, labels)
+	// Service names must be DNS-1035 compliant — sanitize dots to dashes.
+	svc := buildService(extModel.Spec.Endpoint, svcName, ns, port, labels)
 	if err := controllerutil.SetControllerReference(extModel, svc, r.Scheme); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to set owner on Service: %w", err)
 	}
@@ -182,7 +192,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 
 	// 4. HTTPRoute (routes requests to external provider via gateway)
-	hr := buildHTTPRoute(extModel.Spec.Endpoint, name, ns, port, gwName, gwNamespace, labels)
+	hr := buildHTTPRoute(extModel.Spec.Endpoint, name, svcName, ns, port, gwName, gwNamespace, labels)
 	if err := controllerutil.SetControllerReference(extModel, hr, r.Scheme); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to set owner on HTTPRoute: %w", err)
 	}

--- a/maas-controller/pkg/reconciler/externalmodel/resources.go
+++ b/maas-controller/pkg/reconciler/externalmodel/resources.go
@@ -87,7 +87,7 @@ func buildDestinationRule(endpoint, name, namespace string, labels map[string]st
 // Path prefix is /<namespace>/<name> for namespace isolation.
 // Only a Host header filter is set (required for TLS SNI).
 // BBR ext-proc handles path rewriting and provider-specific headers.
-func buildHTTPRoute(endpoint, name, namespace string, port int32, gatewayName, gatewayNamespace string, labels map[string]string) *gatewayapiv1.HTTPRoute {
+func buildHTTPRoute(endpoint, name, svcName, namespace string, port int32, gatewayName, gatewayNamespace string, labels map[string]string) *gatewayapiv1.HTTPRoute {
 	gwNamespace := gatewayapiv1.Namespace(gatewayNamespace)
 	pathType := gatewayapiv1.PathMatchPathPrefix
 	pathPrefix := "/" + namespace + "/" + name
@@ -99,7 +99,7 @@ func buildHTTPRoute(endpoint, name, namespace string, port int32, gatewayName, g
 		{
 			BackendRef: gatewayapiv1.BackendRef{
 				BackendObjectReference: gatewayapiv1.BackendObjectReference{
-					Name: gatewayapiv1.ObjectName(name),
+					Name: gatewayapiv1.ObjectName(svcName),
 					Port: &gwPort,
 				},
 			},
@@ -160,7 +160,7 @@ func buildHTTPRoute(endpoint, name, namespace string, port int32, gatewayName, g
 								{
 									Name:  "X-Gateway-Model-Name",
 									Type:  &headerType,
-									Value: name,
+									Value: namespace + "/" + name,
 								},
 							},
 						},

--- a/maas-controller/pkg/reconciler/externalmodel/resources_test.go
+++ b/maas-controller/pkg/reconciler/externalmodel/resources_test.go
@@ -64,7 +64,7 @@ func TestBuildDestinationRule(t *testing.T) {
 }
 
 func TestBuildHTTPRoute(t *testing.T) {
-	hr := buildHTTPRoute("api.openai.com", "gpt-4o", "llm", 443, "maas-default-gateway", "openshift-ingress", commonLabels("gpt-4o"))
+	hr := buildHTTPRoute("api.openai.com", "gpt-4o", "gpt-4o", "llm", 443, "maas-default-gateway", "openshift-ingress", commonLabels("gpt-4o"))
 
 	assert.Equal(t, "gpt-4o", hr.Name)
 	assert.Equal(t, "llm", hr.Namespace)
@@ -82,7 +82,7 @@ func TestBuildHTTPRoute(t *testing.T) {
 	// Rule 2: header-based match
 	rule2 := hr.Spec.Rules[1]
 	assert.Equal(t, "X-Gateway-Model-Name", string(rule2.Matches[0].Headers[0].Name))
-	assert.Equal(t, "gpt-4o", rule2.Matches[0].Headers[0].Value)
+	assert.Equal(t, "llm/gpt-4o", rule2.Matches[0].Headers[0].Value)
 
 	// Only Host header filter (required for TLS SNI), no URLRewrite
 	for i, rule := range hr.Spec.Rules {
@@ -91,4 +91,29 @@ func TestBuildHTTPRoute(t *testing.T) {
 		assert.Equal(t, "Host", string(rule.Filters[0].RequestHeaderModifier.Set[0].Name))
 		assert.Equal(t, "api.openai.com", rule.Filters[0].RequestHeaderModifier.Set[0].Value)
 	}
+}
+
+func TestBuildHTTPRoute_DotsInName(t *testing.T) {
+	// When model name has dots, Service name is sanitized but path/header keep dots
+	svcName := sanitizeDNSName("openai.gpt-oss-20b")
+	hr := buildHTTPRoute("bedrock-mantle.us-east-2.api.aws", "openai.gpt-oss-20b", svcName, "llm", 443, "maas-default-gateway", "openshift-ingress", commonLabels("openai.gpt-oss-20b"))
+
+	// HTTPRoute name keeps dots
+	assert.Equal(t, "openai.gpt-oss-20b", hr.Name)
+
+	// Path keeps dots
+	assert.Equal(t, "/llm/openai.gpt-oss-20b", *hr.Spec.Rules[0].Matches[0].Path.Value)
+
+	// Header match includes namespace prefix for namespace isolation
+	assert.Equal(t, "llm/openai.gpt-oss-20b", hr.Spec.Rules[1].Matches[0].Headers[0].Value)
+
+	// BackendRef uses sanitized name (dashes)
+	assert.Equal(t, "openai-gpt-oss-20b", string(hr.Spec.Rules[0].BackendRefs[0].Name))
+	assert.Equal(t, "openai-gpt-oss-20b", string(hr.Spec.Rules[1].BackendRefs[0].Name))
+}
+
+func TestSanitizeDNSName(t *testing.T) {
+	assert.Equal(t, "openai-gpt-oss-20b", sanitizeDNSName("openai.gpt-oss-20b"))
+	assert.Equal(t, "gpt-4o", sanitizeDNSName("gpt-4o"))
+	assert.Equal(t, "a-b-c", sanitizeDNSName("a.b.c"))
 }


### PR DESCRIPTION
## Summary

Two fixes for the ExternalModel reconciler:

1. **DNS-1035 Service names**: Sanitize dots to dashes when creating
   Services. Model names like `openai.gpt-oss-20b` are valid for CRDs
   but not for Services.

2. **Namespace isolation in header match**: Use `namespace/name` in the
   HTTPRoute header match instead of just `name`. This prevents
   same-name models in different namespaces from colliding after
   BBR ClearRouteCache.

## Changes

- `reconciler.go`: Add `sanitizeDNSName()`, use sanitized name for Service
- `resources.go`: Accept `svcName` param for backendRef, use `namespace/name`
  in header match value
- `resources_test.go`: Update tests, add dot-sanitization and namespace
  isolation test cases

## Tested

On RHOAI cluster with `openai.gpt-oss-20b` in both `llm` (Bedrock) and
`prod-models` (simulator) namespaces — both route correctly to different
backends with 200.

Fixes #745

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DNS naming compatibility for external models by automatically sanitizing special characters in model names to ensure proper Kubernetes service and route creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->