### PR TITLE
feat: add tenant CRD to e2e artifact collection and debug report

### DIFF
--- a/test/e2e/scripts/auth_utils.sh
+++ b/test/e2e/scripts/auth_utils.sh
@@ -16,6 +16,7 @@
 #     maasauthpolicies.yaml      - MaaSAuthPolicy definitions
 #     maassubscriptions.yaml     - MaaSSubscription definitions
 #     externalmodels.yaml        - ExternalModel definitions
+#     tenants.yaml               - Tenant definitions
 #   pod-logs/                  - Per-pod logs from the deployment namespace
 #
 # Usage:
@@ -127,6 +128,7 @@ MAAS_CRDS=(
   "maasauthpolicies.maas.opendatahub.io"
   "maassubscriptions.maas.opendatahub.io"
   "externalmodels.maas.opendatahub.io"
+  "tenants.maas.opendatahub.io"
 )
 
 collect_maas_crs() {
@@ -208,6 +210,7 @@ collect_cluster_state() {
     echo "--- MaaS CRs ---"
     kubectl get maasmodelrefs -n "$DEPLOYMENT_NAMESPACE" 2>/dev/null || true
     kubectl get maasauthpolicies,maassubscriptions -n "$MAAS_SUBSCRIPTION_NAMESPACE" 2>/dev/null || true
+    kubectl get tenants -n "$MAAS_SUBSCRIPTION_NAMESPACE" 2>/dev/null || true
     echo ""
     echo "--- HTTPRoutes ---"
     kubectl get httproutes -A 2>/dev/null | head -30 || true
@@ -324,6 +327,8 @@ run_auth_debug_report() {
   _run "MaaSSubscriptions" "kubectl get maassubscriptions -n $MAAS_SUBSCRIPTION_NAMESPACE -o wide 2>/dev/null || true"
   _run "MaaSSubscription status details" "kubectl get maassubscriptions -n $MAAS_SUBSCRIPTION_NAMESPACE -o jsonpath='{range .items[*]}{.metadata.name}: {.status.phase} - {.status.conditions[?(@.type==\"Ready\")].message}{\"\\n\"}{end}' 2>/dev/null || true"
   _run "MaaSModelRefs (all namespaces)" "kubectl get maasmodelrefs -A -o wide 2>/dev/null || true"
+  _run "Tenants" "kubectl get tenants -n $MAAS_SUBSCRIPTION_NAMESPACE -o wide 2>/dev/null || true"
+  _run "Tenant status details" "kubectl get tenants -n $MAAS_SUBSCRIPTION_NAMESPACE -o jsonpath='{range .items[*]}{.metadata.name}: {.status.conditions[?(@.type==\"Ready\")].status} - {.status.conditions[?(@.type==\"Ready\")].message}{\"\\n\"}{end}' 2>/dev/null || true"
   _append ""
 
   _section "Test User Information"


### PR DESCRIPTION
## Summary
Add the `tenants.maas.opendatahub.io` CRD to e2e must-gather artifact collection and the auth debug report.

## Description
The Tenant CRD was recently introduced but was missing from the e2e debugging and artifact-collection utilities in `auth_utils.sh`.

- Add `tenants.maas.opendatahub.io` to the `MAAS_CRDS` array so `collect_maas_crs()` dumps Tenant CR YAML to `tenants.yaml`.
- Add `kubectl get tenants` to `collect_cluster_state()` alongside other MaaS CRs.
- Add Tenant listing and status/condition detail to `run_auth_debug_report()` under the MaaS CRs section.
- Update header comment to document the new `tenants.yaml` artifact.

## How it was tested
- Verified script syntax with `bash -n`.
- Confirmed the Tenant CRD name matches `deployment/base/maas-controller/crd/bases/maas.opendatahub.io_tenants.yaml`.
- Confirmed namespace usage aligns with `TenantReconciler.TenantNamespace` (sourced from `--maas-subscription-namespace`).

Made with [Cursor](https://cursor.com)