### PR TITLE
fix(e2e): avoid creating service accounts in default namespace

### DIFF
--- a/test/e2e/tests/test_api_keys.py
+++ b/test/e2e/tests/test_api_keys.py
@@ -1106,8 +1106,8 @@ class TestAPIKeySubscriptionPhases:
         sa_name = "e2e-apikey-active-sa"
 
         try:
-            oc_token = _create_sa_token(sa_name, namespace="default")
-            sa_user = _sa_to_user(sa_name, namespace="default")
+            oc_token = _create_sa_token(sa_name, namespace=MODEL_NAMESPACE)
+            sa_user = _sa_to_user(sa_name, namespace=MODEL_NAMESPACE)
 
             _create_test_auth_policy(auth_name, MODEL_REF, users=[sa_user])
             _create_test_subscription(subscription_name, MODEL_REF, users=[sa_user])
@@ -1130,7 +1130,7 @@ class TestAPIKeySubscriptionPhases:
         finally:
             _delete_cr("maassubscription", subscription_name, namespace=ns)
             _delete_cr("maasauthpolicy", auth_name, namespace=ns)
-            _delete_sa(sa_name, namespace="default")
+            _delete_sa(sa_name, namespace=MODEL_NAMESPACE)
             _wait_reconcile()
 
     def test_create_key_for_degraded_subscription(self):
@@ -1142,8 +1142,8 @@ class TestAPIKeySubscriptionPhases:
         missing_model = "nonexistent-model-apikey"
 
         try:
-            oc_token = _create_sa_token(sa_name, namespace="default")
-            sa_user = _sa_to_user(sa_name, namespace="default")
+            oc_token = _create_sa_token(sa_name, namespace=MODEL_NAMESPACE)
+            sa_user = _sa_to_user(sa_name, namespace=MODEL_NAMESPACE)
 
             _create_test_auth_policy(auth_name, MODEL_REF, users=[sa_user])
             # Create with valid + missing model to trigger Degraded phase
@@ -1171,7 +1171,7 @@ class TestAPIKeySubscriptionPhases:
         finally:
             _delete_cr("maassubscription", subscription_name, namespace=ns)
             _delete_cr("maasauthpolicy", auth_name, namespace=ns)
-            _delete_sa(sa_name, namespace="default")
+            _delete_sa(sa_name, namespace=MODEL_NAMESPACE)
             _wait_reconcile()
 
     def test_create_key_for_failed_subscription(self):
@@ -1182,8 +1182,8 @@ class TestAPIKeySubscriptionPhases:
         sa_name = "e2e-apikey-failed-sa"
 
         try:
-            oc_token = _create_sa_token(sa_name, namespace="default")
-            sa_user = _sa_to_user(sa_name, namespace="default")
+            oc_token = _create_sa_token(sa_name, namespace=MODEL_NAMESPACE)
+            sa_user = _sa_to_user(sa_name, namespace=MODEL_NAMESPACE)
 
             _create_test_auth_policy(auth_name, MODEL_REF, users=[sa_user])
             _create_test_subscription(subscription_name, MODEL_REF, users=[sa_user])
@@ -1235,7 +1235,7 @@ class TestAPIKeySubscriptionPhases:
         finally:
             _delete_cr("maassubscription", subscription_name, namespace=ns)
             _delete_cr("maasauthpolicy", auth_name, namespace=ns)
-            _delete_sa(sa_name, namespace="default")
+            _delete_sa(sa_name, namespace=MODEL_NAMESPACE)
             _wait_reconcile()
 
     def test_create_key_for_pending_subscription(self):
@@ -1246,8 +1246,8 @@ class TestAPIKeySubscriptionPhases:
         sa_name = "e2e-apikey-pending-sa"
 
         try:
-            oc_token = _create_sa_token(sa_name, namespace="default")
-            sa_user = _sa_to_user(sa_name, namespace="default")
+            oc_token = _create_sa_token(sa_name, namespace=MODEL_NAMESPACE)
+            sa_user = _sa_to_user(sa_name, namespace=MODEL_NAMESPACE)
 
             _create_test_auth_policy(auth_name, MODEL_REF, users=[sa_user])
             _create_test_subscription(subscription_name, MODEL_REF, users=[sa_user])
