### PR TITLE
feat(kustomize): add operator-managed image for api key cleanup cronjob

### DIFF
--- a/deployment/components/shared-patches/kustomization.yaml
+++ b/deployment/components/shared-patches/kustomization.yaml
@@ -101,6 +101,19 @@ replacements:
     fieldPaths:
     - spec.template.spec.containers.[name=manager].image
 
+# Replace API key cleanup CronJob image from params.env (ubi-minimal for curl)
+- source:
+    kind: ConfigMap
+    version: v1
+    name: maas-parameters
+    fieldPath: data.maas-api-key-cleanup-image
+  targets:
+  - select:
+      kind: CronJob
+      name: maas-api-key-cleanup
+    fieldPaths:
+    - spec.jobTemplate.spec.template.spec.containers.[name=cleanup].image
+
 # -----------------------------------------------------------------------------
 # 2. GATEWAY CONFIGURATION
 # -----------------------------------------------------------------------------

--- a/deployment/overlays/odh/params.env
+++ b/deployment/overlays/odh/params.env
@@ -1,6 +1,7 @@
 maas-api-image=quay.io/opendatahub/maas-api:latest
 maas-controller-image=quay.io/opendatahub/maas-controller:latest
 payload-processing-image=quay.io/opendatahub/odh-ai-gateway-payload-processing:odh-stable
+maas-api-key-cleanup-image=registry.redhat.io/ubi9/ubi-minimal:9.7
 payload-processing-replicas=1
 gateway-namespace=openshift-ingress
 gateway-name=maas-default-gateway


### PR DESCRIPTION
## Summary

Add `maas-api-key-cleanup-image` to `params.env` and wire it via kustomize replacement into the cleanup CronJob, enabling the ODH operator to override the image at deploy time.

## Description

The `maas-api-key-cleanup` CronJob currently uses a hardcoded `registry.redhat.io/ubi9/ubi-minimal:9.7` image for the curl-based API key cleanup. This means the ODH operator has no way to override it with a pinned SHA digest at deploy time.

- Add `maas-api-key-cleanup-image` key to `deployment/overlays/odh/params.env` with the default ubi-minimal image.
- Add a kustomize replacement in `deployment/components/shared-patches/kustomization.yaml` that wires `data.maas-api-key-cleanup-image` from the `maas-parameters` ConfigMap into the CronJob container image field.
- This enables the operator's `ApplyParams()` to substitute the image via `RELATED_IMAGE_UBI_MINIMAL_IMAGE` (from the bundle CSV), ensuring pinned SHA digests in production and support for disconnected environments.

**Companion changes required:**
- [RHOAI-Build-Config PR #19203](https://github.com/red-hat-data-services/RHOAI-Build-Config/pull/19203) — adds `RELATED_IMAGE_UBI_MINIMAL_IMAGE` to `additional-images-patch.yaml`
- opendatahub-operator — adds `"maas-api-key-cleanup-image": "RELATED_IMAGE_UBI_MINIMAL_IMAGE"` to `imagesMap` in `modelsasservice_support.go`

## How It Was Tested

- Verified kustomize build renders the CronJob with the image from `params.env`.
- Without the operator change, the CronJob uses the default value from `params.env` (same image as today — no behavioral change).

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added configuration for a new API key cleanup task in the deployment environment. Updated deployment settings to include a dedicated container image for cleanup operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->