### PR TITLE
fix(payload-processing): include payload-processing manifests in maas-controller image

### DIFF
--- a/deployment/base/maas-controller/rbac/clusterrole.yaml
+++ b/deployment/base/maas-controller/rbac/clusterrole.yaml
@@ -21,6 +21,7 @@ rules:
   resources:
   - endpoints
   - pods
+  - secrets
   verbs:
   - get
   - list
@@ -31,14 +32,6 @@ rules:
   - namespaces
   verbs:
   - create
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
   - get
   - list
   - watch

--- a/deployment/base/maas-controller/rbac/clusterrole.yaml
+++ b/deployment/base/maas-controller/rbac/clusterrole.yaml
@@ -39,16 +39,9 @@ rules:
   resources:
   - secrets
   verbs:
+  - get
   - list
   - watch
-- apiGroups:
-  - ""
-  resourceNames:
-  - maas-db-config
-  resources:
-  - secrets
-  verbs:
-  - get
 - apiGroups:
   - ""
   resources:

--- a/maas-api/deploy/overlays/odh/kustomization.yaml
+++ b/maas-api/deploy/overlays/odh/kustomization.yaml
@@ -11,6 +11,7 @@ metadata:
 resources:
 - ../../../../deployment/base/maas-api/overlays/tls
 - ../../../../deployment/base/maas-controller/policies
+- ../../../../deployment/base/payload-processing/default
 
 namespace: opendatahub
 
@@ -47,3 +48,106 @@ replacements:
       name: maas-api-backend-tls
     fieldPaths:
     - metadata.namespace
+
+# --- payload-processing replacements ---
+# Image
+- source:
+    kind: ConfigMap
+    version: v1
+    name: maas-parameters
+    fieldPath: data.payload-processing-image
+  targets:
+  - select:
+      kind: Deployment
+      name: payload-processing
+    fieldPaths:
+    - spec.template.spec.containers.[name=payload-processing].image
+# Replicas
+- source:
+    kind: ConfigMap
+    version: v1
+    name: maas-parameters
+    fieldPath: data.payload-processing-replicas
+  targets:
+  - select:
+      kind: Deployment
+      name: payload-processing
+    fieldPaths:
+    - spec.replicas
+# Payload-processing resources must be in the gateway namespace
+- source:
+    kind: ConfigMap
+    version: v1
+    name: maas-parameters
+    fieldPath: data.gateway-namespace
+  targets:
+  - select:
+      kind: Deployment
+      name: payload-processing
+    fieldPaths:
+    - metadata.namespace
+  - select:
+      kind: Service
+      name: payload-processing
+    fieldPaths:
+    - metadata.namespace
+  - select:
+      kind: ServiceAccount
+      name: payload-processing
+    fieldPaths:
+    - metadata.namespace
+  - select:
+      kind: EnvoyFilter
+      name: payload-processing
+    fieldPaths:
+    - metadata.namespace
+  - select:
+      kind: DestinationRule
+      name: payload-processing
+    fieldPaths:
+    - metadata.namespace
+  - select:
+      kind: ConfigMap
+      name: payload-processing-plugins
+    fieldPaths:
+    - metadata.namespace
+  - select:
+      kind: ClusterRoleBinding
+      name: payload-processing-reader
+    fieldPaths:
+    - subjects.0.namespace
+# EnvoyFilter must target the correct gateway name
+- source:
+    kind: ConfigMap
+    version: v1
+    name: maas-parameters
+    fieldPath: data.gateway-name
+  targets:
+  - select:
+      kind: EnvoyFilter
+      name: payload-processing
+    fieldPaths:
+    - spec.targetRefs.0.name
+# Gateway namespace in payload-processing DestinationRule host and EnvoyFilter cluster_name
+- source:
+    kind: ConfigMap
+    version: v1
+    name: maas-parameters
+    fieldPath: data.gateway-namespace
+  targets:
+  - select:
+      kind: DestinationRule
+      name: payload-processing
+    fieldPaths:
+    - spec.host
+    options:
+      delimiter: "."
+      index: 1
+  - select:
+      kind: EnvoyFilter
+      name: payload-processing
+    fieldPaths:
+    - spec.configPatches.0.patch.value.typed_config.grpc_service.envoy_grpc.cluster_name
+    options:
+      delimiter: "."
+      index: 1

