### PR TITLE
fix(cve): cve-2026-33815 and cve-2026-33816 in pgx

### DIFF
--- a/maas-api/go.mod
+++ b/maas-api/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.3.0
 	github.com/golang-migrate/migrate/v4 v4.19.1
 	github.com/google/uuid v1.6.0
-	github.com/jackc/pgx/v5 v5.9.0
+	github.com/jackc/pgx/v5 v5.9.2
 	github.com/kserve/kserve v0.0.0-20251121160314-57d83d202f36
 	github.com/lib/pq v1.10.9
 	github.com/openai/openai-go/v2 v2.3.1

--- a/maas-api/go.sum
+++ b/maas-api/go.sum
@@ -205,8 +205,8 @@ github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsI
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
-github.com/jackc/pgx/v5 v5.9.0 h1:T/dI+2TvmI2H8s/KH1/lXIbz1CUFk3gn5oTjr0/mBsE=
-github.com/jackc/pgx/v5 v5.9.0/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
+github.com/jackc/pgx/v5 v5.9.2 h1:3ZhOzMWnR4yJ+RW1XImIPsD1aNSz4T4fyP7zlQb56hw=
+github.com/jackc/pgx/v5 v5.9.2/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
 github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/jmespath/go-jmespath v0.4.1-0.20220621161143-b0104c826a24 h1:liMMTbpW34dhU4az1GN0pTPADwNmvoRSeoZ6PItiqnY=


### PR DESCRIPTION
## CVE Details

| Field | Value |
|-------|-------|
| **CVE IDs** | CVE-2026-33815, CVE-2026-33816 |
| **Package** | github.com/jackc/pgx/v5 |
| **Type** | Memory-safety vulnerability |
| **Fix** | Update pgx from v5.9.0 to v5.9.2 |

## Fix Summary

Updated `github.com/jackc/pgx/v5` from v5.9.0 to v5.9.2 in `maas-api/go.mod` to resolve two memory-safety vulnerabilities reported in pgx.

### Changes
- `maas-api/go.mod`: pgx v5.9.0 → v5.9.2
- `maas-api/go.sum`: updated checksums

## Test Results

✅ **All tests passed**

```
ok   github.com/opendatahub-io/models-as-a-service/maas-api/cmd
ok   github.com/opendatahub-io/models-as-a-service/maas-api/internal/api_keys
ok   github.com/opendatahub-io/models-as-a-service/maas-api/internal/auth
ok   github.com/opendatahub-io/models-as-a-service/maas-api/internal/config
ok   github.com/opendatahub-io/models-as-a-service/maas-api/internal/handlers
ok   github.com/opendatahub-io/models-as-a-service/maas-api/internal/subscription
```

✅ **Build verified**: `go build ./...` succeeded
✅ **govulncheck verified**: pgx CVEs no longer detected after update

## Breaking Changes

**Risk: Low** — Patch version update (v5.9.0 → v5.9.2), no API changes expected.

## Verification Steps

- [ ] Review go.mod and go.sum changes
- [ ] Verify CI pipeline passes
- [ ] Confirm pgx v5.9.2 resolves CVE-2026-33815 and CVE-2026-33816

## Jira References

RHOAIENG-57067, [RHOAIENG-57063](https://redhat.atlassian.net/browse/RHOAIENG-57063)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database connectivity library to the latest patch version for improved stability and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->