### PR TITLE
fix: use odh-stable image tags in odh overlay and add dev overlay

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,9 +75,11 @@ Konflux builds multi-arch container images (x86_64, arm64, ppc64le, s390x) for b
 | Pipeline | Trigger | Output image |
 |----------|---------|--------------|
 | `odh-maas-api-on-pull-request` | PR to `main` | `quay.io/opendatahub/maas-api:odh-pr` |
-| `odh-maas-api-on-push` | Push to `main` | `quay.io/opendatahub/maas-api:odh-stable` |
+| `odh-maas-api-on-push` | Push to `main` | `quay.io/opendatahub/maas-api:latest` |
+| `odh-maas-api-on-push-stable` | Push to `stable` | `quay.io/opendatahub/maas-api:odh-stable` |
 | `odh-maas-controller-on-pull-request` | PR to `main` | `quay.io/opendatahub/maas-controller:odh-pr` |
-| `odh-maas-controller-on-push` | Push to `main` | `quay.io/opendatahub/maas-controller:odh-stable` |
+| `odh-maas-controller-on-push` | Push to `main` | `quay.io/opendatahub/maas-controller:latest` |
+| `odh-maas-controller-on-push-stable` | Push to `stable` | `quay.io/opendatahub/maas-controller:odh-stable` |
 
 **Integration tests (e2e):** When a PR build completes, Konflux runs an integration test that provisions an ephemeral OpenShift cluster (HyperShift on AWS), deploys the ODH stack with the newly built images, and runs `test/e2e/scripts/prow_run_smoke_test.sh`. This is defined in `odh-konflux-central` under `integration-tests/models-as-a-service/`.
 

--- a/deployment/base/maas-api/core/kustomization.yaml
+++ b/deployment/base/maas-api/core/kustomization.yaml
@@ -10,4 +10,4 @@ resources:
 images:
   - name: maas-api
     newName: quay.io/opendatahub/maas-api
-    newTag: latest
+    newTag: odh-stable

--- a/deployment/base/maas-controller/manager/kustomization.yaml
+++ b/deployment/base/maas-controller/manager/kustomization.yaml
@@ -7,4 +7,4 @@ resources:
 images:
 - name: maas-controller
   newName: quay.io/opendatahub/maas-controller
-  newTag: latest
+  newTag: odh-stable

--- a/deployment/overlays/dev/params.env
+++ b/deployment/overlays/dev/params.env
@@ -1,0 +1,2 @@
+maas-api-image=quay.io/opendatahub/maas-api:latest
+maas-controller-image=quay.io/opendatahub/maas-controller:latest

--- a/deployment/overlays/odh/params.env
+++ b/deployment/overlays/odh/params.env
@@ -1,5 +1,5 @@
-maas-api-image=quay.io/opendatahub/maas-api:latest
-maas-controller-image=quay.io/opendatahub/maas-controller:latest
+maas-api-image=quay.io/opendatahub/maas-api:odh-stable
+maas-controller-image=quay.io/opendatahub/maas-controller:odh-stable
 payload-processing-image=quay.io/opendatahub/odh-ai-gateway-payload-processing:odh-stable
 maas-api-key-cleanup-image=registry.redhat.io/ubi9/ubi-minimal:9.7
 payload-processing-replicas=1

--- a/docs/content/contributing/release-strategy.md
+++ b/docs/content/contributing/release-strategy.md
@@ -47,6 +47,24 @@ Both promotion workflows support `workflow_dispatch`, so they can be triggered o
 
 This is useful when a fix needs to be fast-tracked without waiting for the next scheduled run.
 
