### PR TITLE
fix(observability): fix Perses datasource secret name and add missing CA ConfigMap

### DIFF
--- a/deployment/components/observability/observability/dashboards/kuadrant-prometheus-datasource.yaml
+++ b/deployment/components/observability/observability/dashboards/kuadrant-prometheus-datasource.yaml
@@ -21,6 +21,6 @@ spec:
         proxy:
           kind: HTTPProxy
           spec:
-            secret: cluster-prometheus-datasource-secret
+            secret: kuadrant-prometheus-datasource-secret
             url: 'https://thanos-querier.openshift-monitoring.svc:9092?namespace=kuadrant-system'
         scrapeInterval: 30s

--- a/deployment/components/observability/observability/dashboards/kustomization.yaml
+++ b/deployment/components/observability/observability/dashboards/kustomization.yaml
@@ -7,8 +7,9 @@ metadata:
     config.kubernetes.io/local-config: "true"
 
 resources:
-  - usage-dashboard.yaml
+  - prometheus-web-tls-ca-configmap.yaml
   - kuadrant-prometheus-datasource.yaml
+  - usage-dashboard.yaml
 
 labels:
   - pairs:

--- a/deployment/components/observability/observability/dashboards/prometheus-web-tls-ca-configmap.yaml
+++ b/deployment/components/observability/observability/dashboards/prometheus-web-tls-ca-configmap.yaml
@@ -1,0 +1,12 @@
+# OpenShift service CA bundle for TLS clients (e.g. Perses → Thanos Querier).
+# The service-ca operator injects data.service-ca.crt when the annotation is present.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-web-tls-ca
+  namespace: opendatahub
+  labels:
+    app.kubernetes.io/managed-by: maas-observability
+    app.kubernetes.io/component: perses
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"

--- a/maas-controller/container.mk
+++ b/maas-controller/container.mk
@@ -15,13 +15,13 @@ endif
 .PHONY: build-image
 build-image: ##	Build container image (use REPO= and TAG= to specify image)
 	@echo "Building container image $(FULL_IMAGE)..."
-	$(CONTAINER_ENGINE) build $(DOCKER_BUILD_ARGS) $(CONTAINER_ENGINE_EXTRA_FLAGS) -f $(PROJECT_DIR)/Dockerfile -t "$(FULL_IMAGE)" $(PROJECT_DIR)/..
+	$(CONTAINER_ENGINE) build $(DOCKER_BUILD_ARGS) $(CONTAINER_ENGINE_EXTRA_FLAGS) -t "$(FULL_IMAGE)" .
 	@echo "Container image $(FULL_IMAGE) built successfully"
 
 .PHONY: build-image-konflux
 build-image-konflux: ##	Build container image with Dockerfile.konflux
 	@echo "Building container image $(FULL_IMAGE) using Dockerfile.konflux..."
-	$(CONTAINER_ENGINE) build $(DOCKER_BUILD_ARGS) $(CONTAINER_ENGINE_EXTRA_FLAGS) -f $(PROJECT_DIR)/Dockerfile.konflux -t "$(FULL_IMAGE)" $(PROJECT_DIR)/..
+	$(CONTAINER_ENGINE) build $(DOCKER_BUILD_ARGS) $(CONTAINER_ENGINE_EXTRA_FLAGS) -f Dockerfile.konflux -t "$(FULL_IMAGE)" .
 	@echo "Container image $(FULL_IMAGE) built successfully"
 
 .PHONY: push-image

--- a/maas-controller/container.mk
+++ b/maas-controller/container.mk
@@ -15,13 +15,13 @@ endif
 .PHONY: build-image
 build-image: ##	Build container image (use REPO= and TAG= to specify image)
 	@echo "Building container image $(FULL_IMAGE)..."
-	$(CONTAINER_ENGINE) build $(DOCKER_BUILD_ARGS) $(CONTAINER_ENGINE_EXTRA_FLAGS) -t "$(FULL_IMAGE)" .
+	$(CONTAINER_ENGINE) build $(DOCKER_BUILD_ARGS) $(CONTAINER_ENGINE_EXTRA_FLAGS) -f $(PROJECT_DIR)/Dockerfile -t "$(FULL_IMAGE)" $(PROJECT_DIR)/..
 	@echo "Container image $(FULL_IMAGE) built successfully"
 
 .PHONY: build-image-konflux
 build-image-konflux: ##	Build container image with Dockerfile.konflux
 	@echo "Building container image $(FULL_IMAGE) using Dockerfile.konflux..."
-	$(CONTAINER_ENGINE) build $(DOCKER_BUILD_ARGS) $(CONTAINER_ENGINE_EXTRA_FLAGS) -f Dockerfile.konflux -t "$(FULL_IMAGE)" .
+	$(CONTAINER_ENGINE) build $(DOCKER_BUILD_ARGS) $(CONTAINER_ENGINE_EXTRA_FLAGS) -f $(PROJECT_DIR)/Dockerfile.konflux -t "$(FULL_IMAGE)" $(PROJECT_DIR)/..
 	@echo "Container image $(FULL_IMAGE) built successfully"
 
 .PHONY: push-image


### PR DESCRIPTION
## Description

The MaaS usage dashboard failing to load because the `PersesDatasource` CR referenced two things that were wrong or missing:

1. **Wrong secret name** – `spec.config.plugin.spec.proxy.spec.secret` was set to `cluster-prometheus-datasource-secret`, which is the secret created by the ODH/RHOAI operator in its own monitoring namespace. The correct secret in the `opendatahub` namespace is `kuadrant-prometheus-datasource-secret`.

2. **Missing CA ConfigMap** – `spec.client.tls.caCert` referenced `prometheus-web-tls-ca`, but that ConfigMap was never created in this kustomize bundle. Added it with the `service.beta.openshift.io/inject-cabundle: "true"` annotation so the OpenShift service-CA operator injects `service-ca.crt` automatically.

Both resources are applied by the maas-controller via the ODH overlay(`deployment/overlays/odh/kustomization.yaml` line 46).

https://redhat.atlassian.net/browse/RHOAIENG-59675

## How Has This Been Tested?

- `kubectl kustomize deployment/components/observability/observability/dashboards/`
  builds cleanly with both resources in the output.
- Verified manually on cluster

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TLS certificate authority support for secure observability monitoring.

* **Chores**
  * Updated observability datasource proxy configuration.
  * Adjusted deployment resource ordering and initialization.
  * Enhanced build process configuration for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->