### PR TITLE
fix: route subscription latency to odh monitoring stack

### DIFF
--- a/deployment/base/observability/istio-gateway-servicemonitor.yaml
+++ b/deployment/base/observability/istio-gateway-servicemonitor.yaml
@@ -7,6 +7,9 @@ metadata:
   labels:
     app.kubernetes.io/part-of: maas-observability
     app.kubernetes.io/managed-by: maas-observability
+    monitoring.opendatahub.io/scrape: 'true'
+    monitoring.openshift.io/collection-profile: minimal
+    openshift.io/user-monitoring: 'false'
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The metric of latency at the gateway-level that enables tracking latency per-subscription is not generated by default, but the resources we provide for enabling it make it go to both cluster monitoring (as it resides in the openshift-ingress namespace that is labeled with "openshift.io/cluster-monitoring: 'true'"), and to the user-workload-monitoring stacks, when enabled.

The labels that are added here change this so that it will be scraped only by the ODH/RHOAI monitoring stack.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually on a cluster that includes a fix for the scraping for the ODH/RHOAI monitoring stack.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled metrics scraping so this component’s telemetry can be collected by the OpenShift/ODH monitoring stack.
  * Set the OpenShift collection profile to "minimal" to reduce the volume of diagnostic data gathered.
  * Disabled OpenShift user-monitoring for this component to prevent user-level monitoring data from being collected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->