### PR TITLE
docs(RHOAIENG-54166): remove broken archdiagrams link and add trouble…

### DIFF
--- a/docs/content/concepts/subscription-overview.md
+++ b/docs/content/concepts/subscription-overview.md
@@ -65,5 +65,4 @@ For configuration details, see:
 
 Additional references:
 
-- [Subscription Architecture](https://github.com/opendatahub-io/models-as-a-service/blob/main/archdiagrams/SubscriptionArch.md) — Design document for the subscription model
 - [MaaS Controller old-vs-new flow](https://github.com/opendatahub-io/models-as-a-service/blob/main/maas-controller/docs/old-vs-new-flow.md) — Comparison of subscription-based flows

--- a/docs/content/configuration-and-management/troubleshooting-external-model-rbac.md
+++ b/docs/content/configuration-and-management/troubleshooting-external-model-rbac.md
@@ -1,59 +1,36 @@
-# Troubleshooting: ExternalModel Service `ownerReference` / finalizers (RBAC)
+# ExternalModel RBAC: Service Creation Failures
 
 ## Symptoms
 
-- `external-model-reconciler` logs show Service create failing with:
+ExternalModel-backed MaaSModelRef objects remain `Pending` with backend-not-ready status. The `external-model-reconciler` logs show:
 
-  ```text
-  cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on
-  ```
-
-- `MaaSModelRef` objects that reference `ExternalModel` backends stay `Pending` with a backend-not-ready reason.
+```text
+cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on
+```
 
 ## Cause
 
-The reconciler sets a **controller `ownerReference`** on the `Service` it creates for an `ExternalModel`. With that pattern, the API server checks that the controller identity can **`update` the `externalmodels/finalizers` subresource** (OwnerReferencesPermissionEnforcement).
+The controller sets a controller `ownerReference` on the Service it creates for each ExternalModel. The API server enforces that the controller ServiceAccount (`maas-controller`) must have `update` permission on the `externalmodels/finalizers` subresource (OwnerReferencesPermissionEnforcement admission controller).
 
-If the **`maas-controller` ServiceAccount** is not allowed that verb on that subresource, Service creation fails before routes are healthy.
+If this permission is missing, Service creation fails and routes never become healthy.
 
-## What to fix
+## Resolution
 
-1. **ClusterRole** `maas-controller-role` must include a rule that allows `update` on `externalmodels/finalizers` for API group `maas.opendatahub.io`.
+The ClusterRole `maas-controller-role` must include a rule allowing `update` on `externalmodels/finalizers`:
 
-   Source manifest in this repository: `deployment/base/maas-controller/rbac/clusterrole.yaml`.
-
-2. **ClusterRoleBinding** `maas-controller-rolebinding` must bind that `ClusterRole` to the **`maas-controller` ServiceAccount** in the namespace where the controller runs (commonly `opendatahub` when using the ODH overlay).
-
-On OpenShift, the ODH operator (via the `modelsAsService` DSC component) may **own** these objects; if your live `ClusterRole` is missing the `externalmodels/finalizers` rule, upgrade or re-apply the manifest from this repo, or reconcile the component so the shipped RBAC matches.
-
-## How to verify (important)
-
-`oc auth can-i` **does not** treat `externalmodels/finalizers` as a single resource name the same way RBAC does. Using the slash form often returns **`no` even when the rule is present**.
-
-Use the **`--subresource=finalizers`** form instead:
-
-```bash
-# Replace NAMESPACE with the namespace where ExternalModel CRs live (e.g. llm)
-# Replace SA_NAMESPACE with the controller ServiceAccount namespace (e.g. opendatahub)
-
-oc auth can-i update externalmodels --subresource=finalizers \
-  -n NAMESPACE \
-  --as=system:serviceaccount:SA_NAMESPACE:maas-controller
+```yaml
+apiGroups: ["maas.opendatahub.io"]
+resources: ["externalmodels/finalizers"]
+verbs: ["update"]
 ```
 
-You should see **`yes`**.
+Source manifest: `deployment/base/maas-controller/rbac/clusterrole.yaml`
 
-**Incorrect (misleading false negative):**
+The ClusterRoleBinding `maas-controller-rolebinding` must bind this role to the `maas-controller` ServiceAccount in the controller namespace (typically `opendatahub`).
 
-```bash
-# Often prints "no" even when RBAC is correct — do not use for verification
-oc auth can-i update externalmodels/finalizers -n NAMESPACE \
-  --as=system:serviceaccount:SA_NAMESPACE:maas-controller
-```
+### Fix: Add the Missing Rule
 
-## Optional: add the rule with `oc patch`
-
-If you must patch the live `ClusterRole` (for example before an operator update ships the rule):
+If the ODH operator manages these resources (via the `modelsAsService` DSC component), upgrade or reconcile the component. Otherwise, patch the ClusterRole directly:
 
 ```bash
 oc patch clusterrole maas-controller-role --type=json -p='[
@@ -69,13 +46,23 @@ oc patch clusterrole maas-controller-role --type=json -p='[
 ]'
 ```
 
-Then verify with the **`--subresource=finalizers`** command above, not the slash form.
+## Verification
 
-## What we changed in docs (2026-04-14)
+Verify the ServiceAccount has the required permission:
 
-- Documented that **`oc auth can-i update externalmodels/finalizers`** can incorrectly report **`no`** when permission exists.
-- Documented the supported check: **`oc auth can-i update externalmodels --subresource=finalizers`**.
-- Pointed to **`deployment/base/maas-controller/rbac/clusterrole.yaml`** as the in-repo source for the `maas-controller-role` rules.
+```bash
+# Replace NAMESPACE with the ExternalModel namespace (e.g., llm)
+# Replace SA_NAMESPACE with the controller namespace (e.g., opendatahub)
+
+oc auth can-i update externalmodels --subresource=finalizers \
+  -n NAMESPACE \
+  --as=system:serviceaccount:SA_NAMESPACE:maas-controller
+```
+
+Expected output: `yes`
+
+!!! warning "Common Pitfall"
+    Do not use `oc auth can-i update externalmodels/finalizers` (slash notation). This form often returns `no` even when the permission exists. Always use `--subresource=finalizers` for accurate results.
 
 ## Related
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -79,6 +79,7 @@ nav:
       - Quota and Access Configuration: configuration-and-management/quota-and-access-configuration.md
       - API Key Administration: configuration-and-management/api-key-administration.md
       - Namespace User Permissions (RBAC): configuration-and-management/namespace-rbac.md
+      - Troubleshooting ExternalModel RBAC: configuration-and-management/troubleshooting-external-model-rbac.md
       - TLS Configuration: configuration-and-management/tls-configuration.md
       - Gateway Patterns: configuration-and-management/gateway-patterns.md
     - Models:


### PR DESCRIPTION
…shooting to nav

## Description

Remove broken link to non-existent archdiagrams/SubscriptionArch.md from subscription-overview.md. 
Add troubleshooting-external-model-rbac.md to mkdocs navigation under Configuration & Management.
Revised troubleshooting-external-model-rbac.md 

These are the final two fixes needed to close [RHOAIENG-54166](https://redhat.atlassian.net/browse/RHOAIENG-54166).

<!--- Provide a general summary of your changes in the Title above -->


<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive troubleshooting guide for ExternalModel RBAC failures, detailing symptoms, root causes, and step-by-step resolution.
  * Included verification procedures using command-line tools.
  * Updated documentation site navigation to surface the new troubleshooting resource.
  * Modified subscription documentation references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->