+## Image Tags
+
+Each branch produces and references a specific container image tag:
+
+| Branch | Image Tag | Built By | Manifests |
+|--------|-----------|----------|-----------|
+| `main` | `latest` | Tekton push pipeline (`odh-maas-*-push.yaml`) | `deployment/overlays/dev/` |
+| `stable` | `odh-stable` | Tekton push pipeline (`odh-maas-*-push-stable.yaml`) | `deployment/overlays/odh/` |
+
+The ODH operator consumes manifests from `deployment/overlays/odh/` on the `stable` branch.
+
+### Overlay Layout
+
+- **`deployment/overlays/odh/`** — Production overlay with `:odh-stable` tags. Consumed by the ODH operator.
+- **`deployment/overlays/dev/`** — Development overlay with `:latest` tags. Used by MaaS developers via `./scripts/deploy.sh --dev`.
+
+Both overlays exist identically on all branches. The `dev` overlay wraps `odh` and overrides only the image tags.
+
 ## Release Notes
 
 Release notes in `docs/content/release-notes/index.md` summarize user-visible changes for each MaaS version. Keep them concise and focused on **what changed** and **why it matters**—link to detailed docs for **how** to migrate or configure.

--- a/docs/content/contributing/testing-guide.md
+++ b/docs/content/contributing/testing-guide.md
@@ -48,6 +48,12 @@ test/e2e/
 
 ## Running Tests
 
+!!! tip "Development images"
+    By default, `deploy.sh` uses `:odh-stable` images from the `odh` overlay. To deploy with `:latest` images (built from `main`), pass `--dev`:
+    ```bash
+    ./scripts/deploy.sh --dev
+    ```
+
 ### Unit Tests (Go)
 
 === "maas-api"

--- a/maas-api/deploy/overlays/dev/kustomization.yaml
+++ b/maas-api/deploy/overlays/dev/kustomization.yaml
@@ -5,7 +5,38 @@ metadata:
   name: maas-api-dev
 
 resources:
-- ../../../../deployment/base/maas-api
+  - ../odh
+
+configMapGenerator:
+- name: maas-parameters
+  envs:
+    - params.env
+  behavior: merge
+generatorOptions:
+  disableNameSuffixHash: true
 
 patches:
 - path: patches/debug-mode.yaml
+
+# Re-run image replacements with updated ConfigMap values
+replacements:
+- source:
+    kind: ConfigMap
+    name: maas-parameters
+    fieldPath: data.maas-api-image
+  targets:
+  - select:
+      kind: Deployment
+      name: maas-api
+    fieldPaths:
+    - spec.template.spec.containers.[name=maas-api].image
+- source:
+    kind: ConfigMap
+    name: maas-parameters
+    fieldPath: data.maas-controller-image
+  targets:
+  - select:
+      kind: Deployment
+      name: maas-controller
+    fieldPaths:
+    - spec.template.spec.containers.[name=manager].image

--- a/maas-api/deploy/overlays/dev/params.env
+++ b/maas-api/deploy/overlays/dev/params.env
@@ -1,0 +1,2 @@
+maas-api-image=quay.io/opendatahub/maas-api:latest
+maas-controller-image=quay.io/opendatahub/maas-controller:latest

--- a/maas-api/deploy/overlays/odh/params.env
+++ b/maas-api/deploy/overlays/odh/params.env
@@ -1,6 +1,6 @@
 # Image configuration (overridden by RELATED_IMAGE_* env vars at runtime)
-maas-api-image=quay.io/opendatahub/maas-api:latest
-maas-controller-image=quay.io/opendatahub/maas-controller:latest
+maas-api-image=quay.io/opendatahub/maas-api:odh-stable
+maas-controller-image=quay.io/opendatahub/maas-controller:odh-stable
 # Gateway configuration (overridden by CustomizeParams from Tenant spec)
 gateway-namespace=openshift-ingress
 gateway-name=maas-default-gateway

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -18,6 +18,7 @@
 #   --namespace <namespace>       Target namespace
 #   --verbose                     Enable debug logging
 #   --dry-run                     Show what would be done
+#   --dev                         Use dev overlay with :latest images
 #   --help                        Show full help with all options
 #
 # ADVANCED OPTIONS (PR Testing):
@@ -102,6 +103,7 @@ ENABLE_TLS_BACKEND="${ENABLE_TLS_BACKEND:-true}"
 ENABLE_KEYCLOAK="${ENABLE_KEYCLOAK:-false}"
 VERBOSE="${VERBOSE:-false}"
 DRY_RUN="${DRY_RUN:-false}"
