### PR TITLE
docs: update and deduplicate contents in tls-configuration.md

### DIFF
--- a/docs/content/configuration-and-management/tls-configuration.md
+++ b/docs/content/configuration-and-management/tls-configuration.md
@@ -32,9 +32,6 @@ When TLS is enabled:
 - Internal authentication traffic (Authorino → `maas-api`) is encrypted
 - All certificate validation uses a trusted CA bundle
 
-!!! note "Default deployment"
-    TLS is enabled by default when deploying via `./scripts/deploy.sh` (both operator and kustomize modes). The deployment relies on OpenShift [service-ca-operator](https://docs.openshift.com/container-platform/latest/security/certificates/service-serving-certificate.html) for automatic certificate provisioning. Use `--disable-tls-backend` to deploy with HTTP instead.
-
 ## Prerequisites
 
 ### Authorino TLS Configuration
@@ -46,23 +43,16 @@ Authorino handles two TLS-protected traffic flows:
 
 For ODH/RHOAI deployments, the inbound flow is a [platform pre-requisite](https://github.com/opendatahub-io/kserve/tree/release-v0.15/docs/samples/llmisvc/ocp-setup-for-GA#ssl-authorino) for secure `LLMInferenceService` communication; only the outbound configuration is needed for MaaS.
 
-For all deployments using `./scripts/deploy.sh` (both operator and kustomize modes with TLS enabled), both flows are configured automatically via `scripts/setup-authorino-tls.sh`.
-
-!!! warning "Authorino TLS script modifies operator-managed resources"
-    The `scripts/setup-authorino-tls.sh` script patches Authorino's service and deployment directly. When run (automatically by `deploy.sh` or manually), it will annotate the Authorino service, patch the Authorino CR, and add environment variables to the Authorino deployment. Use `--disable-tls-backend` with `deploy.sh` to skip this if you manage Authorino TLS separately.
-
-#### Gateway → Authorino (Listener TLS)
-
-Enables TLS on Authorino's gRPC listener for incoming authentication requests from the Gateway.
-
-**Quick setup:** Run the standalone script (or let `deploy.sh` run it automatically):
+For all deployments using `./scripts/deploy.sh` (both operator and kustomize modes with TLS enabled), both flows are configured automatically via `scripts/setup-authorino-tls.sh`. Use `--disable-tls-backend` with `deploy.sh` to skip this and manage Authorino TLS separately. To run the standalone script:
 
 ```bash
 ./scripts/setup-authorino-tls.sh
 # Use AUTHORINO_NAMESPACE=rh-connectivity-link for RHCL
 ```
 
-**Manual configuration:**
+#### Gateway → Authorino (Inbound TLS)
+
+Enables TLS on Authorino's gRPC listener for incoming authentication requests from the Gateway.
 
 ```bash
 # Annotate service for certificate generation
@@ -88,33 +78,6 @@ kubectl patch authorino authorino -n kuadrant-system --type=merge --patch '
 ```
 
 For more details, see the [ODH KServe TLS setup guide](https://github.com/opendatahub-io/kserve/tree/release-v0.15/docs/samples/llmisvc/ocp-setup-for-GA#ssl-authorino).
-
-##### Configuring the Gateway for Authorino TLS
-
-When TLS is enabled on Authorino's listener, the Gateway must be configured to trust Authorino's certificate. Without service mesh sidecars (the default for OpenShift Ingress), this requires an EnvoyFilter to configure the upstream TLS context.
-
-For MaaS gateways managed by the ODH Model Controller, use the `security.opendatahub.io/authorino-tls-bootstrap` annotation to enable automatic EnvoyFilter creation:
-
-```yaml
-apiVersion: gateway.networking.k8s.io/v1
-kind: Gateway
-metadata:
-  name: maas-default-gateway
-  namespace: openshift-ingress
-  annotations:
-    security.opendatahub.io/authorino-tls-bootstrap: "true"
-    opendatahub.io/managed: "false"  # Custom AuthPolicies managed externally
-spec:
-  # ... gateway spec ...
-```
-
-| Annotation | Description |
-|------------|-------------|
-| `security.opendatahub.io/authorino-tls-bootstrap` | When `"true"`, creates the EnvoyFilter for Gateway → Authorino TLS communication |
-| `opendatahub.io/managed` | When `"false"`, disables automatic AuthPolicy creation (for custom policy management) |
-
-!!! info "Interim solution"
-    This annotation is an interim solution until [CONNLINK-528](https://issues.redhat.com/browse/CONNLINK-528) ships native support for configuring TLS between the Gateway and Authorino without mesh sidecars. Previously, setting `opendatahub.io/managed=false` would skip both AuthPolicy and EnvoyFilter creation, leaving no way to configure Authorino TLS independently. The `authorino-tls-bootstrap` annotation decouples these concerns, allowing TLS configuration even when AuthPolicies are managed externally.
 
 #### Authorino → maas-api (Outbound TLS)
 
@@ -148,41 +111,18 @@ Client → Gateway (TLS termination) → [DestinationRule] → maas-api:8443 (TL
 
 This section covers how `maas-api` is configured to use TLS certificates. These settings are automatically configured by the kustomize overlays; manual configuration is only needed for custom deployments or non-OpenShift environments.
 
-### Environment Variables
-
 The `maas-api` component accepts TLS configuration via environment variables:
 
-| Variable | Description | Default | Example |
-|----------|-------------|---------|---------|
-| `TLS_CERT` | Path to TLS certificate file | (none) | `/etc/maas-api/tls/tls.crt` |
-| `TLS_KEY` | Path to TLS private key file | (none) | `/etc/maas-api/tls/tls.key` |
-| `TLS_SELF_SIGNED` | Generate a self-signed certificate at startup | `false` | `true` |
-| `TLS_MIN_VERSION` | Minimum accepted TLS version (`1.2` or `1.3`) | `1.2` | `1.3` |
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `TLS_CERT` | Path to TLS certificate file | `/etc/maas-api/tls/tls.crt` |
+| `TLS_KEY` | Path to TLS private key file | `/etc/maas-api/tls/tls.key` |
+| `TLS_SELF_SIGNED` | Generate a self-signed certificate at startup (`true` or `false`) | `false` |
+| `TLS_MIN_VERSION` | Minimum accepted TLS version (`1.2` or `1.3`) | `1.2` |
 
 When `TLS_CERT` and `TLS_KEY` are both set, the API server listens on HTTPS (port 8443) instead of HTTP (port 8080). If `TLS_SELF_SIGNED` is set to `true`, a self-signed certificate is generated automatically and explicit cert/key paths are not required. When both cert/key files and `TLS_SELF_SIGNED` are provided, the cert/key files take precedence.
 
-### Volume Mounts
-
-Certificates should be mounted as a volume from a Kubernetes Secret:
-
-```yaml
-spec:
-  containers:
-  - name: maas-api
-    env:
-    - name: TLS_CERT
-      value: /etc/maas-api/tls/tls.crt
-    - name: TLS_KEY
-      value: /etc/maas-api/tls/tls.key
-    volumeMounts:
-    - name: tls-certs
-      mountPath: /etc/maas-api/tls
-      readOnly: true
-  volumes:
-  - name: tls-certs
-    secret:
-      secretName: maas-api-tls-cert
-```
+By default, certificates are mounted to the paths in the table above from Kubernetes Secret `maas-api-serving-cert`.
 
 ## Kustomize Overlays
 
@@ -192,7 +132,6 @@ Pre-configured overlays are available for common scenarios:
 |---------|-------------|
 | `deployment/base/maas-api/overlays/tls` | Base TLS overlay for maas-api (deployment patch, service annotation, DestinationRule) |
 | `maas-api/deploy/overlays/odh` | Tenant reconciler overlay (TLS, gateway policies, shared-patches) |
-| `deployment/overlays/odh` | ODH operator overlay (TLS, controller, gateway policies, observability) |
 
 The `tls` base overlay includes:
 
@@ -206,31 +145,13 @@ maas-api is deployed by the Tenant reconciler in `maas-controller`. The `deploy.
 installs prerequisites (policy engine, PostgreSQL, Authorino TLS) and then deploys
 `maas-controller`, which creates the `default-tenant` CR and reconciles maas-api via SSA.
 
+To verify that the overlay builds correctly:
+
+```bash
+kustomize build deployment/base/maas-api/overlays/tls
+```
+
 ## Verifying TLS Configuration
 
-!!! note "Application namespace"
-    The `maas-api` service is deployed to the platform's application namespace: `redhat-ods-applications` for RHOAI or `opendatahub` for ODH. Adjust the namespace in the commands below accordingly.
-
-### Check Certificate
-
-```bash
-# View certificate details
-kubectl get secret maas-api-serving-cert -n <application-namespace> -o jsonpath='{.data.tls\.crt}' \
-  | base64 -d | openssl x509 -text -noout
-
-# Check expiry
-kubectl get secret maas-api-serving-cert -n <application-namespace> -o jsonpath='{.data.tls\.crt}' \
-  | base64 -d | openssl x509 -enddate -noout
-```
-
-### Test HTTPS Endpoint
-
-```bash
-# From within the cluster
-kubectl run curl --rm -it --image=curlimages/curl -- \
-  curl -vk https://maas-api.<application-namespace>.svc:8443/health
-
-# Check certificate chain
-openssl s_client -connect maas-api.<application-namespace>.svc:8443 -servername maas-api.<application-namespace>.svc
-```
+For TLS verification commands, see [Validation Guide - TLS Verification](../install/validation.md#tls-verification).
 

--- a/docs/content/install/maas-setup.md
+++ b/docs/content/install/maas-setup.md
@@ -78,12 +78,14 @@ The Gateway must exist before enabling modelsAsService in your DataScienceCluste
     ```
 
 !!! note "Required annotations"
-    The Gateway **must** include these annotations for MaaS to work correctly:
+    The Gateway **must** include these annotations to trust Authorino's certificates:
 
     | Annotation | Purpose |
     |------------|---------|
     | `opendatahub.io/managed: "false"` | Read by **maas-controller**: allows it to manage AuthPolicies and related resources; prevents the ODH Model Controller from overwriting them. |
-    | `security.opendatahub.io/authorino-tls-bootstrap: "true"` | Used by the ODH platform (not maas-controller) to create the EnvoyFilter for Gateway → Authorino TLS when Authorino uses a TLS listener. Required when Authorino TLS is enabled (see [TLS Configuration](../configuration-and-management/tls-configuration.md)). |
+    | `security.opendatahub.io/authorino-tls-bootstrap: "true"` | Used by the ODH platform (not maas-controller) to create the EnvoyFilter for Gateway → Authorino TLS when Authorino uses a TLS listener. Required when Authorino TLS is enabled. |
+
+    The `authorino-tls-bootstrap` annotation is an interim solution until [CONNLINK-528](https://issues.redhat.com/browse/CONNLINK-528) ships native support for configuring TLS between the Gateway and Authorino without mesh sidecars. It decouples TLS configuration from AuthPolicy management, allowing TLS even when `opendatahub.io/managed` is `"false"`.
 
 ```yaml
 CLUSTER_DOMAIN=$(kubectl get ingresses.config.openshift.io cluster -o jsonpath='{.spec.domain}')

--- a/docs/content/install/validation.md
+++ b/docs/content/install/validation.md
@@ -143,12 +143,15 @@ kubectl get secret maas-api-serving-cert -n <application-namespace> \
 ### Test HTTPS Endpoint
 
 ```bash
-# From within the cluster
-kubectl run curl --rm -it --image=curlimages/curl -- \
-  curl -vk https://maas-api.<application-namespace>.svc:8443/health
+# Start port-forward (runs in foreground, use a separate terminal for the
+# commands below)
+kubectl port-forward -n <application-namespace> svc/maas-api 8443:8443
+
+# Test health endpoint
+curl -vk https://localhost:8443/health
 
 # Check certificate chain
-openssl s_client -connect maas-api.<application-namespace>.svc:8443 \
+openssl s_client -connect localhost:8443 \
   -servername maas-api.<application-namespace>.svc
 ```
 

--- a/docs/content/install/validation.md
+++ b/docs/content/install/validation.md
@@ -126,25 +126,30 @@ The script automates the manual validation steps above and provides detailed fee
 
 ## TLS Verification
 
-TLS is enabled by default when deploying via the automated script or ODH overlay.
+TLS is enabled by default when deploying via the automated script or ODH overlay. Use `opendatahub` for ODH or `redhat-ods-applications` for RHOAI in the commands below.
 
 ### Check Certificate
 
 ```bash
-# View certificate details (RHOAI)
-kubectl get secret maas-api-serving-cert -n redhat-ods-applications \
+# View certificate details
+kubectl get secret maas-api-serving-cert -n <application-namespace> \
   -o jsonpath='{.data.tls\.crt}' | base64 -d | openssl x509 -text -noout
 
 # Check expiry
-kubectl get secret maas-api-serving-cert -n redhat-ods-applications \
+kubectl get secret maas-api-serving-cert -n <application-namespace> \
   -o jsonpath='{.data.tls\.crt}' | base64 -d | openssl x509 -enddate -noout
 ```
 
 ### Test HTTPS Endpoint
 
 ```bash
+# From within the cluster
 kubectl run curl --rm -it --image=curlimages/curl -- \
-  curl -vk https://maas-api.redhat-ods-applications.svc:8443/health
+  curl -vk https://maas-api.<application-namespace>.svc:8443/health
+
+# Check certificate chain
+openssl s_client -connect maas-api.<application-namespace>.svc:8443 \
+  -servername maas-api.<application-namespace>.svc
 ```
 
 For detailed TLS configuration options, see [TLS Configuration](../configuration-and-management/tls-configuration.md).

--- a/docs/content/quickstart.md
+++ b/docs/content/quickstart.md
@@ -9,12 +9,6 @@ This guide provides quickstart instructions for deploying the MaaS Platform infr
 
 - **OpenShift cluster** (4.19.9+) with kubectl/oc access
       - **Recommended** 16 vCPUs, 32GB RAM, 100GB storage
-- **ODH/RHOAI requirements**:
-      - RHOAI 3.0 +
-      - ODH 3.0 +
-- **RHCL requirements** (Note: This can be installed automatically by the script below):
-      - RHCL 1.2 +
-- **Authorino TLS**: Listener TLS must be enabled on Authorino (see [Configure Authorino TLS](#configure-authorino-tls))
 - **Cluster admin** or equivalent permissions
 - **Required tools**:
       - `oc` (OpenShift CLI)
@@ -22,17 +16,6 @@ This guide provides quickstart instructions for deploying the MaaS Platform infr
       - `jq`
       - `kustomize` (v5.7.0+)
       - `gsed` (GNU sed) - **macOS only**: `brew install gnu-sed`
-
-## Configure Authorino TLS
-
-Before deploying MaaS, Authorino's listener TLS must be enabled. This is a platform prerequisite for secure `LLMInferenceService` communication:
-
-- **Gateway → Authorino (Listener TLS)**: Enable TLS on Authorino's gRPC listener for incoming authentication requests
-
-For step-by-step commands, see [TLS Configuration: Authorino TLS Configuration](configuration-and-management/tls-configuration.md#authorino-tls-configuration).
-
-!!! tip "Automated configuration"
-    The `deploy.sh` script automatically configures all remaining TLS settings after deployment, including Gateway TLS bootstrap and Authorino → maas-api outbound TLS.
 
 ## Quick Start
 
@@ -125,9 +108,6 @@ kubectl get tenant default-tenant -n models-as-a-service
 kubectl get pods -n kserve
 kubectl get pods -n ${APP_NS}
 ```
-
-!!! tip "TLS Configuration"
-    TLS is enabled by default. See [TLS Configuration](configuration-and-management/tls-configuration.md) for details.
 
 For detailed validation and troubleshooting, see the [Validation Guide](install/validation.md).
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
https://redhat.atlassian.net/browse/RHOAIENG-59748

## Description
<!--- Describe your changes in detail -->
1. `quickstart.md` is basically the use of `deploy.sh`, which includes ODH/RHOAI, RHCL installation and TLS config. Deleting them from that page.
2. Deleting unnecessary details such as volume mounts in `tls-configuration.md`.
3. Removing redundant contents and keeping only one copy of the following topics:
    - Running standalone script `setup-authorino-tls.sh`;
    - Annotations in Gateway to trust Authorino certificates; and
    - TLS config verification.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Consolidated and simplified TLS setup into a streamlined run/setup flow and renamed the manual Gateway→Authorino listener-TLS procedure
  * Clarified Gateway annotation requirement for Authorino TLS communication and noted it as temporary
  * Made verification steps namespace-agnostic and now point to an external validation guide
  * Simplified maas-api TLS docs by removing example env values, volume-mount details, and pruning kustomize overlays
<!-- end of auto-generated comment: release notes by coderabbit.ai -->