### PR TITLE
fix: route model access probes through gateway's internal service

### DIFF
--- a/maas-api/cmd/main.go
+++ b/maas-api/cmd/main.go
@@ -175,7 +175,15 @@ func registerHandlers(ctx context.Context, log *logger.Logger, router *gin.Engin
 
 	subscriptionSelector := subscription.NewSelector(log, cluster.MaaSSubscriptionLister)
 
-	modelManager, err := models.NewManager(log, cfg.AccessCheckTimeoutSeconds)
+	resolveCtx, resolveCancel := context.WithTimeout(ctx, time.Duration(cfg.AccessCheckTimeoutSeconds)*time.Second)
+	gatewayInternalHost, err := config.ResolveGatewayInternalHost(resolveCtx, cluster.ClientSet, cfg.GatewayName, cfg.GatewayNamespace)
+	resolveCancel()
+	if err != nil {
+		return fmt.Errorf("failed to resolve gateway internal address: %w", err)
+	}
+	log.Info("Resolved gateway internal host for access probes", "host", gatewayInternalHost)
+
+	modelManager, err := models.NewManager(log, cfg.AccessCheckTimeoutSeconds, gatewayInternalHost)
 	if err != nil {
 		log.Fatal("Failed to create model manager", "error", err)
 	}

--- a/maas-api/internal/config/cluster_config.go
+++ b/maas-api/internal/config/cluster_config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -147,7 +148,7 @@ func (c *ClusterConfig) StartAndWaitForSync(stopCh <-chan struct{}) bool {
 // gateway.networking.k8s.io/gateway-name=<gatewayName> in gatewayNamespace.
 // Only Services owned by a Gateway resource (via ownerReferences) and exposing
 // port 443 are considered. Returns "<service-name>.<namespace>.svc.cluster.local".
-func ResolveGatewayInternalHost(ctx context.Context, clientset *kubernetes.Clientset, gatewayName, gatewayNamespace string) (string, error) {
+func ResolveGatewayInternalHost(ctx context.Context, clientset kubernetes.Interface, gatewayName, gatewayNamespace string) (string, error) {
 	labelSelector := fmt.Sprintf("gateway.networking.k8s.io/gateway-name=%s", gatewayName)
 	svcs, err := clientset.CoreV1().Services(gatewayNamespace).List(ctx, metav1.ListOptions{
 		LabelSelector: labelSelector,
@@ -160,7 +161,8 @@ func ResolveGatewayInternalHost(ctx context.Context, clientset *kubernetes.Clien
 	for _, svc := range svcs.Items {
 		ownedByGateway := false
 		for _, ref := range svc.OwnerReferences {
-			if ref.Kind == "Gateway" && ref.Name == gatewayName {
+			if ref.Kind == "Gateway" && ref.Name == gatewayName &&
+				strings.HasPrefix(ref.APIVersion, "gateway.networking.k8s.io/") {
 				ownedByGateway = true
 				break
 			}

--- a/maas-api/internal/config/cluster_config.go
+++ b/maas-api/internal/config/cluster_config.go
@@ -1,10 +1,12 @@
 package config
 
 import (
+	"context"
 	"fmt"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/dynamic"
@@ -138,6 +140,50 @@ func (c *ClusterConfig) StartAndWaitForSync(stopCh <-chan struct{}) bool {
 		start(stopCh)
 	}
 	return cache.WaitForCacheSync(stopCh, c.informersSynced...)
+}
+
+// ResolveGatewayInternalHost finds the cluster-internal DNS name of the gateway's
+// Service by looking up Services labeled with the standard Gateway API label
+// gateway.networking.k8s.io/gateway-name=<gatewayName> in gatewayNamespace.
+// Only Services owned by a Gateway resource (via ownerReferences) and exposing
+// port 443 are considered. Returns "<service-name>.<namespace>.svc.cluster.local".
+func ResolveGatewayInternalHost(ctx context.Context, clientset *kubernetes.Clientset, gatewayName, gatewayNamespace string) (string, error) {
+	labelSelector := fmt.Sprintf("gateway.networking.k8s.io/gateway-name=%s", gatewayName)
+	svcs, err := clientset.CoreV1().Services(gatewayNamespace).List(ctx, metav1.ListOptions{
+		LabelSelector: labelSelector,
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to list services in %s with label %s: %w", gatewayNamespace, labelSelector, err)
+	}
+
+	var candidates []string
+	for _, svc := range svcs.Items {
+		ownedByGateway := false
+		for _, ref := range svc.OwnerReferences {
+			if ref.Kind == "Gateway" && ref.Name == gatewayName {
+				ownedByGateway = true
+				break
+			}
+		}
+		if !ownedByGateway {
+			continue
+		}
+		for _, port := range svc.Spec.Ports {
+			if port.Port == 443 {
+				candidates = append(candidates, svc.Name)
+				break
+			}
+		}
+	}
+
+	switch len(candidates) {
+	case 0:
+		return "", fmt.Errorf("no gateway-owned service with HTTPS port found for gateway %s/%s (label: %s)", gatewayNamespace, gatewayName, labelSelector)
+	case 1:
+		return fmt.Sprintf("%s.%s.svc.cluster.local", candidates[0], gatewayNamespace), nil
+	default:
+		return "", fmt.Errorf("expected 1 gateway service for %s/%s, found %d: %v", gatewayNamespace, gatewayName, len(candidates), candidates)
+	}
 }
 
 // LoadRestConfig creates a *rest.Config using client-go loading rules.

--- a/maas-api/internal/config/cluster_config_test.go
+++ b/maas-api/internal/config/cluster_config_test.go
@@ -1,0 +1,121 @@
+package config_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/opendatahub-io/models-as-a-service/maas-api/internal/config"
+)
+
+func TestResolveGatewayInternalHost(t *testing.T) {
+	const (
+		gwName = "my-gateway"
+		gwNS   = "istio-system"
+	)
+
+	newService := func(name string, port int32, ownerAPIVersion string) *corev1.Service {
+		svc := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: gwNS,
+				Labels: map[string]string{
+					"gateway.networking.k8s.io/gateway-name": gwName,
+				},
+			},
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{{Port: port}},
+			},
+		}
+		if ownerAPIVersion != "" {
+			svc.OwnerReferences = []metav1.OwnerReference{{
+				APIVersion: ownerAPIVersion,
+				Kind:       "Gateway",
+				Name:       gwName,
+			}}
+		}
+		return svc
+	}
+
+	tests := []struct {
+		name      string
+		services  []runtime.Object
+		wantHost  string
+		wantError string
+	}{
+		{
+			name: "single valid gateway-owned service",
+			services: []runtime.Object{
+				newService("gw-svc", 443, "gateway.networking.k8s.io/v1"),
+			},
+			wantHost: "gw-svc.istio-system.svc.cluster.local",
+		},
+		{
+			name:      "no matching services",
+			services:  []runtime.Object{},
+			wantError: "no gateway-owned service with HTTPS port found",
+		},
+		{
+			name: "service without ownerReference is skipped",
+			services: []runtime.Object{
+				newService("rogue-svc", 443, ""),
+			},
+			wantError: "no gateway-owned service with HTTPS port found",
+		},
+		{
+			name: "service owned by Istio Gateway CRD is skipped",
+			services: []runtime.Object{
+				newService("istio-svc", 443, "networking.istio.io/v1alpha3"),
+			},
+			wantError: "no gateway-owned service with HTTPS port found",
+		},
+		{
+			name: "service without port 443 is skipped",
+			services: []runtime.Object{
+				newService("http-svc", 80, "gateway.networking.k8s.io/v1"),
+			},
+			wantError: "no gateway-owned service with HTTPS port found",
+		},
+		{
+			name: "multiple valid candidates returns error",
+			services: []runtime.Object{
+				newService("gw-svc-1", 443, "gateway.networking.k8s.io/v1"),
+				newService("gw-svc-2", 443, "gateway.networking.k8s.io/v1beta1"),
+			},
+			wantError: "expected 1 gateway service",
+		},
+		{
+			name: "mixed valid and invalid services selects only valid",
+			services: []runtime.Object{
+				newService("valid-svc", 443, "gateway.networking.k8s.io/v1"),
+				newService("no-owner", 443, ""),
+				newService("wrong-port", 8080, "gateway.networking.k8s.io/v1"),
+				newService("istio-gw", 443, "networking.istio.io/v1"),
+			},
+			wantHost: "valid-svc.istio-system.svc.cluster.local",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clientset := fake.NewSimpleClientset(tt.services...)
+
+			host, err := config.ResolveGatewayInternalHost(context.Background(), clientset, gwName, gwNS)
+
+			if tt.wantError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantError)
+				assert.Empty(t, host)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.wantHost, host)
+			}
+		})
+	}
+}

--- a/maas-api/internal/handlers/models_test.go
+++ b/maas-api/internal/handlers/models_test.go
@@ -332,7 +332,7 @@ func TestListingModels(t *testing.T) {
 	}
 	router, _ := fixtures.SetupTestServer(t, config)
 
-	modelMgr, errMgr := models.NewManager(testLogger, 15)
+	modelMgr, errMgr := models.NewManager(testLogger, 15, "")
 	require.NoError(t, errMgr)
 
 	// Set up test fixtures
@@ -447,7 +447,7 @@ func TestListingModelsWithSubscriptionHeader(t *testing.T) {
 	}
 	router, _ := fixtures.SetupTestServer(t, config)
 
-	modelMgr, errMgr := models.NewManager(testLogger, 15)
+	modelMgr, errMgr := models.NewManager(testLogger, 15, "")
 	require.NoError(t, errMgr)
 
 	_, cleanup := fixtures.StubTokenProviderAPIs(t)
@@ -675,7 +675,7 @@ func TestListModels_ReturnAllModels(t *testing.T) {
 		},
 	}
 
-	modelMgr, err := models.NewManager(testLogger, 15)
+	modelMgr, err := models.NewManager(testLogger, 15, "")
 	require.NoError(t, err)
 
 	subscriptionSelector := subscription.NewSelector(testLogger, subscriptionLister)
@@ -864,7 +864,7 @@ func TestListModels_DeduplicationBySubscription(t *testing.T) {
 		},
 	}
 
-	modelMgr, err := models.NewManager(testLogger, 15)
+	modelMgr, err := models.NewManager(testLogger, 15, "")
 	require.NoError(t, err)
 
 	subscriptionSelector := subscription.NewSelector(testLogger, subscriptionLister)
@@ -982,7 +982,7 @@ func TestListModels_DifferentModelRefsWithSameModelID(t *testing.T) {
 		},
 	}
 
