### PR TITLE
docs: match Observability page title with navigation item

### DIFF
--- a/docs/content/advanced-administration/observability.md
+++ b/docs/content/advanced-administration/observability.md
@@ -1,4 +1,4 @@
-# Observability
+# Observability Dashboard
 
 This document covers the observability stack for the MaaS Platform, including metrics collection, monitoring, and visualization.
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -87,7 +87,7 @@ nav:
       - Controller Overview: configuration-and-management/maas-controller-overview.md
       - CRD Annotations: configuration-and-management/crd-annotations.md
     - Advanced Administration:
-      - Observability: advanced-administration/observability.md
+      - Observability Dashboard: advanced-administration/observability.md
       - Limitador Persistence: advanced-administration/limitador-persistence.md
       - Subscription Cardinality: advanced-administration/subscription-cardinality.md
       - Authorino Caching: configuration-and-management/authorino-caching.md


### PR DESCRIPTION
## Summary
Updates the Observability page title and navigation item to consistently use "Observability Dashboard" instead of just "Observability".

## Changes
- Updated left navigation item in `docs/mkdocs.yml` from "Observability" to "Observability Dashboard"
- Updated page heading in `docs/content/advanced-administration/observability.md` from "# Observability" to "# Observability Dashboard"

## Testing
Ensures consistency between the navigation item name and the page title, improving user experience and navigation clarity.

<img width="1178" height="936" alt="image" src="https://github.com/user-attachments/assets/b107a3b1-463a-4f6b-a8d2-b63039f8ef7a" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Observability section title and navigation label to "Observability Dashboard" in the administration guide documentation and menu structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->