@@ -1292,7 +1292,7 @@ class TestAPIKeySubscriptionPhases:
         finally:
             _delete_cr("maassubscription", subscription_name, namespace=ns)
             _delete_cr("maasauthpolicy", auth_name, namespace=ns)
-            _delete_sa(sa_name, namespace="default")
+            _delete_sa(sa_name, namespace=MODEL_NAMESPACE)
             _wait_reconcile()
 
     def test_reject_key_for_unreconciled_subscription(self):
@@ -1310,8 +1310,8 @@ class TestAPIKeySubscriptionPhases:
             # Scale down controller to prevent reconciliation
             _scale_controller_down()
 
-            oc_token = _create_sa_token(sa_name, namespace="default")
-            sa_user = _sa_to_user(sa_name, namespace="default")
+            oc_token = _create_sa_token(sa_name, namespace=MODEL_NAMESPACE)
+            sa_user = _sa_to_user(sa_name, namespace=MODEL_NAMESPACE)
 
             _create_test_auth_policy(auth_name, MODEL_REF, users=[sa_user])
             # Create subscription (won't reconcile with controller scaled down)
@@ -1350,5 +1350,5 @@ class TestAPIKeySubscriptionPhases:
             _scale_controller_up()
             _delete_cr("maassubscription", subscription_name, namespace=ns)
             _delete_cr("maasauthpolicy", auth_name, namespace=ns)
-            _delete_sa(sa_name, namespace="default")
+            _delete_sa(sa_name, namespace=MODEL_NAMESPACE)
             _wait_reconcile()

--- a/test/e2e/tests/test_subscription.py
+++ b/test/e2e/tests/test_subscription.py
@@ -1394,10 +1394,10 @@ class TestE2ESubscriptionFlow:
             # - sa_with_auth: in auth policy (so the policy exists)
             # - sa_with_sub: in subscription but NOT in auth policy
             _ = _create_sa_token(sa_with_auth, namespace=ns)  # SA creation only - token unused
-            oc_token_with_sub = _create_sa_token(sa_with_sub, namespace="default")  # Different namespace
+            oc_token_with_sub = _create_sa_token(sa_with_sub, namespace=MODEL_NAMESPACE)  # Different namespace
 
             sa_with_auth_user = _sa_to_user(sa_with_auth, namespace=ns)
-            sa_with_sub_user = _sa_to_user(sa_with_sub, namespace="default")
+            sa_with_sub_user = _sa_to_user(sa_with_sub, namespace=MODEL_NAMESPACE)
 
             # Delete simulator-access so system:authenticated doesn't grant auth
             _delete_cr("maasauthpolicy", SIMULATOR_ACCESS_POLICY)
@@ -1426,7 +1426,7 @@ class TestE2ESubscriptionFlow:
             _delete_cr("maassubscription", subscription_name, namespace=ns)
             _delete_cr("maasauthpolicy", auth_policy_name, namespace=ns)
             _delete_sa(sa_with_auth, namespace=ns)
-            _delete_sa(sa_with_sub, namespace="default")
+            _delete_sa(sa_with_sub, namespace=MODEL_NAMESPACE)
             _wait_reconcile()
 
     def test_e2e_single_subscription_auto_selects(self):
@@ -1742,8 +1742,8 @@ class TestStatusReporting:
         sa_name = "e2e-status-active-sa"
 
         try:
-            _create_sa_token(sa_name, namespace="default")
-            sa_user = f"system:serviceaccount:default:{sa_name}"
+            _create_sa_token(sa_name, namespace=MODEL_NAMESPACE)
+            sa_user = _sa_to_user(sa_name, namespace=MODEL_NAMESPACE)
 
             _create_test_auth_policy(auth_name, MODEL_REF, users=[sa_user])
             _create_test_subscription(subscription_name, MODEL_REF, users=[sa_user])
@@ -1769,7 +1769,7 @@ class TestStatusReporting:
         finally:
             _delete_cr("maassubscription", subscription_name, namespace=ns)
             _delete_cr("maasauthpolicy", auth_name, namespace=ns)
