### PR TITLE
fix(cve): cve-2026-33815 - pgx memory-safety

### DIFF
--- a/maas-api/go.mod
+++ b/maas-api/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.3.0
 	github.com/golang-migrate/migrate/v4 v4.19.1
 	github.com/google/uuid v1.6.0
-	github.com/jackc/pgx/v5 v5.7.6
+	github.com/jackc/pgx/v5 v5.9.0
 	github.com/kserve/kserve v0.0.0-20251121160314-57d83d202f36
 	github.com/lib/pq v1.10.9
 	github.com/openai/openai-go/v2 v2.3.1

--- a/maas-api/go.sum
+++ b/maas-api/go.sum
@@ -205,8 +205,8 @@ github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsI
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
-github.com/jackc/pgx/v5 v5.7.6 h1:rWQc5FwZSPX58r1OQmkuaNicxdmExaEz5A2DO2hUuTk=
-github.com/jackc/pgx/v5 v5.7.6/go.mod h1:aruU7o91Tc2q2cFp5h4uP3f6ztExVpyVv88Xl/8Vl8M=
+github.com/jackc/pgx/v5 v5.9.0 h1:T/dI+2TvmI2H8s/KH1/lXIbz1CUFk3gn5oTjr0/mBsE=
+github.com/jackc/pgx/v5 v5.9.0/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
 github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/jmespath/go-jmespath v0.4.1-0.20220621161143-b0104c826a24 h1:liMMTbpW34dhU4az1GN0pTPADwNmvoRSeoZ6PItiqnY=


### PR DESCRIPTION
## summary

update github.com/jackc/pgx/v5 from v5.7.6 to v5.9.0 to resolve memory-safety vulnerability (cve-2026-33815).

## cve details

- **cve id**: cve-2026-33815
- **package**: github.com/jackc/pgx/v5
- **vulnerable versions**: < v5.9.0
- **fixed version**: v5.9.0
- **jira**: [rhoaieng-57067](https://redhat.atlassian.net/browse/rhoaieng-57067)

## changes

- update `github.com/jackc/pgx/v5` from v5.7.6 to v5.9.0 in `maas-api/go.mod`
- run `go mod tidy` to update `maas-api/go.sum`

## test results

⚠️ tests timed out after 300s - manual testing required

post-fix verification with govulncheck confirms cve-2026-33815 is no longer detected.

## test plan

- [x] govulncheck confirms cve no longer present
- [ ] ci/cd pipeline passes

---

🤖 generated with [claude code](https://claude.com/claude-code)
<!-- cve-fixer-workflow -->