### PR TITLE
fix: validate token rate limits and skip invalid subs in TRLP aggregation

### DIFF
--- a/deployment/base/maas-controller/crd/bases/maas.opendatahub.io_maassubscriptions.yaml
+++ b/deployment/base/maas-controller/crd/bases/maas.opendatahub.io_maassubscriptions.yaml
@@ -83,8 +83,11 @@ spec:
                         description: TokenRateLimit defines a token rate limit
                         properties:
                           limit:
-                            description: Limit is the maximum number of tokens allowed
+                            description: |-
+                              Limit is the maximum number of tokens allowed within the window.
+                              Must be between 1 and 1,000,000,000 (1 billion).
                             format: int64
+                            maximum: 1000000000
                             minimum: 1
                             type: integer
                           window:

--- a/maas-controller/api/maas/v1alpha1/maassubscription_types.go
+++ b/maas-controller/api/maas/v1alpha1/maassubscription_types.go
@@ -74,8 +74,10 @@ type ModelSubscriptionRef struct {
 
 // TokenRateLimit defines a token rate limit
 type TokenRateLimit struct {
-	// Limit is the maximum number of tokens allowed
+	// Limit is the maximum number of tokens allowed within the window.
+	// Must be between 1 and 1,000,000,000 (1 billion).
 	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=1000000000
 	Limit int64 `json:"limit"`
 
 	// Window is the time window for rate limiting (e.g., "1m", "1h", "24h").

--- a/maas-controller/pkg/controller/maas/maassubscription_controller.go
+++ b/maas-controller/pkg/controller/maas/maassubscription_controller.go
@@ -20,8 +20,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"regexp"
 	"slices"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/go-logr/logr"
@@ -66,7 +68,58 @@ const (
 	// modelRefIndexKey is the field index key for looking up MaaSSubscriptions by model reference.
 	// The index value format is "namespace/name" of the model.
 	modelRefIndexKey = "spec.modelRef"
+
+	// maxTokenRateLimit caps the token limit to prevent Kuadrant validation failures.
+	// Values above this are unreasonable for any practical rate-limiting scenario.
+	maxTokenRateLimit int64 = 1_000_000_000 // 1 billion tokens
+
+	// maxWindowSeconds caps the window duration to 366 days (one leap year) to prevent
+	// unreasonably large windows from reaching Kuadrant. 8784h fits the CRD pattern
+	// ^[1-9]\d{0,3}(s|m|h)$.
+	maxWindowSeconds int64 = 366 * 24 * 3600 // 366 days (leap year) in seconds
 )
+
+var windowPattern = regexp.MustCompile(`^[1-9]\d{0,3}(s|m|h)$`)
+
+// validateTokenRateLimit checks if a token rate limit has reasonable values that
+// Kuadrant will accept. Returns an error describing the issue if invalid.
+func validateTokenRateLimit(limit int64, window string) error {
+	if limit <= 0 {
+		return fmt.Errorf("token limit %d must be positive", limit)
+	}
+	if limit > maxTokenRateLimit {
+		return fmt.Errorf("token limit %d exceeds maximum allowed value %d", limit, maxTokenRateLimit)
+	}
+
+	matches := windowPattern.FindStringSubmatch(window)
+	if len(matches) != 2 {
+		return fmt.Errorf("invalid window format %q: expected a positive number followed by s, m, or h (e.g. \"1h\", \"30m\")", window)
+	}
+
+	// Extract numeric part (everything except the last character).
+	unit := matches[1]
+	numStr := window[:len(window)-len(unit)]
+	value, err := strconv.ParseInt(numStr, 10, 64)
+	if err != nil {
+		return fmt.Errorf("invalid window numeric value %q: %w", numStr, err)
+	}
+
+	var seconds int64
+	switch unit {
+	case "s":
+		seconds = value
+	case "m":
+		seconds = value * 60
+	case "h":
+		seconds = value * 3600
+	}
+
+	if seconds > maxWindowSeconds {
+		return fmt.Errorf("window %q (%d seconds) exceeds maximum allowed duration (%d seconds)", window, seconds, maxWindowSeconds)
+	}
+
+	return nil
+}
 
 // ConditionSpecPriorityDuplicate is set True when another MaaSSubscription shares the same spec.priority
 // (API key mint and selector use deterministic tie-break; admins should set distinct priorities).
@@ -459,16 +512,39 @@ func (r *MaaSSubscriptionReconciler) reconcileTRLPForModel(ctx context.Context, 
 				continue
 			}
 			var rates []any
+			var hasInvalidLimits bool
 			if len(mRef.TokenRateLimits) > 0 {
 				for _, trl := range mRef.TokenRateLimits {
+					if err := validateTokenRateLimit(trl.Limit, trl.Window); err != nil {
+						log.Error(err, "Skipping subscription with invalid token rate limit — fix the spec to include it in TRLP",
+							"subscription", sub.Name, "model", modelNamespace+"/"+modelName,
+							"limit", trl.Limit, "window", trl.Window)
+						hasInvalidLimits = true
+						break
+					}
 					rates = append(rates, map[string]any{"limit": trl.Limit, "window": trl.Window})
 				}
 			} else {
 				rates = append(rates, map[string]any{"limit": int64(100), "window": "1m"})
 			}
+			if hasInvalidLimits {
+				// Skip this subscription to prevent poisoning the aggregated TRLP.
+				// The subscription is already marked Degraded/Failed by validateModelRefs(),
+				// and maas-api's subscription selector rejects non-Active subscriptions,
+				// so the invalid subscription cannot be used for API key minting.
+				continue
+			}
 			subs = append(subs, subInfo{sub: sub, mRef: mRef, rates: rates})
 			break
 		}
+	}
+
+	// If all subscriptions were skipped due to invalid limits, treat as no effective
+	// subscriptions — delete the TRLP instead of writing one with empty limits.
+	if len(subs) == 0 && len(allSubs) > 0 {
+		log.Info("All subscriptions for model have invalid rate limits — deleting TRLP",
+			"model", modelNamespace+"/"+modelName, "invalidCount", len(allSubs))
+		return r.deleteModelTRLP(ctx, log, modelNamespace, modelName)
 	}
 
 	// Trust auth.identity.selected_subscription_key from AuthPolicy.