-            _delete_sa(sa_name, namespace="default")
+            _delete_sa(sa_name, namespace=MODEL_NAMESPACE)
             _wait_reconcile()
 
     def test_subscription_failed_status_with_missing_model(self):
@@ -1786,8 +1786,8 @@ class TestStatusReporting:
         missing_model = "nonexistent-model-xyz"
 
         try:
-            _create_sa_token(sa_name, namespace="default")
-            sa_user = f"system:serviceaccount:default:{sa_name}"
+            _create_sa_token(sa_name, namespace=MODEL_NAMESPACE)
+            sa_user = _sa_to_user(sa_name, namespace=MODEL_NAMESPACE)
 
             # Create subscription with non-existent model
             _create_test_subscription(subscription_name, missing_model, users=[sa_user])
@@ -1809,7 +1809,7 @@ class TestStatusReporting:
 
         finally:
             _delete_cr("maassubscription", subscription_name, namespace=ns)
-            _delete_sa(sa_name, namespace="default")
+            _delete_sa(sa_name, namespace=MODEL_NAMESPACE)
             _wait_reconcile()
 
     def test_authpolicy_active_status_with_valid_model(self):
@@ -1825,8 +1825,8 @@ class TestStatusReporting:
         sa_name = "e2e-status-active-auth-sa"
 
         try:
-            _create_sa_token(sa_name, namespace="default")
-            sa_user = f"system:serviceaccount:default:{sa_name}"
+            _create_sa_token(sa_name, namespace=MODEL_NAMESPACE)
+            sa_user = _sa_to_user(sa_name, namespace=MODEL_NAMESPACE)
 
             _create_test_auth_policy(auth_name, MODEL_REF, users=[sa_user])
 
@@ -1847,7 +1847,7 @@ class TestStatusReporting:
 
         finally:
             _delete_cr("maasauthpolicy", auth_name, namespace=ns)
-            _delete_sa(sa_name, namespace="default")
+            _delete_sa(sa_name, namespace=MODEL_NAMESPACE)
             _wait_reconcile()
 
     def test_authpolicy_failed_status_with_missing_model(self):
@@ -1864,8 +1864,8 @@ class TestStatusReporting:
         missing_model = "nonexistent-model-abc"
 
         try:
-            _create_sa_token(sa_name, namespace="default")
-            sa_user = f"system:serviceaccount:default:{sa_name}"
+            _create_sa_token(sa_name, namespace=MODEL_NAMESPACE)
+            sa_user = _sa_to_user(sa_name, namespace=MODEL_NAMESPACE)
 
             # Create auth policy with non-existent model
             _create_test_auth_policy(auth_name, missing_model, users=[sa_user])
@@ -1880,7 +1880,7 @@ class TestStatusReporting:
 
         finally:
             _delete_cr("maasauthpolicy", auth_name, namespace=ns)
-            _delete_sa(sa_name, namespace="default")
+            _delete_sa(sa_name, namespace=MODEL_NAMESPACE)
             _wait_reconcile()
 
     def test_subscription_degraded_status_with_partial_models(self):
@@ -1898,8 +1898,8 @@ class TestStatusReporting:
         missing_model = "nonexistent-model-partial"
 
         try:
-            _create_sa_token(sa_name, namespace="default")
-            sa_user = f"system:serviceaccount:default:{sa_name}"
+            _create_sa_token(sa_name, namespace=MODEL_NAMESPACE)
+            sa_user = _sa_to_user(sa_name, namespace=MODEL_NAMESPACE)
 
             # Create auth policy for valid model only
             _create_test_auth_policy(auth_name, MODEL_REF, users=[sa_user])
@@ -1929,7 +1929,7 @@ class TestStatusReporting:
         finally:
             _delete_cr("maassubscription", subscription_name, namespace=ns)
             _delete_cr("maasauthpolicy", auth_name, namespace=ns)
-            _delete_sa(sa_name, namespace="default")
+            _delete_sa(sa_name, namespace=MODEL_NAMESPACE)
             _wait_reconcile()
 
     def test_subscription_degraded_trlp_blocks_inference(self):
