### PR TITLE
docs: add Observability tab, GenAI Studio, and OdhDashboardConfig setup to install guides

### DIFF
--- a/docs/content/advanced-administration/observability.md
+++ b/docs/content/advanced-administration/observability.md
@@ -110,6 +110,28 @@ curl -sk -H "Authorization: Bearer $(oc whoami -t)" \
 !!! note "Cluster Admin Permissions"
     Configuring User Workload Monitoring requires cluster admin permissions to create ConfigMaps in the `openshift-monitoring` namespace. If you don't have these permissions, contact your cluster administrator.
 
+## RHOAI Dashboard Observability Tab
+
+The RHOAI Dashboard includes a built-in **Observability** tab that displays Perses-based dashboards
+for platform monitoring. This is separate from the MaaS-specific Grafana dashboards described later
+in this document.
+
+The following must be in place for the Observability tab to work:
+
+- **Cluster Observability Operator (COO)** and **OpenTelemetry Operator** — install both from OperatorHub
+- **DSCI `monitoring.metrics`** — see [Platform Setup](../install/platform-setup.md#install-platform-operator) for DSCI configuration
+- **`observabilityDashboard: true`** on OdhDashboardConfig — see [Feature Flags](../install/maas-setup.md#odhdashboardconfig-feature-flags)
+
+**Quick verification:**
+
+```bash
+kubectl get csv -A | grep -E 'cluster-observability|opentelemetry'
+kubectl get dsciinitialization default-dsci -o jsonpath='{.spec.monitoring}' | jq .
+kubectl get pods -n redhat-ods-monitoring | grep perses
+```
+
+For the full setup procedure, see [Managing observability (RHOAI 3.4)](https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.4/html/managing_openshift_ai/managing-observability_managing-rhoai).
+
 ## Overview
 
 As part of Dev Preview, MaaS Platform includes a basic observability stack that provides insights into system performance, usage patterns, and operational health.

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -34,9 +34,9 @@ Use this platform to streamline the deployment of your models, monitor usage, an
 
 ### 📖 Installation Guide
 
-- **[Prerequisites](install/prerequisites.md)** - Requirements and database setup
+- **[Prerequisites](install/prerequisites.md)** - Requirements, database setup, observability and GenAI Studio prerequisites
 - **[Platform Setup](install/platform-setup.md)** - Install ODH/RHOAI with MaaS
-- **[MaaS Setup](install/maas-setup.md)** - Gateway AuthPolicy and policies
+- **[MaaS Setup](install/maas-setup.md)** - Gateway, DataScienceCluster, OdhDashboardConfig feature flags
 - **[Validation](install/validation.md)** - Verify your deployment
 
 ### 🔄 Migration

--- a/docs/content/install/maas-setup.md
+++ b/docs/content/install/maas-setup.md
@@ -156,8 +156,16 @@ After creating the database Secret and Gateways, create or update your DataScien
             managementState: Managed
         dashboard:
           managementState: Managed
+        llamastackoperator:
+          managementState: Managed
     EOF
     ```
+
+    !!! tip "LlamaStack Operator (GenAI Studio)"
+        The `llamastackoperator` component is required for **GenAI Studio** functionality.
+        If you do not need GenAI Studio, you can omit it or set it to `Removed`.
+        You also need to enable the `genAiStudio` feature flag on `OdhDashboardConfig` —
+        see [OdhDashboardConfig Feature Flags](#odhdashboardconfig-feature-flags) below.
 
     !!! note "Connectivity Link warning (ODH with Kuadrant)"
         When using ODH with Kuadrant (upstream), you may see `Warning: Red Hat Connectivity Link is not installed, LLMInferenceService cannot be used` in the Kserve status initially. This typically resolves after a few minutes as the operator reconciles. If it persists, apply the `scripts/workaround-odh-rhcl-check.yaml` workaround.
@@ -267,6 +275,35 @@ After creating the database Secret and Gateways, create or update your DataScien
 
 !!! tip "Troubleshooting"
     If components do not become ready, run `kubectl describe datasciencecluster default-dsc` to inspect conditions and events.
+
+## OdhDashboardConfig Feature Flags
+
+The RHOAI Dashboard uses feature flags in the `OdhDashboardConfig` resource to control which tabs
+and features are visible in the UI. The operator creates this resource automatically when the
+Dashboard component is deployed, but the following flags may need to be enabled manually.
+
+Patch the `OdhDashboardConfig` in your applications namespace (typically `redhat-ods-applications`
+for RHOAI or `opendatahub` for ODH):
+
+```bash
+kubectl patch odhdashboardconfig odh-dashboard-config \
+  -n redhat-ods-applications --type=merge \
+  -p '{"spec":{"dashboardConfig":{"genAiStudio":true,"observabilityDashboard":true}}}'
+```
+
+| Flag | Effect | Prerequisites |
+|------|--------|---------------|
+| `genAiStudio: true` | Shows the **GenAI Studio** tab in the Dashboard | `llamastackoperator` set to `Managed` in DSC |
+| `observabilityDashboard: true` | Shows the **Observability** tab in the Dashboard | COO, OpenTelemetry Operator installed; DSCI `monitoring.metrics` configured |
+
+!!! note "Namespace"
+    For ODH installations, replace `redhat-ods-applications` with `opendatahub` (or your configured
+    applications namespace from DSCI `spec.applicationsNamespace`).
+
+!!! note "Flag names"
+    These flags are defined in the odh-dashboard source. The `OdhDashboardConfig` CRD is of
+    API version `opendatahub.io/v1alpha`. The operator re-creates this resource with factory
+    defaults if it is deleted, but does not overwrite user changes to existing fields.
 
 ## Next steps
 

--- a/docs/content/install/prerequisites.md
+++ b/docs/content/install/prerequisites.md
@@ -50,3 +50,14 @@ If you plan to use MaaS dashboards, showback, or usage metrics, additional platf
 - **Kuadrant Observability** — Required for rate-limiting and usage metrics (e.g., `authorized_calls`, `limited_calls`)
 
 See [Observability Prerequisites](../advanced-administration/observability.md#prerequisites) for detailed configuration steps.
+
+### RHOAI Dashboard Observability Tab
+
+To enable the **Observability** tab in the RHOAI Dashboard (Perses-based dashboards), you need the
+Cluster Observability Operator, OpenTelemetry Operator, DSCI monitoring configuration, and a
+Dashboard feature flag. See [RHOAI Dashboard Observability Tab](../advanced-administration/observability.md#rhoai-dashboard-observability-tab) for the full setup and verification steps.
+
+### GenAI Studio
+
+To enable **GenAI Studio** in the RHOAI Dashboard, you need the LlamaStack Operator enabled in your
+DSC and a Dashboard feature flag. See [OdhDashboardConfig Feature Flags](maas-setup.md#odhdashboardconfig-feature-flags) for setup.

--- a/docs/content/install/troubleshooting.md
+++ b/docs/content/install/troubleshooting.md
@@ -81,6 +81,19 @@ This guide helps you diagnose and resolve common issues with MaaS Platform deplo
       kubectl get podmonitor -n kuadrant-system
       ```
 
+9. **RHOAI Dashboard Observability tab returns `503 Service Unavailable`**: The Dashboard cannot reach the Perses backend.
+
+      The error typically appears as `{"statusCode": 503, "code": "FST_REPLY_FROM_SERVICE_UNAVAILABLE", ...}`.
+      This is a Fastify/Dashboard-level error (not a gateway 503) indicating the monitoring stack
+      is not deployed or Perses is not running. The most common causes are missing operators (COO,
+      OpenTelemetry) or DSCI `monitoring.metrics` not being configured.
+
+      See [RHOAI Dashboard Observability Tab](../advanced-administration/observability.md#rhoai-dashboard-observability-tab) for the full prerequisites and verification checklist.
+
+10. **GenAI Studio tab not visible in Dashboard**: Requires `llamastackoperator` set to `Managed` in the DSC and the `genAiStudio` feature flag enabled on `OdhDashboardConfig`.
+
+      See [OdhDashboardConfig Feature Flags](maas-setup.md#odhdashboardconfig-feature-flags) for setup.
+
 ## Additional Resources
 
 - [Validation Guide](validation.md) — Manual validation steps


### PR DESCRIPTION
## Description

The MaaS install docs did not cover how to enable the RHOAI Dashboard Observability tab or GenAI Studio. This was surfaced in an internal Slack thread where a team member could not get either feature working without asking the Dashboard team directly.

https://redhat.atlassian.net/browse/RHOAIENG-60528

## How Has This Been Tested?

- All internal cross-links verified — no dead anchors (each `#anchor` resolves to an existing heading)
- Each topic has a single source of truth with no duplicated setup steps across files
- Doc-only change; no code, manifests, or tests affected

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work