### PR TITLE
fix: use app-namespace for payload-processing EnvoyFilter and DestinationRule

### DIFF
--- a/deployment/overlays/odh/kustomization.yaml
+++ b/deployment/overlays/odh/kustomization.yaml
@@ -170,12 +170,15 @@ replacements:
       name: payload-processing
     fieldPaths:
     - spec.targetRefs.0.name
-# Replace gateway namespace in payload-processing DestinationRule host and EnvoyFilter cluster_name
+# Replace namespace in payload-processing DestinationRule host and EnvoyFilter cluster_name.
+# Kustomize default: openshift-ingress (gateway ns, where payload-processing is deployed).
+# RHOAI operator overrides to app namespace (its NamespaceApplierPlugin moves all
+# resources to the app ns, so the FQDN must match). See RHOAIENG-59726.
 - source:
     kind: ConfigMap
     version: v1
     name: maas-parameters
-    fieldPath: data.gateway-namespace
+    fieldPath: data.payload-processing-namespace
   targets:
   - select:
       kind: DestinationRule

--- a/deployment/overlays/odh/params.env
+++ b/deployment/overlays/odh/params.env
@@ -5,6 +5,10 @@ maas-api-key-cleanup-image=registry.redhat.io/ubi9/ubi-minimal:9.7
 payload-processing-replicas=1
 gateway-namespace=openshift-ingress
 gateway-name=maas-default-gateway
+# payload-processing runs in the gateway namespace for kustomize deployments.
+# The RHOAI operator overrides this to the app namespace (NamespaceApplierPlugin
+# moves all resources to the app namespace).
+payload-processing-namespace=openshift-ingress
 # IMPORTANT: app-namespace must match 'namespace:' in overlay kustomization.yaml
 # Used for AuthPolicy URL (maas-api.<app-namespace>.svc) and DestinationRule host
 app-namespace=opendatahub

--- a/maas-api/deploy/overlays/odh/kustomization.yaml
+++ b/maas-api/deploy/overlays/odh/kustomization.yaml
@@ -129,12 +129,14 @@ replacements:
       name: payload-processing
     fieldPaths:
     - spec.targetRefs.0.name
-# Gateway namespace in payload-processing DestinationRule host and EnvoyFilter cluster_name
+# Replace namespace in payload-processing DestinationRule host and EnvoyFilter cluster_name.
+# Kustomize default: openshift-ingress (gateway ns). RHOAI operator overrides to app ns.
+# See RHOAIENG-59726.
 - source:
     kind: ConfigMap
     version: v1
     name: maas-parameters
-    fieldPath: data.gateway-namespace
+    fieldPath: data.payload-processing-namespace
   targets:
   - select:
       kind: DestinationRule

--- a/maas-api/deploy/overlays/odh/params.env
+++ b/maas-api/deploy/overlays/odh/params.env
@@ -4,6 +4,9 @@ maas-controller-image=quay.io/opendatahub/maas-controller:latest
 # Gateway configuration (overridden by CustomizeParams from Tenant spec)
 gateway-namespace=openshift-ingress
 gateway-name=maas-default-gateway
+# payload-processing namespace for EnvoyFilter/DestinationRule FQDN.
+# Kustomize: openshift-ingress (gateway ns). RHOAI operator overrides to app ns.
+payload-processing-namespace=openshift-ingress
 # Application namespace (overridden by CustomizeParams)
 app-namespace=opendatahub
 # Cluster audience for kubernetesTokenReview (overridden by CustomizeParams from Authentication/cluster)


### PR DESCRIPTION


The payload-processing (BBR) service runs in the app namespace (e.g. opendatahub, redhat-ods-applications), but the kustomize replacements used gateway-namespace for the EnvoyFilter cluster_name and DestinationRule host. This caused Envoy to look for the service in the wrong namespace, breaking ext_proc routing for external models.

Change the replacement source from data.gateway-namespace to data.app-namespace in both ODH overlay kustomization files.

Ref: [RHOAIENG-59726](https://redhat.atlassian.net/browse/RHOAIENG-59726)

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Aligned payload-processing namespace resolution so service routing and proxy cluster names derive from the payload-processing namespace for consistent runtime routing across environments.
  * Added a payload-processing-namespace setting (default: openshift-ingress) with explanatory comments to deployment overlays and params.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->