### PR TITLE
chore: post-split RBAC audit, nil CR fixes, and lifecycle observability

### DIFF
--- a/maas-controller/cmd/manager/main.go
+++ b/maas-controller/cmd/manager/main.go
@@ -507,9 +507,14 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Ensure the default-tenant CR exists in the MaaS subscription namespace
-	// (same namespace as MaaSSubscription / MaaSAuthPolicy CRs).
-	// maas-controller owns creation; ODH operator only reads status and deletes on disable.
+	// Startup ordering contract:
+	//   1. ensureSubscriptionNamespaceWithClient runs synchronously above, before the manager starts.
+	//   2. ensureDefaultTenantRunnable (below) runs after cache sync and creates the default-tenant CR.
+	//   3. TenantReconciler is registered after this runnable. If a reconcile fires before the
+	//      runnable creates the Tenant CR (narrow race window), IsNotFound returns ctrl.Result{}
+	//      with no error; the CRD watch re-triggers once the runnable creates the CR.
+	//   4. ODH operator may also apply the Tenant CR independently. The singleton check in
+	//      TenantReconciler (tenant.Name != TenantInstanceName) ensures only the expected CR is acted on.
 	if err := mgr.Add(ensureDefaultTenantRunnable(mgr, maasSubscriptionNamespace)); err != nil {
 		setupLog.Error(err, "unable to register ensureDefaultTenant runnable")
 		os.Exit(1)

--- a/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
@@ -256,10 +256,6 @@ const maasAuthPolicyFinalizer = "maas.opendatahub.io/authpolicy-cleanup"
 func (r *MaaSAuthPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := logr.FromContextOrDiscard(ctx).WithValues("MaaSAuthPolicy", req.NamespacedName)
 
-	// Fetch OIDC configuration from Tenant CR (if present)
-	// This is checked on every reconcile to handle dynamic updates to the CR
-	oidcConfig := r.fetchOIDCConfig(ctx, log)
-
 	policy := &maasv1alpha1.MaaSAuthPolicy{}
 	if err := r.Get(ctx, req.NamespacedName, policy); err != nil {
 		if apierrors.IsNotFound(err) {
@@ -268,6 +264,10 @@ func (r *MaaSAuthPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		log.Error(err, "unable to fetch MaaSAuthPolicy")
 		return ctrl.Result{}, err
 	}
+
+	// Fetch OIDC configuration from Tenant CR after confirming the policy exists,
+	// so stale or deleted-race events do not trigger an unnecessary Tenant Get.
+	oidcConfig := r.fetchOIDCConfig(ctx, log)
 
 	if !policy.GetDeletionTimestamp().IsZero() {
 		return r.handleDeletion(ctx, log, policy)

--- a/maas-controller/pkg/controller/maas/maasauthpolicy_controller_test.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_controller_test.go
@@ -1483,3 +1483,26 @@ func TestMaaSAuthPolicyReconciler_NoSpec(t *testing.T) {
 		t.Errorf("Ready.Message = %q, expected it to contain %q", ready.Message, "spec is required")
 	}
 }
+
+// TestMaaSAuthPolicyReconciler_StaleEvent_NoOp verifies the W4a contract: a reconcile
+// request for a MaaSAuthPolicy that no longer exists (stale queue entry or deleted-race)
+// returns cleanly without error. After the W4a fix, fetchOIDCConfig is only called after
+// confirming the policy CR exists, so the Tenant is not queried on stale events.
+func TestMaaSAuthPolicyReconciler_StaleEvent_NoOp(t *testing.T) {
+	// Empty store — policy was deleted before this reconcile fired.
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithRESTMapper(testRESTMapper()).
+		Build()
+
+	r := &MaaSAuthPolicyReconciler{Client: c, Scheme: scheme, MaaSAPINamespace: "maas-system"}
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: "gone-policy", Namespace: "default"}}
+
+	res, err := r.Reconcile(context.Background(), req)
+	if err != nil {
+		t.Fatalf("expected no error for stale event, got: %v", err)
+	}
+	if res != (ctrl.Result{}) {
+		t.Errorf("expected empty Result, got %+v", res)
+	}
+}

--- a/maas-controller/pkg/controller/maas/self_deployment_controller.go
+++ b/maas-controller/pkg/controller/maas/self_deployment_controller.go
@@ -62,6 +62,11 @@ type LifecycleReconciler struct {
 	TenantNamespace string
 }
 
+// LifecycleReconciler watches the controller's own Deployment and cleans up cluster-scoped resources
+// (ClusterRoles, CRDs, ClusterRoleBindings stamped with app.opendatahub.io/modelsasservice=true)
+// when the Deployment is deleted (i.e. when ODH disables the modelsAsService component).
+// clusterroles/clusterrolebindings list;delete and customresourcedefinitions list;delete are
+// teardown-only verbs — narrower than TenantReconciler's CRUD grant above.
 //+kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;update;patch
 //+kubebuilder:rbac:groups=apps,resources=deployments/finalizers,verbs=update
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;clusterrolebindings,verbs=list;delete
@@ -80,6 +85,11 @@ func (r *LifecycleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 
 	if !controllerutil.ContainsFinalizer(&dep, CleanupFinalizer) {
+		// The finalizer is absent on a terminating Deployment. This happens if the controller
+		// is deployed against a pre-existing Deployment that is deleted before the first
+		// reconcile sets the finalizer, or if a previous run already removed it. Teardown
+		// is skipped; cluster-scoped resources (ClusterRoles, CRDs) will not be cleaned up.
+		log.Info("Deployment terminating but CleanupFinalizer absent; skipping teardown")
 		return ctrl.Result{}, nil
 	}
 
@@ -158,9 +168,14 @@ func (r *LifecycleReconciler) deleteTenants(ctx context.Context, log logr.Logger
 // still grants the SA the permissions to do so. ClusterRoleBindings are deleted last
 // because removing them revokes all RBAC permissions for this SA.
 func (r *LifecycleReconciler) deleteClusterScopedResources(ctx context.Context) error {
+	log := ctrl.LoggerFrom(ctx)
+
 	crList := &rbacv1.ClusterRoleList{}
 	if err := r.List(ctx, crList, componentLabel); err != nil {
 		return fmt.Errorf("list maas-controller ClusterRoles: %w", err)
+	}
+	if len(crList.Items) == 0 {
+		log.Info("no ClusterRoles matched component label; skipping deletion (operator may not have stamped the label)")
 	}
 	for i := range crList.Items {
 		if err := r.Delete(ctx, &crList.Items[i]); err != nil && !apierrors.IsNotFound(err) {
@@ -171,6 +186,9 @@ func (r *LifecycleReconciler) deleteClusterScopedResources(ctx context.Context) 
 	crdList := &apiextensionsv1.CustomResourceDefinitionList{}
 	if err := r.List(ctx, crdList, componentLabel); err != nil {
 		return fmt.Errorf("list maas-controller CRDs: %w", err)
+	}
+	if len(crdList.Items) == 0 {
+		log.Info("no CRDs matched component label; skipping deletion (operator may not have stamped the label)")
 	}
 	for i := range crdList.Items {
 		if err := r.Delete(ctx, &crdList.Items[i]); err != nil && !apierrors.IsNotFound(err) {
@@ -183,6 +201,9 @@ func (r *LifecycleReconciler) deleteClusterScopedResources(ctx context.Context) 
 	crbList := &rbacv1.ClusterRoleBindingList{}
 	if err := r.List(ctx, crbList, componentLabel); err != nil {
 		return fmt.Errorf("list maas-controller ClusterRoleBindings: %w", err)
+	}
+	if len(crbList.Items) == 0 {
+		log.Info("no ClusterRoleBindings matched component label; skipping deletion (operator may not have stamped the label)")
 	}
 	for i := range crbList.Items {
 		if err := r.Delete(ctx, &crbList.Items[i]); err != nil && !apierrors.IsNotFound(err) {

--- a/maas-controller/pkg/controller/maas/self_deployment_controller_test.go
+++ b/maas-controller/pkg/controller/maas/self_deployment_controller_test.go
@@ -67,6 +67,56 @@ func TestLifecycleReconciler(t *testing.T) {
 		g.Expect(res).To(Equal(ctrl.Result{}))
 	})
 
+	t.Run("no-op when Deployment is terminating but CleanupFinalizer is absent", func(t *testing.T) {
+		// W4b contract: if the finalizer was never set (e.g. controller first deployed against
+		// a Deployment that is immediately deleted), Reconcile returns cleanly with no error
+		// and skips all teardown rather than panicking or re-queuing indefinitely.
+		//
+		// The fake client refuses to store objects with DeletionTimestamp but no finalizers, so we
+		// use a placeholder finalizer (not CleanupFinalizer) and Delete to trigger DeletionTimestamp.
+		g := NewWithT(t)
+		const placeholderFinalizer = "test/placeholder"
+		dep := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
+			Name:       depName,
+			Namespace:  depNS,
+			Finalizers: []string{placeholderFinalizer},
+		}}
+		cli := fake.NewClientBuilder().WithScheme(selfDepScheme(t)).WithObjects(dep).Build()
+
+		g.Expect(cli.Delete(t.Context(), dep)).To(Succeed())
+
+		r := &LifecycleReconciler{Client: cli, DeploymentName: depName, DeploymentNS: depNS, TenantNamespace: tenantNS}
+		res, err := r.Reconcile(t.Context(), req)
+		g.Expect(err).ShouldNot(HaveOccurred())
+		g.Expect(res).To(Equal(ctrl.Result{}))
+	})
+
+	t.Run("removes finalizer cleanly when no labeled cluster resources exist", func(t *testing.T) {
+		// W4c contract: if no ClusterRoles/CRDs/ClusterRoleBindings match the component label
+		// (e.g. operator did not stamp the label), deleteClusterScopedResources still returns
+		// nil and the finalizer is released — no panic, no error, no requeue.
+		g := NewWithT(t)
+		now := metav1.NewTime(time.Now())
+		dep := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
+			Name: depName, Namespace: depNS,
+			DeletionTimestamp: &now,
+			Finalizers:        []string{CleanupFinalizer},
+		}}
+		// No Tenant, no labeled ClusterRoles/CRDs/ClusterRoleBindings in the fake store.
+		cli := fake.NewClientBuilder().WithScheme(selfDepScheme(t)).WithObjects(dep).Build()
+
+		r := &LifecycleReconciler{Client: cli, DeploymentName: depName, DeploymentNS: depNS, TenantNamespace: tenantNS}
+		res, err := r.Reconcile(t.Context(), req)
+		g.Expect(err).ShouldNot(HaveOccurred())
+		g.Expect(res).To(Equal(ctrl.Result{}))
+
+		// Finalizer removed → fake client GCs the Deployment.
+		var updated appsv1.Deployment
+		getErr := cli.Get(t.Context(), req.NamespacedName, &updated)
+		g.Expect(getErr).Should(HaveOccurred())
+		g.Expect(getErr.Error()).To(ContainSubstring("not found"))
+	})
+
 	t.Run("deletes Tenants then RBAC and CRDs when Deployment is terminating", func(t *testing.T) {
 		g := NewWithT(t)
 		now := metav1.NewTime(time.Now())

--- a/maas-controller/pkg/controller/maas/tenant_controller.go
+++ b/maas-controller/pkg/controller/maas/tenant_controller.go
@@ -54,19 +54,17 @@ type TenantReconciler struct {
 	TenantNamespace string
 }
 
+// Tenant platform pipeline — resources the TenantReconciler creates and manages on behalf of maas-api.
 // +kubebuilder:rbac:groups=maas.opendatahub.io,resources=tenants,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=maas.opendatahub.io,resources=tenants/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=maas.opendatahub.io,resources=tenants/finalizers,verbs=update
 // +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=gateways,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;patch;delete
-// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;patch;delete
 // +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;patch;delete
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;patch;delete
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;create;patch;delete
 // +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=httproutes,verbs=get;list;watch;create;patch;delete
-// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=get;list;watch;create;patch;delete
-// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings,verbs=get;list;watch;create;patch;delete
 // +kubebuilder:rbac:groups=config.openshift.io,resources=authentications,verbs=get;list;watch
 // +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch
 // +kubebuilder:rbac:groups=operator.authorino.kuadrant.io,resources=authorinos,verbs=get;list;watch
@@ -79,9 +77,19 @@ type TenantReconciler struct {
 // +kubebuilder:rbac:groups=monitoring.coreos.com,resources=podmonitors,verbs=get;list;watch;create;patch;delete
 // +kubebuilder:rbac:groups=perses.dev,resources=persesdashboards;persesdatasources,verbs=get;list;watch;create;patch;delete
 
-// maas-controller creates the maas-api ClusterRole via SSA.
-// The rules below mirror the maas-api ClusterRole so the controller can pass the API-server escalation check.
-//
+// clusterroles/clusterrolebindings: TenantReconciler SSA-applies the maas-api and payload-processing-reader
+// ClusterRoles. The API-server escalation check requires the applying SA to already hold every permission those
+// ClusterRoles grant — which is why secrets get;list;watch must remain unrestricted (payload-processing-reader
+// grants unrestricted get on secrets; Kubernetes also does not support resourceNames on list/watch).
+// The client-side predicate secretNamedMaaSDB() filters informer events to maas-db-config only.
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=get;list;watch;create;patch;delete
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings,verbs=get;list;watch;create;patch;delete
+
+// Escalation-check mirror for maas-api ClusterRole — maas-controller must hold every verb it grants.
+// namespaces create: bootstrap the subscription namespace at startup (ensureSubscriptionNamespaceWithClient).
+// serviceaccounts/token create, tokenreviews, subjectaccessreviews: required by maas-api for bound SA token
+// projection and access checks. maasmodelrefs/maassubscriptions: read-only cross-reconciler references.
 // +kubebuilder:rbac:groups="",resources=endpoints,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch;create
 // +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch


### PR DESCRIPTION
Addresses https://redhat.atlassian.net/browse/RHOAIENG-60708

## Description
Post-split cleanup for `maas-controller` RBAC, CR lifecycle edge cases, and controller observability. Addresses the three ACs from the ticket:

**AC1 / AC3** — RBAC justification at source

Moved RBAC permission rationale from `clusterrole.yaml` (where `controller-gen` strips it on every regeneration) into the `+kubebuilder:rbac` marker blocks in Go source, where it is permanent and visible to developers changing permissions:

* `tenant_controller.go`: documents why secrets `get;list;watch` must remain unrestricted (`payload-processing-reader` escalation check + Kubernetes `list/watch` cannot use resourceNames); why `clusterroles/clusterrolebindings` CRUD is required (SSA-applies `maas-api` and `payload-processing-reader` ClusterRoles); and the escalation-check mirror pattern for maas-api verbs (`endpoints`, `pods`, `serviceaccounts/token`, `tokenreviews`, `subjectaccessreviews`).
* `self_deployment_controller.go`: documents the teardown-only `list;delete` verbs for ClusterRoles and CRDs used by LifecycleReconciler on ODH disable.

**AC2** — CR lifecycle nil/partial CR handling

Three targeted fixes with matching unit tests:
* `maasauthpolicy_controller.go`: `fetchOIDCConfig` moved after the MaaSAuthPolicy not-found guard — stale or deleted-race reconcile events no longer trigger an unnecessary Tenant Get.
* `self_deployment_controller.go`: log a visible Info message when a terminating Deployment has no CleanupFinalizer (previously a silent no-op with no observability).
* `self_deployment_controller.go`: log a visible Info message in deleteClusterScopedResources when no ClusterRoles, CRDs, or ClusterRoleBindings match the componentLabel — surfaces cases where the operator did not stamp the label.
* main.go: document the four-step startup ordering contract (namespace bootstrap → ensureDefaultTenantRunnable → TenantReconciler → ODH operator race window) as a code comment.


## How Has This Been Tested?
```
# Unit tests — all pass including three new tests
make -C maas-controller test

# Generated files still in sync with markers after comments moved to Go source
make -C maas-controller manifests verify-codegen
```
Also, added couple of new unit tests

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced handling of stale events in authentication policy reconciliation to prevent unnecessary operations.

* **Documentation**
  * Clarified startup ordering contract and expanded RBAC permissions documentation for controller initialization.

* **Improvements**
  * Added explicit logging for deployment cleanup operations for better observability.

* **Tests**
  * Increased test coverage for edge cases including missing finalizers and stale event scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->