--- a/maas-api/deploy/overlays/odh/params.env
+++ b/maas-api/deploy/overlays/odh/params.env
@@ -8,7 +8,7 @@ gateway-name=maas-default-gateway
 app-namespace=opendatahub
 # Cluster audience for kubernetesTokenReview (overridden by CustomizeParams from Authentication/cluster)
 cluster-audience=https://kubernetes.default.svc
-# Payload-processing configuration (overridden by CustomizeParams)
+# Payload-processing image (overridden by RELATED_IMAGE_ODH_AI_GATEWAY_PAYLOAD_PROCESSING_IMAGE env var)
 payload-processing-image=quay.io/opendatahub/odh-ai-gateway-payload-processing:odh-stable
 payload-processing-replicas=1
 # API key cleanup CronJob image

--- a/maas-api/deploy/overlays/odh/params.env
+++ b/maas-api/deploy/overlays/odh/params.env
@@ -8,5 +8,8 @@ gateway-name=maas-default-gateway
 app-namespace=opendatahub
 # Cluster audience for kubernetesTokenReview (overridden by CustomizeParams from Authentication/cluster)
 cluster-audience=https://kubernetes.default.svc
+# Payload-processing configuration (overridden by CustomizeParams)
+payload-processing-image=quay.io/opendatahub/odh-ai-gateway-payload-processing:odh-stable
+payload-processing-replicas=1
 # API key cleanup CronJob image
 maas-api-key-cleanup-image=registry.redhat.io/ubi9/ubi-minimal:9.7

--- a/maas-controller/Dockerfile
+++ b/maas-controller/Dockerfile
@@ -28,6 +28,7 @@ RUN chmod +x /manager
 COPY maas-api/deploy /maas-api/deploy
 COPY deployment/base/maas-api /deployment/base/maas-api
 COPY deployment/base/maas-controller/policies /deployment/base/maas-controller/policies
+COPY deployment/base/payload-processing /deployment/base/payload-processing
 COPY deployment/components /deployment/components
 RUN chmod -R g=u /maas-api /deployment
 

--- a/maas-controller/Dockerfile.konflux
+++ b/maas-controller/Dockerfile.konflux
@@ -27,6 +27,7 @@ RUN chmod +x /manager
 COPY maas-api/deploy /maas-api/deploy
 COPY deployment/base/maas-api /deployment/base/maas-api
 COPY deployment/base/maas-controller/policies /deployment/base/maas-controller/policies
+COPY deployment/base/payload-processing /deployment/base/payload-processing
 COPY deployment/components /deployment/components
 RUN chmod -R g=u /maas-api /deployment
 

--- a/maas-controller/go.mod
+++ b/maas-controller/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/kserve/kserve v0.15.0
 	github.com/onsi/gomega v1.37.0
 	github.com/stretchr/testify v1.11.1
+	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.33.1
 	k8s.io/apiextensions-apiserver v0.33.1
 	k8s.io/apimachinery v0.33.1
@@ -111,7 +112,6 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/go-playground/validator.v9 v9.31.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff // indirect
 	k8s.io/utils v0.0.0-20241210054802-24370beab758 // indirect

