### PR TITLE
fix: resolve postgresql image from operator CSV in setup-database

### DIFF
--- a/scripts/setup-database.sh
+++ b/scripts/setup-database.sh
@@ -12,8 +12,6 @@
 #
 # Environment variables:
 #   NAMESPACE          Target namespace (default: opendatahub)
-#   POSTGRES_IMAGE     Override PostgreSQL image (default: resolved from operator CSV,
-#                      falls back to registry.redhat.io/rhel9/postgresql-16:latest)
 #   POSTGRES_USER      Database user (default: maas)
 #   POSTGRES_DB        Database name (default: maas)
 #   POSTGRES_PASSWORD  Database password (default: auto-generated)
@@ -41,8 +39,6 @@ DEFAULT_POSTGRES_IMAGE="registry.redhat.io/rhel9/postgresql-16:latest"
 
 # Resolve the PostgreSQL image from the RHOAI operator CSV's relatedImages.
 # Expects the RHOAI operator (or its CSV) to be installed on the cluster.
-# Replaces the registry prefix with registry.redhat.io so that IDMS can
-# redirect to the correct mirror in disconnected environments.
 # Falls back to DEFAULT_POSTGRES_IMAGE if the CSV is not found or the entry
 # is missing.
 resolve_postgres_image() {
@@ -51,9 +47,7 @@ resolve_postgres_image() {
     -o jsonpath='{.items[0].spec.relatedImages[?(@.name=="postgresql_16_image")].image}' 2>/dev/null) || true
 
   if [[ -n "${csv_image}" ]]; then
-    # Strip the registry host and prepend the canonical registry.redhat.io
-    # e.g., bastion.example.com:8443/rhel9/postgresql-16@sha256:abc → registry.redhat.io/rhel9/postgresql-16@sha256:abc
-    echo "registry.redhat.io/${csv_image#*/}"
+    echo "${csv_image}"
   else
     echo "${DEFAULT_POSTGRES_IMAGE}"
   fi
@@ -97,9 +91,7 @@ fi
 echo "  Creating PostgreSQL deployment..."
 echo "  ⚠️  Using POC configuration (ephemeral storage)"
 
-# Allow explicit override via POSTGRES_IMAGE env var; otherwise resolve from
-# the operator CSV, falling back to the default :latest tag.
-POSTGRES_IMAGE="${POSTGRES_IMAGE:-$(resolve_postgres_image)}"
+POSTGRES_IMAGE="$(resolve_postgres_image)"
 if [[ "${POSTGRES_IMAGE}" == "${DEFAULT_POSTGRES_IMAGE}" ]]; then
   echo "  Using default PostgreSQL image (operator CSV not available)"
 else
@@ -141,7 +133,7 @@ spec:
     spec:
       containers:
       - name: postgres
-        image: ${POSTGRES_IMAGE}
+        image: "${POSTGRES_IMAGE}"
         env:
         - name: POSTGRESQL_USER
           valueFrom:

--- a/scripts/setup-database.sh
+++ b/scripts/setup-database.sh
@@ -11,9 +11,11 @@
 #   - Default: opendatahub (ODH) or redhat-ods-applications (RHOAI)
 #
 # Environment variables:
-#   NAMESPACE       Target namespace (default: opendatahub)
-#   POSTGRES_USER   Database user (default: maas)
-#   POSTGRES_DB     Database name (default: maas)
+#   NAMESPACE          Target namespace (default: opendatahub)
+#   POSTGRES_IMAGE     Override PostgreSQL image (default: resolved from operator CSV,
+#                      falls back to registry.redhat.io/rhel9/postgresql-16:latest)
+#   POSTGRES_USER      Database user (default: maas)
+#   POSTGRES_DB        Database name (default: maas)
 #   POSTGRES_PASSWORD  Database password (default: auto-generated)
 #
 # Usage:
@@ -32,6 +34,30 @@ source "${SCRIPT_DIR}/deployment-helpers.sh"
 
 # Default namespace for ODH; use redhat-ods-applications for RHOAI
 : "${NAMESPACE:=opendatahub}"
+
+# Fallback image when the RHOAI operator CSV is not available (e.g., vanilla
+# Kubernetes, ODH-only clusters, or dev environments without OLM).
+DEFAULT_POSTGRES_IMAGE="registry.redhat.io/rhel9/postgresql-16:latest"
+
+# Resolve the PostgreSQL image from the RHOAI operator CSV's relatedImages.
+# Expects the RHOAI operator (or its CSV) to be installed on the cluster.
+# Replaces the registry prefix with registry.redhat.io so that IDMS can
+# redirect to the correct mirror in disconnected environments.
+# Falls back to DEFAULT_POSTGRES_IMAGE if the CSV is not found or the entry
+# is missing.
+resolve_postgres_image() {
+  local csv_image
+  csv_image=$(kubectl get csv -l 'olm.copiedFrom=redhat-ods-operator' \
+    -o jsonpath='{.items[0].spec.relatedImages[?(@.name=="postgresql_16_image")].image}' 2>/dev/null) || true
+
+  if [[ -n "${csv_image}" ]]; then
+    # Strip the registry host and prepend the canonical registry.redhat.io
+    # e.g., bastion.example.com:8443/rhel9/postgresql-16@sha256:abc → registry.redhat.io/rhel9/postgresql-16@sha256:abc
+    echo "registry.redhat.io/${csv_image#*/}"
+  else
+    echo "${DEFAULT_POSTGRES_IMAGE}"
+  fi
+}
 
 # Ensure namespace exists
 if ! kubectl get namespace "$NAMESPACE" >/dev/null 2>&1; then
@@ -70,6 +96,16 @@ fi
 
 echo "  Creating PostgreSQL deployment..."
 echo "  ⚠️  Using POC configuration (ephemeral storage)"
+
+# Allow explicit override via POSTGRES_IMAGE env var; otherwise resolve from
+# the operator CSV, falling back to the default :latest tag.
+POSTGRES_IMAGE="${POSTGRES_IMAGE:-$(resolve_postgres_image)}"
+if [[ "${POSTGRES_IMAGE}" == "${DEFAULT_POSTGRES_IMAGE}" ]]; then
+  echo "  Using default PostgreSQL image (operator CSV not available)"
+else
+  echo "  Resolved PostgreSQL image from operator CSV"
+fi
+echo "  Image: ${POSTGRES_IMAGE}"
 echo ""
 
 # Deploy PostgreSQL resources
@@ -105,7 +141,7 @@ spec:
     spec:
       containers:
       - name: postgres
-        image: registry.redhat.io/rhel9/postgresql-16:latest@sha256:680b42d2c51b76d23cd5b68dd774af456b1e4c98c4aaeb49d0de0948dc933716
+        image: ${POSTGRES_IMAGE}
         env:
         - name: POSTGRESQL_USER
           valueFrom:


### PR DESCRIPTION
## Summary

Resolve the PostgreSQL container image dynamically from the RHOAI operator CSV instead of using a hardcoded image reference, fixing deployments in disconnected environments.

## Description

- Add \`resolve_postgres_image\` function that queries the RHOAI operator CSV's \`spec.relatedImages\` for the \`postgresql_16_image\` entry, scoped to \`$NAMESPACE\`.
- Use the CSV image verbatim (no registry-prefix rewriting) so IDMS redirects correctly with whatever path the operator already stores.
- Fall back to \`registry.redhat.io/rhel9/postgresql-16:latest\` when the CSV is not available (dev/ODH environments without OLM).
- Replace the hardcoded image in the deployment YAML with the resolved variable.

### Image resolution behavior

| Scenario | CSV found? | IDMS? | Image resolved to | What gets pulled |
|---|---|---|---|---|
| Disconnected + RHOAI operator installed | Yes | Yes | CSV image (digest-pinned) | IDMS redirects to mirror |
| Connected + RHOAI operator installed | Yes | No | CSV image (digest-pinned) | Pulls directly from registry |
| Connected + no operator (dev/ODH) | No | No | \`registry.redhat.io/rhel9/postgresql-16:latest\` | Pulls :latest from registry.redhat.io |
| Disconnected + no operator | No | Yes | \`registry.redhat.io/rhel9/postgresql-16:latest\` | Fails — IDMS does not redirect tag-based refs |

## How it was tested

- Ran \`setup-database.sh\` on a disconnected RHOAI cluster (\`maas-dis-aws-rhoai-3-3\`) with the operator installed.
- Verified the script resolved the image from the CSV.
- Confirmed the postgres pod started successfully with the digest-pinned image.
- Verified IDMS redirected the image to the bastion mirror.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Database setup script now dynamically determines PostgreSQL container images at runtime with an automatic fallback to a default image if resolution fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->