### PR TITLE
fix: add podmonitor permission to maas-controller

### DIFF
--- a/deployment/base/maas-controller/rbac/clusterrole.yaml
+++ b/deployment/base/maas-controller/rbac/clusterrole.yaml
@@ -209,6 +209,17 @@ rules:
   - patch
   - update
 - apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - podmonitors
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
   - networking.istio.io
   resources:
   - destinationrules

--- a/maas-controller/pkg/controller/maas/tenant_controller.go
+++ b/maas-controller/pkg/controller/maas/tenant_controller.go
@@ -77,6 +77,7 @@ type TenantReconciler struct {
 // +kubebuilder:rbac:groups=telemetry.istio.io,resources=telemetries,verbs=get;list;watch;create;patch;delete
 // +kubebuilder:rbac:groups=batch,resources=cronjobs,verbs=get;list;watch;create;patch;delete
 // +kubebuilder:rbac:groups=perses.dev,resources=persesdashboards;persesdatasources,verbs=get;list;watch;create;patch;delete
+// +kubebuilder:rbac:groups=monitoring.coreos.com,resources=podmonitors,verbs=get;list;watch;create;patch;delete
 
 // maas-controller creates the maas-api ClusterRole via SSA.
 // The rules below mirror the maas-api ClusterRole so the controller can pass the API-server escalation check.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Add RBAC permissions for `PodMonitor` resources (`monitoring.coreos.com`) to the maas-controller ClusterRole
- Add the corresponding `+kubebuilder:rbac` marker on the `TenantReconciler` so the controller can manage `PodMonitor` objects in tenant namespaces
- Without this permission, the controller fails to create/update PodMonitor resources during tenant reconciliation

## How Has This Been Tested?
- Verified the ClusterRole includes the new `podmonitors` rule
- Confirmed the kubebuilder RBAC marker matches the ClusterRole definition

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated system permissions to enable the controller to manage monitoring configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->