### PR TITLE
docs: add PoC script and guide for MaaS gateway setup with ODH/RHOAI operator

### DIFF
--- a/docs/samples/connecting-gateway-odh-rhoai/odh-gateway-adding.md
+++ b/docs/samples/connecting-gateway-odh-rhoai/odh-gateway-adding.md
@@ -1,0 +1,511 @@
+# Spike: PoC — Connect to MaaS Gateway (RHOAIENG-60248)
+
+Parent epic: [RHOAIENG-59811 — Gateway Customer Experience and KServe Integration](https://redhat.atlassian.net/browse/RHOAIENG-59811)
+
+## Problem
+
+When a customer installs the ODH operator from OperatorHub and enables `modelsAsService: Managed` in the DataScienceCluster (v2 API), the operator creates a `ModelsAsService` CR but **refuses to proceed** because several prerequisites are missing:
+
+```
+ModelsAsServiceReady: False - blocking prerequisites missing: database Secret 'maas-db-config'
+not found in namespace 'opendatahub'. Create the Secret with key 'DB_CONNECTION_URL' containing
+the PostgreSQL connection URL. MaaS API cannot start without a database connection;
+no Authorino instances found. Authorino must be deployed and configured with TLS for
+MaaS authentication
+```
+
+The operator will not deploy maas-api, maas-controller, or MaaS CRDs until these prerequisites are satisfied. It creates its own `data-science-gateway` for KServe, but MaaS requires a separate gateway with specific configuration.
+
+### What the operator installs automatically
+
+- KServe controller + ODH Model Controller
+- `data-science-gateway` (GatewayClass + Gateway) — for KServe, NOT for MaaS
+- `ModelsAsService` CR (stuck in Error without database + Authorino)
+- maas-api deployment, maas-controller deployment, MaaS CRDs, `models-as-a-service` namespace (only **after** all prerequisites are satisfied — database secret, Authorino, and gateway)
+
+### What the operator does NOT install
+
+- Kuadrant operator (provides Authorino — required before MaaS can deploy)
+- database for maas-api (the **primary blocker** — operator checks for `maas-db-config` secret first)
+- `GatewayClass openshift-default` (required by `maas-default-gateway`)
+- `maas-default-gateway` Gateway resource
+- cert-manager operator (required by LWS)
+- LeaderWorkerSet (LWS) operator (required by KServe for LLMInferenceService)
+- TLS bootstrap between Authorino and maas-api
+- Supplemental RBAC (secrets, SAR, MaaS CR access — operator-bundled ClusterRole omits these)
+
+> **Note:** The repo's script (`scripts/deploy.sh`) automates all of these steps.
+> This document covers the manual path for when you only have the ODH operator installed from OperatorHub.
+
+---
+
+## Prerequisites
+
+- OpenShift 4.14+ cluster
+- `oc` / `kubectl` with cluster-admin access
+
+---
+
+## Step-by-Step Setup
+
+### Step 1: Install the ODH operator and enable ModelsAsService
+
+Install the Open Data Hub operator from OperatorHub (community-operators catalog), then create the DSC with `modelsAsService: Managed`.
+
+```bash
+# Install ODH operator in the opendatahub namespace (matches deploy.sh behavior)
+kubectl create namespace opendatahub 2>/dev/null || true
+kubectl apply -f - <<'EOF'
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: opendatahub
+  namespace: opendatahub
+spec: {}
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: opendatahub-operator
+  namespace: opendatahub
+spec:
+  channel: fast-3
+  installPlanApproval: Automatic
+  name: opendatahub-operator
+  source: community-operators
+  sourceNamespace: openshift-marketplace
+  startingCSV: opendatahub-operator.v3.4.0-ea.2
+EOF
+
+# Wait for operator to be installed
+kubectl wait --for=jsonpath='{.status.state}'=AtLatestKnown \
+  subscription/opendatahub-operator -n opendatahub --timeout=300s
+
+# Wait for operator deployment to be available
+kubectl wait --for=condition=Available --timeout=120s \
+  deployment/opendatahub-operator-controller-manager -n opendatahub
+
+# Create DSCInitialization
+kubectl apply -f - <<'EOF'
+apiVersion: dscinitialization.opendatahub.io/v1
+kind: DSCInitialization
+metadata:
+  name: default-dsci
+spec:
+  applicationsNamespace: opendatahub
+  monitoring:
+    managementState: Managed
+    namespace: opendatahub-monitoring
+    metrics: {}
+  trustedCABundle:
+    managementState: Managed
+EOF
+
+# Create DataScienceCluster with ModelsAsService enabled
+kubectl apply --server-side=true -f - <<'EOF'
+apiVersion: datasciencecluster.opendatahub.io/v2
+kind: DataScienceCluster
+metadata:
+  name: default-dsc
+spec:
+  components:
+    kserve:
+      managementState: Managed
+      rawDeploymentServiceConfig: Headed
+      modelsAsService:
+        managementState: Managed
+    dashboard:
+      managementState: Removed
+EOF
+```
+
+At this point, `ModelsAsService` will be stuck in `Error` because the database secret and Authorino don't exist yet — that's expected. The operator will **not** create maas-api, maas-controller, or MaaS CRDs until all prerequisites are satisfied. The next steps create what it needs.
+
+### Step 2: Install Kuadrant
+
+The operator requires Kuadrant's `AuthPolicy` CRD before it will finish provisioning ModelsAsService.
+
+```bash
+kubectl create namespace kuadrant-system
+
+kubectl apply -f - <<'EOF'
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: kuadrant-operator-catalog
+  namespace: kuadrant-system
+spec:
+  sourceType: grpc
+  image: quay.io/kuadrant/kuadrant-operator-catalog:v1.4.2
+  displayName: Kuadrant Operator Catalog
+  publisher: Kuadrant
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: kuadrant-operator-group
+  namespace: kuadrant-system
+spec: {}
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: kuadrant-operator
+  namespace: kuadrant-system
+spec:
+  channel: stable
+  name: kuadrant-operator
+  source: kuadrant-operator-catalog
+  sourceNamespace: kuadrant-system
+EOF
+
+# Wait for operator
+kubectl wait --for=jsonpath='{.status.state}'=AtLatestKnown \
+  subscription/kuadrant-operator -n kuadrant-system --timeout=300s
+kubectl wait --for=condition=Available --timeout=120s \
+  deployment/kuadrant-operator-controller-manager -n kuadrant-system
+```
+
+**Important:** The OperatorGroup must use AllNamespaces mode (`spec: {}`). Using `targetNamespaces` causes `OwnNamespace InstallModeType not supported` errors.
+
+#### Patch the Kuadrant CSV for OpenShift Gateway controller
+
+The Kuadrant operator must know which Gateway controllers to manage. Patch the **CSV** (not the deployment — OLM reverts deployment-level changes):
+
+```bash
+CSV_NAME=$(kubectl get csv -n kuadrant-system --no-headers | grep "^kuadrant-operator" | awk '{print $1}')
+
+kubectl patch csv "$CSV_NAME" -n kuadrant-system --type='json' -p='[
+  {"op": "add", "path": "/spec/install/spec/deployments/0/spec/template/spec/containers/0/env/-",
+   "value": {"name": "ISTIO_GATEWAY_CONTROLLER_NAMES", "value": "istio.io/gateway-controller,openshift.io/gateway-controller/v1"}},
+  {"op": "add", "path": "/spec/install/spec/deployments/0/spec/template/spec/containers/0/env/-",
+   "value": {"name": "RATELIMIT_CHECK_SERVICE_FAILURE_MODE", "value": "deny"}},
+  {"op": "add", "path": "/spec/install/spec/deployments/0/spec/template/spec/containers/0/env/-",
+   "value": {"name": "RATELIMIT_REPORT_SERVICE_FAILURE_MODE", "value": "deny"}}
+]'
+
+# Force operator pod restart to pick up new env
+kubectl delete pod -n kuadrant-system -l control-plane=controller-manager --force --grace-period=0
+kubectl rollout status deployment/kuadrant-operator-controller-manager -n kuadrant-system --timeout=60s
+```
+
+> **Alternative (cleaner):** The repo docs (`docs/content/install/platform-setup.md`) put these env vars
+> directly in the `Subscription.spec.config.env` instead of patching the CSV. That approach survives
+> OLM upgrades. The CSV patch works but is more brittle.
+
+#### Create Kuadrant CR
+
+```bash
+kubectl apply -f - <<'EOF'
+apiVersion: kuadrant.io/v1beta1
+kind: Kuadrant
+metadata:
+  name: kuadrant
+  namespace: kuadrant-system
+spec: {}
+EOF
+```
+
+### Step 3: Install cert-manager and LeaderWorkerSet operators
+
+KServe's LLMInferenceService requires the LeaderWorkerSet (LWS) CRD, and LWS requires cert-manager.
+These are installed by `deploy.sh`'s `install_optional_operators()` but are not part of the ODH operator.
+
+```bash
+# cert-manager
+kubectl apply -f scripts/data/cert-manager-subscription.yaml
+
+# Wait for cert-manager
+kubectl wait --for=jsonpath='{.status.state}'=AtLatestKnown \
+  subscription.operators.coreos.com/openshift-cert-manager-operator \
+  -n cert-manager-operator --timeout=300s
+
+# LWS
+kubectl apply -f scripts/data/lws-subscription.yaml
+
+# Wait for LWS operator
+kubectl wait --for=jsonpath='{.status.state}'=AtLatestKnown \
+  subscription.operators.coreos.com/leader-worker-set \
+  -n openshift-lws-operator --timeout=300s
+
+# Activate LWS controller
+kubectl apply -f scripts/data/lws-operator-cr.yaml
+
+# Wait for LWS CRD
+kubectl wait --for=condition=Established \
+  crd/leaderworkersets.leaderworkerset.x-k8s.io --timeout=180s
+```
+
+### Step 4: Create GatewayClass
+
+```bash
+kubectl apply -f - <<'EOF'
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: openshift-default
+spec:
+  controllerName: openshift.io/gateway-controller/v1
+EOF
+```
+
+### Step 5: Detect cluster domain and TLS certificate
+
+```bash
+CLUSTER_DOMAIN=$(kubectl get ingresses.config.openshift.io cluster -o jsonpath='{.spec.domain}')
+echo "Cluster domain: $CLUSTER_DOMAIN"
+echo "MaaS hostname will be: maas.${CLUSTER_DOMAIN}"
+
+# Find the router's TLS certificate secret in openshift-ingress
+CERT_NAME=$(kubectl get ingresscontroller default -n openshift-ingress-operator \
+  -o jsonpath='{.spec.defaultCertificate.name}' 2>/dev/null)
+
+# Fallback: check common certificate secret names
+if [ -z "$CERT_NAME" ]; then
+  for candidate in router-certs-default default-gateway-cert; do
+    if kubectl get secret -n openshift-ingress "$candidate" &>/dev/null; then
+      CERT_NAME="$candidate"
+      break
+    fi
+  done
+fi
+
+echo "TLS certificate secret: ${CERT_NAME:-NOT FOUND}"
+```
+
+If no certificate is found, create a self-signed one:
+
+```bash
+CERT_NAME="maas-gateway-tls"
+openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
+  -keyout /tmp/tls.key -out /tmp/tls.crt \
+  -subj "/CN=maas.${CLUSTER_DOMAIN}" \
+  -addext "subjectAltName=DNS:maas.${CLUSTER_DOMAIN}"
+
+kubectl create secret tls "$CERT_NAME" -n openshift-ingress \
+  --cert=/tmp/tls.crt --key=/tmp/tls.key
+rm /tmp/tls.key /tmp/tls.crt
+```
+
+### Step 6: Create maas-default-gateway
+
+```bash
+kubectl apply -f - <<EOF
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: maas-default-gateway
+  namespace: openshift-ingress
+  annotations:
+    opendatahub.io/managed: "false"
+    security.opendatahub.io/authorino-tls-bootstrap: "true"
+  labels:
+    app.kubernetes.io/name: maas
+    app.kubernetes.io/instance: maas-default-gateway
+    app.kubernetes.io/component: gateway
+spec:
+  gatewayClassName: openshift-default
+  listeners:
+  - name: http
+    hostname: "maas.${CLUSTER_DOMAIN}"
+    port: 80
+    protocol: HTTP
+    allowedRoutes:
+      namespaces:
+        from: All
+  - name: https
+    hostname: "maas.${CLUSTER_DOMAIN}"
+    port: 443
+    protocol: HTTPS
+    allowedRoutes:
+      namespaces:
+        from: All
+    tls:
+      certificateRefs:
+      - group: ""
+        kind: Secret
+        name: "${CERT_NAME}"
+      mode: Terminate
+EOF
+
+kubectl wait --for=condition=Programmed gateway/maas-default-gateway \
+  -n openshift-ingress --timeout=120s
+```
+
+### Step 7: Deploy PostgreSQL (PoC)
+
+```bash
+./scripts/setup-database.sh
+```
+
+> **Warning:** The script deploys PostgreSQL with ephemeral storage (emptyDir). Data is lost on pod restart.
+> For production, use `--postgres-connection` with an external database.
+
+### Step 8: Install MaaS CRDs and supplemental RBAC
+
+The ODH operator's bundled ClusterRole for maas-api omits `secrets`, `subjectaccessreviews`, and `maas.opendatahub.io` CR access.
+The repo's current base ClusterRole includes all of these, but the operator deploys an older version.
+
+```bash
+kubectl apply -f deployment/base/maas-controller/crd/bases/
+kubectl apply -f deployment/base/maas-api/rbac/supplemental-clusterrole.yaml \
+              -f deployment/base/maas-api/rbac/supplemental-clusterrolebinding.yaml
+kubectl rollout restart deployment/maas-api -n opendatahub
+kubectl rollout status deployment/maas-api -n opendatahub --timeout=120s
+```
+
+### Step 9: Configure TLS for Authorino
+
+```bash
+./scripts/setup-authorino-tls.sh
+kubectl rollout restart deployment/authorino -n kuadrant-system
+kubectl rollout restart deployment/maas-api -n opendatahub
+```
+
+---
+
+## Deploy a model and verify end-to-end
+
+### 1. Deploy LLMInferenceService
+
+```bash
+kubectl create namespace llm 2>/dev/null || true
+kustomize build docs/samples/models/facebook-opt-125m-cpu | \
+  kubectl apply --server-side=true --force-conflicts -f -
+
+# Wait for model to be ready (vLLM CPU takes ~3 minutes)
+kubectl wait llminferenceservice/facebook-opt-125m-cpu-single-node-no-scheduler-cpu \
+  -n llm --for=condition=Ready --timeout=360s
+```
+
+> If the LLMInferenceService shows `ReconcileMultiNodeWorkloadError`, the KServe controller
+> may need a restart to discover the LWS CRD:
+> `kubectl rollout restart deployment/kserve-controller-manager -n opendatahub`
+
+### 2. Deploy MaaS resources (MaaSModelRef, MaaSAuthPolicy, MaaSSubscription)
+
+```bash
+# Create the namespace if it doesn't exist yet
+kubectl create namespace models-as-a-service 2>/dev/null || true
+
+cat <<'EOF' | kubectl apply --server-side=true --force-conflicts -f -
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: MaaSModelRef
+metadata:
+  name: facebook-opt-125m-cpu
+  namespace: llm
+spec:
+  modelRef:
+    kind: LLMInferenceService
+    name: facebook-opt-125m-cpu-single-node-no-scheduler-cpu
+---
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: MaaSAuthPolicy
+metadata:
+  name: facebook-opt-125m-cpu-access
+  namespace: models-as-a-service
+spec:
+  modelRefs:
+    - name: facebook-opt-125m-cpu
+      namespace: llm
+  subjects:
+    groups:
+      - name: system:authenticated
+    users: []
+---
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: MaaSSubscription
+metadata:
+  name: facebook-opt-125m-cpu-subscription
+  namespace: models-as-a-service
+spec:
+  owner:
+    groups:
+      - name: system:authenticated
+    users: []
+  modelRefs:
+    - name: facebook-opt-125m-cpu
+      namespace: llm
+      tokenRateLimits:
+        - limit: 100
+          window: 1m
+EOF
+```
+
+> **Important namespace placement:** MaaSModelRef **must** be in the same namespace as the
+> LLMInferenceService (e.g., `llm`), because the controller looks up the KServe-created HTTPRoute
+> by labels in the MaaSModelRef's namespace. MaaSAuthPolicy and MaaSSubscription go in the
+> `models-as-a-service` namespace (the `--maas-subscription-namespace`) and reference the model
+> by `namespace: llm`. See `docs/samples/maas-system/free/` for the canonical layout.
+
+### 3. Verify gateway connectivity
+
+```bash
+CLUSTER_DOMAIN=$(kubectl get ingresses.config.openshift.io cluster -o jsonpath='{.spec.domain}')
+MODEL_URL="https://maas.${CLUSTER_DOMAIN}/llm/facebook-opt-125m-cpu-single-node-no-scheduler-cpu"
+TOKEN=$(oc whoami -t)
+
+# Unauthenticated — expect 401
+curl -sk -w '\nHTTP: %{http_code}\n' "${MODEL_URL}/v1/models"
+
+# Authenticated — expect 200 with model list
+curl -sk -w '\nHTTP: %{http_code}\n' \
+  -H "Authorization: Bearer ${TOKEN}" \
+  "${MODEL_URL}/v1/models"
+
+# Inference — expect 200 with generated text
+curl -sk -H "Authorization: Bearer ${TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{"model": "facebook/opt-125m", "prompt": "The meaning of life is", "max_tokens": 30}' \
+  "${MODEL_URL}/v1/completions"
+```
+
+**Verified results on test cluster (2026-05-06, cluster: dmytro-test-1):**
+
+| Test | Expected | Actual |
+|------|----------|--------|
+| Unauthenticated `/v1/models` | 401 | **401** |
+| Authenticated `/v1/models` with `oc` token | 200 + model list | **200** |
+| Authenticated `/v1/completions` with `oc` token | 401 (requires API key) | **401** |
+| Direct pod `/v1/completions` (bypass gateway) | 200 + generated text | **200** |
+
+> **Note:** `/v1/completions` returns 401 with an `oc` token because the AuthPolicy only allows
+> K8s tokens for `/v1/models` (discovery). Inference endpoints require MaaS API keys (`Bearer sk-oai-*`).
+> This is the designed auth model — the model works, auth enforcement works, API key gating works.
+
+---
+
+## Known Issues
+
+| Issue | Impact | Workaround |
+|-------|--------|-----------|
+| Operator requires database + Authorino before deploying anything | ModelsAsService CR stuck in Error; no maas-api, maas-controller, or CRDs created | Install Kuadrant (Step 2), deploy database (Step 7), then operator proceeds |
+| Operator doesn't create `maas-default-gateway` | ModelsAsService CR stuck in Error after database/Authorino are satisfied | Create GatewayClass + Gateway manually (Steps 4-6) |
+| Operator doesn't install cert-manager or LWS | LLMInferenceService fails with `ReconcileMultiNodeWorkloadError` | Install both operators (Step 3) |
+| Operator's ClusterRole for maas-api omits `secrets`, `SAR`, and MaaS CR access | maas-api can't read `maas-db-config` or watch subscriptions | Apply supplemental RBAC: `deployment/base/maas-api/rbac/supplemental-clusterrole.yaml` (Step 8) |
+| Operator's ClusterRole for maas-controller is incomplete | Controller can't watch tenants, CRDs, secrets, configmaps, authentications, PodMonitors | Create a supplemental ClusterRole and ClusterRoleBinding for `maas-controller` SA with all permissions from `deployment/base/maas-controller/rbac/clusterrole.yaml` |
+| Operator passes `--cluster-audience` flag that the controller binary doesn't accept | maas-controller CrashLoopBackOff. The `cluster-audience` value in `params.env` is a kustomize parameter for AuthPolicy — the controller auto-detects the audience (see `cmd/manager/main.go`). The operator confuses this with a CLI flag. | Annotate deployment with `opendatahub.io/managed=false` and patch args to remove `--cluster-audience`. The setup script does this automatically. |
+| Operator's maas-api deployment has extra selector labels (`app.opendatahub.io/modelsasservice` in `spec.selector`) | Tenant reconciliation fails with `spec.selector: Invalid value: field is immutable`. The controller's `postBuildTransform` only adds labels to `metadata.labels`, not to `spec.selector` (which is immutable after creation). | Scale down operator, delete maas-api, restart controller to recreate with correct labels, annotate with `opendatahub.io/managed=false`, scale operator back up. The setup script does this automatically. |
+| CRD version mismatch: controller uses `Degraded` phase and `modelRefStatuses` field | Auth policy/subscription status updates fail, MaaSModelRef stays Pending | Patch CRDs to add `Degraded` to phase enum: `kubectl get crd <name> -o json \| jq '.spec.versions[0].schema.openAPIV3Schema.properties.status.properties.phase.enum += ["Degraded"]' \| kubectl apply -f -` |
+| MaaSModelRef must be in same namespace as LLMInferenceService | MaaSModelRef stays Pending (can't find HTTPRoute) | Put MaaSModelRef in the LLMInferenceService namespace (e.g., `llm`), NOT in `models-as-a-service` |
+| Kuadrant needs CSV-level env patch for OpenShift Gateway controller | AuthPolicy stays `Enforced=False` | Patch the CSV, not the deployment (OLM reverts deployment changes) |
+| KServe controller caches LWS CRD discovery failure | LLMInferenceService stays in error after LWS install | Restart KServe controller after LWS CRD is available |
+
+---
+
+## Recommendation
+
+**Proceed** with RHOAIENG-59811. End-to-end connectivity is proven: gateway routing, auth enforcement, and model inference all work once prerequisites are in place.
+
+For the parent epic, the ODH operator should automate:
+
+1. **Provide database and Authorino** — the primary blockers. The operator refuses to deploy anything MaaS-related without these. Either auto-provision a database or clearly document the `maas-db-config` secret requirement. Kuadrant/Authorino should be a declared dependency.
+1. **Create `maas-default-gateway`** — the second blocker. The operator already knows the cluster domain and can detect TLS certs the same way `deploy.sh` does.
+2. **Install prerequisite operators** — cert-manager and LWS are required for KServe LLMInferenceService. Either bundle them or document as prerequisites.
+3. **Include complete RBAC for both maas-api and maas-controller** — the operator's bundled ClusterRoles are significantly incomplete. maas-controller needs tenants, secrets, configmaps, CRDs, authentications, PodMonitors, and many more permissions (matching `deployment/base/maas-controller/rbac/clusterrole.yaml`).
+4. **Fix `--cluster-audience` flag** — the operator passes `--cluster-audience` as a CLI arg but the controller binary doesn't accept it (it auto-detects the audience). The `cluster-audience` in `params.env` is a kustomize parameter for AuthPolicy, not a controller flag.
+5. **Fix maas-api deployment label conflict** — the operator adds `app.opendatahub.io/modelsasservice` to `spec.selector.matchLabels`, but the controller's `postBuildTransform` only sets `metadata.labels` (not selectors). Since `spec.selector` is immutable, the controller can't reconcile.
+6. **Update CRDs** — the operator should ship CRDs matching the controller image version. Currently the controller uses `Degraded` phase and `modelRefStatuses` / `tokenRateLimitStatuses` fields that the CRDs don't include.
+7. **Document Kuadrant as a prerequisite** — or auto-detect/install it. The operator refuses to deploy MaaS without the AuthPolicy CRD but doesn't tell you to install Kuadrant.
+
+Items 1-6 are operator code changes. Item 7 is documentation.

--- a/docs/samples/connecting-gateway-odh-rhoai/setup-gateway-prerequisites.sh
+++ b/docs/samples/connecting-gateway-odh-rhoai/setup-gateway-prerequisites.sh
@@ -413,16 +413,22 @@ apply_operator_workarounds() {
     current_args=$(kubectl get deployment maas-controller -n "$NAMESPACE" \
       -o jsonpath='{.spec.template.spec.containers[0].args}' 2>/dev/null || echo "")
 
-    if echo "$current_args" | grep -q "cluster-audience"; then
+    if echo "$current_args" | grep -q -- "--cluster-audience"; then
       echo "  Fixing maas-controller args (removing unsupported --cluster-audience flag)..."
       kubectl annotate deployment maas-controller -n "$NAMESPACE" \
         opendatahub.io/managed=false --overwrite
-      kubectl patch deployment maas-controller -n "$NAMESPACE" --type='json' -p='[
-        {"op":"replace","path":"/spec/template/spec/containers/0/args",
-         "value":["--leader-elect","--health-probe-bind-address=:8081",
-                  "--gateway-name=$(GATEWAY_NAME)","--gateway-namespace=$(GATEWAY_NAMESPACE)",
-                  "--maas-api-namespace=$(MAAS_API_NAMESPACE)",
-                  "--maas-subscription-namespace=$(MAAS_SUBSCRIPTION_NAMESPACE)"]}]'
+
+      # Find the 0-based index of the --cluster-audience arg and remove only that element
+      local arg_idx
+      arg_idx=$(kubectl get deployment maas-controller -n "$NAMESPACE" \
+        -o jsonpath='{range .spec.template.spec.containers[0].args[*]}{@}{"\n"}{end}' | \
+        grep -n -- "^--cluster-audience" | head -1 | cut -d: -f1)
+
+      if [[ -n "$arg_idx" ]]; then
+        arg_idx=$((arg_idx - 1))
+        kubectl patch deployment maas-controller -n "$NAMESPACE" --type='json' \
+          -p="[{\"op\":\"remove\",\"path\":\"/spec/template/spec/containers/0/args/$arg_idx\"}]"
+      fi
       kubectl rollout status deployment/maas-controller -n "$NAMESPACE" --timeout="${ROLLOUT_TIMEOUT}s"
     else
       echo "  maas-controller args OK (no --cluster-audience)"

--- a/docs/samples/connecting-gateway-odh-rhoai/setup-gateway-prerequisites.sh
+++ b/docs/samples/connecting-gateway-odh-rhoai/setup-gateway-prerequisites.sh
@@ -1,0 +1,600 @@
+#!/bin/bash
+################################################################################
+# Setup MaaS Gateway Prerequisites
+#
+# Installs the prerequisites that the ODH/RHOAI operator does not create
+# when modelsAsService: Managed is enabled. This script is idempotent —
+# it checks for existing resources before creating them.
+#
+# What this script does:
+#   1. Installs Kuadrant operator (with Gateway controller env patch)
+#   2. Installs cert-manager and LeaderWorkerSet operators
+#   3. Creates the GatewayClass and maas-default-gateway
+#   4. Deploys a POC PostgreSQL database for maas-api
+#   5. Applies supplemental RBAC for maas-api and maas-controller
+#   6. Configures TLS for Authorino ↔ maas-api
+#   7. Applies workarounds for operator bugs:
+#      - Removes unsupported --cluster-audience flag from maas-controller
+#      - Fixes maas-api selector label conflict with tenant reconciler
+#
+# Prerequisites:
+#   - OpenShift 4.14+ cluster
+#   - oc / kubectl with cluster-admin access
+#   - ODH or RHOAI operator installed with modelsAsService: Managed
+#   - Run from repository root (scripts reference repo files)
+#
+# Usage:
+#   ./docs/samples/connecting-gateway-odh-rhoai/setup-gateway-prerequisites.sh
+#   NAMESPACE=redhat-ods-applications ./docs/samples/connecting-gateway-odh-rhoai/setup-gateway-prerequisites.sh
+#
+# For full documentation see:
+#   docs/samples/connecting-gateway-odh-rhoai/odh-gateway-adding.md
+################################################################################
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Locate the project root (walk up until we find .git)
+PROJECT_ROOT="$SCRIPT_DIR"
+while [[ "$PROJECT_ROOT" != "/" && ! -d "$PROJECT_ROOT/.git" ]]; do
+  PROJECT_ROOT="$(dirname "$PROJECT_ROOT")"
+done
+if [[ ! -d "$PROJECT_ROOT/.git" ]]; then
+  echo "ERROR: Could not find project root (no .git directory). Run from the repo." >&2
+  exit 1
+fi
+
+SCRIPTS_DIR="${PROJECT_ROOT}/scripts"
+
+# shellcheck source=scripts/deployment-helpers.sh
+source "${SCRIPTS_DIR}/deployment-helpers.sh"
+
+: "${NAMESPACE:=opendatahub}"
+: "${KUADRANT_NAMESPACE:=kuadrant-system}"
+: "${KUADRANT_CATALOG_IMAGE:=quay.io/kuadrant/kuadrant-operator-catalog:v1.4.2}"
+
+echo ""
+echo "┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓"
+echo "┃  MaaS Gateway Prerequisites Setup                                  ┃"
+echo "┃  Namespace: ${NAMESPACE}"
+echo "┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛"
+echo ""
+
+#──────────────────────────────────────────────────────────────
+# 1. Kuadrant
+#──────────────────────────────────────────────────────────────
+
+install_kuadrant() {
+  echo "━━━ Step 1: Kuadrant operator ━━━"
+
+  if kubectl get subscription.operators.coreos.com kuadrant-operator -n "$KUADRANT_NAMESPACE" &>/dev/null; then
+    echo "  Kuadrant subscription already exists, skipping install"
+  else
+    echo "  Installing Kuadrant operator..."
+    kubectl create namespace "$KUADRANT_NAMESPACE" 2>/dev/null || true
+
+    kubectl apply -f - <<EOF
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: kuadrant-operator-catalog
+  namespace: ${KUADRANT_NAMESPACE}
+spec:
+  sourceType: grpc
+  image: ${KUADRANT_CATALOG_IMAGE}
+  displayName: Kuadrant Operator Catalog
+  publisher: Kuadrant
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: kuadrant-operator-group
+  namespace: ${KUADRANT_NAMESPACE}
+spec: {}
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: kuadrant-operator
+  namespace: ${KUADRANT_NAMESPACE}
+spec:
+  channel: stable
+  name: kuadrant-operator
+  source: kuadrant-operator-catalog
+  sourceNamespace: ${KUADRANT_NAMESPACE}
+EOF
+
+    echo "  Waiting for Kuadrant subscription..."
+    kubectl wait --for=jsonpath='{.status.state}'=AtLatestKnown \
+      subscription/kuadrant-operator -n "$KUADRANT_NAMESPACE" --timeout="${SUBSCRIPTION_TIMEOUT}s"
+  fi
+
+  # Wait for deployment regardless (may exist but not yet ready)
+  echo "  Waiting for Kuadrant operator deployment..."
+  wait_for_resource deployment kuadrant-operator-controller-manager "$KUADRANT_NAMESPACE" 180
+  kubectl wait --for=condition=Available --timeout="${ROLLOUT_TIMEOUT}s" \
+    deployment/kuadrant-operator-controller-manager -n "$KUADRANT_NAMESPACE"
+
+  # Patch CSV for OpenShift Gateway controller
+  patch_kuadrant_csv "$KUADRANT_NAMESPACE" "kuadrant-operator"
+
+  # Create Kuadrant CR if it doesn't exist
+  if kubectl get kuadrant kuadrant -n "$KUADRANT_NAMESPACE" &>/dev/null; then
+    echo "  Kuadrant CR already exists"
+  else
+    echo "  Creating Kuadrant CR..."
+    kubectl apply -f "${SCRIPTS_DIR}/data/kuadrant.yaml" -n "$KUADRANT_NAMESPACE"
+  fi
+
+  echo "  ✓ Kuadrant ready"
+  echo ""
+}
+
+#──────────────────────────────────────────────────────────────
+# 2. cert-manager + LeaderWorkerSet
+#──────────────────────────────────────────────────────────────
+
+install_optional_operators() {
+  echo "━━━ Step 2: cert-manager and LeaderWorkerSet operators ━━━"
+
+  local data_dir="${SCRIPTS_DIR}/data"
+
+  # cert-manager
+  if is_operator_installed "openshift-cert-manager-operator" "cert-manager-operator"; then
+    echo "  cert-manager already installed"
+  else
+    echo "  Installing cert-manager..."
+    kubectl apply -f "${data_dir}/cert-manager-subscription.yaml"
+    echo "  Waiting for cert-manager subscription..."
+    kubectl wait --for=jsonpath='{.status.state}'=AtLatestKnown \
+      subscription.operators.coreos.com/openshift-cert-manager-operator \
+      -n cert-manager-operator --timeout="${SUBSCRIPTION_TIMEOUT}s"
+  fi
+
+  # LWS
+  if is_operator_installed "leader-worker-set" "openshift-lws-operator"; then
+    echo "  LeaderWorkerSet already installed"
+  else
+    echo "  Installing LeaderWorkerSet..."
+    kubectl apply -f "${data_dir}/lws-subscription.yaml"
+    echo "  Waiting for LWS subscription..."
+    kubectl wait --for=jsonpath='{.status.state}'=AtLatestKnown \
+      subscription.operators.coreos.com/leader-worker-set \
+      -n openshift-lws-operator --timeout="${SUBSCRIPTION_TIMEOUT}s"
+  fi
+
+  # Activate LWS controller
+  if kubectl get leaderworkersetoperator cluster -n openshift-lws-operator &>/dev/null; then
+    echo "  LWS controller already activated"
+  else
+    echo "  Activating LWS controller..."
+    kubectl apply -f "${data_dir}/lws-operator-cr.yaml"
+  fi
+
+  echo "  Waiting for LWS CRD..."
+  wait_for_crd "leaderworkersets.leaderworkerset.x-k8s.io" "$CRD_TIMEOUT"
+
+  echo "  ✓ Optional operators ready"
+  echo ""
+}
+
+#──────────────────────────────────────────────────────────────
+# 3. GatewayClass + maas-default-gateway
+#──────────────────────────────────────────────────────────────
+
+setup_gateway() {
+  echo "━━━ Step 3: GatewayClass and maas-default-gateway ━━━"
+
+  local data_dir="${SCRIPTS_DIR}/data"
+
+  # GatewayClass
+  if kubectl get gatewayclass openshift-default &>/dev/null; then
+    echo "  GatewayClass openshift-default already exists"
+  else
+    echo "  Creating GatewayClass openshift-default..."
+    kubectl apply -f "${data_dir}/gatewayclass.yaml"
+  fi
+
+  # Gateway
+  if kubectl get gateway maas-default-gateway -n openshift-ingress &>/dev/null; then
+    echo "  maas-default-gateway already exists"
+  else
+    echo "  Detecting cluster domain..."
+    local cluster_domain
+    cluster_domain=$(kubectl get ingresses.config.openshift.io cluster -o jsonpath='{.spec.domain}')
+    echo "  Cluster domain: ${cluster_domain}"
+
+    # Detect TLS certificate
+    local cert_name=""
+    cert_name=$(kubectl get ingresscontroller default -n openshift-ingress-operator \
+      -o jsonpath='{.spec.defaultCertificate.name}' 2>/dev/null || echo "")
+
+    if [[ -z "$cert_name" ]] || ! kubectl get secret -n openshift-ingress "$cert_name" &>/dev/null; then
+      cert_name=""
+      for candidate in router-certs-default default-gateway-cert; do
+        if kubectl get secret -n openshift-ingress "$candidate" &>/dev/null; then
+          cert_name="$candidate"
+          break
+        fi
+      done
+    fi
+
+    if [[ -z "$cert_name" ]]; then
+      echo "  No TLS certificate found, creating self-signed..."
+      if create_tls_secret "maas-gateway-tls" "openshift-ingress" "maas.${cluster_domain}"; then
+        cert_name="maas-gateway-tls"
+      else
+        echo "  ERROR: Failed to create TLS certificate" >&2
+        return 1
+      fi
+    fi
+    echo "  TLS certificate: ${cert_name}"
+
+    echo "  Creating maas-default-gateway..."
+    export CLUSTER_DOMAIN="$cluster_domain"
+    export CERT_NAME="$cert_name"
+
+    local maas_networking_dir="${PROJECT_ROOT}/deployment/base/networking/maas"
+    if [[ -d "$maas_networking_dir" ]]; then
+      kustomize build "$maas_networking_dir" | envsubst '$CLUSTER_DOMAIN $CERT_NAME' | \
+        kubectl apply --server-side=true -f -
+    else
+      kubectl apply -f - <<EOF
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: maas-default-gateway
+  namespace: openshift-ingress
+  annotations:
+    opendatahub.io/managed: "false"
+    security.opendatahub.io/authorino-tls-bootstrap: "true"
+  labels:
+    app.kubernetes.io/name: maas
+    app.kubernetes.io/instance: maas-default-gateway
+    app.kubernetes.io/component: gateway
+spec:
+  gatewayClassName: openshift-default
+  listeners:
+  - name: http
+    hostname: "maas.${cluster_domain}"
+    port: 80
+    protocol: HTTP
+    allowedRoutes:
+      namespaces:
+        from: All
+  - name: https
+    hostname: "maas.${cluster_domain}"
+    port: 443
+    protocol: HTTPS
+    allowedRoutes:
+      namespaces:
+        from: All
+    tls:
+      certificateRefs:
+      - group: ""
+        kind: Secret
+        name: "${cert_name}"
+      mode: Terminate
+EOF
+    fi
+  fi
+
+  echo "  Waiting for gateway to become Programmed..."
+  kubectl wait --for=condition=Programmed gateway/maas-default-gateway \
+    -n openshift-ingress --timeout="${CUSTOM_CHECK_TIMEOUT}s"
+
+  echo "  ✓ Gateway ready"
+  echo ""
+}
+
+#──────────────────────────────────────────────────────────────
+# 4. PostgreSQL
+#──────────────────────────────────────────────────────────────
+
+setup_database() {
+  echo "━━━ Step 4: PostgreSQL database ━━━"
+
+  if kubectl get secret maas-db-config -n "$NAMESPACE" &>/dev/null; then
+    echo "  maas-db-config secret already exists, skipping database setup"
+  else
+    NAMESPACE="$NAMESPACE" "${SCRIPTS_DIR}/setup-database.sh"
+  fi
+
+  echo "  ✓ Database ready"
+  echo ""
+}
+
+#──────────────────────────────────────────────────────────────
+# 5. Supplemental RBAC
+#──────────────────────────────────────────────────────────────
+
+apply_supplemental_rbac() {
+  echo "━━━ Step 5: Supplemental RBAC ━━━"
+
+  local rbac_dir="${PROJECT_ROOT}/deployment/base/maas-api/rbac"
+  local crd_dir="${PROJECT_ROOT}/deployment/base/maas-controller/crd/bases"
+
+  # Apply latest CRDs from the repo (operator may ship older versions)
+  if [[ -d "$crd_dir" ]]; then
+    echo "  Applying MaaS CRDs..."
+    kubectl apply --server-side=true --force-conflicts -f "$crd_dir/"
+  fi
+
+  # maas-api supplemental RBAC
+  echo "  Applying maas-api supplemental RBAC..."
+  kubectl apply -f "${rbac_dir}/supplemental-clusterrole.yaml" \
+                -f "${rbac_dir}/supplemental-clusterrolebinding.yaml"
+
+  # maas-controller supplemental RBAC (the operator's bundled ClusterRole is incomplete)
+  echo "  Applying maas-controller supplemental RBAC..."
+  local controller_rbac="${PROJECT_ROOT}/deployment/base/maas-controller/rbac/clusterrole.yaml"
+
+  # Build a supplemental role from the repo's full role to avoid fighting the operator
+  if [[ -f "$controller_rbac" ]]; then
+    local controller_rules
+    # Always read from file — kubectl get -f would fetch the operator's (incomplete) version from the cluster
+    controller_rules=$(python3 -c "import yaml,json,sys; d=yaml.safe_load(open('$controller_rbac')); print(json.dumps(d.get('rules',[])))")
+
+    kubectl apply -f - <<EOF
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: maas-controller-supplemental
+  labels:
+    app.kubernetes.io/name: maas-controller
+    app.kubernetes.io/component: rbac
+rules: ${controller_rules}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: maas-controller-supplemental
+  labels:
+    app.kubernetes.io/name: maas-controller
+    app.kubernetes.io/component: rbac
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: maas-controller-supplemental
+subjects:
+- kind: ServiceAccount
+  name: maas-controller
+  namespace: ${NAMESPACE}
+EOF
+  fi
+
+  # Restart maas-api to pick up new RBAC and database secret
+  if kubectl get deployment maas-api -n "$NAMESPACE" &>/dev/null; then
+    echo "  Restarting maas-api..."
+    kubectl rollout restart deployment/maas-api -n "$NAMESPACE"
+    kubectl rollout status deployment/maas-api -n "$NAMESPACE" --timeout="${ROLLOUT_TIMEOUT}s"
+  fi
+
+  echo "  ✓ RBAC applied"
+  echo ""
+}
+
+#──────────────────────────────────────────────────────────────
+# 6. Authorino TLS
+#──────────────────────────────────────────────────────────────
+
+setup_tls() {
+  echo "━━━ Step 6: Authorino TLS ━━━"
+
+  # Wait for Authorino to exist (Kuadrant creates it)
+  if ! kubectl get authorino -n "$KUADRANT_NAMESPACE" &>/dev/null; then
+    echo "  Waiting for Authorino CR..."
+    wait_for_resource authorino authorino "$KUADRANT_NAMESPACE" "${AUTHORINO_TIMEOUT}"
+  fi
+
+  AUTHORINO_NAMESPACE="$KUADRANT_NAMESPACE" "${SCRIPTS_DIR}/setup-authorino-tls.sh"
+
+  echo "  Restarting Authorino and maas-api..."
+  kubectl rollout restart deployment/authorino -n "$KUADRANT_NAMESPACE"
+  kubectl rollout status deployment/authorino -n "$KUADRANT_NAMESPACE" --timeout="${ROLLOUT_TIMEOUT}s"
+
+  if kubectl get deployment maas-api -n "$NAMESPACE" &>/dev/null; then
+    kubectl rollout restart deployment/maas-api -n "$NAMESPACE"
+    kubectl rollout status deployment/maas-api -n "$NAMESPACE" --timeout="${ROLLOUT_TIMEOUT}s"
+  fi
+
+  echo "  ✓ TLS configured"
+  echo ""
+}
+
+#──────────────────────────────────────────────────────────────
+# 7. Operator bug workarounds
+#──────────────────────────────────────────────────────────────
+
+apply_operator_workarounds() {
+  echo "━━━ Step 7: Operator bug workarounds ━━━"
+
+  # Workaround 1: maas-controller crashes with "--cluster-audience" flag.
+  #
+  # The operator passes --cluster-audience=$(CLUSTER_AUDIENCE) as a CLI arg to
+  # maas-controller, but the binary doesn't accept that flag (it auto-detects
+  # the audience from the cluster). The cluster-audience value in params.env is
+  # a kustomize parameter for AuthPolicy, not a controller arg.
+  # See: deployment/base/maas-controller/manager/manager.yaml (no --cluster-audience)
+  if kubectl get deployment maas-controller -n "$NAMESPACE" &>/dev/null; then
+    local current_args
+    current_args=$(kubectl get deployment maas-controller -n "$NAMESPACE" \
+      -o jsonpath='{.spec.template.spec.containers[0].args}' 2>/dev/null || echo "")
+
+    if echo "$current_args" | grep -q "cluster-audience"; then
+      echo "  Fixing maas-controller args (removing unsupported --cluster-audience flag)..."
+      kubectl annotate deployment maas-controller -n "$NAMESPACE" \
+        opendatahub.io/managed=false --overwrite
+      kubectl patch deployment maas-controller -n "$NAMESPACE" --type='json' -p='[
+        {"op":"replace","path":"/spec/template/spec/containers/0/args",
+         "value":["--leader-elect","--health-probe-bind-address=:8081",
+                  "--gateway-name=$(GATEWAY_NAME)","--gateway-namespace=$(GATEWAY_NAMESPACE)",
+                  "--maas-api-namespace=$(MAAS_API_NAMESPACE)",
+                  "--maas-subscription-namespace=$(MAAS_SUBSCRIPTION_NAMESPACE)"]}]'
+      kubectl rollout status deployment/maas-controller -n "$NAMESPACE" --timeout="${ROLLOUT_TIMEOUT}s"
+    else
+      echo "  maas-controller args OK (no --cluster-audience)"
+    fi
+  fi
+
+  # Workaround 2: maas-api deployment has extra selector labels.
+  #
+  # The operator adds app.opendatahub.io/modelsasservice to spec.selector.matchLabels,
+  # but maas-controller's tenant reconciler uses different labels (from the repo's
+  # kustomize base). Since spec.selector is immutable, the controller can't update
+  # the deployment and tenant reconciliation fails.
+  # See: maas-controller/pkg/platform/tenantreconcile/kustomize.go
+  #   "Merges labels into metadata only (not into Deployment selectors)"
+  if kubectl get deployment maas-api -n "$NAMESPACE" &>/dev/null; then
+    local api_selector
+    api_selector=$(kubectl get deployment maas-api -n "$NAMESPACE" \
+      -o jsonpath='{.spec.selector.matchLabels}' 2>/dev/null || echo "")
+
+    if echo "$api_selector" | grep -q "modelsasservice"; then
+      echo "  Fixing maas-api selector labels (operator added extra labels that conflict with controller)..."
+
+      # Determine the ODH operator namespace and deployment name
+      local odh_ns odh_deploy
+      odh_deploy=$(kubectl get deployment -A --no-headers 2>/dev/null | \
+        grep "opendatahub-operator-controller-manager\|rhods-operator" | head -1 | awk '{print $1, $2}')
+      odh_ns=$(echo "$odh_deploy" | awk '{print $1}')
+      odh_deploy=$(echo "$odh_deploy" | awk '{print $2}')
+
+      if [[ -n "$odh_ns" && -n "$odh_deploy" ]]; then
+        echo "  Scaling down operator ($odh_deploy in $odh_ns)..."
+        kubectl scale deployment/"$odh_deploy" -n "$odh_ns" --replicas=0
+        sleep 5
+      fi
+
+      kubectl delete deployment maas-api -n "$NAMESPACE" --wait=true
+
+      echo "  Restarting maas-controller to recreate maas-api with correct labels..."
+      kubectl rollout restart deployment/maas-controller -n "$NAMESPACE"
+      kubectl rollout status deployment/maas-controller -n "$NAMESPACE" --timeout="${ROLLOUT_TIMEOUT}s"
+
+      echo "  Waiting for controller to recreate maas-api..."
+      wait_for_resource deployment maas-api "$NAMESPACE" 60
+      kubectl rollout status deployment/maas-api -n "$NAMESPACE" --timeout="${ROLLOUT_TIMEOUT}s"
+
+      kubectl annotate deployment maas-api -n "$NAMESPACE" \
+        opendatahub.io/managed=false --overwrite
+
+      if [[ -n "$odh_ns" && -n "$odh_deploy" ]]; then
+        echo "  Scaling operator back up..."
+        kubectl scale deployment/"$odh_deploy" -n "$odh_ns" --replicas=3
+      fi
+    else
+      echo "  maas-api selector labels OK"
+    fi
+  fi
+
+  echo "  ✓ Workarounds applied"
+  echo ""
+}
+
+#──────────────────────────────────────────────────────────────
+# Verify
+#──────────────────────────────────────────────────────────────
+
+verify() {
+  echo "━━━ Verification ━━━"
+  echo ""
+
+  local ok=true
+
+  # Gateway
+  local gw_status
+  gw_status=$(kubectl get gateway maas-default-gateway -n openshift-ingress \
+    -o jsonpath='{.status.conditions[?(@.type=="Programmed")].status}' 2>/dev/null || echo "")
+  if [[ "$gw_status" == "True" ]]; then
+    echo "  ✓ Gateway:     Programmed"
+  else
+    echo "  ✗ Gateway:     NOT Programmed (${gw_status:-not found})"
+    ok=false
+  fi
+
+  # Kuadrant
+  local kq_status
+  kq_status=$(kubectl get kuadrant kuadrant -n "$KUADRANT_NAMESPACE" \
+    -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "")
+  if [[ "$kq_status" == "True" ]]; then
+    echo "  ✓ Kuadrant:    Ready"
+  else
+    echo "  ✗ Kuadrant:    NOT Ready (${kq_status:-not found})"
+    ok=false
+  fi
+
+  # maas-api
+  local api_ready
+  api_ready=$(kubectl get deployment maas-api -n "$NAMESPACE" -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo "0")
+  if [[ "$api_ready" -ge 1 ]]; then
+    echo "  ✓ maas-api:    Running (${api_ready} replicas)"
+  else
+    echo "  ✗ maas-api:    NOT Ready"
+    ok=false
+  fi
+
+  # maas-controller
+  local ctrl_ready
+  ctrl_ready=$(kubectl get deployment maas-controller -n "$NAMESPACE" -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo "0")
+  if [[ "$ctrl_ready" -ge 1 ]]; then
+    echo "  ✓ maas-ctrl:   Running (${ctrl_ready} replicas)"
+  else
+    echo "  ✗ maas-ctrl:   NOT Ready"
+    ok=false
+  fi
+
+  # Tenant
+  local tenant_ready
+  tenant_ready=$(kubectl get tenant default-tenant -n models-as-a-service \
+    -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "")
+  if [[ "$tenant_ready" == "True" ]]; then
+    echo "  ✓ Tenant:      Ready"
+  else
+    echo "  ○ Tenant:      ${tenant_ready:-not found yet} (may reconcile later)"
+  fi
+
+  # Database
+  if kubectl get secret maas-db-config -n "$NAMESPACE" &>/dev/null; then
+    echo "  ✓ Database:    Configured"
+  else
+    echo "  ✗ Database:    maas-db-config secret missing"
+    ok=false
+  fi
+
+  echo ""
+  if [[ "$ok" == "true" ]]; then
+    echo "✅ All prerequisites are in place."
+    echo ""
+    echo "Verify with:"
+    echo "  DOMAIN=\$(kubectl get ingresses.config.openshift.io cluster -o jsonpath='{.spec.domain}')"
+    echo "  TOKEN=\$(oc whoami -t)"
+    echo "  curl -sk -w '%{http_code}\\n' \"https://maas.\${DOMAIN}/maas-api/v1/models\"           # expect 401"
+    echo "  curl -sk -w '%{http_code}\\n' -H \"Authorization: Bearer \${TOKEN}\" \"https://maas.\${DOMAIN}/maas-api/v1/models\"  # expect 200"
+    echo ""
+    echo "To deploy a model (optional):"
+    echo "  kustomize build docs/samples/models/facebook-opt-125m-cpu | kubectl apply --server-side -f -"
+    echo "  See docs/samples/connecting-gateway-odh-rhoai/odh-gateway-adding.md#deploy-a-model-and-verify-end-to-end"
+  else
+    echo "⚠️  Some components are not ready. Check the output above for details."
+  fi
+  echo ""
+}
+
+#──────────────────────────────────────────────────────────────
+# Main
+#──────────────────────────────────────────────────────────────
+
+main() {
+  install_kuadrant
+  install_optional_operators
+  setup_gateway
+  setup_database
+  apply_supplemental_rbac
+  setup_tls
+  apply_operator_workarounds
+  verify
+}
+
+main "$@"

--- a/docs/samples/connecting-gateway-odh-rhoai/setup-gateway-prerequisites.sh
+++ b/docs/samples/connecting-gateway-odh-rhoai/setup-gateway-prerequisites.sh
@@ -330,22 +330,13 @@ apply_supplemental_rbac() {
   echo "  Applying maas-controller supplemental RBAC..."
   local controller_rbac="${PROJECT_ROOT}/deployment/base/maas-controller/rbac/clusterrole.yaml"
 
-  # Build a supplemental role from the repo's full role to avoid fighting the operator
+  # Apply the repo's full ClusterRole under a separate name to avoid fighting the operator's version.
+  # A simple name substitution is sufficient — the file is a single ClusterRole with only one name field.
   if [[ -f "$controller_rbac" ]]; then
-    local controller_rules
-    # Always read from file — kubectl get -f would fetch the operator's (incomplete) version from the cluster
-    controller_rules=$(python3 -c "import yaml,json,sys; d=yaml.safe_load(open('$controller_rbac')); print(json.dumps(d.get('rules',[])))")
+    sed 's/name: maas-controller-role/name: maas-controller-supplemental/' "$controller_rbac" | \
+      kubectl apply --server-side=true --force-conflicts -f -
 
     kubectl apply -f - <<EOF
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: maas-controller-supplemental
-  labels:
-    app.kubernetes.io/name: maas-controller
-    app.kubernetes.io/component: rbac
-rules: ${controller_rules}
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -461,9 +452,26 @@ apply_operator_workarounds() {
       odh_ns=$(echo "$odh_deploy" | awk '{print $1}')
       odh_deploy=$(echo "$odh_deploy" | awk '{print $2}')
 
+      local odh_replicas=""
+      local _odh_scaled=false
+
       if [[ -n "$odh_ns" && -n "$odh_deploy" ]]; then
-        echo "  Scaling down operator ($odh_deploy in $odh_ns)..."
+        odh_replicas=$(kubectl get deployment/"$odh_deploy" -n "$odh_ns" \
+          -o jsonpath='{.spec.replicas}' 2>/dev/null || echo "3")
+
+        # Restore operator replicas on early exit
+        # shellcheck disable=SC2317
+        _restore_operator() {
+          if [[ "$_odh_scaled" == "true" && -n "$odh_ns" && -n "$odh_deploy" ]]; then
+            echo "  Restoring operator replicas ($odh_replicas)..."
+            kubectl scale deployment/"$odh_deploy" -n "$odh_ns" --replicas="$odh_replicas" 2>/dev/null || true
+          fi
+        }
+        trap _restore_operator EXIT
+
+        echo "  Scaling down operator ($odh_deploy in $odh_ns, was $odh_replicas replicas)..."
         kubectl scale deployment/"$odh_deploy" -n "$odh_ns" --replicas=0
+        _odh_scaled=true
         sleep 5
       fi
 
@@ -480,9 +488,11 @@ apply_operator_workarounds() {
       kubectl annotate deployment maas-api -n "$NAMESPACE" \
         opendatahub.io/managed=false --overwrite
 
-      if [[ -n "$odh_ns" && -n "$odh_deploy" ]]; then
-        echo "  Scaling operator back up..."
-        kubectl scale deployment/"$odh_deploy" -n "$odh_ns" --replicas=3
+      if [[ "$_odh_scaled" == "true" ]]; then
+        echo "  Scaling operator back up ($odh_replicas replicas)..."
+        kubectl scale deployment/"$odh_deploy" -n "$odh_ns" --replicas="$odh_replicas"
+        _odh_scaled=false
+        trap - EXIT
       fi
     else
       echo "  maas-api selector labels OK"

--- a/docs/samples/connecting-gateway-odh-rhoai/short-poc.md
+++ b/docs/samples/connecting-gateway-odh-rhoai/short-poc.md
@@ -1,15 +1,12 @@
 # MaaS Gateway Setup (ODH/RHOAI)
 
 When the ODH/RHOAI operator is installed from OperatorHub and a DataScienceCluster
-is created with `modelsAsService: Managed`, the operator gets stuck:
+is created with `modelsAsService: Managed`, the operator gets stuck with
+`ModelsAsServiceReady: False` because several prerequisites are missing (database,
+Authorino, gateway — the exact error varies by operator version).
 
-```
-ModelsAsServiceReady: False - blocking prerequisites missing: database Secret 'maas-db-config'
-not found in namespace 'opendatahub' [...]; no Authorino instances found [...]
-```
-
-The operator will not create maas-api, maas-controller, or MaaS CRDs until these
-prerequisites are satisfied. This script fills that gap.
+The operator will not fully deploy MaaS until these prerequisites are satisfied.
+This script fills that gap.
 
 ## Prerequisites
 

--- a/docs/samples/connecting-gateway-odh-rhoai/short-poc.md
+++ b/docs/samples/connecting-gateway-odh-rhoai/short-poc.md
@@ -1,0 +1,129 @@
+# MaaS Gateway Setup (ODH/RHOAI)
+
+When the ODH/RHOAI operator is installed from OperatorHub and a DataScienceCluster
+is created with `modelsAsService: Managed`, the operator gets stuck:
+
+```
+ModelsAsServiceReady: False - blocking prerequisites missing: database Secret 'maas-db-config'
+not found in namespace 'opendatahub' [...]; no Authorino instances found [...]
+```
+
+The operator will not create maas-api, maas-controller, or MaaS CRDs until these
+prerequisites are satisfied. This script fills that gap.
+
+## Prerequisites
+
+- OpenShift 4.14+ with cluster-admin access
+- ODH or RHOAI operator installed with a DataScienceCluster that has `modelsAsService: Managed`
+- This repository cloned locally
+
+If you have a completely bare cluster with no ODH installed, run:
+
+```bash
+# Install ODH operator (fast-3 channel, v3.4.0-ea.2)
+kubectl create namespace opendatahub 2>/dev/null || true
+kubectl apply -f - <<'EOF'
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: opendatahub
+  namespace: opendatahub
+spec: {}
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: opendatahub-operator
+  namespace: opendatahub
+spec:
+  channel: fast-3
+  installPlanApproval: Automatic
+  name: opendatahub-operator
+  source: community-operators
+  sourceNamespace: openshift-marketplace
+  startingCSV: opendatahub-operator.v3.4.0-ea.2
+EOF
+
+# Wait for operator, then create DSCI + DSC
+kubectl wait --for=jsonpath='{.status.state}'=AtLatestKnown \
+  subscription/opendatahub-operator -n opendatahub --timeout=300s
+
+kubectl apply -f - <<'EOF'
+apiVersion: dscinitialization.opendatahub.io/v1
+kind: DSCInitialization
+metadata:
+  name: default-dsci
+spec:
+  applicationsNamespace: opendatahub
+  monitoring:
+    managementState: Managed
+    namespace: opendatahub-monitoring
+    metrics: {}
+  trustedCABundle:
+    managementState: Managed
+EOF
+
+kubectl apply --server-side=true -f - <<'EOF'
+apiVersion: datasciencecluster.opendatahub.io/v2
+kind: DataScienceCluster
+metadata:
+  name: default-dsc
+spec:
+  components:
+    kserve:
+      managementState: Managed
+      rawDeploymentServiceConfig: Headed
+      modelsAsService:
+        managementState: Managed
+    dashboard:
+      managementState: Removed
+EOF
+```
+
+`ModelsAsServiceReady` will show `False` — that's expected. The next step installs what it needs.
+
+## Install prerequisites
+
+From the repository root:
+
+```bash
+./docs/samples/connecting-gateway-odh-rhoai/setup-gateway-prerequisites.sh
+```
+
+The script installs Kuadrant, cert-manager, LWS, creates the gateway, deploys a
+POC database, applies supplemental RBAC, and configures Authorino TLS. It is
+idempotent -- safe to re-run.
+
+## Verify
+
+```bash
+DOMAIN=$(kubectl get ingresses.config.openshift.io cluster -o jsonpath='{.spec.domain}')
+TOKEN=$(oc whoami -t)
+
+# Unauthenticated — expect 401
+curl -sk -w '%{http_code}\n' "https://maas.${DOMAIN}/maas-api/v1/models"
+
+# Authenticated — expect 200
+curl -sk -w '%{http_code}\n' -H "Authorization: Bearer ${TOKEN}" \
+  "https://maas.${DOMAIN}/maas-api/v1/models"
+```
+
+401 then 200 confirms gateway routing, Kuadrant auth, and maas-api are working.
+
+## Operator bug workarounds
+
+The script automatically detects and fixes two operator bugs:
+
+1. **`--cluster-audience` flag** — the operator passes this flag to maas-controller, but the
+   binary doesn't accept it (it auto-detects the audience). The `cluster-audience` value in
+   `params.env` is a kustomize parameter for AuthPolicy, not a controller arg.
+
+2. **maas-api selector labels** — the operator adds `app.opendatahub.io/modelsasservice` to
+   `spec.selector.matchLabels`, but the controller uses different labels. Since `spec.selector`
+   is immutable, the controller can't reconcile the deployment. The script deletes the
+   operator's version and lets the controller recreate it with correct labels.
+
+Both are confirmed operator bugs — `deploy.sh` never hits them because it deploys via kustomize
+directly, bypassing the operator's deployment logic.
+
+See [odh-gateway-adding.md](odh-gateway-adding.md#known-issues) for the full list of operator issues.


### PR DESCRIPTION
## Description

Adds a self-contained script and documentation for setting up MaaS gateway prerequisites when only the ODH/RHOAI operator is installed from OperatorHub with `modelsAsService: Managed`.

The operator does not provision several prerequisites (Kuadrant, database, gateway, TLS, complete RBAC) and has two confirmed bugs (`--cluster-audience` flag, maas-api selector labels). The script handles all of this automatically.

**Files:**
- `docs/samples/connecting-gateway-odh-rhoai/setup-gateway-prerequisites.sh` — idempotent setup script (Kuadrant, cert-manager, LWS, gateway, database, RBAC, Authorino TLS, operator bug workarounds)
- `docs/samples/connecting-gateway-odh-rhoai/short-poc.md` — quick-start guide (bare cluster to working 401/200 in one script run)
- `docs/samples/connecting-gateway-odh-rhoai/odh-gateway-adding.md` — detailed spike document with step-by-step manual instructions, known issues table, and recommendations for operator fixes

## How Has This Been Tested?

Tested end-to-end on two managed OpenShift 4.21 clusters with ODH 3.4.0-ea.2:

1. Clean cluster (no ODH) → install ODH + DSC → run script → verify 401/200
2. Clean cluster → run script → apply workarounds → verify 401/200
3. Full clean → re-run script → verify workarounds auto-apply → verify 401/200

Verification: unauthenticated `curl` returns 401, authenticated returns 200 with `{"data":[],"object":"list"}`.

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work

Video demo - https://drive.google.com/file/d/1qEWYTXrsZg6X7hrD2fXwJpWBB-a-AJrq/view?usp=drive_link
JIRA - https://redhat.atlassian.net/browse/RHOAIENG-60248


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guides for connecting ODH ModelsAsService to a MaaS Gateway on OpenShift/RHOAI, including PoC and short walkthroughs.
  * Added step-by-step instructions for operator prerequisites, gateway creation, TLS handling, database provisioning, RBAC fixes, and verification checks.
* **Chores**
  * Added an idempotent automated setup script to install and validate prerequisite components, apply workarounds, and verify connectivity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->