### PR TITLE
fix(kustomize): restore cleanup CronJob image replacement dropped by Tenant refactor

### DIFF
--- a/deployment/components/shared-patches/kustomization.yaml
+++ b/deployment/components/shared-patches/kustomization.yaml
@@ -100,6 +100,21 @@ replacements:
     fieldPaths:
     - spec.template.spec.containers.[name=manager].image
 
+# Replace API key cleanup CronJob image from params.env (ubi-minimal for curl).
+# Enables the operator to override the image with a pinned SHA digest for
+# disconnected environments via RELATED_IMAGE_UBI_MINIMAL_IMAGE.
+- source:
+    kind: ConfigMap
+    version: v1
+    name: maas-parameters
+    fieldPath: data.maas-api-key-cleanup-image
+  targets:
+  - select:
+      kind: CronJob
+      name: maas-api-key-cleanup
+    fieldPaths:
+    - spec.jobTemplate.spec.template.spec.containers.[name=cleanup].image
+
 # -----------------------------------------------------------------------------
 # 2. GATEWAY CONFIGURATION
 # -----------------------------------------------------------------------------

--- a/maas-controller/pkg/platform/tenantreconcile/constants.go
+++ b/maas-controller/pkg/platform/tenantreconcile/constants.go
@@ -40,9 +40,10 @@ const (
 
 // ImageParamKeys maps params.env keys to RELATED_IMAGE_* env vars (same as ODH modelsasservice_support.go).
 var ImageParamKeys = map[string]string{
-	"maas-api-image":           "RELATED_IMAGE_ODH_MAAS_API_IMAGE",
-	"maas-controller-image":    "RELATED_IMAGE_ODH_MAAS_CONTROLLER_IMAGE",
-	"payload-processing-image": "RELATED_IMAGE_ODH_AI_GATEWAY_PAYLOAD_PROCESSING_IMAGE",
+	"maas-api-image":             "RELATED_IMAGE_ODH_MAAS_API_IMAGE",
+	"maas-controller-image":      "RELATED_IMAGE_ODH_MAAS_CONTROLLER_IMAGE",
+	"payload-processing-image":   "RELATED_IMAGE_ODH_AI_GATEWAY_PAYLOAD_PROCESSING_IMAGE",
+	"maas-api-key-cleanup-image": "RELATED_IMAGE_UBI_MINIMAL_IMAGE",
 }
 
 // GVKs used for post-render and readiness (mirrors opendatahub-operator/pkg/cluster/gvk selections for modelsasservice).


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
PR #751 added operator-managed image support for the `maas-api-key-cleanup` CronJob so the ODH operator can override `registry.redhat.io/ubi9/ubi-minimal:9.7` with a SHA-pinned digest for disconnected environments via `RELATED_IMAGE_UBI_MINIMAL_IMAGE`.

The Tenant refactor (#735, merged two days later) accidentally removed the kustomize replacement from `shared-patches/kustomization.yaml` and did not add the corresponding `ImageParamKeys` entry in the Tenant reconciler. Without this fix the CronJob falls back to the hardcoded tag in the base manifest, which breaks disconnected/air-gapped clusters where images must be pulled by digest from a mirror.

This PR restores the wiring in two places:
- **`deployment/components/shared-patches/kustomization.yaml`** — re-adds the replacement that maps `data.maas-api-key-cleanup-image` from the `maas-parameters` ConfigMap into `spec.jobTemplate.spec.template.spec.containers.[name=cleanup].image` on the CronJob.
- **`maas-controller/pkg/platform/tenantreconcile/constants.go`** — adds `"maas-api-key-cleanup-image": "RELATED_IMAGE_UBI_MINIMAL_IMAGE"` to `ImageParamKeys` so the Tenant reconciler's `ApplyParams` substitutes the digest into `params.env` before kustomize build.


https://redhat.atlassian.net/browse/RHOAIENG-59430

## How Has This Been Tested?
Verified both overlays render the CronJob with the image sourced from `params.env`:
```sh
kustomize build deployment/overlays/odh | grep -A2 'name: cleanup'
kustomize build maas-api/deploy/overlays/odh | grep -A2 'name: cleanup'
```
## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended image replacement functionality to the API key cleanup CronJob, allowing operators to customize the container image via configuration parameters.

* **Improvements**
  * Unified image customization now covers both standard deployments and the API key cleanup job, enabling flexible container image management across all components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->