-	modelMgr, err := models.NewManager(testLogger, 15)
+	modelMgr, err := models.NewManager(testLogger, 15, "")
 	require.NoError(t, err)
 
 	subscriptionSelector := subscription.NewSelector(testLogger, subscriptionLister)
@@ -1089,7 +1089,7 @@ func TestListModels_DifferentModelRefsWithSameURLAndModelID(t *testing.T) {
 		},
 	}
 
-	modelMgr, err := models.NewManager(testLogger, 15)
+	modelMgr, err := models.NewManager(testLogger, 15, "")
 	require.NoError(t, err)
 
 	subscriptionSelector := subscription.NewSelector(testLogger, subscriptionLister)
@@ -1195,7 +1195,7 @@ func TestListModels_DifferentModelRefsWithSameModelIDAndDifferentSubscriptions(t
 		},
 	}
 
-	modelMgr, err := models.NewManager(testLogger, 15)
+	modelMgr, err := models.NewManager(testLogger, 15, "")
 	require.NoError(t, err)
 
 	subscriptionSelector := subscription.NewSelector(testLogger, subscriptionLister)

--- a/maas-api/internal/models/discovery.go
+++ b/maas-api/internal/models/discovery.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"sync"
@@ -45,16 +46,20 @@ const (
 
 // Manager runs access validation (probe model endpoints) for models listed from MaaSModelRef.
 type Manager struct {
-	logger             *logger.Logger
-	httpClient         *http.Client
-	accessCheckTimeout time.Duration
+	logger              *logger.Logger
+	httpClient          *http.Client
+	accessCheckTimeout  time.Duration
+	gatewayInternalHost string
 }
 
 // NewManager creates a Manager for filtering models by access. The client uses InsecureSkipVerify
 // for cluster-internal probes; auth is enforced by the gateway/model server.
 // accessCheckTimeoutSeconds controls the total duration bound for access validation;
 // if <= 0, the default of 15 seconds is used.
-func NewManager(log *logger.Logger, accessCheckTimeoutSeconds int) (*Manager, error) {
+// gatewayInternalHost, when non-empty, routes all probe TCP connections to this
+// cluster-internal address while preserving the original URL hostname for TLS SNI
+// and the Host header, so gateway routing and Authorino auth work identically.
+func NewManager(log *logger.Logger, accessCheckTimeoutSeconds int, gatewayInternalHost string) (*Manager, error) {
 	if log == nil {
 		return nil, errors.New("log is required")
 	}
@@ -62,19 +67,31 @@ func NewManager(log *logger.Logger, accessCheckTimeoutSeconds int) (*Manager, er
 	if accessCheckTimeoutSeconds > 0 {
 		timeout = time.Duration(accessCheckTimeoutSeconds) * time.Second
 	}
+
+	transport := &http.Transport{
+		TLSClientConfig:     &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // cluster-internal only
+		MaxIdleConns:        httpMaxIdleConns,
+		MaxIdleConnsPerHost: maxDiscoveryConcurrency,
+		IdleConnTimeout:     httpIdleConnTimeout,
+	}
+
+	if gatewayInternalHost != "" {
+		dialer := &net.Dialer{}
+		transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+			_, port, err := net.SplitHostPort(addr)
+			if err != nil {
+				port = "443"
+			}
+			return dialer.DialContext(ctx, network, net.JoinHostPort(gatewayInternalHost, port))
+		}
+	}
+
 	return &Manager{
-		logger:             log,
-		accessCheckTimeout: timeout,
+		logger:              log,
+		accessCheckTimeout:  timeout,
+		gatewayInternalHost: gatewayInternalHost,
 		httpClient: &http.Client{
-			// No per-client Timeout — each request inherits the accessCheckTimeout
-			// deadline via its context. This ensures that configuring a longer
-			// ACCESS_CHECK_TIMEOUT_SECONDS actually allows slower backends to respond.
-			Transport: &http.Transport{
-				TLSClientConfig:     &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // cluster-internal only
-				MaxIdleConns:        httpMaxIdleConns,
-				MaxIdleConnsPerHost: maxDiscoveryConcurrency,
-				IdleConnTimeout:     httpIdleConnTimeout,
-			},
+			Transport: transport,
 		},
 	}, nil
 }

--- a/maas-api/internal/models/discovery.go
+++ b/maas-api/internal/models/discovery.go
@@ -69,7 +69,7 @@ func NewManager(log *logger.Logger, accessCheckTimeoutSeconds int, gatewayIntern
 	}
 
 	transport := &http.Transport{
-		TLSClientConfig:     &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // cluster-internal only
+		TLSClientConfig:     &tls.Config{InsecureSkipVerify: true, MinVersion: tls.VersionTLS12}, //nolint:gosec // cluster-internal only
 		MaxIdleConns:        httpMaxIdleConns,
 		MaxIdleConnsPerHost: maxDiscoveryConcurrency,
 		IdleConnTimeout:     httpIdleConnTimeout,


### PR DESCRIPTION
## Summary
- On disconnected clusters, `FilterModelsByAccess` probes fail because they connect to the gateway via its external URL, which resolves to public ELB IPs unreachable from workload pods (blocked by `AdminNetworkPolicy` or VPC routing). Every probe hangs for 15 seconds (the `accessCheckTimeout`) and returns an empty model list.
- At startup, the maas-api now resolves the gateway's cluster-internal service address by looking up Services labeled with `gateway.networking.k8s.io/gateway-name` in the configured gateway namespace.
- A custom `DialContext` on the HTTP Transport routes all probe TCP connections to this internal address, while the original URL is preserved unchanged — keeping TLS SNI and the Host header correct so Envoy routing and Authorino ext-authz work identically.

## Details
- **Custom DialContext** — rather than rewriting probe URLs (which breaks TLS SNI matching on Envoy's filter chain), the Transport intercepts TCP connections and redirects them to the internal service. The probe URL, TLS ServerName, and Host header all remain the original external hostname.
- **Service resolution** is bounded by the configured `ACCESS_CHECK_TIMEOUT_SECONDS` to prevent stalling startup.
- **Service validation** requires the Service to have an `ownerReference` with `kind: Gateway` matching the configured gateway name, and exactly one matching candidate. This prevents a rogue Service with the same label from receiving probe traffic containing auth headers.
- HTTPS is maintained end-to-end; `InsecureSkipVerify: true` (already present) handles the cert mismatch between the external hostname and the internal service.

## Test plan
- [x] `go build ./...` and `go vet ./...` pass
- [x] Existing unit tests pass (they use httptest.Server URLs with empty `gatewayInternalHost`, so `DialContext` is not installed)
- [x] Deploy updated maas-api on a disconnected cluster and verify `GET /v1/models` returns non-empty model list
- [x] Verify Authorino ext-authz still enforces auth on probes (unauthorized users see empty list)
- [x] Re-run maas-tests Jenkins job to confirm the 22 disconnected-cluster failures are resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added gateway internal host resolution during startup to enable access probes to route through the gateway's internal network, improving internal communication pathways.

* **Refactor**
  * Updated system initialization and underlying logic to support gateway internal host configuration and routing.

* **Tests**
  * Updated test cases to accommodate gateway internal host parameter changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->