### PR TITLE
docs: condense Limitador persistence page and fix formatting

### DIFF
--- a/docs/content/advanced-administration/limitador-persistence.md
+++ b/docs/content/advanced-administration/limitador-persistence.md
@@ -40,30 +40,6 @@ The script deploys a basic Redis instance and outputs instructions for configuri
 
 ---
 
-## Validation
-
-To verify persistence works:
-
-1. Configure Limitador with persistent storage (see steps above)
-2. Send traffic to a rate-limited route until counters are non-zero
-3. Delete the Limitador pod: `kubectl delete pod <limitador-pod> -n <namespace>`
-4. Wait for the new pod to start
-5. Send another request to the same route
-
-The counter should continue from its previous value instead of resetting to 1.
-
-**Monitor counters** via Prometheus:
-
-```bash
-# Port-forward to Prometheus
-kubectl port-forward -n monitoring svc/prometheus-k8s 9091:9091
-
-# Query: authorized_hits
-# Open http://localhost:9091
-```
-
----
-
 ## Related Documentation
 
 - [Limitador Configuration](https://github.com/Kuadrant/limitador/blob/main/doc/server/configuration.md) - Storage backend options and configuration

--- a/docs/content/advanced-administration/limitador-persistence.md
+++ b/docs/content/advanced-administration/limitador-persistence.md
@@ -46,7 +46,7 @@ To verify persistence works:
 
 1. Configure Limitador with persistent storage (see steps above)
 2. Send traffic to a rate-limited route until counters are non-zero
-3. Delete the Limitador pod: `kubectl delete pod <limitador-pod>`
+3. Delete the Limitador pod: `kubectl delete pod <limitador-pod> -n <namespace>`
 4. Wait for the new pod to start
 5. Send another request to the same route
 
@@ -56,10 +56,10 @@ The counter should continue from its previous value instead of resetting to 1.
 
 ```bash
 # Port-forward to Prometheus
-kubectl port-forward -n monitoring svc/prometheus-k8s 9090:9091
+kubectl port-forward -n monitoring svc/prometheus-k8s 9091:9091
 
 # Query: authorized_hits
-# Open http://localhost:9090
+# Open http://localhost:9091
 ```
 
 ---

--- a/docs/content/advanced-administration/limitador-persistence.md
+++ b/docs/content/advanced-administration/limitador-persistence.md
@@ -1,154 +1,70 @@
-# Persisting Limitador Metric Counts
+# Limitador Persistence
 
-By default, Limitador stores its rate-limiting counters in memory. This provides high performance but has a significant drawback: if a Limitador pod restarts, scales down, or is rescheduled, all hit counts are lost.
+By default, Limitador stores rate-limit counters in memory. Counters reset when pods restart, scale, or are rescheduled. For production deployments, configure Limitador to use Redis for persistent storage.
 
-For persistent, production-ready rate limiting where counts are maintained across pod lifecycles, you must configure Limitador to use an external Redis backend.
-
-!!! warning
-    **Production Considerations**: The basic Redis setup script provided in this document is intended for local development and validation only. For production deployments, follow the official Red Hat documentation for proper Redis configuration and high availability.
+!!! info "Other Storage Options"
+    Limitador supports additional storage backends. See the [Limitador configuration documentation](https://github.com/Kuadrant/limitador/blob/main/doc/server/configuration.md) for details. This guide focuses on Redis.
 
 ---
 
-## Table of Contents
+## Configuration
 
-. [Requirements for Persistent Counts](#requirements-for-persistent-counts)
-. [Example Limitador CR Configuration](#example-limitador-cr-configuration)
-. [Local Validation Script](#local-validation-script-basic-dev-only-redis)
-. [How to Validate Persistence](#how-to-validate-persistence)
-. [Related Documentation](#related-documentation)
+To configure Limitador with Redis persistent storage:
 
----
+1. Deploy Redis according to your environment's requirements
+2. Create a Kubernetes Secret with the Redis connection URL
+3. Update the Limitador CR to reference the Secret
 
-## Requirements for Persistent Counts
-
-To enable persistence, two conditions must be met:
-
-. **A Running Redis Instance**: A Redis instance must be deployed and network-accessible from within the Kubernetes cluster.
-
-. **Limitador Custom Resource (CR) Configuration**: The Limitador CR that manages your deployment must be updated to point to the running Redis instance by specifying the storage configuration in its spec.
+**For complete configuration steps**, see [Red Hat Connectivity Link - Configure Redis](https://docs.redhat.com/en/documentation/red_hat_connectivity_link/1.3/html/installing_on_openshift_container_platform/rhcl-install-on-ocp#configure-redis_installing-rhcl-on-ocp).
 
 ---
 
-## Example Limitador CR Configuration
+## Local Development Setup
 
-To configure Limitador to use Redis for persistent storage, you need to:
+For local development and testing, use the provided Redis setup script:
 
-. **Create a Kubernetes Secret** containing the Redis connection URL:
-
-   ```bash
-   kubectl create secret generic redis-config \
-     --from-literal=URL=redis://redis-service.redis-limitador.svc:6379 \
-     --namespace=<your-limitador-namespace>
-   ```
-
-. **Update your Limitador CR** to reference the secret:
-
-   ```yaml
-   apiVersion: limitador.kuadrant.io/v1alpha1
-   kind: Limitador
-   metadata:
-     name: limitador
-   spec:
-     storage:
-       redis:
-         configSecretRef:
-           name: redis-config
-   ```
-
-   Edit your existing Limitador CR:
-
-   ```bash
-   kubectl edit limitador <your-instance-name> -n <your-limitador-namespace>
-   ```
-
-For detailed, official instructions on production Redis setup, refer to the Red Hat documentation:
-
-- [Red Hat Connectivity Link - Configure Redis](https://docs.redhat.com/en/documentation/red_hat_connectivity_link/1.2/html/installing_on_openshift_container_platform/rhcl-install-on-ocp#configure-redis_installing-rhcl-on-ocp)
-
----
-
-## Local Validation Script (Basic Dev-only Redis)
-
-A basic Redis setup script is provided for local development and validation. This script deploys a non-production Redis instance.
-
-**Script Location:** [`scripts/setup-redis.sh`](https://github.com/opendatahub-io/models-as-a-service/blob/main/scripts/setup-redis.sh)
-
-### Namespace Selection
-
-The script uses a simple namespace selection logic:
-
-- **`NAMESPACE` environment variable** (if set)
-- **Default: `redis-limitador`** (created automatically if it doesn't exist)
-
-This opinionated default simplifies troubleshooting and ensures consistent deployments.
-
-### Usage
+**Script:** [`scripts/setup-redis.sh`](https://github.com/opendatahub-io/models-as-a-service/blob/main/scripts/setup-redis.sh)
 
 ```bash
-# Make the script executable
-chmod +x scripts/setup-redis.sh
-
-# Run with default namespace (redis-limitador)
+# Default namespace: redis-limitador
 ./scripts/setup-redis.sh
 
-# Or override with environment variable
+# Or specify custom namespace
 NAMESPACE=my-namespace ./scripts/setup-redis.sh
 ```
 
-The script will:
+The script deploys a basic Redis instance and outputs instructions for configuring your Limitador CR.
 
-- Create the namespace if it doesn't exist (for default `redis-limitador` namespace)
-- Deploy a Redis Deployment and Service
-- Wait for Redis to be ready
-- Output instructions for creating a Secret and configuring your Limitador CR
-
-!!! note
-    **Single Source of Truth**: The script content is maintained only in `scripts/setup-redis.sh`. Any updates to the script are automatically reflected when users download and run it.
+!!! warning "Development Only"
+    This script deploys a non-HA Redis instance for local development. For production, follow the [Red Hat Connectivity Link documentation](https://docs.redhat.com/en/documentation/red_hat_connectivity_link/1.3/html/installing_on_openshift_container_platform/rhcl-install-on-ocp#configure-redis_installing-rhcl-on-ocp).
 
 ---
 
-## How to Validate Persistence
+## Validation
 
-. **Run the script**: `./scripts/setup-redis.sh`
+To verify persistence works:
 
-   This will deploy Redis to the `redis-limitador` namespace by default (or use your `NAMESPACE` env var).
+1. Configure Limitador with persistent storage (see steps above)
+2. Send traffic to a rate-limited route until counters are non-zero
+3. Delete the Limitador pod: `kubectl delete pod <limitador-pod>`
+4. Wait for the new pod to start
+5. Send another request to the same route
 
-. **Follow the output instructions** to create the Secret and configure your Limitador CR with the Redis storage configuration.
+The counter should continue from its previous value instead of resetting to 1.
 
-. **Send traffic** against a rate-limited route until you have a non-zero hit count.
+**Monitor counters** via Prometheus:
 
-   You can verify metrics in Prometheus:
+```bash
+# Port-forward to Prometheus
+kubectl port-forward -n monitoring svc/prometheus-k8s 9090:9091
 
-   ```bash
-   # Port-forward to Prometheus (adjust namespace as needed)
-   kubectl port-forward -n monitoring svc/prometheus-k8s 9090:9091
-
-   # Query for authorized_hits metric
-   # Open http://localhost:9090 and search for: authorized_hits
-   ```
-
-. **Find your Limitador pod**:
-
-   ```bash
-   kubectl get pods -l app=limitador
-   ```
-
-. **Delete the pod** to force a restart:
-
-   ```bash
-   kubectl delete pod <limitador-pod-name>
-   ```
-
-. **Wait for the new pod** to become Running:
-
-   ```bash
-   kubectl get pods -l app=limitador -w
-   ```
-
-. **Send another request** to the same route. You will see that the metric count continues from its previous value instead of resetting to 1.
+# Query: authorized_hits
+# Open http://localhost:9090
+```
 
 ---
 
 ## Related Documentation
 
-- [Red Hat Connectivity Link - Configure Redis](https://docs.redhat.com/en/documentation/red_hat_connectivity_link/1.2/html/installing_on_openshift_container_platform/rhcl-install-on-ocp#configure-redis_installing-rhcl-on-ocp) - Official Red Hat documentation for production Redis setup
+- [Limitador Configuration](https://github.com/Kuadrant/limitador/blob/main/doc/server/configuration.md) - Storage backend options and configuration
+- [Red Hat Connectivity Link - Configure Redis](https://docs.redhat.com/en/documentation/red_hat_connectivity_link/1.3/html/installing_on_openshift_container_platform/rhcl-install-on-ocp#configure-redis_installing-rhcl-on-ocp) - Production Redis setup


### PR DESCRIPTION
## Description

https://redhat.atlassian.net/browse/RHOAIENG-59736

Reduced limitador-persistence.md from 155 to 70 lines (55% reduction) by removing duplicated content and fixing markdown formatting issues.

Changes:
- Removed duplicated configuration steps (delegate to RHCL docs)
- Focused on Redis with note about other storage options
- Updated RHCL link to version 1.3
- Added upstream Limitador configuration reference
- Fixed broken numbered lists (was using `. ` instead of `1. `)
- Removed redundant Table of Contents
- Simplified validation steps
- Cleaned up formatting (admonitions, code blocks, headings)

Content kept:
- Local development script (MaaS-specific)
- Validation procedure
- Brief configuration overview with link to complete steps

Links updated:
- Red Hat Connectivity Link 1.3 for production Redis
- Limitador configuration docs for alternative storage options

<!--- Provide a general summary of your changes in the Title above -->


<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
local mkdocs serve 

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reorganized Limitador persistence guide into a concise Redis-focused page for easier navigation
  * Added a production note that in-memory counters reset and summarized Redis setup steps (deploy Redis, create secret, reference it)
  * Kept minimal local development setup examples and added a “development only / non‑HA Redis” warning
  * Added callout to alternative storage backends and updated external configuration links
<!-- end of auto-generated comment: release notes by coderabbit.ai -->