### PR TITLE
chore: increase maas-controller terminationGracePeriod to 10 minutes

### DIFF
--- a/deployment/base/maas-controller/manager/manager.yaml
+++ b/deployment/base/maas-controller/manager/manager.yaml
@@ -100,4 +100,8 @@ spec:
             cpu: 10m
             memory: 64Mi
       serviceAccountName: maas-controller
-      terminationGracePeriodSeconds: 10
+      # Allow up to 10 minutes for the LifecycleReconciler to complete the full
+      # teardown sequence (Tenants → ClusterRoles → CRDs → ClusterRoleBindings)
+      # before the pod is killed. The default 10s is far too short for Tenant
+      # finalizers to cascade through maas-api, auth policies, and dashboards.
+      terminationGracePeriodSeconds: 600


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The maas-controller pod had a terminationGracePeriodSeconds of 10s. When ODH disables MaaS and deletes the Deployment, the LifecycleReconciler runs a sequential cleanup:

```
Delete Tenants → wait for Tenant finalizers to cascade (maas-api, auth policies, dashboards)
→ Delete ClusterRoles, CRDs → Delete ClusterRoleBindings → Remove cleanup finalizer
```

This chain takes minutes, far longer than 10 seconds. When the pod was killed before cleanup finished, the maas.opendatahub.io/cleanup finalizer remained on the Deployment, blocking deletion of the opendatahub namespace and breaking subsequent test runs.

Raises terminationGracePeriodSeconds to 600s (10 minutes) to give the controller enough time to complete the full teardown before being force-killed.

## How Has This Been Tested?
Observed in CI: after the e2e test suite timed out, the opendatahub namespace was stuck with:
```
NamespaceFinalizersRemaining: maas.opendatahub.io/cleanup in 1 resource instances
NamespaceContentRemaining: deployments.apps has 1 resource instances
```
All three CI retries failed at cleanup for the same reason. The 10s grace period was confirmed to be the root cause.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased pod termination grace period for improved shutdown reliability in the controller deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->