--- a/maas-controller/pkg/controller/maas/tenant_controller.go
+++ b/maas-controller/pkg/controller/maas/tenant_controller.go
@@ -57,8 +57,7 @@ type TenantReconciler struct {
 // +kubebuilder:rbac:groups=maas.opendatahub.io,resources=tenants/finalizers,verbs=update
 // +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=gateways,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;patch;delete
-// +kubebuilder:rbac:groups="",resources=secrets,resourceNames=maas-db-config,verbs=get
-// +kubebuilder:rbac:groups="",resources=secrets,verbs=list;watch
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;patch;delete
 // +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;patch;delete
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;patch;delete

--- a/maas-controller/pkg/platform/tenantreconcile/kustomize.go
+++ b/maas-controller/pkg/platform/tenantreconcile/kustomize.go
@@ -70,7 +70,9 @@ func postBuildTransform(resMap resmap.ResMap, appNamespace string) error {
 		if appNamespace != "" {
 			ns := res.GetNamespace()
 			if ns == overlayDefaultNamespace {
-				res.SetNamespace(appNamespace)
+				if err := res.SetNamespace(appNamespace); err != nil {
+					return fmt.Errorf("set namespace on %s %s: %w", res.GetKind(), res.GetName(), err)
+				}
 			}
 		}
 
@@ -83,9 +85,9 @@ func postBuildTransform(resMap resmap.ResMap, appNamespace string) error {
 		if appNamespace != "" {
 			kind := res.GetKind()
 			if kind == "ClusterRoleBinding" || kind == "RoleBinding" {
-				if subjects, ok := m["subjects"].([]interface{}); ok {
+				if subjects, ok := m["subjects"].([]any); ok {
 					for _, s := range subjects {
-						if subj, ok := s.(map[string]interface{}); ok {
+						if subj, ok := s.(map[string]any); ok {
 							if sns, ok := subj["namespace"].(string); ok && sns == overlayDefaultNamespace {
 								subj["namespace"] = appNamespace
 							}

--- a/maas-controller/pkg/platform/tenantreconcile/kustomize.go
+++ b/maas-controller/pkg/platform/tenantreconcile/kustomize.go
@@ -5,10 +5,13 @@ import (
 	"os"
 	"path/filepath"
 
+	"gopkg.in/yaml.v3"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/kustomize/api/krusty"
 	"sigs.k8s.io/kustomize/api/resmap"
+	"sigs.k8s.io/kustomize/api/resource"
 	"sigs.k8s.io/kustomize/kyaml/filesys"
+	kyaml "sigs.k8s.io/kustomize/kyaml/yaml"
 
 	maasv1alpha1 "github.com/opendatahub-io/models-as-a-service/maas-controller/api/maas/v1alpha1"
 )
@@ -66,7 +69,7 @@ func postBuildTransform(resMap resmap.ResMap, appNamespace string) error {
 	}
 
 	for _, res := range resMap.Resources() {
-		// --- namespace remapping ---
+		// --- namespace remapping (uses RNode API, persists directly) ---
 		if appNamespace != "" {
 			ns := res.GetNamespace()
 			if ns == overlayDefaultNamespace {
@@ -74,41 +77,72 @@ func postBuildTransform(resMap resmap.ResMap, appNamespace string) error {
 					return fmt.Errorf("set namespace on %s %s: %w", res.GetKind(), res.GetName(), err)
 				}
 			}
-		}
 
-		m, err := res.Map()
-		if err != nil {
-			continue
-		}
-
-		// Remap CRB/RB subject namespaces
-		if appNamespace != "" {
-			kind := res.GetKind()
-			if kind == "ClusterRoleBinding" || kind == "RoleBinding" {
-				if subjects, ok := m["subjects"].([]any); ok {
-					for _, s := range subjects {
-						if subj, ok := s.(map[string]any); ok {
-							if sns, ok := subj["namespace"].(string); ok && sns == overlayDefaultNamespace {
-								subj["namespace"] = appNamespace
-							}
-						}
-					}
-				}
+			if err := remapSubjectNamespaces(res, appNamespace); err != nil {
+				return fmt.Errorf("remap subjects on %s %s: %w", res.GetKind(), res.GetName(), err)
 			}
 		}
 
-		// --- ODH component labels (metadata only) ---
-		labels, _, _ := unstructured.NestedStringMap(m, "metadata", "labels")
+		// --- ODH component labels (uses RNode API, persists directly) ---
+		labels := res.GetLabels()
 		if labels == nil {
 			labels = make(map[string]string)
 		}
 		for k, v := range componentLabels {
 			labels[k] = v
 		}
-		if err := unstructured.SetNestedStringMap(m, labels, "metadata", "labels"); err != nil {
+		if err := res.SetLabels(labels); err != nil {
 			return fmt.Errorf("set labels on %s %s: %w", res.GetKind(), res.GetName(), err)
 		}
 	}
+	return nil
+}
+
+// remapSubjectNamespaces rewrites ClusterRoleBinding/RoleBinding subjects that
+// reference the overlay default namespace to use appNamespace instead. Uses the
+// RNode Pipe API to mutate the underlying YAML tree directly (res.Map() returns
+// a detached copy that would discard mutations).
+func remapSubjectNamespaces(res *resource.Resource, appNamespace string) error {
+	kind := res.GetKind()
+	if kind != "ClusterRoleBinding" && kind != "RoleBinding" {
+		return nil
+	}
+
+	m, err := res.Map()
+	if err != nil {
+		return fmt.Errorf("map: %w", err)
+	}
+	subjects, ok := m["subjects"].([]any)
+	if !ok {
+		return nil
+	}
+
+	changed := false
+	for _, s := range subjects {
+		subj, ok := s.(map[string]any)
+		if !ok {
+			continue
+		}
+		if sns, ok := subj["namespace"].(string); ok && sns == overlayDefaultNamespace {
+			subj["namespace"] = appNamespace
+			changed = true
+		}
+	}
+	if !changed {
+		return nil
+	}
+
+	// Write modified map back to the RNode via YAML round-trip.
+	m["subjects"] = subjects
+	b, err := yaml.Marshal(m)
+	if err != nil {
+		return fmt.Errorf("marshal: %w", err)
+	}
+	node, err := kyaml.Parse(string(b))
+	if err != nil {
+		return fmt.Errorf("parse: %w", err)
+	}
+	res.ResetRNode((&resource.Resource{RNode: *node}))
 	return nil
 }
 

--- a/maas-controller/pkg/platform/tenantreconcile/kustomize.go
+++ b/maas-controller/pkg/platform/tenantreconcile/kustomize.go
@@ -6,55 +6,20 @@ import (
 	"path/filepath"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"sigs.k8s.io/kustomize/api/builtins" //nolint:staticcheck // no replacement until kustomize API v1
-	"sigs.k8s.io/kustomize/api/filters/namespace"
 	"sigs.k8s.io/kustomize/api/krusty"
-	"sigs.k8s.io/kustomize/api/types"
+	"sigs.k8s.io/kustomize/api/resmap"
 	"sigs.k8s.io/kustomize/kyaml/filesys"
-	"sigs.k8s.io/kustomize/kyaml/resid"
 
 	maasv1alpha1 "github.com/opendatahub-io/models-as-a-service/maas-controller/api/maas/v1alpha1"
 )
 
-// createNamespaceApplierPlugin mirrors opendatahub-operator/pkg/plugins.CreateNamespaceApplierPlugin.
-func createNamespaceApplierPlugin(targetNamespace string) *builtins.NamespaceTransformerPlugin {
-	return &builtins.NamespaceTransformerPlugin{
-		ObjectMeta: types.ObjectMeta{
-			Name:      "maas-namespace-plugin",
-			Namespace: targetNamespace,
-		},
-		FieldSpecs: []types.FieldSpec{
-			{Gvk: resid.Gvk{}, Path: "metadata/namespace", CreateIfNotPresent: true},
-			{Gvk: resid.Gvk{Group: "rbac.authorization.k8s.io", Kind: "ClusterRoleBinding"}, Path: "subjects/namespace", CreateIfNotPresent: true},
-			{Gvk: resid.Gvk{Group: "rbac.authorization.k8s.io", Kind: "RoleBinding"}, Path: "subjects/namespace", CreateIfNotPresent: true},
-			{Gvk: resid.Gvk{Group: "admissionregistration.k8s.io", Kind: "ValidatingWebhookConfiguration"}, Path: "webhooks/clientConfig/service/namespace", CreateIfNotPresent: false},
-			{Gvk: resid.Gvk{Group: "admissionregistration.k8s.io", Kind: "MutatingWebhookConfiguration"}, Path: "webhooks/clientConfig/service/namespace", CreateIfNotPresent: false},
-			{Gvk: resid.Gvk{Group: "apiextensions.k8s.io", Kind: "CustomResourceDefinition"}, Path: "spec/conversion/webhook/clientConfig/service/namespace", CreateIfNotPresent: false},
-		},
-		UnsetOnly:              false,
-		SetRoleBindingSubjects: namespace.AllServiceAccountSubjects,
-	}
-}
+// overlayDefaultNamespace is the namespace hardcoded in the overlay's
+// kustomization.yaml (namespace: opendatahub). postBuildTransform remaps
+// it to the actual appNamespace from the Tenant CR.
+const overlayDefaultNamespace = "opendatahub"
 
-func odhComponentLabels() map[string]string {
-	return map[string]string{
-		LabelODHAppPrefix + "/" + ComponentName: "true",
-		LabelK8sPartOf:                          "models-as-a-service",
-	}
-}
-
-func createSetLabelsPlugin(labels map[string]string) *builtins.LabelTransformerPlugin {
-	return &builtins.LabelTransformerPlugin{
-		Labels: labels,
-		FieldSpecs: []types.FieldSpec{
-			{Gvk: resid.Gvk{Kind: "Deployment"}, Path: "spec/template/metadata/labels", CreateIfNotPresent: true},
-			{Gvk: resid.Gvk{Kind: "Deployment"}, Path: "spec/selector/matchLabels", CreateIfNotPresent: true},
-			{Gvk: resid.Gvk{}, Path: "metadata/labels", CreateIfNotPresent: true},
-		},
-	}
-}
-
-// RenderKustomize runs kustomize build for the ODH maas-api overlay and applies ODH-equivalent namespace + labels.
+// RenderKustomize runs kustomize build for the ODH maas-api overlay and
+// applies ODH-equivalent namespace remapping and component labels.
 func RenderKustomize(manifestDir, appNamespace string) ([]unstructured.Unstructured, error) {
 	kustomizationPath := manifestDir
 	if !fileExists(filepath.Join(manifestDir, "kustomization.yaml")) {
@@ -68,16 +33,8 @@ func RenderKustomize(manifestDir, appNamespace string) ([]unstructured.Unstructu
 		return nil, fmt.Errorf("kustomize build %q: %w", kustomizationPath, err)
 	}
 
-	if appNamespace != "" {
-		plugin := createNamespaceApplierPlugin(appNamespace)
-		if err := plugin.Transform(resMap); err != nil {
-			return nil, fmt.Errorf("namespace transform: %w", err)
-		}
-	}
-
-	labelPlugin := createSetLabelsPlugin(odhComponentLabels())
-	if err := labelPlugin.Transform(resMap); err != nil {
-		return nil, fmt.Errorf("labels transform: %w", err)
+	if err := postBuildTransform(resMap, appNamespace); err != nil {
+		return nil, fmt.Errorf("post-build transform: %w", err)
 	}
 
 	rendered := resMap.Resources()
@@ -91,6 +48,66 @@ func RenderKustomize(manifestDir, appNamespace string) ([]unstructured.Unstructu
 		out = append(out, unstructured.Unstructured{Object: m})
 	}
 	return out, nil
+}
+
+// postBuildTransform remaps the overlay's hardcoded default namespace to the
+// actual appNamespace and merges ODH component labels into metadata. Unlike the
+// blanket kustomize NamespaceTransformerPlugin + LabelTransformerPlugin, this:
+//   - Leaves cluster-scoped resources (no namespace) untouched
+//   - Preserves cross-namespace resources placed in a non-default namespace by
+//     kustomize replacements (e.g., payload-processing in the gateway namespace)
+//   - Preserves ClusterRoleBinding/RoleBinding subjects with non-default namespaces
+//   - Merges labels into metadata only (not into Deployment selectors, which are
+//     already correct from each base's own kustomization)
+func postBuildTransform(resMap resmap.ResMap, appNamespace string) error {
+	componentLabels := map[string]string{
+		LabelODHAppPrefix + "/" + ComponentName: "true",
+		LabelK8sPartOf:                          "models-as-a-service",
+	}
+
+	for _, res := range resMap.Resources() {
+		// --- namespace remapping ---
+		if appNamespace != "" {
+			ns := res.GetNamespace()
+			if ns == overlayDefaultNamespace {
+				res.SetNamespace(appNamespace)
+			}
+		}
+
+		m, err := res.Map()
+		if err != nil {
+			continue
+		}
+
+		// Remap CRB/RB subject namespaces
+		if appNamespace != "" {
+			kind := res.GetKind()
+			if kind == "ClusterRoleBinding" || kind == "RoleBinding" {
+				if subjects, ok := m["subjects"].([]interface{}); ok {
+					for _, s := range subjects {
+						if subj, ok := s.(map[string]interface{}); ok {
+							if sns, ok := subj["namespace"].(string); ok && sns == overlayDefaultNamespace {
+								subj["namespace"] = appNamespace
+							}
+						}
+					}
+				}
+			}
+		}
+
+		// --- ODH component labels (metadata only) ---
+		labels, _, _ := unstructured.NestedStringMap(m, "metadata", "labels")
+		if labels == nil {
+			labels = make(map[string]string)
+		}
+		for k, v := range componentLabels {
+			labels[k] = v
+		}
+		if err := unstructured.SetNestedStringMap(m, labels, "metadata", "labels"); err != nil {
+			return fmt.Errorf("set labels on %s %s: %w", res.GetKind(), res.GetName(), err)
+		}
+	}
+	return nil
 }
 
 // normalizeJSONTypes converts Go int values to int64 in an unstructured map.


### PR DESCRIPTION

## Description
The Tenant reconciler (maas-controller) renders maas-api platform workloads using the Kustomize overlay at maas-api/deploy/overlays/odh/. This overlay included maas-api (with TLS), gateway policies, and shared-patches — but not payload-processing. The standalone `deployment/overlays/odh/` overlay already included it, creating an inconsistency: clusters deployed via the ODH operator path were missing the payload-processing Deployment, Service, EnvoyFilter, and related resources.

## How Has This Been Tested?
* Kustomize build — kustomize build maas-api/deploy/overlays/odh exits 0 and renders all payload-processing resources (Deployment, Service, ServiceAccount, EnvoyFilter, DestinationRule, ConfigMap, ClusterRole, ClusterRoleBinding)
* Namespace verification — all payload-processing resources render with namespace: openshift-ingress (gateway namespace), not opendatahub (app namespace)
* DestinationRule / EnvoyFilter — spec.host and cluster_name contain payload-processing.openshift-ingress.svc.cluster.local; EnvoyFilter targetRefs.0.name is maas-default-gateway
* Image build — make build-image TAG=test from maas-controller/ succeeds with podman (build context resolves to repo root)
* Cluster deployment — built linux/amd64 image (quay.io/isequeir/maas-controller:payload-processing), pushed to quay.io, updated the deployment on a ROSA cluster, verified controller pod starts and runs without errors

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Parameterized ODH overlay for payload-processing (image, replicas, gateway namespace/name).
  * Added environment parameters to configure the payload-processing component.
  * Included payload-processing deployment artifacts in controller images.
  * Updated overlay post-deploy namespace and label handling to better preserve resource namespaces and merge component labels.

* **Bug Fixes**
  * Broadened secret access permissions to ensure required runtime access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->