### PR TITLE
docs: condense Authorino caching documentation

### DIFF
--- a/docs/content/configuration-and-management/authorino-caching.md
+++ b/docs/content/configuration-and-management/authorino-caching.md
@@ -47,14 +47,19 @@ These values are injected into the maas-controller deployment via ConfigMap.
 
 #### Via manager.yaml (Base Deployment)
 
-Edit `deployment/base/maas-controller/manager/manager.yaml`:
+Edit `deployment/base/maas-controller/manager/manager.yaml` to change hardcoded values and add env vars:
 
 ```yaml
+args:
+  # ... other args ...
+  - --metadata-cache-ttl=$(METADATA_CACHE_TTL)  # Change from hardcoded 60
+  - --authz-cache-ttl=$(AUTHZ_CACHE_TTL)        # Change from hardcoded 60
 env:
   - name: METADATA_CACHE_TTL
     value: "300"  # 5 minutes
   - name: AUTHZ_CACHE_TTL
     value: "30"   # 30 seconds
+  # ... other env vars ...
 ```
 
 > **Note on Customization:** Direct modification of Authorino deployments or settings may interact with operator reconciliation during upgrades. Test changes in non-production environments and document any customizations for support handoff.
@@ -69,7 +74,7 @@ Cache TTL represents the maximum staleness window for access control changes:
 
 - **API key revocation or group membership changes:** May take up to `METADATA_CACHE_TTL` seconds to propagate
 - **Subscription selection:** If a user's group membership changes, the cached subscription selection uses the old groups until the TTL expires (up to `METADATA_CACHE_TTL` seconds)
-- **Authorization policy changes:** May take up to `AUTHZ_CACHE_TTL` seconds to propagate
+- **Authorization policy changes:** May take up to the effective authorization cache TTL (the minimum of `AUTHZ_CACHE_TTL` and `METADATA_CACHE_TTL`) to propagate
 
 For immediate enforcement after changes:
 1. Delete the affected AuthPolicy to clear Authorino's cache (triggers reconciliation)

--- a/docs/content/configuration-and-management/authorino-caching.md
+++ b/docs/content/configuration-and-management/authorino-caching.md
@@ -1,23 +1,21 @@
 # Authorino Caching Configuration
 
-This document describes the Authorino/Kuadrant caching configuration in MaaS, including how to tune cache TTLs for metadata and authorization evaluators.
+This document describes how to tune Authorino cache TTLs for metadata and authorization evaluators in MaaS.
 
 ---
 
-## Overview
+## What is Cached
 
-MaaS-generated AuthPolicy resources enable Authorino-style caching on:
+MaaS-generated AuthPolicy resources enable caching on:
 
 - **Metadata evaluators** (HTTP calls to maas-api):
   - `apiKeyValidation` - validates API keys and returns user identity + groups
   - `subscription-info` - selects the appropriate subscription for the request
 
 - **Authorization evaluators** (OPA policy evaluation):
-  - `auth-valid` - validates authentication (API key OR K8s token)
-  - `subscription-valid` - ensures a valid subscription was selected
-  - `require-group-membership` - checks user/group membership against allowed lists
+  - `auth-valid`, `subscription-valid`, `require-group-membership`
 
-Caching reduces load on maas-api and CPU spent on Rego re-evaluation by reusing results when the cache key repeats within the TTL window.
+Caching reduces load on maas-api and OPA CPU by reusing results when the cache key repeats within the TTL window. Cache keys include user ID, groups, subscription, and model to prevent cross-principal or cross-subscription cache sharing.
 
 ---
 
@@ -25,14 +23,14 @@ Caching reduces load on maas-api and CPU spent on Rego re-evaluation by reusing 
 
 ### Environment Variables
 
-The maas-controller deployment supports the following environment variables to configure cache TTLs:
+The maas-controller deployment supports the following environment variables:
 
-| Variable | Description | Default | Unit | Constraints |
-|----------|-------------|---------|------|-------------|
-| `METADATA_CACHE_TTL` | TTL for metadata HTTP caching (apiKeyValidation, subscription-info) | `60` | seconds | Must be ≥ 0 |
-| `AUTHZ_CACHE_TTL` | TTL for OPA authorization caching (auth-valid, subscription-valid, require-group-membership) | `60` | seconds | Must be ≥ 0 |
+| Variable | Description | Default | Constraints |
+|----------|-------------|---------|-------------|
+| `METADATA_CACHE_TTL` | TTL for metadata HTTP caching (seconds) | `60` | Must be ≥ 0 |
+| `AUTHZ_CACHE_TTL` | TTL for OPA authorization caching (seconds) | `60` | Must be ≥ 0 |
 
