### PR TITLE
fix: Fix/controller related image env vars

### DIFF
--- a/deployment/base/maas-controller/manager/manager.yaml
+++ b/deployment/base/maas-controller/manager/manager.yaml
@@ -45,6 +45,30 @@ spec:
                 fieldPath: metadata.namespace
           - name: MAAS_SUBSCRIPTION_NAMESPACE
             value: "models-as-a-service"
+          - name: RELATED_IMAGE_ODH_MAAS_API_IMAGE
+            valueFrom:
+              configMapKeyRef:
+                key: maas-api-image
+                name: maas-parameters
+                optional: true
+          - name: RELATED_IMAGE_ODH_MAAS_CONTROLLER_IMAGE
+            valueFrom:
+              configMapKeyRef:
+                key: maas-controller-image
+                name: maas-parameters
+                optional: true
+          - name: RELATED_IMAGE_ODH_AI_GATEWAY_PAYLOAD_PROCESSING_IMAGE
+            valueFrom:
+              configMapKeyRef:
+                key: payload-processing-image
+                name: maas-parameters
+                optional: true
+          - name: RELATED_IMAGE_UBI_MINIMAL_IMAGE
+            valueFrom:
+              configMapKeyRef:
+                key: maas-api-key-cleanup-image
+                name: maas-parameters
+                optional: true
         image: maas-controller
         name: manager
         imagePullPolicy: Always

--- a/deployment/overlays/odh/kustomization.yaml
+++ b/deployment/overlays/odh/kustomization.yaml
@@ -43,7 +43,6 @@ resources:
   - ../../base/maas-api/overlays/tls  # maas-api with TLS (includes DestinationRule + NetworkPolicy)
   - ../../base/maas-controller/default
   - ../../base/payload-processing/default  # BBR ext_proc for external model payload processing
-  - ../../components/observability/observability/dashboards/
 
 # Include shared-patches component for common configuration
 # This provides: env vars, image replacements, gateway config, URL placeholder fix

--- a/deployment/overlays/odh/kustomization.yaml
+++ b/deployment/overlays/odh/kustomization.yaml
@@ -50,9 +50,7 @@ components:
   - ../../components/shared-patches
 
 # ODH-SPECIFIC PATCHES
-# Controller configuration: cache TTLs and cluster audience from maas-parameters ConfigMap.
-# RELATED_IMAGE_* env vars are in the base manager.yaml (used by both overlay and
-# AppendOperatorInstallManifests paths).
+# Additional cache TTL configuration for maas-controller
 patches:
 - patch: |-
     apiVersion: apps/v1
@@ -75,12 +73,6 @@ patches:
             - --metadata-cache-ttl=$(METADATA_CACHE_TTL)
             - --authz-cache-ttl=$(AUTHZ_CACHE_TTL)
             env:
-            - name: CLUSTER_AUDIENCE
-              valueFrom:
-                configMapKeyRef:
-                  key: cluster-audience
-                  name: maas-parameters
-                  optional: false
             - name: METADATA_CACHE_TTL
               valueFrom:
                 configMapKeyRef:

--- a/deployment/overlays/odh/kustomization.yaml
+++ b/deployment/overlays/odh/kustomization.yaml
@@ -50,7 +50,9 @@ components:
   - ../../components/shared-patches
 
 # ODH-SPECIFIC PATCHES
-# Additional cache TTL configuration for maas-controller
+# Controller configuration: cache TTLs and cluster audience from maas-parameters ConfigMap.
+# RELATED_IMAGE_* env vars are in the base manager.yaml (used by both overlay and
+# AppendOperatorInstallManifests paths).
 patches:
 - patch: |-
     apiVersion: apps/v1
@@ -73,6 +75,12 @@ patches:
             - --metadata-cache-ttl=$(METADATA_CACHE_TTL)
             - --authz-cache-ttl=$(AUTHZ_CACHE_TTL)
             env:
+            - name: CLUSTER_AUDIENCE
+              valueFrom:
+                configMapKeyRef:
+                  key: cluster-audience
+                  name: maas-parameters
+                  optional: false
             - name: METADATA_CACHE_TTL
               valueFrom:
                 configMapKeyRef:

--- a/maas-api/deploy/overlays/odh/kustomization.yaml
+++ b/maas-api/deploy/overlays/odh/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
 - ../../../../deployment/base/maas-api/overlays/tls
 - ../../../../deployment/base/maas-controller/policies
 - ../../../../deployment/base/payload-processing/default
+- ../../../../deployment/components/observability/observability/dashboards
 
 namespace: opendatahub
 

