### PR TITLE
fix(rbac): cherry-pick perses.dev RBAC fix to stable

### DIFF
--- a/deployment/base/maas-controller/rbac/clusterrole.yaml
+++ b/deployment/base/maas-controller/rbac/clusterrole.yaml
@@ -261,6 +261,18 @@ rules:
   - list
   - watch
 - apiGroups:
+  - perses.dev
+  resources:
+  - persesdashboards
+  - persesdatasources
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - clusterrolebindings

--- a/maas-controller/pkg/controller/maas/tenant_controller.go
+++ b/maas-controller/pkg/controller/maas/tenant_controller.go
@@ -75,6 +75,7 @@ type TenantReconciler struct {
 // +kubebuilder:rbac:groups=networking.istio.io,resources=envoyfilters,verbs=get;list;watch;create;patch;delete
 // +kubebuilder:rbac:groups=telemetry.istio.io,resources=telemetries,verbs=get;list;watch;create;patch;delete
 // +kubebuilder:rbac:groups=batch,resources=cronjobs,verbs=get;list;watch;create;patch;delete
+// +kubebuilder:rbac:groups=perses.dev,resources=persesdashboards;persesdatasources,verbs=get;list;watch;create;patch;delete
 
 // maas-controller creates the maas-api ClusterRole via SSA.
 // The rules below mirror the maas-api ClusterRole so the controller can pass the API-server escalation check.


### PR DESCRIPTION
## Summary

Cherry-pick of #818 to the `stable` branch.

- Adds kubebuilder RBAC marker and ClusterRole entries granting `maas-controller` permissions to manage `persesdashboards` and `persesdatasources` in the `perses.dev` API group.
- Fixes "forbidden" errors when `maas-controller` attempts to patch Perses resources on clusters where COO is installed.

## Original PR

https://github.com/opendatahub-io/models-as-a-service/pull/818

## Files changed

- `deployment/base/maas-controller/rbac/clusterrole.yaml` — added `perses.dev` rules
- `maas-controller/pkg/controller/maas/tenant_controller.go` — added kubebuilder RBAC marker

## Test plan

- [ ] Verify ClusterRole includes `perses.dev` group with `persesdashboards` and `persesdatasources` resources
- [ ] Confirm `maas-controller` can create/patch/delete Perses resources without "forbidden" errors on a cluster with COO installed


Made with [Cursor](https://cursor.com)