-**Note:** The controller will fail to start if either TTL is set to a negative value.
+**Authorization cache TTL capping:** Authorization caches are automatically capped at the metadata cache TTL to prevent stale authorization decisions. If `AUTHZ_CACHE_TTL > METADATA_CACHE_TTL`, the authorization cache uses the metadata TTL instead, and a warning is logged at startup.
 
 ### Deployment Configuration
 
@@ -59,168 +57,45 @@ env:
     value: "30"   # 30 seconds
 ```
 
-### Important: Authorization Cache TTL Capping
-
-**Authorization caches are automatically capped at the metadata cache TTL** to prevent stale authorization decisions.
-
-Authorization evaluators (auth-valid, subscription-valid, require-group-membership) depend on metadata evaluators (apiKeyValidation, subscription-info). If authorization caches outlive metadata caches, stale metadata can lead to incorrect authorization decisions.
-
-**Example:**
-```yaml
-METADATA_CACHE_TTL=60   # 1 minute
-AUTHZ_CACHE_TTL=300     # 5 minutes (will be capped at 60 seconds)
-```
-
-In this scenario:
-- Metadata caches use 60-second TTL ✅
-- Authorization caches use **60-second TTL** (capped, not 300) ✅
-- A warning is logged at startup: "Authorization cache TTL exceeds metadata cache TTL"
-
-**Recommendation:** Set `AUTHZ_CACHE_TTL ≤ METADATA_CACHE_TTL` to avoid confusion.
+> **Note on Customization:** Direct modification of Authorino deployments or settings may interact with operator reconciliation during upgrades. Test changes in non-production environments and document any customizations for support handoff.
 
 ---
 
-## Cache Key Design
-
-Cache keys are carefully designed to prevent data leakage between principals, subscriptions, and models.
-
-### Collision Resistance
-
-Cache keys use single-character delimiters (`|` and `,`) to separate components:
-
-- **Field delimiter**: `|` separates major components (user ID, groups, subscription, model)
-- **Group delimiter**: `,` joins multiple group names
-
-**For API Keys - Collision Resistant:**
-Cache keys use database-assigned UUIDs instead of usernames:
-- User ID: Database primary key (UUID format in `api_keys.id` column)
-- Immutable and unique per API key
-- Not user-controllable (assigned by database on creation)
-- Example key: `550e8400-e29b-41d4-a716-446655440000|team,admin|sub1|ns/model`
-- No collision risk even if groups contain delimiters (UUID prefix ensures uniqueness)
-
-**For Kubernetes Tokens - Already Safe:**
-Kubernetes usernames follow validated format enforced by the K8s API:
-- Pattern: `system:serviceaccount:namespace:sa-name`
-- Kubernetes validates namespace/SA names (DNS-1123: alphanumeric + hyphens only)
-- No special characters like `|` or `,` allowed in usernames
-- Creating service accounts requires cluster permissions (not user self-service)
-
-**Implementation:**
-The `apiKeyValidation` metadata evaluator returns a `userId` field:
-- API keys: Set to `api_keys.id` (database UUID)
-- Cache keys reference `auth.metadata.apiKeyValidation.userId` in CEL expressions
-- This eliminates username-based collision attacks
-
-### Metadata Caches
-
-**apiKeyValidation:**
-- **Only runs for API key requests** (Authorization header matches `Bearer sk-oai-*`)
-- Key: `<api-key-value>`
-- Ensures each unique API key has its own cache entry
-- Does not run for Kubernetes token requests (prevents cache pollution)
-- Returns `userId` field set to database UUID (`api_keys.id`)
-
-**subscription-info:**
-- Key: `<userId>|<groups>|<requested-subscription>|<model-namespace>/<model-name>`
-- For API keys: `userId` is database UUID from `apiKeyValidation` response
-- For K8s tokens: `userId` is validated K8s username (`system:serviceaccount:...`)
-- Groups joined with `,` delimiter
-- Ensures cache isolation per user, group membership, requested subscription, and model
-
-### Authorization Caches
-
-**auth-valid:**
-- Key: `<auth-type>|<identity>|<model-namespace>/<model-name>`
-- For API keys: `api-key|<key-value>|model`
-- For K8s tokens: `k8s-token|<username>|model`
-
-**subscription-valid:**
-- Key: Same as subscription-info metadata (ensures cache coherence)
-- Format: `<userId>|<groups>|<requested-subscription>|<model>`
-- For API keys: `userId` is database UUID. For K8s tokens: validated username.
-
-**require-group-membership:**
-- Key: `<userId>|<groups>|<model-namespace>/<model-name>`
-- For API keys: `userId` is database UUID. For K8s tokens: validated username.
-- Groups joined with `,` delimiter
-- Ensures cache isolation per user identity and model
-
----
-
-## Operational Tuning
-
-### When to Increase Metadata Cache TTL
-
-- **High API key validation load**: If maas-api is experiencing high load from repeated `/internal/v1/api-keys/validate` calls
-- **Stable API keys**: API key metadata (username, groups) doesn't change frequently
-- **Example**: Set `METADATA_CACHE_TTL=300` (5 minutes) to reduce maas-api load by 5x
-
-### When to Decrease Authorization Cache TTL
-
-- **Group membership changes**: If users are frequently added/removed from groups
-- **Security compliance**: Shorter TTL ensures access changes propagate faster
-- **Example**: Set `AUTHZ_CACHE_TTL=30` (30 seconds) for faster group membership updates
-
-### Monitoring
-
-After changing TTL values, monitor:
-- **maas-api load**: Reduced `/internal/v1/api-keys/validate` and `/internal/v1/subscriptions/select` call rates
-- **Authorino CPU**: Reduced OPA evaluation CPU usage
-- **Request latency**: Cache hits should have lower P99 latency
-
----
-
-## Security Notes
-
-### Cache Key Correctness
-
-All cache keys include sufficient dimensions to prevent cross-principal or cross-subscription cache sharing:
-
-- **Never share cache entries between different users**
-- **Never share cache entries between different API keys**
-- **Never share cache entries between different models** (model namespace/name in key)
-- **Never share cache entries between different group memberships** (groups in key)
-
-### Cache Key Collision Risk
-
-**API Keys - No Collision Risk:**
-Cache keys use database-assigned UUIDs instead of usernames:
-- User IDs are unique 128-bit UUIDs (format: `550e8400-e29b-41d4-a716-446655440000`)
-- Immutable and assigned by PostgreSQL at API key creation
-- Not user-controllable (no self-service user ID selection)
-- Even if groups contain delimiters (`,` or `|`), the UUID prefix prevents collision
-- Example: Two users with groups `["team,admin"]` and `["team", "admin"]` have different UUIDs, so no collision
-
-**Kubernetes Tokens - No Collision Risk:**
-Kubernetes usernames are validated by the K8s API server:
-- Format: `system:serviceaccount:namespace:sa-name`
-- Kubernetes enforces DNS-1123 naming: `[a-z0-9]([-a-z0-9]*[a-z0-9])?`
-- No special characters like `|` or `,` allowed
-- Creating service accounts requires cluster RBAC permissions (not user self-service)
-
-**Remaining Edge Case - Group Ordering:**
-Group array ordering affects cache keys:
-- `["admin", "user"]` produces different key than `["user", "admin"]`
-- CEL has no array sort() function
-- Impact: Suboptimal cache hit rate if group order varies between OIDC token refreshes
-- Mitigation: OIDC providers and K8s TokenReview typically return groups in consistent order
+## Operational Impact
 
 ### Stale Data Window
 
-Cache TTL represents the maximum staleness window:
+Cache TTL represents the maximum staleness window for access control changes:
 
-- **Metadata caches**: API key revocation or group membership changes may take up to `METADATA_CACHE_TTL` seconds to propagate
-- **Authorization caches**: Authorization policy changes may take up to `AUTHZ_CACHE_TTL` seconds to propagate
+- **API key revocation or group membership changes:** May take up to `METADATA_CACHE_TTL` seconds to propagate
+- **Subscription selection:** If a user's group membership changes, the cached subscription selection uses the old groups until the TTL expires (up to `METADATA_CACHE_TTL` seconds)
+- **Authorization policy changes:** May take up to `AUTHZ_CACHE_TTL` seconds to propagate
 
-For immediate policy enforcement after changes:
-1. Delete the affected AuthPolicy to clear Authorino's cache
-2. Or wait for the TTL to expire
+For immediate enforcement after changes:
+1. Delete the affected AuthPolicy to clear Authorino's cache (triggers reconciliation)
+2. Restart Authorino pods to force cache invalidation (disruptive; use during maintenance windows)
+3. Or wait for the TTL to expire
+
+### When to Tune
+
+**Increase metadata cache TTL** if:
+- maas-api experiences high load from repeated validation calls
+- API key metadata changes infrequently
+- Example: `METADATA_CACHE_TTL=300` (5 minutes) reduces maas-api load by 5x
+
+**Decrease authorization cache TTL** if:
+- Users are frequently added/removed from groups
+- Faster access change propagation is required for compliance
+- Example: `AUTHZ_CACHE_TTL=30` (30 seconds) for faster group membership updates
+
+**Monitor after changes:**
+- maas-api load: Reduced `/internal/v1/api-keys/validate` and `/internal/v1/subscriptions/select` call rates
+- Authorino CPU: Reduced OPA evaluation usage
+- Request latency: Cache hits should show lower P99 latency
 
 ---
 
 ## References
 
-- [Authorino Caching User Guide](https://docs.kuadrant.io/latest/authorino/docs/features/#caching)
 - [AuthPolicy Reference](https://docs.kuadrant.io/latest/kuadrant-operator/doc/reference/authpolicy/)
 - [MaaS Controller Overview](./maas-controller-overview.md)

--- a/docs/content/configuration-and-management/subscription-known-issues.md
+++ b/docs/content/configuration-and-management/subscription-known-issues.md
@@ -2,25 +2,6 @@
 
 This document describes known issues and operational considerations for the subscription-based MaaS Platform.
 
-## Subscription Selection Caching
-
-### Cache TTL for Subscription Selection
-
-**Impact:** Medium
-
-**Description:**
-
-Authorino caches the result of the MaaS API subscription selection call (e.g., 60 second TTL). If a user's group membership changes:
-
-- Within the cache window, the old subscription selection may still apply
-- After cache expiry, the new group membership is used
-- Restarting Authorino pods forces immediate cache invalidation (disruptive)
-
-**Workaround:**
-
-- Wait for cache TTL for changes to fully propagate
-- For immediate effect, restart Authorino pods (disruptive; use during maintenance windows)
-
 ## API Key vs OpenShift Token
 
 ### Group Snapshot in API Keys

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -16,7 +16,7 @@ Use this platform to streamline the deployment of your models, monitor usage, an
 ### ⚙️ Configuration & Management
 
 - **[Access and Quota Overview](concepts/subscription-overview.md)** - Policies (access) and subscriptions (quota) for model access
-- **[Subscription limitations and known issues](configuration-and-management/subscription-known-issues.md)** - Rate limits on shared routes, API keys, caching, and other planning notes
+- **[Subscription limitations and known issues](configuration-and-management/subscription-known-issues.md)** - Rate limits on shared routes, API keys, and other planning notes
 - **[Model Setup (On Cluster)](configuration-and-management/model-setup.md)** - Setting up models for MaaS
 - **[Self-Service Model Access](user-guide/self-service-model-access.md)** - Managing model access and policies
 


### PR DESCRIPTION
## Description
https://redhat.atlassian.net/browse/RHOAIENG-59733

Reduced authorino-caching.md from 227 to 101 lines by removing redundant cache key implementation details and security theory. Moved content to upstream Kuadrant docs reference.

Retained all operator-critical content:
- Environment variable configuration (METADATA_CACHE_TTL, AUTHZ_CACHE_TTL)
- TTL capping behavior
- Stale data window impacts
- When to tune guidance
- Monitoring recommendations
- Customization warning

Consolidated subscription selection caching content from subscription-known-issues.md into authorino-caching.md.

Updated index.md to remove "caching" from subscription-known-issues description.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Simplified caching documentation with improved clarity on key benefits and configuration options.
  * Removed outdated known issue regarding subscription selection caching behavior.
  * Updated documentation index to reflect current capabilities and limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->