--- a/maas-controller/container.mk
+++ b/maas-controller/container.mk
@@ -15,13 +15,13 @@ endif
 .PHONY: build-image
 build-image: ##	Build container image (use REPO= and TAG= to specify image)
 	@echo "Building container image $(FULL_IMAGE)..."
-	$(CONTAINER_ENGINE) build $(DOCKER_BUILD_ARGS) $(CONTAINER_ENGINE_EXTRA_FLAGS) -f $(PROJECT_DIR)/Dockerfile -t "$(FULL_IMAGE)" $(PROJECT_DIR)/..
+	$(CONTAINER_ENGINE) build $(DOCKER_BUILD_ARGS) $(CONTAINER_ENGINE_EXTRA_FLAGS) -t "$(FULL_IMAGE)" .
 	@echo "Container image $(FULL_IMAGE) built successfully"
 
 .PHONY: build-image-konflux
 build-image-konflux: ##	Build container image with Dockerfile.konflux
 	@echo "Building container image $(FULL_IMAGE) using Dockerfile.konflux..."
-	$(CONTAINER_ENGINE) build $(DOCKER_BUILD_ARGS) $(CONTAINER_ENGINE_EXTRA_FLAGS) -f $(PROJECT_DIR)/Dockerfile.konflux -t "$(FULL_IMAGE)" $(PROJECT_DIR)/..
+	$(CONTAINER_ENGINE) build $(DOCKER_BUILD_ARGS) $(CONTAINER_ENGINE_EXTRA_FLAGS) -f Dockerfile.konflux -t "$(FULL_IMAGE)" .
 	@echo "Container image $(FULL_IMAGE) built successfully"
 
 .PHONY: push-image

--- a/maas-controller/container.mk
+++ b/maas-controller/container.mk
@@ -15,13 +15,13 @@ endif
 .PHONY: build-image
 build-image: ##	Build container image (use REPO= and TAG= to specify image)
 	@echo "Building container image $(FULL_IMAGE)..."
-	$(CONTAINER_ENGINE) build $(DOCKER_BUILD_ARGS) $(CONTAINER_ENGINE_EXTRA_FLAGS) -t "$(FULL_IMAGE)" .
+	$(CONTAINER_ENGINE) build $(DOCKER_BUILD_ARGS) $(CONTAINER_ENGINE_EXTRA_FLAGS) -f $(PROJECT_DIR)/Dockerfile -t "$(FULL_IMAGE)" $(PROJECT_DIR)/..
 	@echo "Container image $(FULL_IMAGE) built successfully"
 
 .PHONY: build-image-konflux
 build-image-konflux: ##	Build container image with Dockerfile.konflux
 	@echo "Building container image $(FULL_IMAGE) using Dockerfile.konflux..."
-	$(CONTAINER_ENGINE) build $(DOCKER_BUILD_ARGS) $(CONTAINER_ENGINE_EXTRA_FLAGS) -f Dockerfile.konflux -t "$(FULL_IMAGE)" .
+	$(CONTAINER_ENGINE) build $(DOCKER_BUILD_ARGS) $(CONTAINER_ENGINE_EXTRA_FLAGS) -f $(PROJECT_DIR)/Dockerfile.konflux -t "$(FULL_IMAGE)" $(PROJECT_DIR)/..
 	@echo "Container image $(FULL_IMAGE) built successfully"
 
 .PHONY: push-image

--- a/maas-controller/pkg/controller/maas/tenant_controller.go
+++ b/maas-controller/pkg/controller/maas/tenant_controller.go
@@ -18,6 +18,7 @@ package maas
 
 import (
 	"context"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -110,6 +111,20 @@ func crdLabeledForMaaSComponent() predicate.Predicate {
 	})
 }
 