--- a/maas-controller/pkg/controller/maas/maassubscription_controller_test.go
+++ b/maas-controller/pkg/controller/maas/maassubscription_controller_test.go
@@ -1248,7 +1248,7 @@ func TestMaaSSubscriptionReconciler_WindowValuesInTRLP(t *testing.T) {
 		{"seconds", "30s"},      // short window, typical for burst limits
 		{"minutes", "5m"},       // default-like value used across the codebase
 		{"hours", "24h"},        // common replacement for the now-removed "1d"
-		{"max digits", "9999h"}, // upper bound of the 4-digit numeric cap
+		{"max digits", "8784h"}, // upper bound: 366 days (leap year) in hours
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Prevent invalid token rate limits from poisoning the aggregated TokenRateLimitPolicy and blocking deletion of subscriptions that share a model.

Changes:
- Add validateTokenRateLimit() that rejects unreasonable values before they reach Kuadrant (limit > 1B tokens, window > 365 days, bad format)
- Skip subscriptions with invalid limits during TRLP aggregation instead of including them and causing Kuadrant validation failures
- Log clear error messages identifying the offending subscription
- Add Maximum=1000000000 CRD validation on TokenRateLimit.Limit to reject extreme values at admission time

Root cause: When one subscription had invalid limits (e.g. limit: 9007199254740991, window: 9007199254740991d), the controller built an aggregated TRLP that Kuadrant rejected. On delete, the controller tried to rebuild the TRLP (still including the bad sub if others shared the model), which failed again, preventing finalizer removal and leaving subscriptions stuck in Terminating.


<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced token rate limit validation (allowed range 1–1,000,000,000) and stricter window format/duration checks.
  * Subscriptions with invalid limits are skipped during aggregation; if all candidates are invalid, existing aggregated rate limits are removed.
* **Documentation**
  * Clarified CRD schema description to state the maximum allowed token limit.
* **Tests**
  * Updated test input to reflect the adjusted maximum window value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->