+DEV_MODE="${DEV_MODE:-false}"
 OPERATOR_CATALOG="${OPERATOR_CATALOG:-}"
 OPERATOR_IMAGE="${OPERATOR_IMAGE:-}"
 OPERATOR_CHANNEL="${OPERATOR_CHANNEL:-}"
@@ -162,6 +164,10 @@ OPTIONS:
 
   --dry-run
       Show what would be done without applying changes
+
+  --dev
+      Use dev overlay with :latest images (for MaaS developers)
+      Default: uses odh overlay with :odh-stable images
 
   --help
       Display this help message
@@ -334,6 +340,10 @@ parse_arguments() {
         ;;
       --external-oidc)
         EXTERNAL_OIDC="true"
+        shift
+        ;;
+      --dev)
+        DEV_MODE="true"
         shift
         ;;
       --help|-h)
@@ -1439,13 +1449,15 @@ patch_operator_csv() {
 #──────────────────────────────────────────────────────────────
 
 # get_odh_overlay_param
-#   Reads a value from deployment/overlays/odh/params.env.
+#   Reads a value from the active overlay's params.env.
 get_odh_overlay_param() {
   local key="$1"
   local project_root
   project_root="$(find_project_root)" || return 1
 
-  local params_file="$project_root/deployment/overlays/odh/params.env"
+  local overlay="odh"
+  [[ "${DEV_MODE:-false}" == "true" ]] && overlay="dev"
+  local params_file="$project_root/deployment/overlays/$overlay/params.env"
   [[ -f "$params_file" ]] || return 1
 
   awk -F= -v key="$key" '$1 == key { print substr($0, index($0, "=") + 1); exit }' "$params_file"

--- a/scripts/deployment-helpers.sh
+++ b/scripts/deployment-helpers.sh
@@ -874,7 +874,9 @@ find_project_root() {
 #   Patches a key=value line in params.env. Creates a backup on first call.
 _patch_params_env() {
   local key="$1" value="$2" project_root="$3"
-  export _MAAS_PARAMS_ENV="$project_root/deployment/overlays/odh/params.env"
+  local overlay="odh"
+  [[ "${DEV_MODE:-false}" == "true" ]] && overlay="dev"
+  export _MAAS_PARAMS_ENV="$project_root/deployment/overlays/$overlay/params.env"
   [ -f "$_MAAS_PARAMS_ENV" ] || return 0
   export _MAAS_PARAMS_ENV_BACKUP="${_MAAS_PARAMS_ENV}.backup"
   if [ ! -f "$_MAAS_PARAMS_ENV_BACKUP" ]; then


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-60590

## Summary

- Change `deployment/overlays/odh/params.env` image tags from `:latest` to `:odh-stable` so the ODH operator (which reads from the `stable` branch) deploys images matching the stable codebase
- Change base kustomization `newTag` values to `odh-stable` for consistency
- Create `deployment/overlays/dev/params.env` with `:latest` tags for the deploy script's `--dev` flag
- Update `maas-api/deploy/overlays/dev/` to wrap the odh overlay with `:latest` image overrides
- Add `--dev` flag to `deploy.sh` to select the dev overlay
- Document the branch-to-image-tag mapping in `docs/content/contributing/release-strategy.md`
- Update `CONTRIBUTING.md` Tekton pipeline table (outdated after PR #877)

## Test plan

- [x] `kustomize build deployment/overlays/odh` — N/A (no kustomization.yaml since #840)
- [x] `kustomize build maas-api/deploy/overlays/odh` produces `:odh-stable` tags
- [x] `kustomize build maas-api/deploy/overlays/dev` produces `:latest` tags
- [x] `diff` between maas-api odh and dev overlays shows only image tag lines differ
- [x] `./scripts/ci/validate-manifests.sh` passes for all kustomization files (tested with kustomize 5.7.1 to match CI)
- [x] `deploy.sh --help` shows `--dev` flag
- [x] `deploy.sh --dev --dry-run` sets `DEV_MODE=true`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--dev` flag to deployment script to enable development-mode image deployments.

* **Documentation**
  * Updated CI pipeline documentation with clarified image tag conventions for different branches and overlays.
  * Added testing guide section explaining development vs. stable image selection for deployments.
  * Added release strategy documentation covering image tag conventions and overlay layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->