### PR TITLE
fix: update default RHOAI operator channel from fast-3.x to stable-3.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ For detailed instructions, see the [Installation Guide](docs/content/quickstart.
 |------|-------------|---------|
 | `--operator-catalog` | Custom operator catalog/index image | `quay.io/opendatahub/catalog:pr-456` |
 | `--operator-image` | Custom operator image (patches CSV) | `quay.io/opendatahub/operator:pr-456` |
-| `--channel` | Operator channel override | `fast`, `fast-3` |
+| `--channel` | Operator channel override | `fast-3`, `stable-3.x` |
 
 ### Environment Variables
 

--- a/docs/content/install/platform-setup.md
+++ b/docs/content/install/platform-setup.md
@@ -437,7 +437,7 @@ Install the platform operator (ODH or RHOAI) and initialize the platform with DS
       name: rhoai3-operator
       namespace: redhat-ods-operator
     spec:
-      channel: fast-3.x
+      channel: stable-3.x
       installPlanApproval: Automatic
       name: rhods-operator
       source: redhat-operators

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -45,7 +45,7 @@ Automated deployment script for OpenShift clusters supporting both operator-base
 - `--dry-run` - Show what would be done without applying changes
 - `--operator-catalog <image>` - Custom operator catalog image for PR testing
 - `--operator-image <image>` - Custom operator image for PR testing
-- `--channel <channel>` - Operator channel override (default: fast-3 for ODH, fast-3.x for RHOAI)
+- `--channel <channel>` - Operator channel override (default: fast-3 for ODH, stable-3.x for RHOAI)
 
 **Requirements:**
 - OpenShift cluster (4.19.9+)

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -185,7 +185,7 @@ ADVANCED OPTIONS (PR Testing):
 
   --channel <channel>
       Operator channel override
-      Default: fast-3 (ODH), fast-3.x (RHOAI)
+      Default: fast-3 (ODH), stable-3.x (RHOAI)
 
   --external-oidc
       Enable external OIDC on the maas-api AuthPolicy.
@@ -973,9 +973,9 @@ install_primary_operator() {
         channel="${OPERATOR_CHANNEL:-fast}"
       else
         catalog_source="redhat-operators"
-        # Use 'fast-3.x' channel for RHOAI v3 (with MaaS support)
+        # Use 'stable-3.x' channel for RHOAI v3 (with MaaS support)
         # RHOAI 2.x (fast channel) does not support modelsAsService
-        channel="${OPERATOR_CHANNEL:-fast-3.x}"
+        channel="${OPERATOR_CHANNEL:-stable-3.x}"
       fi
 
       log_info "Installing RHOAI v3 operator..."

--- a/scripts/deployment-helpers.sh
+++ b/scripts/deployment-helpers.sh
@@ -503,7 +503,7 @@ should_install_operator() {
 #   operator_name - Name of the operator (e.g., "rhods-operator")
 #   namespace - Target namespace for the operator
 #   catalog_source - CatalogSource name (e.g., "redhat-operators")
-#   channel - Subscription channel (e.g., "fast-3")
+#   channel - Subscription channel (e.g., "stable-3.x")
 #   starting_csv - Starting CSV (optional, can be empty)
 #   operatorgroup_target - Target namespace for OperatorGroup (optional, uses namespace if empty)
 #   source_namespace - Catalog source namespace (optional, defaults to openshift-marketplace)


### PR DESCRIPTION
## Description

Updates the default operator subscription channel for RHOAI from `fast-3.x` to `stable-3.x` now that RHOAI 3.4 is GA.

`stable-3.x` resolves to `rhods-operator.3.4.0` while `fast-3.x` was stuck at `rhods-operator.3.3.1`.

ODH defaults remain on `fast-3` (the only v3 channel available in `community-operators`, currently resolving to `opendatahub-operator.v3.4.0`).

Changes across `scripts/deploy.sh`, `.github/hack/install-odh.sh`, docs, and READMEs.

Ref: [RHOAIENG-62541](https://redhat.atlassian.net/browse/RHOAIENG-62541)

## How Has This Been Tested?

- Verified available channels via `oc get packagemanifest` on a live OCP 4.21 cluster:
  - RHOAI `stable-3.x` -> `rhods-operator.3.4.0`
  - ODH `fast-3` -> `opendatahub-operator.v3.4.0`
  - Confirmed `stable-3.x` does not exist for ODH `community-operators`
- Deployed ODH with `fast-3` channel using `deploy.sh` — operator v3.4.0 installed, DSCI ready, DSC created, gateway programmed, kuadrant ready, postgres deployed, TLS configured, maas-api running

## Merge criteria:

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work

## Risk analysis

- **Risk rating**: 2
- **Why**: Script-only change affecting default channel values. Low blast radius — only impacts fresh deployments that don't override `--channel`. Validated on a live cluster. Existing `--channel` overrides continue to work unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Revised all deployment documentation, installation guides, and related resources with updated operator channel configurations for OpenShift AI deployments.
  * Updated default `--channel` parameter values across deployment tooling and documentation to reflect current operator subscription channel recommendations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->