### PR TITLE
fix(RHOAIENG-61344): clean up maas-controller bundle on disable via LifecycleReconciler

### DIFF
--- a/deployment/base/maas-controller/rbac/clusterrole.yaml
+++ b/deployment/base/maas-controller/rbac/clusterrole.yaml
@@ -58,6 +58,7 @@ rules:
   resources:
   - customresourcedefinitions
   verbs:
+  - delete
   - get
   - list
   - watch
@@ -71,7 +72,14 @@ rules:
   - get
   - list
   - patch
+  - update
   - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments/finalizers
+  verbs:
+  - update
 - apiGroups:
   - authentication.k8s.io
   resources:

--- a/docs/content/install/maas-setup.md
+++ b/docs/content/install/maas-setup.md
@@ -12,7 +12,9 @@ Complete [Operator Setup](platform-setup.md) before proceeding.
 
 ## Database Setup
 
-A PostgreSQL database is required. Create the `maas-db-config` Secret in your ODH/RHOAI namespace (typically `opendatahub` for ODH or `redhat-ods-applications` for RHOAI):
+`maas-api` uses PostgreSQL as its persistence layer for API key metadata: hashed tokens, subscription bindings, expiration dates, and revocation state. The database must be reachable before `maas-api` starts; the pod will crash-loop until the connection succeeds and the schema migration completes.
+
+Create the `maas-db-config` Secret in your ODH/RHOAI namespace (typically `opendatahub` for ODH or `redhat-ods-applications` for RHOAI):
 
 ```bash
 kubectl create secret generic maas-db-config \

--- a/maas-controller/cmd/manager/main.go
+++ b/maas-controller/cmd/manager/main.go
@@ -535,6 +535,20 @@ func main() {
 		os.Exit(1)
 	}
 
+	// LifecycleReconciler manages the cleanup finalizer on the maas-controller
+	// Deployment. When ODH deletes the Deployment (MaaS disable), the finalizer ensures
+	// Tenant CRs are cleaned up before the controller process exits.
+	// maasAPINamespace is the namespace ODH deployed maas-controller into (same namespace).
+	if err := (&maas.LifecycleReconciler{
+		Client:          mgr.GetClient(),
+		DeploymentName:  "maas-controller",
+		DeploymentNS:    maasAPINamespace,
+		TenantNamespace: maasSubscriptionNamespace,
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "SelfDeployment")
+		os.Exit(1)
+	}
+
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
 		setupLog.Error(err, "unable to set up health check")
 		os.Exit(1)

--- a/maas-controller/pkg/controller/maas/self_deployment_controller.go
+++ b/maas-controller/pkg/controller/maas/self_deployment_controller.go
@@ -1,0 +1,203 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package maas
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/go-logr/logr"
+	appsv1 "k8s.io/api/apps/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	maasv1alpha1 "github.com/opendatahub-io/models-as-a-service/maas-controller/api/maas/v1alpha1"
+)
+
+// CleanupFinalizer is added to the maas-controller Deployment so that when ODH
+// deletes it (on MaaS disable), the controller can clean up Tenant CRs, RBAC,
+// and CRDs before the Deployment object is removed. Tenant finalizers cascade
+// to delete maas-api, policies, and other children.
+const CleanupFinalizer = "maas.opendatahub.io/cleanup"
+
+// componentLabel selects all resources belonging to the MaaS component.
+// The ODH operator stamps every deployed resource with app.opendatahub.io/<component-name>=true.
+var componentLabel = client.MatchingLabels{"app.opendatahub.io/modelsasservice": "true"}
+
+// requeueInterval is how often we recheck while Tenants are still terminating.
+const requeueInterval = 5 * time.Second
+
+// LifecycleReconciler watches the maas-controller Deployment and manages
+// the cleanup finalizer lifecycle. While running it ensures CleanupFinalizer
+// is present on the Deployment. When DeletionTimestamp is set (ODH disabled
+// MaaS) it deletes all Tenant CRs, then removes cluster-scoped RBAC and CRDs,
+// then releases the finalizer so the Deployment object can be fully removed.
+// This gives Tenant's own finalizer time to clean up maas-api, auth policies,
+// Perses dashboards, and other owned resources before the controller exits.
+//
+//+kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;update;patch
+//+kubebuilder:rbac:groups=apps,resources=deployments/finalizers,verbs=update
+//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;clusterrolebindings,verbs=list;delete
+//+kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=list;delete
+type LifecycleReconciler struct {
+	client.Client
+	DeploymentName  string
+	DeploymentNS    string
+	TenantNamespace string
+}
+
+func (r *LifecycleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := ctrl.Log.WithName("self-deployment").WithValues("deployment", req.NamespacedName)
+
+	var dep appsv1.Deployment
+	if err := r.Get(ctx, req.NamespacedName, &dep); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	if dep.DeletionTimestamp.IsZero() {
+		return ctrl.Result{}, r.ensureFinalizer(ctx, log, &dep)
+	}
+
+	if !controllerutil.ContainsFinalizer(&dep, CleanupFinalizer) {
+		return ctrl.Result{}, nil
+	}
+
+	return r.runCleanup(ctx, log, &dep)
+}
+
+// ensureFinalizer adds the CleanupFinalizer to the Deployment when it is absent.
+func (r *LifecycleReconciler) ensureFinalizer(ctx context.Context, log logr.Logger, dep *appsv1.Deployment) error {
+	if controllerutil.ContainsFinalizer(dep, CleanupFinalizer) {
+		return nil
+	}
+	controllerutil.AddFinalizer(dep, CleanupFinalizer)
+	if err := r.Update(ctx, dep); err != nil {
+		return fmt.Errorf("add cleanup finalizer to Deployment: %w", err)
+	}
+	log.Info("added cleanup finalizer to Deployment")
+	return nil
+}
+
+// runCleanup drives the teardown sequence when the Deployment is terminating:
+// delete Tenants, wait for them to be gone, then delete RBAC and CRDs, then
+// release the finalizer.
+func (r *LifecycleReconciler) runCleanup(ctx context.Context, log logr.Logger, dep *appsv1.Deployment) (ctrl.Result, error) {
+	log.Info("Deployment is terminating; running cleanup before releasing finalizer")
+
+	pending, err := r.deleteTenants(ctx, log)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if pending {
+		log.Info("waiting for Tenant CRs to finish terminating")
+		return ctrl.Result{RequeueAfter: requeueInterval}, nil
+	}
+
+	if err := r.deleteClusterScopedResources(ctx); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	controllerutil.RemoveFinalizer(dep, CleanupFinalizer)
+	if err := r.Update(ctx, dep); err != nil {
+		return ctrl.Result{}, fmt.Errorf("remove cleanup finalizer from Deployment: %w", err)
+	}
+	log.Info("removed cleanup finalizer from Deployment; cleanup complete")
+	return ctrl.Result{}, nil
+}
+
+// deleteTenants deletes all Tenant CRs and returns true while any are still terminating.
+func (r *LifecycleReconciler) deleteTenants(ctx context.Context, log logr.Logger) (pending bool, _ error) {
+	tenantList := &maasv1alpha1.TenantList{}
+	if err := r.List(ctx, tenantList, client.InNamespace(r.TenantNamespace)); err != nil {
+		return false, fmt.Errorf("list Tenants in %q: %w", r.TenantNamespace, err)
+	}
+	for i := range tenantList.Items {
+		t := &tenantList.Items[i]
+		if !t.DeletionTimestamp.IsZero() {
+			pending = true
+			continue
+		}
+		if err := r.Delete(ctx, t); err != nil && !apierrors.IsNotFound(err) {
+			return false, fmt.Errorf("delete Tenant %s/%s: %w", t.Namespace, t.Name, err)
+		}
+		log.Info("deleted Tenant", "namespace", t.Namespace, "name", t.Name)
+		pending = true
+	}
+	return pending, nil
+}
+
+// deleteClusterScopedResources removes the cluster-scoped resources (ClusterRole,
+// ClusterRoleBinding, CRDs) that the ODH operator deployed for maas-controller,
+// selected by the component label.
+//
+// We list+delete individually rather than DeleteAllOf to avoid the deletecollection
+// verb, which is often restricted in managed environments.
+//
+// Order matters: ClusterRoles and CRDs are deleted first while the ClusterRoleBinding
+// still grants the SA the permissions to do so. ClusterRoleBindings are deleted last
+// because removing them revokes all RBAC permissions for this SA.
+func (r *LifecycleReconciler) deleteClusterScopedResources(ctx context.Context) error {
+	crList := &rbacv1.ClusterRoleList{}
+	if err := r.List(ctx, crList, componentLabel); err != nil {
+		return fmt.Errorf("list maas-controller ClusterRoles: %w", err)
+	}
+	for i := range crList.Items {
+		if err := r.Delete(ctx, &crList.Items[i]); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("delete ClusterRole %s: %w", crList.Items[i].Name, err)
+		}
+	}
+
+	crdList := &apiextensionsv1.CustomResourceDefinitionList{}
+	if err := r.List(ctx, crdList, componentLabel); err != nil {
+		return fmt.Errorf("list maas-controller CRDs: %w", err)
+	}
+	for i := range crdList.Items {
+		if err := r.Delete(ctx, &crdList.Items[i]); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("delete CRD %s: %w", crdList.Items[i].Name, err)
+		}
+	}
+
+	// ClusterRoleBindings are deleted last: removing them revokes all cluster-scoped
+	// permissions for the maas-controller SA, so this must come after ClusterRoles and CRDs.
+	crbList := &rbacv1.ClusterRoleBindingList{}
+	if err := r.List(ctx, crbList, componentLabel); err != nil {
+		return fmt.Errorf("list maas-controller ClusterRoleBindings: %w", err)
+	}
+	for i := range crbList.Items {
+		if err := r.Delete(ctx, &crbList.Items[i]); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("delete ClusterRoleBinding %s: %w", crbList.Items[i].Name, err)
+		}
+	}
+	return nil
+}
+
+// SetupWithManager registers the controller to watch only the maas-controller Deployment.
+func (r *LifecycleReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	selfOnly := predicate.NewPredicateFuncs(func(o client.Object) bool {
+		return o.GetName() == r.DeploymentName && o.GetNamespace() == r.DeploymentNS
+	})
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&appsv1.Deployment{}, builder.WithPredicates(selfOnly)).
+		Complete(r)
+}

--- a/maas-controller/pkg/controller/maas/self_deployment_controller.go
+++ b/maas-controller/pkg/controller/maas/self_deployment_controller.go
@@ -55,17 +55,17 @@ const requeueInterval = 5 * time.Second
 // then releases the finalizer so the Deployment object can be fully removed.
 // This gives Tenant's own finalizer time to clean up maas-api, auth policies,
 // Perses dashboards, and other owned resources before the controller exits.
-//
-//+kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;update;patch
-//+kubebuilder:rbac:groups=apps,resources=deployments/finalizers,verbs=update
-//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;clusterrolebindings,verbs=list;delete
-//+kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=list;delete
 type LifecycleReconciler struct {
 	client.Client
 	DeploymentName  string
 	DeploymentNS    string
 	TenantNamespace string
 }
+
+//+kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;update;patch
+//+kubebuilder:rbac:groups=apps,resources=deployments/finalizers,verbs=update
+//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;clusterrolebindings,verbs=list;delete
+//+kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=list;delete
 
 func (r *LifecycleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := ctrl.Log.WithName("self-deployment").WithValues("deployment", req.NamespacedName)

--- a/maas-controller/pkg/controller/maas/self_deployment_controller_test.go
+++ b/maas-controller/pkg/controller/maas/self_deployment_controller_test.go
@@ -1,0 +1,115 @@
+//nolint:testpackage
+package maas
+
+import (
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	maasv1alpha1 "github.com/opendatahub-io/models-as-a-service/maas-controller/api/maas/v1alpha1"
+
+	. "github.com/onsi/gomega"
+)
+
+func selfDepScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := tenantTestScheme(t)
+	utilruntime.Must(appsv1.AddToScheme(s))
+	utilruntime.Must(rbacv1.AddToScheme(s))
+	utilruntime.Must(apiextensionsv1.AddToScheme(s))
+	return s
+}
+
+func TestLifecycleReconciler(t *testing.T) {
+	const (
+		depName  = "maas-controller"
+		depNS    = "redhat-ods-applications"
+		tenantNS = "models-as-a-service"
+	)
+	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: depName, Namespace: depNS}}
+
+	t.Run("adds cleanup finalizer when Deployment has none", func(t *testing.T) {
+		g := NewWithT(t)
+		dep := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: depName, Namespace: depNS}}
+		cli := fake.NewClientBuilder().WithScheme(selfDepScheme(t)).WithObjects(dep).Build()
+
+		r := &LifecycleReconciler{Client: cli, DeploymentName: depName, DeploymentNS: depNS, TenantNamespace: tenantNS}
+		res, err := r.Reconcile(t.Context(), req)
+		g.Expect(err).ShouldNot(HaveOccurred())
+		g.Expect(res).To(Equal(ctrl.Result{}))
+
+		var updated appsv1.Deployment
+		g.Expect(cli.Get(t.Context(), req.NamespacedName, &updated)).To(Succeed())
+		g.Expect(updated.Finalizers).To(ContainElement(CleanupFinalizer))
+	})
+
+	t.Run("no-op when finalizer already present and Deployment is running", func(t *testing.T) {
+		g := NewWithT(t)
+		dep := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
+			Name: depName, Namespace: depNS,
+			Finalizers: []string{CleanupFinalizer},
+		}}
+		cli := fake.NewClientBuilder().WithScheme(selfDepScheme(t)).WithObjects(dep).Build()
+
+		r := &LifecycleReconciler{Client: cli, DeploymentName: depName, DeploymentNS: depNS, TenantNamespace: tenantNS}
+		res, err := r.Reconcile(t.Context(), req)
+		g.Expect(err).ShouldNot(HaveOccurred())
+		g.Expect(res).To(Equal(ctrl.Result{}))
+	})
+
+	t.Run("deletes Tenants then RBAC and CRDs when Deployment is terminating", func(t *testing.T) {
+		g := NewWithT(t)
+		now := metav1.NewTime(time.Now())
+		dep := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
+			Name: depName, Namespace: depNS,
+			DeletionTimestamp: &now,
+			Finalizers:        []string{CleanupFinalizer},
+		}}
+		tenant := &maasv1alpha1.Tenant{ObjectMeta: metav1.ObjectMeta{
+			Name: maasv1alpha1.TenantInstanceName, Namespace: tenantNS,
+		}}
+		crb := &rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{
+			Name: "maas-controller-crb", Labels: map[string]string(componentLabel),
+		}}
+		cr := &rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{
+			Name: "maas-controller-cr", Labels: map[string]string(componentLabel),
+		}}
+		cli := fake.NewClientBuilder().WithScheme(selfDepScheme(t)).WithObjects(dep, tenant, crb, cr).Build()
+
+		r := &LifecycleReconciler{Client: cli, DeploymentName: depName, DeploymentNS: depNS, TenantNamespace: tenantNS}
+
+		// First reconcile: Tenant exists — deleted, requeue while pending.
+		res, err := r.Reconcile(t.Context(), req)
+		g.Expect(err).ShouldNot(HaveOccurred())
+		g.Expect(res.RequeueAfter).To(Equal(requeueInterval))
+
+		// Second reconcile: Tenant gone — RBAC cleaned, finalizer released, Deployment removed by GC.
+		res, err = r.Reconcile(t.Context(), req)
+		g.Expect(err).ShouldNot(HaveOccurred())
+		g.Expect(res).To(Equal(ctrl.Result{}))
+
+		crbList := &rbacv1.ClusterRoleBindingList{}
+		g.Expect(cli.List(t.Context(), crbList, componentLabel)).To(Succeed())
+		g.Expect(crbList.Items).To(BeEmpty())
+
+		crList := &rbacv1.ClusterRoleList{}
+		g.Expect(cli.List(t.Context(), crList, componentLabel)).To(Succeed())
+		g.Expect(crList.Items).To(BeEmpty())
+
+		// Deployment is fully removed once the finalizer is released.
+		var updated appsv1.Deployment
+		err = cli.Get(t.Context(), req.NamespacedName, &updated)
+		g.Expect(err).Should(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("not found"))
+	})
+}


### PR DESCRIPTION
## Description

Fixes [RHOAIENG-61344](https://redhat.atlassian.net/browse/RHOAIENG-61344).

### **Background**

The ODH operator deploys `maas-controller` via `AppendOperatorInstallManifests`, SSA-applying the full bundle (Deployment, CRDs, ClusterRole, ClusterRoleBinding, ServiceAccount) labeled `app.opendatahub.io/modelsasservice=true`.

When MaaS was disabled, `removeTenantIfModelsAsServiceDisabled` in the ODH operator deleted only the `Tenant` CR. The Tenant finalizer correctly cleaned up maas-api, gateway policies, and Perses dashboards — but nothing deleted the `maas-controller` bundle itself. The Deployment, CRDs, ClusterRoles, ClusterRoleBindings, and ServiceAccount remained on the cluster indefinitely.

Root cause: unlike other ODH components, MaaS has `NewCRObject` returning `(nil, nil)`, which means there is no intermediate component CR and no ownerReference chain. The ODH GC machinery has nothing to cascade-delete the
controller bundle from.

Additionally, the orphaned `maas-controller` was not passive — it actively fought cleanup by re-creating `default-tenant` and logging conflict errors on every reconcile cycle.

### **Fix (this PR)**

Adds a `LifecycleReconciler` that manages a `maas.opendatahub.io/cleanup` finalizer on the `maas-controller` Deployment. The companion ODH operator PR ([RHOAIENG-61344](https://redhat.atlassian.net/browse/RHOAIENG-61344)) deletes the Deployment when MaaS is set to `Removed`. The finalizer keeps the Deployment object alive while `LifecycleReconciler` runs
teardown in the correct order:

1. Deletes all `Tenant` CRs and waits for their finalizers to complete (cascades to maas-api, auth policies, Perses dashboards).
2. Deletes `ClusterRole`s and CRDs — while the `ClusterRoleBinding` still grants the SA the permissions to do so.
3. Deletes `ClusterRoleBinding`s last — removing them revokes all cluster-scoped permissions for this SA.

**Companion PR in `opendatahub-operator`**: replaces `removeTenantIfModelsAsServiceDisabled` with `deleteMaaSDeploymentIfDisabled`, which triggers this cleanup by deleting the Deployment when MaaS is set to `Removed`. (To be created)

<img width="833" height="492" alt="image" src="https://github.com/user-attachments/assets/13806a44-be03-4858-a2b2-2865907f295f" />


## How Has This Been Tested?

**Unit tests** (`go test ./maas-controller/pkg/controller/maas/...`):
- `TestLifecycleReconciler` covers: finalizer added on healthy Deployment,
  no-op when finalizer already present, Tenants deleted and requeued while
  terminating, ClusterRoles/ClusterRoleBindings/CRDs deleted and finalizer
  removed once all Tenants are gone.

**Live cluster**:
- Enabled MaaS via DSC, confirmed `maas-controller` Deployment running with
  finalizer present.
- Patched DSC to `managementState: Removed`. Observed in pod logs: Tenants
  deleted → ClusterRoles and CRDs deleted → ClusterRoleBindings deleted →
  finalizer removed → Deployment object fully deleted.
- Verified: `kubectl get all,clusterrole,clusterrolebinding,crd -l app.opendatahub.io/modelsasservice=true`
  returned empty after one reconcile cycle.

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deployment lifecycle management with automatic resource cleanup and orderly shutdown sequence.

* **Documentation**
  * Enhanced database setup documentation with clarity on data persistence and initialization requirements.

* **Tests**
  * Added unit tests for lifecycle management functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->