### PR TITLE
fix(test): use HTTPS endpoint for cleanup in e2e API key test

### DIFF
--- a/test/e2e/tests/test_api_keys.py
+++ b/test/e2e/tests/test_api_keys.py
@@ -1046,8 +1046,8 @@ class TestEphemeralKeyCleanup:
 
         cleanup_result = sp.run(
             ["oc", "exec", pod_name, "-n", deployment_namespace, "--",
-             "curl", "-sf", "-X", "POST",
-             "http://localhost:8080/internal/v1/api-keys/cleanup"],
+             "curl", "-skf", "-X", "POST",
+             "https://localhost:8443/internal/v1/api-keys/cleanup"],
             capture_output=True, text=True, timeout=30,
         )
 
@@ -1055,8 +1055,8 @@ class TestEphemeralKeyCleanup:
             # curl may not be available in the maas-api container; try wget
             cleanup_result = sp.run(
                 ["oc", "exec", pod_name, "-n", deployment_namespace, "--",
-                 "wget", "-q", "-O-", "--post-data=",
-                 "http://localhost:8080/internal/v1/api-keys/cleanup"],
+                 "wget", "-q", "--no-check-certificate", "-O-", "--post-data=",
+                 "https://localhost:8443/internal/v1/api-keys/cleanup"],
                 capture_output=True, text=True, timeout=30,
             )
 


### PR DESCRIPTION
## Summary

- The `test_trigger_cleanup_preserves_active_keys` e2e test triggers the internal cleanup endpoint by exec'ing into the maas-api pod. The internal server listens on port 8443 with TLS, not plain HTTP on 8080.
- Updates both curl and wget commands to use `https://localhost:8443` instead of `http://localhost:8080`.
- Adds `-k` (curl) / `--no-check-certificate` (wget) to skip TLS certificate verification for the self-signed/cluster-internal certificate.

## Test plan
- [ ] Run `test_trigger_cleanup_preserves_active_keys` e2e test against a cluster with TLS-enabled maas-api
- [ ] Verify the cleanup endpoint is reachable and returns a valid response

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated API key cleanup test to use HTTPS instead of HTTP for improved security in test infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->