@@ -1965,8 +1965,8 @@ class TestStatusReporting:
 
             # Step 2: Create auth policy and subscription
             log.info("Step 2: Creating subscription with Kuadrant controller down...")
-            sa_token = _create_sa_token(sa_name, namespace="default")
-            sa_user = f"system:serviceaccount:default:{sa_name}"
+            sa_token = _create_sa_token(sa_name, namespace=MODEL_NAMESPACE)
+            sa_user = _sa_to_user(sa_name, namespace=MODEL_NAMESPACE)
 
             _create_test_auth_policy(auth_name, TRLP_TEST_MODEL_REF, users=[sa_user])
             _create_test_subscription(subscription_name, TRLP_TEST_MODEL_REF, users=[sa_user])
@@ -2042,7 +2042,7 @@ class TestStatusReporting:
             # Clean up resources (but not the model - it's pre-deployed)
             _delete_cr("maassubscription", subscription_name, namespace=ns)
             _delete_cr("maasauthpolicy", auth_name, namespace=ns)
-            _delete_sa(sa_name, namespace="default")
+            _delete_sa(sa_name, namespace=MODEL_NAMESPACE)
             _wait_reconcile()
 
     def test_authpolicy_degraded_status_with_partial_models(self):
@@ -2059,8 +2059,8 @@ class TestStatusReporting:
         missing_model = "nonexistent-model-auth-partial"
 
         try:
-            _create_sa_token(sa_name, namespace="default")
-            sa_user = f"system:serviceaccount:default:{sa_name}"
+            _create_sa_token(sa_name, namespace=MODEL_NAMESPACE)
+            sa_user = _sa_to_user(sa_name, namespace=MODEL_NAMESPACE)
 
             # Create auth policy with both valid and missing models
             _create_test_auth_policy(auth_name, [MODEL_REF, missing_model], users=[sa_user])
@@ -2082,7 +2082,7 @@ class TestStatusReporting:
 
         finally:
             _delete_cr("maasauthpolicy", auth_name, namespace=ns)
-            _delete_sa(sa_name, namespace="default")
+            _delete_sa(sa_name, namespace=MODEL_NAMESPACE)
             _wait_reconcile()
 
     def test_subscription_status_transitions_on_model_deletion(self):
@@ -2099,8 +2099,8 @@ class TestStatusReporting:
         sa_name = "e2e-status-transition-sa"
 
         try:
-            _create_sa_token(sa_name, namespace="default")
-            sa_user = f"system:serviceaccount:default:{sa_name}"
+            _create_sa_token(sa_name, namespace=MODEL_NAMESPACE)
+            sa_user = _sa_to_user(sa_name, namespace=MODEL_NAMESPACE)
 
             # Create a temporary model
             _create_test_maas_model(model_name, llmis_name=MODEL_REF, namespace=MODEL_NAMESPACE)
@@ -2156,7 +2156,7 @@ class TestStatusReporting:
             _delete_cr("maassubscription", subscription_name, namespace=ns)
             _delete_cr("maasauthpolicy", auth_name, namespace=ns)
             _delete_cr("maasmodelref", model_name, namespace=MODEL_NAMESPACE)
-            _delete_sa(sa_name, namespace="default")
+            _delete_sa(sa_name, namespace=MODEL_NAMESPACE)
             _wait_reconcile()
 
 class TestDegradedSubscriptionFiltering:
@@ -2192,8 +2192,8 @@ class TestDegradedSubscriptionFiltering:
         missing_model = "nonexistent-model-inf"
 
         try:
-            oc_token = _create_sa_token(sa_name, namespace="default")
-            sa_user = f"system:serviceaccount:default:{sa_name}"
+            oc_token = _create_sa_token(sa_name, namespace=MODEL_NAMESPACE)
+            sa_user = _sa_to_user(sa_name, namespace=MODEL_NAMESPACE)
 
             # Create auth policy for valid model only
             _create_test_auth_policy(auth_name, MODEL_REF, users=[sa_user])
@@ -2249,7 +2249,7 @@ class TestDegradedSubscriptionFiltering:
         finally:
             _delete_cr("maassubscription", subscription_name, namespace=ns)
             _delete_cr("maasauthpolicy", auth_name, namespace=ns)