+// crdInOptionalAPIGroup matches CRDs belonging to optional platform operator API groups
+// (e.g. perses.dev from COO). CRD names follow the pattern "<plural>.<group>", so a
+// suffix check is sufficient to identify the group without parsing the spec.
+func crdInOptionalAPIGroup() predicate.Predicate {
+	return predicate.NewPredicateFuncs(func(o client.Object) bool {
+		for group := range tenantreconcile.OptionalAPIGroups {
+			if strings.HasSuffix(o.GetName(), "."+group) {
+				return true
+			}
+		}
+		return false
+	})
+}
+
 func secretNamedMaaSDB() predicate.Predicate {
 	return predicate.NewPredicateFuncs(func(o client.Object) bool {
 		return o.GetName() == tenantreconcile.MaaSDBSecretName
@@ -164,6 +179,13 @@ func (r *TenantReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			&extv1.CustomResourceDefinition{},
 			handler.EnqueueRequestsFromMapFunc(r.enqueueDefaultTenant),
 			builder.WithPredicates(crdLabeledForMaaSComponent()),
+		).
+		// Re-reconcile when optional operator CRDs (e.g. Perses from COO) are installed
+		// so that resources previously skipped due to missing CRDs are applied immediately.
+		Watches(
+			&extv1.CustomResourceDefinition{},
+			handler.EnqueueRequestsFromMapFunc(r.enqueueDefaultTenant),
+			builder.WithPredicates(crdInOptionalAPIGroup()),
 		).
 		Watches(
 			&corev1.ConfigMap{},

--- a/maas-controller/pkg/platform/tenantreconcile/apply.go
+++ b/maas-controller/pkg/platform/tenantreconcile/apply.go
@@ -8,10 +8,12 @@ import (
 	"path/filepath"
 	"strings"
 
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	maasv1alpha1 "github.com/opendatahub-io/models-as-a-service/maas-controller/api/maas/v1alpha1"
 )
@@ -134,6 +136,16 @@ func ApplyRendered(ctx context.Context, c client.Client, scheme *runtime.Scheme,
 		// Tenant platform resources. During migration from the ODH modelsasservice
 		// pipeline, force ensures a clean field-manager handoff without conflicts.
 		if err := c.Patch(ctx, u, client.Apply, client.FieldOwner(ssaFieldOwner), client.ForceOwnership); err != nil {
+			if apimeta.IsNoMatchError(err) && isOptionalAPIGroup(u.GroupVersionKind().Group) {
+				// CRD not yet registered for a known optional dependency (e.g. Perses CRDs
+				// installed by COO which may not be present yet). Skip so the rest of the
+				// platform manifests are applied and Tenant reconcile does not fail.
+				// The CRD watch will re-trigger reconcile once the CRDs appear.
+				log.FromContext(ctx).Info("skipping resource: optional CRD not yet registered, will apply once installed",
+					"group", u.GroupVersionKind().Group, "kind", u.GetKind(),
+					"name", u.GetName(), "namespace", u.GetNamespace())
+				continue
+			}
 			return fmt.Errorf("apply %s %s/%s: %w", u.GetKind(), u.GetNamespace(), u.GetName(), err)
 		}
 	}

--- a/maas-controller/pkg/platform/tenantreconcile/constants.go
+++ b/maas-controller/pkg/platform/tenantreconcile/constants.go
@@ -2,7 +2,23 @@
 // (initialize → dependencies → prerequisites → gateway → params → kustomize → post-render → apply → deployment status).
 package tenantreconcile
 
-import "k8s.io/apimachinery/pkg/runtime/schema"
+import (
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// OptionalAPIGroups lists API groups whose CRDs are installed by optional platform
+// components (e.g. COO for Perses). Resources in these groups are skipped gracefully
+// when their CRDs are not yet registered, instead of failing the Tenant reconcile.
+// The CRD watch in the controller re-triggers reconcile once the CRDs appear.
+var OptionalAPIGroups = map[string]bool{
+	"perses.dev": true, // Cluster Observability Operator (COO) — Perses dashboards and datasources
+}
+
+// isOptionalAPIGroup returns true when missing CRDs for the given group should not
+// fail the reconcile (i.e. the dependency is installed by an optional operator).
+func isOptionalAPIGroup(group string) bool {
+	return OptionalAPIGroups[group]
+}
 
 const (
 	// ComponentName matches the ODH modelsasservice component label key suffix (app.opendatahub.io/<name>).


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The Tenant reconciler calls ApplyParams which reads RELATED_IMAGE_* env vars via os.Getenv to substitute operator-pinned SHA digests into params.env before per-tenant kustomize builds. Without these env vars on the controller pod, all images except payload-processing stayed at baked-in defaults (:latest tags) instead of the pinned digests from the operator CSV.

Changes:
- Add RELATED_IMAGE_* env vars to base manager.yaml sourced from maas-parameters ConfigMap
- Covers both AppendOperatorInstallManifests path (operator builds from base) and the overlay path
- Remove now-redundant duplicate RELATED_IMAGE env vars from ODH overlay patch
- Add missing CLUSTER_AUDIENCE env var to ODH overlay (referenced in args but was undefined)

Env vars added to controller pod:
- RELATED_IMAGE_ODH_MAAS_API_IMAGE (from maas-api-image)
- RELATED_IMAGE_ODH_MAAS_CONTROLLER_IMAGE (from maas-controller-image)
- RELATED_IMAGE_ODH_AI_GATEWAY_PAYLOAD_PROCESSING_IMAGE (from payload-processing-image)
- RELATED_IMAGE_UBI_MINIMAL_IMAGE (from maas-api-key-cleanup-image)

Depends on: opendatahub-operator fix/maas-related-image-env-vars
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
