### PR TITLE
fix: make MaaSModelRef ExternalModel handler API-group agnostic

### DIFF
--- a/maas-controller/pkg/controller/maas/providers_external.go
+++ b/maas-controller/pkg/controller/maas/providers_external.go
@@ -23,7 +23,6 @@ import (
 	"github.com/go-logr/logr"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
@@ -41,22 +40,12 @@ type externalModelHandler struct {
 }
 
 // ReconcileRoute validates the HTTPRoute for an external model and populates status.
-// The ExternalModel reconciler creates the "maas-model-<model.Name>" HTTPRoute in the
-// model's namespace. This method validates that it exists and is accepted by the gateway.
+// The ExternalModel reconciler creates the HTTPRoute in the model's namespace.
+// This method validates that it exists and is accepted by the gateway.
+// Note: we don't read the ExternalModel CR itself — only the HTTPRoute matters.
+// This keeps MaaSModelRef agnostic to the ExternalModel API group
+// (maas.opendatahub.io or inference.opendatahub.io).
 func (h *externalModelHandler) ReconcileRoute(ctx context.Context, log logr.Logger, model *maasv1alpha1.MaaSModelRef) error {
-	// Fetch the referenced ExternalModel CR to get provider configuration
-	externalModel := &maasv1alpha1.ExternalModel{}
-	externalModelKey := types.NamespacedName{
-		Name:      model.Spec.ModelRef.Name,
-		Namespace: model.Namespace,
-	}
-	if err := h.r.Get(ctx, externalModelKey, externalModel); err != nil {
-		if apierrors.IsNotFound(err) {
-			return fmt.Errorf("ExternalModel %s not found in namespace %s", model.Spec.ModelRef.Name, model.Namespace)
-		}
-		return fmt.Errorf("failed to get ExternalModel %s: %w", model.Spec.ModelRef.Name, err)
-	}
-
 	routeName := model.Spec.ModelRef.Name
 	routeNS := model.Namespace
 
@@ -155,7 +144,6 @@ func (h *externalModelHandler) ReconcileRoute(ctx context.Context, log logr.Logg
 
 	log.Info("HTTPRoute validated for ExternalModel",
 		"routeName", routeName, "namespace", routeNS, "model", model.Name,
-		"externalModel", externalModel.Name, "provider", externalModel.Spec.Provider,
 		"gateway", fmt.Sprintf("%s/%s", gatewayNamespace, gatewayName), "hostnames", hostnames)
 
 	return nil

--- a/maas-controller/pkg/controller/maas/providers_external_test.go
+++ b/maas-controller/pkg/controller/maas/providers_external_test.go
@@ -146,18 +146,19 @@ func TestExternalModel_ReconcileRoute_MissingHTTPRoute(t *testing.T) {
 
 func TestExternalModel_ReconcileRoute_MissingExternalModel(t *testing.T) {
 	model := newExternalModel("gpt-4o", "default", "openai", "api.openai.com")
-	// Don't create ExternalModel CR - it should fail
+	// No ExternalModel CR — ReconcileRoute only checks HTTPRoute, not the ExternalModel CR.
+	// Without an HTTPRoute, it should return nil and clear status (waiting state).
 
 	r, _ := newTestReconciler(model)
 	handler := &externalModelHandler{r: r}
 	log := zap.New(zap.UseDevMode(true))
 
 	err := handler.ReconcileRoute(context.Background(), log, model)
-	if err == nil {
-		t.Fatal("ReconcileRoute: expected error for missing ExternalModel CR")
+	if err != nil {
+		t.Fatalf("ReconcileRoute: unexpected error: %v", err)
 	}
-	if !strings.Contains(err.Error(), "ExternalModel") || !strings.Contains(err.Error(), "not found") {
-		t.Errorf("ReconcileRoute: error = %q, want to contain 'ExternalModel' and 'not found'", err.Error())
+	if model.Status.HTTPRouteName != "" {
+		t.Errorf("HTTPRouteName should be empty when HTTPRoute not found, got %q", model.Status.HTTPRouteName)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Remove the `maas.opendatahub.io` ExternalModel CR read from `externalModelHandler.ReconcileRoute` — it was only used for a validation check and a log line
- The handler now only checks for the HTTPRoute (which is the actual resource that AuthPolicy/TRLP target)
- This makes MaaSModelRef work with ExternalModels from any API group, as long as an HTTPRoute with the matching name exists

## Why

The new `inference.opendatahub.io/v1alpha1` ExternalProvider/ExternalModel CRDs ([ai-gateway-payload-processing#183](https://github.com/opendatahub-io/ai-gateway-payload-processing/pull/183), [#184](https://github.com/opendatahub-io/ai-gateway-payload-processing/pull/184)) create HTTPRoutes via the BBR ExternalModel controller. Creating a `MaaSModelRef` pointing at these models failed with:

```
ExternalModel new-katan-openai not found in namespace llm
```

The handler tried to read the `maas.opendatahub.io` ExternalModel CR, which doesn't exist — the model is in a different API group. But the HTTPRoute (created by the BBR reconciler) does exist with the correct name, and that's all the auth/rate-limit chain needs.

## What changed

**`providers_external.go`**: Removed the `h.r.Get(ctx, externalModelKey, externalModel)` call and the log line referencing `externalModel.Name`/`externalModel.Spec.Provider`. Removed unused `types` import.

**`providers_external_test.go`**: Updated `TestExternalModel_ReconcileRoute_MissingExternalModel` — now expects success (waiting state) instead of error when ExternalModel CR is missing, since only the HTTPRoute matters.

## Test plan

- [x] All existing unit tests pass (`make -C maas-controller test`)
- [x] Verified on Kind cluster (maas-experimental):
  - Created `MaaSModelRef` pointing at `inference.opendatahub.io` ExternalModel `new-katan-openai` → **Phase: Ready**
  - Created `MaaSAuthPolicy` + `MaaSSubscription` → Kuadrant AuthPolicy + TRLP created
  - Applied gateway-level default-deny AuthPolicy
  - No auth → **401**, invalid key → **401**, valid API key → **200**
  - All existing `maas.opendatahub.io` MaaSModelRefs still **Ready**

Closes #856

cc @jland-redhat @nirrozenbaum

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified route validation logic to reduce external dependencies and improve performance.
  * Enhanced system resilience by gracefully handling missing references during route reconciliation.
  * Updated related tests to reflect new validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->