### PR TITLE
chore: add .worktrees/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,9 @@ apps/backend/.env
 CLAUDE.md
 .cursor/
 
+# Git worktrees
+.worktrees/
+
 # Docs build and site directories
 docs/build/
 docs/site/


### PR DESCRIPTION
This is a minor change, relevant for people working with Git worktrees.
The feature requires a working directory, and `.worktrees` is a popular name for it (in the project root directory).

## How Has This Been Tested?
Git ignores the directory after updating `.gitignore` properly

## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `.gitignore` to exclude Git worktree directories from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->