### PR TITLE
fix: per-model(s) top-level values in usage dashboard

### DIFF
--- a/deployment/components/observability/observability/dashboards/usage-dashboard.yaml
+++ b/deployment/components/observability/observability/dashboards/usage-dashboard.yaml
@@ -81,7 +81,29 @@ spec:
                   datasource:
                     kind: PrometheusDatasource
                     name: kuadrant-prometheus-datasource
-                  query: 'count(count by (user) (increase(authorized_calls{user!="", user=~"$user", subscription=~"$subscription"}[$__range]) > 0)) or vector(0)'
+                  query: |-
+                    count(
+                      count by (user) (
+                        (
+                          (
+                            sum by (user, subscription, limitador_namespace) (
+                              increase(authorized_calls{user!="", user=~"$user", subscription=~"$subscription"}[$__range])
+                            )
+                            +
+                            sum by (user, subscription, limitador_namespace) (
+                              increase(limited_calls{user!="", user=~"$user", subscription=~"$subscription"}[$__range])
+                            )
+                          )
+                          or
+                          sum by (user, subscription, limitador_namespace) (
+                            increase(authorized_calls{user!="", user=~"$user", subscription=~"$subscription"}[$__range])
+                          )
+                        )
+                        * on(user, subscription, limitador_namespace)
+                        (0 * max by (user, subscription, limitador_namespace) (max_over_time(authorized_hits{model=~"$model"}[$__range])) + 1)
+                        > 0
+                      )
+                    ) or vector(0)
                   seriesNameFormat: Users
     successRate:
       kind: Panel
@@ -105,7 +127,41 @@ spec:
                   datasource:
                     kind: PrometheusDatasource
                     name: kuadrant-prometheus-datasource
-                  query: '((sum(increase(authorized_calls{user!="", user=~"$user", subscription=~"$subscription"}[$__range]))) / ((sum(increase(authorized_calls{user!="", user=~"$user", subscription=~"$subscription"}[$__range])) + (sum(increase(limited_calls{user!="", user=~"$user", subscription=~"$subscription"}[$__range])) or vector(0))) > 0)) or vector(1)'
+                  query: |-
+                    (
+                      (
+                        sum(
+                          sum by (user, subscription, limitador_namespace) (
+                            increase(authorized_calls{user!="", user=~"$user", subscription=~"$subscription"}[$__range])
+                          )
+                          * on(user, subscription, limitador_namespace)
+                          (0 * max by (user, subscription, limitador_namespace) (max_over_time(authorized_hits{model=~"$model"}[$__range])) + 1)
+                        )
+                      )
+                      /
+                      (
+                        (
+                          sum(
+                            sum by (user, subscription, limitador_namespace) (
+                              increase(authorized_calls{user!="", user=~"$user", subscription=~"$subscription"}[$__range])
+                            )
+                            * on(user, subscription, limitador_namespace)
+                            (0 * max by (user, subscription, limitador_namespace) (max_over_time(authorized_hits{model=~"$model"}[$__range])) + 1)
+                          )
+                          +
+                          (
+                            sum(
+                              sum by (user, subscription, limitador_namespace) (
+                                increase(limited_calls{user!="", user=~"$user", subscription=~"$subscription"}[$__range])
+                              )
+                              * on(user, subscription, limitador_namespace)
+                              (0 * max by (user, subscription, limitador_namespace) (max_over_time(authorized_hits{model=~"$model"}[$__range])) + 1)
+                            )
+                            or vector(0)
+                          )
+                        ) > 0
+                      )
+                    ) or vector(1)
                   seriesNameFormat: Success Rate
     tokenConsumptionByUser:
       kind: Panel
@@ -180,7 +236,15 @@ spec:
                   query: |-
                     round(
                       sum by (user, subscription, model) (
-                        sum by (user, subscription, limitador_namespace) (increase(authorized_calls{user!="", user=~"$user", subscription=~"$subscription"}[$__range]))
+                        (
+                          (
+                            sum by (user, subscription, limitador_namespace) (increase(authorized_calls{user!="", user=~"$user", subscription=~"$subscription"}[$__range]))
+                            +
+                            sum by (user, subscription, limitador_namespace) (increase(limited_calls{user!="", user=~"$user", subscription=~"$subscription"}[$__range]))
+                          )
+                          or
+                          sum by (user, subscription, limitador_namespace) (increase(authorized_calls{user!="", user=~"$user", subscription=~"$subscription"}[$__range]))
+                        )
                         * on(user, subscription, limitador_namespace) group_left(model)
                         (0 * max by (user, subscription, limitador_namespace, model) (max_over_time(authorized_hits{model=~"$model"}[$__range])) + 1)
                       )
@@ -228,7 +292,15 @@ spec:
                   datasource:
                     kind: PrometheusDatasource
                     name: kuadrant-prometheus-datasource
-                  query: 'sum(increase(limited_calls{user!="", user=~"$user", subscription=~"$subscription"}[$__range])) or vector(0)'
+                  query: |-
+                    sum(
+                      sum by (user, subscription, limitador_namespace) (
+                        increase(limited_calls{user!="", user=~"$user", subscription=~"$subscription"}[$__range])
+                      )
+                      * on(user, subscription, limitador_namespace)
+                      (0 * max by (user, subscription, limitador_namespace) (max_over_time(authorized_hits{model=~"$model"}[$__range])) + 1)
+                    )
+                    or vector(0)
                   seriesNameFormat: Errors
     totalRequests:
       kind: Panel
@@ -253,7 +325,28 @@ spec:
                   datasource:
                     kind: PrometheusDatasource
                     name: kuadrant-prometheus-datasource
-                  query: '(sum(increase(authorized_calls{user!="", user=~"$user", subscription=~"$subscription"}[$__range])) or vector(0)) + (sum(increase(limited_calls{user!="", user=~"$user", subscription=~"$subscription"}[$__range])) or vector(0))'
+                  query: |-
+                    (
+                      sum(
+                        sum by (user, subscription, limitador_namespace) (
+                          increase(authorized_calls{user!="", user=~"$user", subscription=~"$subscription"}[$__range])
+                        )
+                        * on(user, subscription, limitador_namespace)
+                        (0 * max by (user, subscription, limitador_namespace) (max_over_time(authorized_hits{model=~"$model"}[$__range])) + 1)
+                      )
+                      or vector(0)
+                    )
+                    +
+                    (
+                      sum(
+                        sum by (user, subscription, limitador_namespace) (
+                          increase(limited_calls{user!="", user=~"$user", subscription=~"$subscription"}[$__range])
+                        )
+                        * on(user, subscription, limitador_namespace)
+                        (0 * max by (user, subscription, limitador_namespace) (max_over_time(authorized_hits{model=~"$model"}[$__range])) + 1)
+                      )
+                      or vector(0)
+                    )
                   seriesNameFormat: Requests
     totalTokens:
       kind: Panel


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The top-levels values of Total Requests, Total Errors, Success Rate, and Active Users, are now calculated also based on the selected model(s).

## How Has This Been Tested?
Tested manually

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved Usage dashboard to be model-aware and aggregated per user/subscription/namespace, enhancing accuracy for Active Users, Success Rate, Token Consumption, Total Errors, and Total Requests.
  * Updated gating and fallback logic for authorization and rate-limit signals to produce more reliable time-series and per-user token consumption reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->