### PR TITLE
fix: use targetModel in HTTPRoute header match

### DIFF
--- a/maas-controller/pkg/reconciler/externalmodel/reconciler.go
+++ b/maas-controller/pkg/reconciler/externalmodel/reconciler.go
@@ -182,7 +182,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 
 	// 4. HTTPRoute (routes requests to external provider via gateway)
-	hr := buildHTTPRoute(extModel.Spec.Endpoint, name, ns, port, gwName, gwNamespace, labels)
+	hr := buildHTTPRoute(extModel.Spec.Endpoint, name, extModel.Spec.TargetModel, ns, port, gwName, gwNamespace, labels)
 	if err := controllerutil.SetControllerReference(extModel, hr, r.Scheme); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to set owner on HTTPRoute: %w", err)
 	}

--- a/maas-controller/pkg/reconciler/externalmodel/resources.go
+++ b/maas-controller/pkg/reconciler/externalmodel/resources.go
@@ -87,7 +87,7 @@ func buildDestinationRule(endpoint, name, namespace string, labels map[string]st
 // Path prefix is /<namespace>/<name> for namespace isolation.
 // Only a Host header filter is set (required for TLS SNI).
 // BBR ext-proc handles path rewriting and provider-specific headers.
-func buildHTTPRoute(endpoint, name, namespace string, port int32, gatewayName, gatewayNamespace string, labels map[string]string) *gatewayapiv1.HTTPRoute {
+func buildHTTPRoute(endpoint, name, targetModel, namespace string, port int32, gatewayName, gatewayNamespace string, labels map[string]string) *gatewayapiv1.HTTPRoute {
 	gwNamespace := gatewayapiv1.Namespace(gatewayNamespace)
 	pathType := gatewayapiv1.PathMatchPathPrefix
 	pathPrefix := "/" + namespace + "/" + name
@@ -160,7 +160,7 @@ func buildHTTPRoute(endpoint, name, namespace string, port int32, gatewayName, g
 								{
 									Name:  "X-Gateway-Model-Name",
 									Type:  &headerType,
-									Value: name,
+									Value: targetModel,
 								},
 							},
 						},

--- a/maas-controller/pkg/reconciler/externalmodel/resources_test.go
+++ b/maas-controller/pkg/reconciler/externalmodel/resources_test.go
@@ -64,7 +64,7 @@ func TestBuildDestinationRule(t *testing.T) {
 }
 
 func TestBuildHTTPRoute(t *testing.T) {
-	hr := buildHTTPRoute("api.openai.com", "gpt-4o", "llm", 443, "maas-default-gateway", "openshift-ingress", commonLabels("gpt-4o"))
+	hr := buildHTTPRoute("api.openai.com", "gpt-4o", "gpt-4o", "llm", 443, "maas-default-gateway", "openshift-ingress", commonLabels("gpt-4o"))
 
 	assert.Equal(t, "gpt-4o", hr.Name)
 	assert.Equal(t, "llm", hr.Namespace)
@@ -79,7 +79,7 @@ func TestBuildHTTPRoute(t *testing.T) {
 	assert.Equal(t, "/llm/gpt-4o", *rule1.Matches[0].Path.Value)
 	assert.Equal(t, "gpt-4o", string(rule1.BackendRefs[0].Name))
 
-	// Rule 2: header-based match
+	// Rule 2: header-based match uses targetModel
 	rule2 := hr.Spec.Rules[1]
 	assert.Equal(t, "X-Gateway-Model-Name", string(rule2.Matches[0].Headers[0].Name))
 	assert.Equal(t, "gpt-4o", rule2.Matches[0].Headers[0].Value)
@@ -91,4 +91,18 @@ func TestBuildHTTPRoute(t *testing.T) {
 		assert.Equal(t, "Host", string(rule.Filters[0].RequestHeaderModifier.Set[0].Name))
 		assert.Equal(t, "api.openai.com", rule.Filters[0].RequestHeaderModifier.Set[0].Value)
 	}
+}
+
+func TestBuildHTTPRoute_TargetModelDiffersFromName(t *testing.T) {
+	hr := buildHTTPRoute("bedrock-mantle.us-east-2.api.aws", "my-bedrock", "openai.gpt-oss-20b", "llm", 443, "maas-default-gateway", "openshift-ingress", commonLabels("my-bedrock"))
+
+	// Name and path use ExternalModel name
+	assert.Equal(t, "my-bedrock", hr.Name)
+	assert.Equal(t, "/llm/my-bedrock", *hr.Spec.Rules[0].Matches[0].Path.Value)
+
+	// Header match uses targetModel (what the user sends in body.model)
+	assert.Equal(t, "openai.gpt-oss-20b", hr.Spec.Rules[1].Matches[0].Headers[0].Value)
+
+	// BackendRef uses ExternalModel name (Service name)
+	assert.Equal(t, "my-bedrock", string(hr.Spec.Rules[0].BackendRefs[0].Name))
 }


### PR DESCRIPTION
## Problem

The HTTPRoute header-based rule matches `X-Gateway-Model-Name` against
the ExternalModel `metadata.name`. This breaks when `targetModel`
differs from the name (e.g., Bedrock models: `name=my-bedrock`,
`targetModel=openai.gpt-oss-20b`).

The user sends `targetModel` in the request body. BBR's
`body-field-to-header` plugin extracts it as `X-Gateway-Model-Name`.
After ClearRouteCache, the header doesn't match → `route_not_found`.

## Fix

Pass `targetModel` to `buildHTTPRoute` and use it in the header match
value instead of `name`.

## Changes

- `reconciler.go`: pass `extModel.Spec.TargetModel` to `buildHTTPRoute`
- `resources.go`: accept `targetModel` param, use in header match
- `resources_test.go`: update existing test, add test case where
  targetModel differs from name

## Tested

On RHOAI cluster:
- `llm/my-bedrock` (targetModel: `openai.gpt-oss-20b`) → Bedrock 200 ✓
- Header match correctly uses `openai.gpt-oss-20b` not `my-bedrock`

Fixes #745

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced HTTP routing logic for external models to separately use target model identifiers in request matching, enabling more precise routing when the model name differs from its target model designation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->