### PR TITLE
feat(observability): add Perses resources to Tenant finalizer cleanup

### DIFF
--- a/maas-controller/pkg/controller/maas/tenant_finalize.go
+++ b/maas-controller/pkg/controller/maas/tenant_finalize.go
@@ -52,6 +52,8 @@ var optionalPlatformGVKs = []schema.GroupVersionKind{
 	{Group: "networking.istio.io", Version: "v1", Kind: "DestinationRule"},
 	{Group: "networking.istio.io", Version: "v1alpha3", Kind: "EnvoyFilter"},
 	{Group: "telemetry.istio.io", Version: "v1", Kind: "Telemetry"},
+	tenantreconcile.GVKPersesDashboard,
+	tenantreconcile.GVKPersesDatasource,
 }
 
 func (r *TenantReconciler) operatorNamespace() string {

--- a/maas-controller/pkg/controller/maas/tenant_reconcile_test.go
+++ b/maas-controller/pkg/controller/maas/tenant_reconcile_test.go
@@ -10,6 +10,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -404,6 +405,80 @@ func TestTenantReconcile_DeletionIncludesAppNamespace(t *testing.T) {
 	err = cl.Get(context.Background(), client.ObjectKey{Name: maasv1alpha1.TenantInstanceName, Namespace: testNS}, &updated)
 	// Object should be gone (finalizer removed → fake client deletes it)
 	g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "tenant should be fully deleted after finalization")
+}
+
+func TestTenantReconcile_DeletionCleansUpPersesResourcesByTrackingLabel(t *testing.T) {
+	g := NewWithT(t)
+	s := tenantTestScheme(t)
+
+	const tenantNS = "models-as-a-service"
+	const appNS = "opendatahub"
+	now := metav1.NewTime(time.Now())
+	tenant := &maasv1alpha1.Tenant{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              maasv1alpha1.TenantInstanceName,
+			Namespace:         tenantNS,
+			UID:               types.UID("tenant-uid"),
+			DeletionTimestamp: &now,
+			Finalizers:        []string{tenantFinalizer},
+		},
+	}
+
+	dashboard := &unstructured.Unstructured{}
+	dashboard.SetGroupVersionKind(tenantreconcile.GVKPersesDashboard)
+	dashboard.SetName("dashboard-3-maas-usage-admin")
+	dashboard.SetNamespace(appNS)
+	dashboard.SetLabels(map[string]string{
+		tenantreconcile.LabelTenantName:      tenant.Name,
+		tenantreconcile.LabelTenantNamespace: tenant.Namespace,
+	})
+
+	datasource := &unstructured.Unstructured{}
+	datasource.SetGroupVersionKind(tenantreconcile.GVKPersesDatasource)
+	datasource.SetName("kuadrant-prometheus-datasource")
+	datasource.SetNamespace(appNS)
+	datasource.SetLabels(map[string]string{
+		tenantreconcile.LabelTenantName:      tenant.Name,
+		tenantreconcile.LabelTenantNamespace: tenant.Namespace,
+	})
+
+	cl := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(&maasv1alpha1.Tenant{}).
+		WithObjects(tenant, dashboard, datasource).
+		Build()
+
+	r := &TenantReconciler{
+		Client:            cl,
+		Scheme:            s,
+		OperatorNamespace: appNS,
+		AppNamespace:      appNS,
+		TenantNamespace:   tenantNS,
+	}
+
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: tenant.Name, Namespace: tenantNS}}
+
+	res1, err := r.Reconcile(context.Background(), req)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(res1.RequeueAfter).To(Equal(finalizeRequeueInterval), "first pass issues child deletes and requeues")
+
+	// Second reconcile: children are gone, finalizer removed.
+	res2, err := r.Reconcile(context.Background(), req)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(res2.RequeueAfter).To(BeNumerically("==", 0))
+
+	// Verify Perses resources are deleted.
+	dashList := &unstructured.UnstructuredList{}
+	dashList.SetGroupVersionKind(tenantreconcile.GVKPersesDashboard)
+	dashList.GetObjectKind().SetGroupVersionKind(tenantreconcile.GVKPersesDashboard.GroupVersion().WithKind("PersesDashboardList"))
+	g.Expect(cl.List(context.Background(), dashList, client.InNamespace(appNS))).To(Succeed())
+	g.Expect(dashList.Items).To(BeEmpty(), "PersesDashboard should be deleted by finalizer")
+
+	dsList := &unstructured.UnstructuredList{}
+	dsList.SetGroupVersionKind(tenantreconcile.GVKPersesDatasource)
+	dsList.GetObjectKind().SetGroupVersionKind(tenantreconcile.GVKPersesDatasource.GroupVersion().WithKind("PersesDatasourceList"))
+	g.Expect(cl.List(context.Background(), dsList, client.InNamespace(appNS))).To(Succeed())
+	g.Expect(dsList.Items).To(BeEmpty(), "PersesDatasource should be deleted by finalizer")
 }
 
 func TestTenantReconcile_NotFoundIsNoOp(t *testing.T) {

--- a/maas-controller/pkg/platform/tenantreconcile/constants.go
+++ b/maas-controller/pkg/platform/tenantreconcile/constants.go
@@ -74,4 +74,6 @@ var (
 	GVKIstioTelemetry       = schema.GroupVersionKind{Group: "telemetry.istio.io", Version: "v1", Kind: "Telemetry"}
 	GVKAuthConfig           = schema.GroupVersionKind{Group: "authorino.kuadrant.io", Version: "v1beta3", Kind: "AuthConfig"}
 	GVKAuthorino            = schema.GroupVersionKind{Group: "operator.authorino.kuadrant.io", Version: "v1beta1", Kind: "Authorino"}
+	GVKPersesDashboard      = schema.GroupVersionKind{Group: "perses.dev", Version: "v1alpha1", Kind: "PersesDashboard"}
+	GVKPersesDatasource     = schema.GroupVersionKind{Group: "perses.dev", Version: "v1alpha1", Kind: "PersesDatasource"}
 )


### PR DESCRIPTION
## Description

Add `PersesDashboard` and `PersesDatasource` to the Tenant finalizer's cleanup path so that Perses observability resources are removed when the MaaS Tenant CR is deleted.

Perses resources are rendered into the `opendatahub` namespace while the Tenant CR lives in `models-as-a-service`. Because Kubernetes forbids cross-namespace ownerReferences, `ApplyRendered` applies tracking labels (`maas.opendatahub.io/tenant-name`, `maas.opendatahub.io/tenant-namespace`) instead. The finalizer already uses these labels to clean up other cross-namespace extension resources (Kuadrant policies, Istio DestinationRules, etc.) — this PR extends that list to include the Perses GVKs.

Context: @ahadas flagged this gap in https://github.com/opendatahub-io/models-as-a-service/pull/805#pullrequestreview-4181758593.

https://redhat.atlassian.net/browse/RHOAIENG-60373

## How Has This Been Tested?

**Unit tests:**
- New test `TestTenantReconcile_DeletionCleansUpPersesResourcesByTrackingLabel` creates `PersesDashboard` and `PersesDatasource` unstructured objects with tracking labels in the `AppNamespace` (cross-namespace from the Tenant CR), triggers Tenant deletion, and asserts both resources are removed by the finalizer.
- All existing tests continue to pass (`go test ./... -count=1`).

**Manual cluster test (ROSA):**
1. Installed MaaS CRDs, stub Perses CRDs, and RBAC on a fresh cluster.
2. Created a Tenant CR in `models-as-a-service` and Perses resources with tracking labels in `opendatahub`.
3. Ran the controller locally, deleted the Tenant CR.
4. Verified both `PersesDashboard` and `PersesDatasource` were cleaned up (`No resources found in opendatahub namespace.`).

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tenant deletion now includes proper cleanup of Perses Dashboard and Datasource resources, ensuring complete removal of tenant-owned instances across the system.

* **Tests**
  * Added test coverage to verify that Perses Dashboard and Datasource resources are properly cleaned up when tenants are deleted and finalization completes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->