### PR TITLE
chore: restrict rbac for db secret

### DIFF
--- a/deployment/base/maas-controller/rbac/clusterrole.yaml
+++ b/deployment/base/maas-controller/rbac/clusterrole.yaml
@@ -21,7 +21,6 @@ rules:
   resources:
   - endpoints
   - pods
-  - secrets
   verbs:
   - get
   - list
@@ -35,6 +34,21 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resourceNames:
+  - maas-db-config
+  resources:
+  - secrets
+  verbs:
+  - get
 - apiGroups:
   - ""
   resources:

--- a/maas-controller/pkg/controller/maas/maasmodelref_controller.go
+++ b/maas-controller/pkg/controller/maas/maasmodelref_controller.go
@@ -84,7 +84,7 @@ func (r *MaaSModelRefReconciler) gatewayNamespace() string {
 //+kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=gateways,verbs=get;list;watch
 //+kubebuilder:rbac:groups=kuadrant.io,resources=authpolicies,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=serving.kserve.io,resources=llminferenceservices,verbs=get;list;watch
-//+kubebuilder:rbac:groups="",resources=secrets,verbs=get
+
 
 const maasModelFinalizer = "maas.opendatahub.io/model-cleanup"
 

--- a/maas-controller/pkg/controller/maas/maasmodelref_controller.go
+++ b/maas-controller/pkg/controller/maas/maasmodelref_controller.go
@@ -85,7 +85,6 @@ func (r *MaaSModelRefReconciler) gatewayNamespace() string {
 //+kubebuilder:rbac:groups=kuadrant.io,resources=authpolicies,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=serving.kserve.io,resources=llminferenceservices,verbs=get;list;watch
 
-
 const maasModelFinalizer = "maas.opendatahub.io/model-cleanup"
 
 // Field index for efficiently finding MaaSModelRefs by their modelRef.name

--- a/maas-controller/pkg/controller/maas/tenant_controller.go
+++ b/maas-controller/pkg/controller/maas/tenant_controller.go
@@ -57,7 +57,8 @@ type TenantReconciler struct {
 // +kubebuilder:rbac:groups=maas.opendatahub.io,resources=tenants/finalizers,verbs=update
 // +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=gateways,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;patch;delete
-// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=secrets,resourceNames=maas-db-config,verbs=get
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=list;watch
 // +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;patch;delete
 // +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;patch;delete
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;patch;delete


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Restrict the maas-controller-role ClusterRole so that get on secrets is scoped to only `maas-db-config` via resourceNames, rather than granting get on all secrets cluster-wide.

Why list/watch remains unrestricted: The controller-runtime informer started by `Watches(&corev1.Secret{})` requires list and watch. Kubernetes RBAC does not support resourceNames on collection verbs — the API server ignores it. The Watch already has a client-side predicate (`secretNamedMaaSDB`) that filters to only `maas-db-config`.

Addresses: lphiri's feedback on PR #735 — "The DB secret has a specific name we know ahead of time. I suggest creating a role with a resourceName constraint."

https://redhat.atlassian.net/browse/RHOAIENG-58934

How Has This Been Tested?
```
make -C maas-controller manifests — generated YAML matches updated markers
make -C maas-controller test — all unit tests pass (no logic changes)
make -C maas-controller verify-codegen — confirms markers and YAML are in sync
```
To verify on a cluster after deploy:
```
# Should return "yes"
kubectl auth can-i get secrets/maas-db-config \
  --as=system:serviceaccount:opendatahub:maas-controller -n opendatahub
# Should return "no"
kubectl auth can-i get secrets/some-other-secret \
  --as=system:serviceaccount:opendatahub:maas-controller -n opendatahub
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Updates**
  * Restricted secret access: get permission is now limited to the specific maas-db-config secret.
  * List and watch permissions for secrets remain available, preserving discovery and monitoring capabilities while reducing exposure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->