-            _delete_sa(sa_name, namespace="default")
+            _delete_sa(sa_name, namespace=MODEL_NAMESPACE)
             _wait_reconcile()
 
     def test_failed_subscription_blocks_inference(self):
@@ -2271,8 +2271,8 @@ class TestDegradedSubscriptionFiltering:
         sa_name = "e2e-failed-sub-inf-sa"
 
         try:
-            oc_token = _create_sa_token(sa_name, namespace="default")
-            sa_user = f"system:serviceaccount:default:{sa_name}"
+            oc_token = _create_sa_token(sa_name, namespace=MODEL_NAMESPACE)
+            sa_user = _sa_to_user(sa_name, namespace=MODEL_NAMESPACE)
 
             # Create auth policy for valid model
             _create_test_auth_policy(auth_name, MODEL_REF, users=[sa_user])
@@ -2364,7 +2364,7 @@ class TestDegradedSubscriptionFiltering:
         finally:
             _delete_cr("maassubscription", subscription_name, namespace=ns)
             _delete_cr("maasauthpolicy", auth_name, namespace=ns)
-            _delete_sa(sa_name, namespace="default")
+            _delete_sa(sa_name, namespace=MODEL_NAMESPACE)
             _wait_reconcile()
 
     def test_models_endpoint_with_degraded_subscription_api_key(self):
@@ -2382,8 +2382,8 @@ class TestDegradedSubscriptionFiltering:
         missing_model = "nonexistent-model-apikey"
 
         try:
-            oc_token = _create_sa_token(sa_name, namespace="default")
-            sa_user = f"system:serviceaccount:default:{sa_name}"
+            oc_token = _create_sa_token(sa_name, namespace=MODEL_NAMESPACE)
+            sa_user = _sa_to_user(sa_name, namespace=MODEL_NAMESPACE)
 
             # Create auth policy
             _create_test_auth_policy(auth_name, MODEL_REF, users=[sa_user])
@@ -2437,7 +2437,7 @@ class TestDegradedSubscriptionFiltering:
         finally:
             _delete_cr("maassubscription", subscription_name, namespace=ns)
             _delete_cr("maasauthpolicy", auth_name, namespace=ns)
-            _delete_sa(sa_name, namespace="default")
+            _delete_sa(sa_name, namespace=MODEL_NAMESPACE)
             _wait_reconcile()
 
     def test_models_endpoint_with_degraded_subscription_kube_token(self):
@@ -2454,8 +2454,8 @@ class TestDegradedSubscriptionFiltering:
         missing_model = "nonexistent-model-kube"
 
         try:
-            oc_token = _create_sa_token(sa_name, namespace="default")
-            sa_user = f"system:serviceaccount:default:{sa_name}"
+            oc_token = _create_sa_token(sa_name, namespace=MODEL_NAMESPACE)
+            sa_user = _sa_to_user(sa_name, namespace=MODEL_NAMESPACE)
 
             # Create auth policy
             _create_test_auth_policy(auth_name, MODEL_REF, users=[sa_user])
@@ -2509,5 +2509,5 @@ class TestDegradedSubscriptionFiltering:
         finally:
             _delete_cr("maassubscription", subscription_name, namespace=ns)
             _delete_cr("maasauthpolicy", auth_name, namespace=ns)
-            _delete_sa(sa_name, namespace="default")
+            _delete_sa(sa_name, namespace=MODEL_NAMESPACE)
             _wait_reconcile()


### PR DESCRIPTION
## Summary
Some clusters (eg. ROSA) restrict deletion of service accounts in the `default` namespace, causing test cleanup failures.

- Replace `namespace="default"` with `namespace=MODEL_NAMESPACE` for all e2e test service account operations (`_create_sa_token`, `_sa_to_user`, `_delete_sa`)
- Replace hardcoded `f"system:serviceaccount:default:{sa_name}"` strings with `_sa_to_user(sa_name, namespace=MODEL_NAMESPACE)` for consistency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end tests to use model-scoped namespace configuration for service account operations, improving test environment consistency and cleanup procedures.

**Note:** This release contains no user-facing changes. Updates are internal to testing infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->