### PR TITLE
fix: add timeout to cleanup finalizer to prevent stuck namespace deletion

### DIFF
--- a/maas-controller/pkg/controller/maas/self_deployment_controller.go
+++ b/maas-controller/pkg/controller/maas/self_deployment_controller.go
@@ -109,23 +109,35 @@ func (r *LifecycleReconciler) ensureFinalizer(ctx context.Context, log logr.Logg
 	return nil
 }
 
+// cleanupTimeout bounds the total time we wait for Tenants to terminate.
+// If exceeded, we force-remove the finalizer so the Deployment (and its
+// namespace) can be deleted. Without this, a namespace delete kills the
+// controller pod before cleanup finishes, leaving the finalizer stuck.
+const cleanupTimeout = 2 * time.Minute
+
 // runCleanup drives the teardown sequence when the Deployment is terminating:
 // delete Tenants, wait for them to be gone, then delete RBAC and CRDs, then
-// release the finalizer.
+// release the finalizer. If the cleanup takes longer than cleanupTimeout
+// (measured from DeletionTimestamp), the finalizer is force-removed.
 func (r *LifecycleReconciler) runCleanup(ctx context.Context, log logr.Logger, dep *appsv1.Deployment) (ctrl.Result, error) {
 	log.Info("Deployment is terminating; running cleanup before releasing finalizer")
 
+	timedOut := time.Since(dep.DeletionTimestamp.Time) > cleanupTimeout
+
 	pending, err := r.deleteTenants(ctx, log)
 	if err != nil {
-		return ctrl.Result{}, err
+		log.Error(err, "error deleting Tenants during cleanup")
 	}
-	if pending {
+	if pending && !timedOut {
 		log.Info("waiting for Tenant CRs to finish terminating")
 		return ctrl.Result{RequeueAfter: requeueInterval}, nil
 	}
+	if timedOut && pending {
+		log.Info("cleanup timeout exceeded with Tenants still pending; force-releasing finalizer")
+	}
 
 	if err := r.deleteClusterScopedResources(ctx); err != nil {
-		return ctrl.Result{}, err
+		log.Error(err, "error deleting cluster-scoped resources during cleanup")
 	}
 
 	controllerutil.RemoveFinalizer(dep, CleanupFinalizer)


### PR DESCRIPTION
The `LifecycleReconciler` adds `maas.opendatahub.io/cleanup` finalizer to the maas-controller Deployment and removes it after cleaning up Tenants and cluster-scoped resources. When a **namespace** is deleted (e.g., during ODH e2e test teardown), the controller pod is terminated before cleanup completes, leaving the finalizer stuck. The Deployment can't be garbage-collected, and the namespace stays in `Terminating` indefinitely.

This is currently blocking all PRs from merging to `opendatahub-operator` — the RHOAI e2e test fails on every run with:
```
NamespaceFinalizersRemaining: Some content in the namespace has finalizers
remaining: maas.opendatahub.io/cleanup in 1 resource instances
```

**Fix:** Add a 2-minute timeout (measured from `DeletionTimestamp`) to `runCleanup`. If Tenants are still pending after the timeout, force-remove the finalizer so the Deployment and namespace can be deleted. Cleanup errors are logged but no longer block finalizer removal.

**File:** `maas-controller/pkg/controller/maas/self_deployment_controller.go`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Introduced a 2-minute timeout for deployment cleanup to prevent indefinite waiting during teardown operations.
  * Enhanced error resilience during cleanup, allowing the process to continue gracefully despite failures instead of halting entirely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->