### PR TITLE
chore: enforce strict OpenAPI validation

### DIFF
--- a/.github/workflows/openapi-validation.yml
+++ b/.github/workflows/openapi-validation.yml
@@ -115,7 +115,8 @@ jobs:
           # Run breaking change detection
           oasdiff breaking base-spec.yaml maas-api/openapi3.yaml > breaking-changes.txt || true
 
-          if [ -s breaking-changes.txt ]; then
+          # Check if actual breaking changes were detected (not just "No changes detected" message)
+          if [ -s breaking-changes.txt ] && ! grep -q "^No changes detected$" breaking-changes.txt; then
             echo "has_breaking_changes=true" >> $GITHUB_OUTPUT
             echo "## ⚠️  Breaking Changes Detected" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/openapi-validation.yml
+++ b/.github/workflows/openapi-validation.yml
@@ -32,9 +32,6 @@ jobs:
         run: npm install -g @stoplight/spectral-cli@6.13.1
 
       - name: Validate OpenAPI Spec
-        # NOTE: continue-on-error is temporary until existing errors are fixed in PR #694
-        # Once #694 merges, remove this line to enforce strict validation
-        continue-on-error: true
         run: |
           echo "🔍 Validating OpenAPI specification..."
           spectral lint maas-api/openapi3.yaml --format stylish --verbose
@@ -142,10 +139,6 @@ jobs:
 
       - name: Fail on Breaking Changes
         if: steps.breaking_changes.outputs.has_breaking_changes == 'true'
-        # NOTE: continue-on-error is temporary to allow PR #693 to merge
-        # This establishes the validation infrastructure. Once #694 fixes existing issues,
-        # remove this line to enforce strict breaking change checks
-        continue-on-error: true
         run: |
           echo "❌ Breaking changes detected. If intentional, document in PR and get approval."
           echo "   Consider:"


### PR DESCRIPTION
## Summary
Remove temporary `continue-on-error` flags from OpenAPI validation workflow and fix breaking changes detection bug.

Related to - https://redhat.atlassian.net/browse/RHOAIENG-60249

## Changes

### 1. Enforce Strict Validation
- Remove `continue-on-error` from "Validate OpenAPI Spec" step
- Remove `continue-on-error` from "Fail on Breaking Changes" step
- OpenAPI validation failures and breaking changes now block PRs

### 2. Fix Breaking Changes Detection Bug
**Problem:** Workflow incorrectly flagged "No changes detected" message as breaking changes.

**Fix:** Add grep check to exclude "No changes detected" from detection:
```bash
if [ -s breaking-changes.txt ] && ! grep -q "^No changes detected$" breaking-changes.txt; then
```

## Testing

**OpenAPI Validation:**
```
✖ 6 problems (0 errors, 0 warnings, 0 infos, 6 hints)
```

**Breaking Changes Detection:**
```bash
$ oasdiff breaking <(git show upstream/main:maas-api/openapi3.yaml) maas-api/openapi3.yaml
No changes detected
```

**Logic Verification:**
- ✅ "No changes detected" → `has_breaking_changes=false`
- ✅ Actual breaking changes → `has_breaking_changes=true`
- ✅ Empty file → `has_breaking_changes=false`

## Related
- Depends on #694 (merged - fixed OpenAPI validation errors)
- Depends on #693 (merged - added validation workflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)