### PR TITLE
chore: update llm-katan simulator endpoint to new AWS instance

### DIFF
--- a/test/e2e/scripts/LOCAL-DEPLOY.md
+++ b/test/e2e/scripts/LOCAL-DEPLOY.md
@@ -78,7 +78,7 @@ Kind cluster (maas-local)
 +-- kube-system (7 pods)                # Kubernetes core
 |
 +-- llm (0 pods, networking only)       # External model namespace
-|   +-- ExternalModel: llm-katan-openai # -> 3-13-21-181.sslip.io (AWS, Let's Encrypt TLS)
+|   +-- ExternalModel: llm-katan-openai # -> 3-147-232-199.sslip.io (AWS, Let's Encrypt TLS)
 |   +-- ServiceEntry + DestinationRule  # Created by controller
 |   +-- HTTPRoute + AuthPolicy          # Created by controller
 |

--- a/test/e2e/scripts/local-deploy.sh
+++ b/test/e2e/scripts/local-deploy.sh
@@ -1311,7 +1311,7 @@ ok "MaaS controller + API deployed"
 
 step "Deploying test fixtures"
 
-LLM_KATAN_FQDN="${LLM_KATAN_FQDN:-3-13-21-181.sslip.io}"
+LLM_KATAN_FQDN="${LLM_KATAN_FQDN:-3-147-232-199.sslip.io}"
 MODEL_NAMESPACE="llm"
 INTERNAL_MODEL_NAMESPACE="llm-internal"
 


### PR DESCRIPTION
## Summary
- Migrate llm-katan simulator endpoint from `3-13-21-181.sslip.io` to `3-147-232-199.sslip.io` (new AWS account)
- Same llm-katan version (0.15.3), same configuration, lifetime stats preserved

## Files changed
- `test/e2e/scripts/local-deploy.sh` — default `LLM_KATAN_FQDN`
- `test/e2e/scripts/LOCAL-DEPLOY.md` — documentation reference

## Test plan
- [x] New endpoint verified: health, all 5 providers, tool calling, streaming, auth, stats, dashboard
- [x] TLS cert valid (Let's Encrypt via sslip.io)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated external model endpoint configuration in deployment guide.

* **Tests**
  * Added new authentication enforcement tests for external models to verify proper authorization requirements are applied.

* **Chores**
  * Updated default endpoint configuration in deployment script.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->