### PR TITLE
feat(maas-api): enrich model refs with displayName and description in GET /subscriptions

### DIFF
--- a/.github/workflows/openapi-validation.yml
+++ b/.github/workflows/openapi-validation.yml
@@ -115,8 +115,11 @@ jobs:
           # Run breaking change detection
           oasdiff breaking base-spec.yaml maas-api/openapi3.yaml > breaking-changes.txt || true
 
-          # Check if actual breaking changes were detected (not just "No changes detected" message)
-          if [ -s breaking-changes.txt ] && ! grep -q "^No changes detected$" breaking-changes.txt; then
+          # Check if actual breaking changes were detected.
+          # oasdiff outputs "No changes detected" when specs are identical, and
+          # "No breaking changes to report, but the specs are different" when only
+          # non-breaking changes (e.g. new optional fields) are present. Both are safe.
+          if [ -s breaking-changes.txt ] && ! grep -qE "^No changes detected$|^No breaking changes" breaking-changes.txt; then
             echo "has_breaking_changes=true" >> $GITHUB_OUTPUT
             echo "## ⚠️  Breaking Changes Detected" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY

--- a/maas-api/cmd/main.go
+++ b/maas-api/cmd/main.go
@@ -184,7 +184,7 @@ func registerHandlers(ctx context.Context, log *logger.Logger, router *gin.Engin
 
 	v1Routes := router.Group("/v1")
 
-	subscriptionSelector := subscription.NewSelector(log, cluster.MaaSSubscriptionLister)
+	subscriptionSelector := subscription.NewSelector(log, cluster.MaaSSubscriptionLister, cluster.MaaSModelRefLister)
 
 	resolveCtx, resolveCancel := context.WithTimeout(ctx, time.Duration(cfg.AccessCheckTimeoutSeconds)*time.Second)
 	gatewayInternalHost, err := config.ResolveGatewayInternalHost(resolveCtx, cluster.ClientSet, cfg.GatewayName, cfg.GatewayNamespace)

--- a/maas-api/internal/handlers/models_test.go
+++ b/maas-api/internal/handlers/models_test.go
@@ -340,7 +340,7 @@ func TestListingModels(t *testing.T) {
 	defer cleanup()
 
 	// Create a mock subscription selector that auto-selects for single subscription users
-	subscriptionSelector := subscription.NewSelector(testLogger, &fakeSubscriptionLister{})
+	subscriptionSelector := subscription.NewSelector(testLogger, &fakeSubscriptionLister{}, nil)
 
 	modelsHandler := handlers.NewModelsHandler(testLogger, modelMgr, subscriptionSelector, maasModelRefLister)
 
@@ -458,7 +458,7 @@ func TestListingModelsWithSubscriptionHeader(t *testing.T) {
 		"premium": []string{"premium-users"},
 		"free":    []string{"free-users"},
 	}
-	subscriptionSelector := subscription.NewSelector(testLogger, multiSubLister)
+	subscriptionSelector := subscription.NewSelector(testLogger, multiSubLister, nil)
 
 	modelsHandler := handlers.NewModelsHandler(testLogger, modelMgr, subscriptionSelector, maasModelRefLister)
 	tokenHandler := token.NewHandler(testLogger, fixtures.TestTenant)
@@ -678,7 +678,7 @@ func TestListModels_ReturnAllModels(t *testing.T) {
 	modelMgr, err := models.NewManager(testLogger, 15, "")
 	require.NoError(t, err)
 
-	subscriptionSelector := subscription.NewSelector(testLogger, subscriptionLister)
+	subscriptionSelector := subscription.NewSelector(testLogger, subscriptionLister, nil)
 	modelsHandler := handlers.NewModelsHandler(testLogger, modelMgr, subscriptionSelector, lister)
 
 	config := fixtures.TestServerConfig{Objects: []runtime.Object{}}
@@ -731,7 +731,7 @@ func TestListModels_ReturnAllModels(t *testing.T) {
 			},
 		}
 
-		subscriptionSelector := subscription.NewSelector(testLogger, emptySubscriptionLister)
+		subscriptionSelector := subscription.NewSelector(testLogger, emptySubscriptionLister, nil)
 		emptyHandler := handlers.NewModelsHandler(testLogger, modelMgr, subscriptionSelector, lister)
 
 		config := fixtures.TestServerConfig{Objects: []runtime.Object{}}
@@ -867,7 +867,7 @@ func TestListModels_DeduplicationBySubscription(t *testing.T) {
 	modelMgr, err := models.NewManager(testLogger, 15, "")
 	require.NoError(t, err)
 
-	subscriptionSelector := subscription.NewSelector(testLogger, subscriptionLister)
+	subscriptionSelector := subscription.NewSelector(testLogger, subscriptionLister, nil)
 	modelsHandler := handlers.NewModelsHandler(testLogger, modelMgr, subscriptionSelector, lister)
 
 	config := fixtures.TestServerConfig{Objects: []runtime.Object{}}
@@ -985,7 +985,7 @@ func TestListModels_DifferentModelRefsWithSameModelID(t *testing.T) {
 	modelMgr, err := models.NewManager(testLogger, 15, "")
 	require.NoError(t, err)
 
-	subscriptionSelector := subscription.NewSelector(testLogger, subscriptionLister)
+	subscriptionSelector := subscription.NewSelector(testLogger, subscriptionLister, nil)
 	modelsHandler := handlers.NewModelsHandler(testLogger, modelMgr, subscriptionSelector, lister)
 
 	config := fixtures.TestServerConfig{Objects: []runtime.Object{}}
@@ -1092,7 +1092,7 @@ func TestListModels_DifferentModelRefsWithSameURLAndModelID(t *testing.T) {
 	modelMgr, err := models.NewManager(testLogger, 15, "")
 	require.NoError(t, err)
 
-	subscriptionSelector := subscription.NewSelector(testLogger, subscriptionLister)
+	subscriptionSelector := subscription.NewSelector(testLogger, subscriptionLister, nil)
 	modelsHandler := handlers.NewModelsHandler(testLogger, modelMgr, subscriptionSelector, lister)
 
 	config := fixtures.TestServerConfig{Objects: []runtime.Object{}}
@@ -1198,7 +1198,7 @@ func TestListModels_DifferentModelRefsWithSameModelIDAndDifferentSubscriptions(t
 	modelMgr, err := models.NewManager(testLogger, 15, "")
 	require.NoError(t, err)
 
-	subscriptionSelector := subscription.NewSelector(testLogger, subscriptionLister)
+	subscriptionSelector := subscription.NewSelector(testLogger, subscriptionLister, nil)
 	modelsHandler := handlers.NewModelsHandler(testLogger, modelMgr, subscriptionSelector, lister)
 
 	config := fixtures.TestServerConfig{Objects: []runtime.Object{}}

--- a/maas-api/internal/subscription/handler_test.go
+++ b/maas-api/internal/subscription/handler_test.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/opendatahub-io/models-as-a-service/maas-api/internal/logger"
+	"github.com/opendatahub-io/models-as-a-service/maas-api/internal/models"
 	"github.com/opendatahub-io/models-as-a-service/maas-api/internal/subscription"
 	"github.com/opendatahub-io/models-as-a-service/maas-api/internal/token"
 )
@@ -80,7 +81,7 @@ func setupTestRouter(lister subscription.Lister) *gin.Engine {
 	router := gin.New()
 
 	log := logger.New(false)
-	selector := subscription.NewSelector(log, lister)
+	selector := subscription.NewSelector(log, lister, nil)
 	handler := subscription.NewHandler(log, selector)
 
 	router.POST("/subscriptions/select", handler.SelectSubscription)
@@ -1001,11 +1002,15 @@ func TestHandler_SelectSubscription_MultipleSubscriptionsSameModel(t *testing.T)
 }
 
 func setupListTestRouter(lister subscription.Lister, username string, groups []string) *gin.Engine {
+	return setupListTestRouterWithModels(lister, nil, username, groups)
+}
+
+func setupListTestRouterWithModels(lister subscription.Lister, modelLister models.MaaSModelRefLister, username string, groups []string) *gin.Engine {
 	gin.SetMode(gin.TestMode)
 	router := gin.New()
 
 	log := logger.New(false)
-	selector := subscription.NewSelector(log, lister)
+	selector := subscription.NewSelector(log, lister, modelLister)
 	handler := subscription.NewHandler(log, selector)
 
 	setUser := func(c *gin.Context) {
@@ -1206,6 +1211,157 @@ func TestListSubscriptions_DescriptionFallback(t *testing.T) {
 	// No annotations: falls back to name
 	if byID["no-annotations"].SubscriptionDescription != "no-annotations" {
 		t.Errorf("expected name fallback, got %q", byID["no-annotations"].SubscriptionDescription)
+	}
+}
+
+// fakeModelLister implements models.MaaSModelRefLister for testing model ref enrichment.
+type fakeModelLister struct {
+	items []*unstructured.Unstructured
+}
+
+func (f *fakeModelLister) List() ([]*unstructured.Unstructured, error) {
+	return f.items, nil
+}
+
+// createTestMaaSModelRef builds a fake MaaSModelRef unstructured object with display name and description annotations.
+func createTestMaaSModelRef(name, namespace, displayName, description string) *unstructured.Unstructured {
+	annotations := map[string]any{}
+	if displayName != "" {
+		annotations["openshift.io/display-name"] = displayName
+	}
+	if description != "" {
+		annotations["openshift.io/description"] = description
+	}
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "maas.opendatahub.io/v1alpha1",
+			"kind":       "MaaSModelRef",
+			"metadata": map[string]any{
+				"name":        name,
+				"namespace":   namespace,
+				"annotations": annotations,
+			},
+		},
+	}
+}
+
+func TestListSubscriptions_ModelRefEnrichment(t *testing.T) {
+	sub := createTestSubscriptionWithModels(
+		"free-sub",
+		[]string{"free-users"},
+		[]struct{ ns, name string }{
+			{ns: "llm-ns", name: "model-a"},
+			{ns: "llm-ns", name: "model-b"},
+		},
+		10, "org-1", "cc-1",
+	)
+
+	subLister := &mockLister{subscriptions: []*unstructured.Unstructured{sub}}
+	modelLister := &fakeModelLister{
+		items: []*unstructured.Unstructured{
+			createTestMaaSModelRef("model-a", "llm-ns", "Model A Display", "A great model"),
+			createTestMaaSModelRef("model-b", "llm-ns", "Model B Display", ""),
+		},
+	}
+
+	router := setupListTestRouterWithModels(subLister, modelLister, "alice", []string{"free-users"})
+	req := httptest.NewRequest(http.MethodGet, "/v1/subscriptions", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+
+	var result []subscription.SubscriptionInfo
+	if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+	if len(result) != 1 {
+		t.Fatalf("expected 1 subscription, got %d", len(result))
+	}
+
+	refs := result[0].ModelRefs
+	byName := make(map[string]subscription.ModelRefInfo, len(refs))
+	for _, r := range refs {
+		byName[r.Name] = r
+	}
+
+	// model-a has both display_name and description
+	if byName["model-a"].DisplayName != "Model A Display" {
+		t.Errorf("model-a: expected display_name %q, got %q", "Model A Display", byName["model-a"].DisplayName)
+	}
+	if byName["model-a"].Description != "A great model" {
+		t.Errorf("model-a: expected description %q, got %q", "A great model", byName["model-a"].Description)
+	}
+
+	// model-b has a display_name but no description annotation
+	if byName["model-b"].DisplayName != "Model B Display" {
+		t.Errorf("model-b: expected display_name %q, got %q", "Model B Display", byName["model-b"].DisplayName)
+	}
+	if byName["model-b"].Description != "" {
+		t.Errorf("model-b: expected empty description, got %q", byName["model-b"].Description)
+	}
+}
+
+func TestListSubscriptions_ModelRefEnrichment_NilLister(t *testing.T) {
+	sub := createTestSubscriptionWithAnnotations("free-sub", []string{"free-users"}, []string{"model-a"}, nil)
+	subLister := &mockLister{subscriptions: []*unstructured.Unstructured{sub}}
+
+	// nil model lister: enrichment is skipped, response must still succeed with empty display_name/description
+	router := setupListTestRouterWithModels(subLister, nil, "alice", []string{"free-users"})
+	req := httptest.NewRequest(http.MethodGet, "/v1/subscriptions", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+
+	var result []subscription.SubscriptionInfo
+	if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+	if len(result) != 1 {
+		t.Fatalf("expected 1 subscription, got %d", len(result))
+	}
+	for _, ref := range result[0].ModelRefs {
+		if ref.DisplayName != "" || ref.Description != "" {
+			t.Errorf("expected empty display_name and description with nil lister, got %q / %q", ref.DisplayName, ref.Description)
+		}
+	}
+}
+
+func TestListSubscriptions_ModelRefEnrichment_ModelNotFound(t *testing.T) {
+	sub := createTestSubscriptionWithAnnotations("free-sub", []string{"free-users"}, []string{"unknown-model"}, nil)
+	subLister := &mockLister{subscriptions: []*unstructured.Unstructured{sub}}
+	// model lister does not contain "unknown-model"
+	modelLister := &fakeModelLister{
+		items: []*unstructured.Unstructured{
+			createTestMaaSModelRef("other-model", "llm-ns", "Other Model", "Some description"),
+		},
+	}
+
+	router := setupListTestRouterWithModels(subLister, modelLister, "alice", []string{"free-users"})
+	req := httptest.NewRequest(http.MethodGet, "/v1/subscriptions", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+
+	var result []subscription.SubscriptionInfo
+	if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+	if len(result) != 1 {
+		t.Fatalf("expected 1 subscription, got %d", len(result))
+	}
+	for _, ref := range result[0].ModelRefs {
+		if ref.DisplayName != "" || ref.Description != "" {
+			t.Errorf("expected empty fields when model not found, got %q / %q", ref.DisplayName, ref.Description)
+		}
 	}
 }
 

--- a/maas-api/internal/subscription/selector.go
+++ b/maas-api/internal/subscription/selector.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/opendatahub-io/models-as-a-service/maas-api/internal/constant"
 	"github.com/opendatahub-io/models-as-a-service/maas-api/internal/logger"
+	"github.com/opendatahub-io/models-as-a-service/maas-api/internal/models"
 )
 
 // Phase constants for MaaSSubscription status.
@@ -29,19 +30,42 @@ type Lister interface {
 
 // Selector handles subscription selection logic.
 type Selector struct {
-	lister Lister
-	logger *logger.Logger
+	lister      Lister
+	modelLister models.MaaSModelRefLister
+	logger      *logger.Logger
 }
 
 // NewSelector creates a new subscription selector.
-func NewSelector(log *logger.Logger, lister Lister) *Selector {
+// modelLister is optional; when provided, model refs in list responses are enriched with displayName and description.
+func NewSelector(log *logger.Logger, lister Lister, modelLister models.MaaSModelRefLister) *Selector {
 	if log == nil {
 		log = logger.Production()
 	}
 	return &Selector{
-		lister: lister,
-		logger: log,
+		lister:      lister,
+		modelLister: modelLister,
+		logger:      log,
 	}
+}
+
+// buildModelIndex builds a lookup map keyed by "namespace/name" from the MaaSModelRef cache.
+// Called once per loadSubscriptions to avoid repeated List() calls for every model ref.
+// Returns nil when the lister is nil or the List() call fails.
+func (s *Selector) buildModelIndex() map[string]*unstructured.Unstructured {
+	if s.modelLister == nil {
+		return nil
+	}
+	items, err := s.modelLister.List()
+	if err != nil {
+		s.logger.Error("failed to list MaaSModelRefs for model ref enrichment", "error", err)
+		return nil
+	}
+	index := make(map[string]*unstructured.Unstructured, len(items))
+	for _, u := range items {
+		key := u.GetNamespace() + "/" + u.GetName()
+		index[key] = u
+	}
+	return index
 }
 
 // subscription represents a parsed MaaSSubscription for selection.
@@ -240,6 +264,8 @@ func (s *Selector) loadSubscriptions() ([]subscription, error) {
 		return nil, err
 	}
 
+	modelIndex := s.buildModelIndex()
+
 	subscriptions := make([]subscription, 0, len(objects))
 	for _, obj := range objects {
 		sub, err := parseSubscription(obj)
@@ -251,10 +277,28 @@ func (s *Selector) loadSubscriptions() ([]subscription, error) {
 			)
 			continue
 		}
+		s.enrichModelRefs(sub.ModelRefs, modelIndex)
 		subscriptions = append(subscriptions, sub)
 	}
 
 	return subscriptions, nil
+}
+
+// enrichModelRefs populates DisplayName and Description on each ModelRefInfo by looking up
+// the corresponding MaaSModelRef in the pre-built index.
+func (s *Selector) enrichModelRefs(refs []ModelRefInfo, index map[string]*unstructured.Unstructured) {
+	if index == nil {
+		return
+	}
+	for i := range refs {
+		key := refs[i].Namespace + "/" + refs[i].Name
+		if u, ok := index[key]; ok {
+			if annotations := u.GetAnnotations(); annotations != nil {
+				refs[i].DisplayName = annotations[constant.AnnotationDisplayName]
+				refs[i].Description = annotations[constant.AnnotationDescription]
+			}
+		}
+	}
 }
 
 // parseSubscription extracts subscription data from unstructured object.

--- a/maas-api/internal/subscription/selector_test.go
+++ b/maas-api/internal/subscription/selector_test.go
@@ -273,7 +273,7 @@ func TestGetAllAccessible(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			lister := &fakeLister{subscriptions: tt.subscriptions}
-			selector := subscription.NewSelector(log, lister)
+			selector := subscription.NewSelector(log, lister, nil)
 
 			result, err := selector.GetAllAccessible(tt.groups, tt.username)
 
@@ -333,7 +333,7 @@ func TestGetAllAccessible_ErrorHandling(t *testing.T) {
 
 	t.Run("requires groups or username", func(t *testing.T) {
 		lister := &fakeLister{subscriptions: []*unstructured.Unstructured{}}
-		selector := subscription.NewSelector(log, lister)
+		selector := subscription.NewSelector(log, lister, nil)
 
 		_, err := selector.GetAllAccessible(nil, "")
 		if err == nil {
@@ -353,7 +353,7 @@ func TestSelectHighestPriority(t *testing.T) {
 			createSubscription("low-sub", []string{"g1"}, nil, 10, defaultTestTokenRateLimit, "L", "d1"),
 			createSubscription("high-sub", []string{"g1"}, nil, 50, defaultTestTokenRateLimit, "H", "d2"),
 		}}
-		sel := subscription.NewSelector(log, lister)
+		sel := subscription.NewSelector(log, lister, nil)
 		got, err := sel.SelectHighestPriority([]string{"g1"}, "")
 		if err != nil {
 			t.Fatalf("SelectHighestPriority: %v", err)
@@ -368,7 +368,7 @@ func TestSelectHighestPriority(t *testing.T) {
 			createSubscription("sub-a", []string{"g1"}, nil, 10, 10, "", ""),
 			createSubscription("sub-b", []string{"g1"}, nil, 10, 20, "", ""),
 		}}
-		sel := subscription.NewSelector(log, lister)
+		sel := subscription.NewSelector(log, lister, nil)
 		got, err := sel.SelectHighestPriority([]string{"g1"}, "")
 		if err != nil {
 			t.Fatalf("SelectHighestPriority: %v", err)
@@ -383,7 +383,7 @@ func TestSelectHighestPriority(t *testing.T) {
 			createSubscription("zebra", []string{"g1"}, nil, 5, defaultTestTokenRateLimit, "", ""),
 			createSubscription("alpha", []string{"g1"}, nil, 5, defaultTestTokenRateLimit, "", ""),
 		}}
-		sel := subscription.NewSelector(log, lister)
+		sel := subscription.NewSelector(log, lister, nil)
 		got, err := sel.SelectHighestPriority([]string{"g1"}, "")
 		if err != nil {
 			t.Fatalf("SelectHighestPriority: %v", err)
@@ -397,7 +397,7 @@ func TestSelectHighestPriority(t *testing.T) {
 		lister := &fakeLister{subscriptions: []*unstructured.Unstructured{
 			createSubscription("other", []string{"other-group"}, nil, 10, defaultTestTokenRateLimit, "", ""),
 		}}
-		sel := subscription.NewSelector(log, lister)
+		sel := subscription.NewSelector(log, lister, nil)
 		_, err := sel.SelectHighestPriority([]string{"g1"}, "")
 		if err == nil {
 			t.Fatal("expected error")
@@ -553,7 +553,7 @@ func TestSelector_HealthFieldParsing(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			lister := &fakeLister{subscriptions: []*unstructured.Unstructured{tt.subscription}}
-			selector := subscription.NewSelector(log, lister)
+			selector := subscription.NewSelector(log, lister, nil)
 
 			//nolint:unqueryvet,nolintlint // False positive - not a SQL query
 			result, err := selector.Select([]string{"g1"}, "", "", "")
@@ -597,7 +597,7 @@ func TestSelector_ListAccessibleWithHealth(t *testing.T) {
 	}
 
 	lister := &fakeLister{subscriptions: subscriptions}
-	selector := subscription.NewSelector(log, lister)
+	selector := subscription.NewSelector(log, lister, nil)
 
 	results, err := selector.GetAllAccessible([]string{"g1"}, "")
 	if err != nil {
@@ -788,7 +788,7 @@ func TestSelector_DegradedSubscriptionTRLPFiltering(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			lister := &fakeLister{subscriptions: []*unstructured.Unstructured{tt.subscription}}
-			selector := subscription.NewSelector(log, lister)
+			selector := subscription.NewSelector(log, lister, nil)
 
 			//nolint:unqueryvet,nolintlint // False positive - not a SQL query
 			result, err := selector.Select([]string{"g1"}, "", "", tt.requestedModel)

--- a/maas-api/internal/subscription/types.go
+++ b/maas-api/internal/subscription/types.go
@@ -55,6 +55,8 @@ type SubscriptionInfo struct {
 type ModelRefInfo struct {
 	Name            string           `json:"name"`
 	Namespace       string           `json:"namespace,omitempty"`
+	DisplayName     string           `json:"display_name,omitempty"`
+	Description     string           `json:"description,omitempty"`
 	TokenRateLimits []TokenRateLimit `json:"token_rate_limits,omitempty"`
 	BillingRate     *BillingRate     `json:"billing_rate,omitempty"`
 }

--- a/maas-api/openapi3.yaml
+++ b/maas-api/openapi3.yaml
@@ -839,6 +839,14 @@ components:
                     type: string
                     description: Namespace where the MaaSModelRef lives
                     example: llm
+                display_name:
+                    type: string
+                    description: Human-readable display name from the openshift.io/display-name annotation on the MaaSModelRef
+                    example: Free Model
+                description:
+                    type: string
+                    description: Description from the openshift.io/description annotation on the MaaSModelRef
+                    example: A free-tier model for general use
                 token_rate_limits:
                     type: array
                     items:

--- a/test/e2e/fixtures/distinct/maas/maas-model.yaml
+++ b/test/e2e/fixtures/distinct/maas/maas-model.yaml
@@ -7,6 +7,9 @@ kind: MaaSModelRef
 metadata:
   name: e2e-distinct-simulated
   namespace: llm
+  annotations:
+    openshift.io/display-name: "E2E Distinct Simulated Model"
+    openshift.io/description: "Simulated model used for e2e distinct-tier testing"
 spec:
   modelRef:
     kind: LLMInferenceService

--- a/test/e2e/tests/test_subscription_list_endpoints.py
+++ b/test/e2e/tests/test_subscription_list_endpoints.py
@@ -66,8 +66,15 @@ def _validate_subscription_info_schema(sub):
     for ref in sub["model_refs"]:
         assert "name" in ref, f"model_ref missing name: {ref}"
         assert isinstance(ref["name"], str), "model_ref name must be string"
+        # display_name and description are optional (omitempty) but must be strings when present
+        if "display_name" in ref:
+            assert isinstance(ref["display_name"], str), \
+                f"model_ref display_name must be string, got {type(ref['display_name'])}: {ref}"
+        if "description" in ref:
+            assert isinstance(ref["description"], str), \
+                f"model_ref description must be string, got {type(ref['description'])}: {ref}"
 
-    # Optional fields
+    # Optional subscription-level fields
     if "display_name" in sub:
         assert isinstance(sub["display_name"], str), "display_name must be string"
     if "organization_id" in sub:
@@ -183,6 +190,97 @@ class TestListSubscriptions:
 
         finally:
             _delete_cr("maassubscription", subscription_name, namespace=maas_ns)
+            _delete_sa(sa_name, namespace=sa_ns)
+
+
+    def test_model_ref_display_name_and_description_enriched(self):
+        """Model refs include display_name and description from MaaSModelRef annotations."""
+        sa_name = "e2e-enrichment-sa"
+        sa_ns = "default"
+        maas_ns = _ns()
+        model_ref_name = "e2e-enrichment-model-ref"
+        model_ns = MODEL_NAMESPACE
+        subscription_name = "e2e-enrichment-sub"
+        expected_display_name = "E2E Enrichment Test Model"
+        expected_description = "Model created by e2e test to verify display_name/description enrichment"
+
+        try:
+            sa_token = _create_sa_token(sa_name, namespace=sa_ns)
+            sa_user = _sa_to_user(sa_name, namespace=sa_ns)
+
+            # Create a MaaSModelRef with display-name and description annotations.
+            # Points to the existing e2e-distinct-simulated LLMIS so the controller
+            # can reconcile the subscription to Active.
+            _apply_cr({
+                "apiVersion": "maas.opendatahub.io/v1alpha1",
+                "kind": "MaaSModelRef",
+                "metadata": {
+                    "name": model_ref_name,
+                    "namespace": model_ns,
+                    "annotations": {
+                        "openshift.io/display-name": expected_display_name,
+                        "openshift.io/description": expected_description,
+                    },
+                },
+                "spec": {
+                    "modelRef": {
+                        "kind": "LLMInferenceService",
+                        "name": "e2e-distinct-simulated",
+                    }
+                },
+            })
+
+            _create_test_subscription(
+                subscription_name,
+                model_ref_name,
+                users=[sa_user],
+            )
+
+            api_key = _create_api_key(sa_token, name=f"{sa_name}-key")
+            _wait_reconcile()
+
+            url = f"{_maas_api_url()}/v1/subscriptions"
+            r = requests.get(
+                url,
+                headers={"Authorization": f"Bearer {api_key}"},
+                timeout=TIMEOUT,
+                verify=TLS_VERIFY,
+            )
+
+            assert r.status_code == 200, f"Expected 200, got {r.status_code}: {r.text}"
+            data = r.json()
+
+            test_sub = next(
+                (s for s in data if s["subscription_id_header"] == subscription_name),
+                None,
+            )
+            assert test_sub is not None, \
+                f"Subscription '{subscription_name}' not found in {[s['subscription_id_header'] for s in data]}"
+
+            refs = test_sub.get("model_refs", [])
+            assert len(refs) >= 1, "Expected at least 1 model_ref"
+
+            enriched_ref = next((r for r in refs if r["name"] == model_ref_name), None)
+            assert enriched_ref is not None, \
+                f"model_ref '{model_ref_name}' not found in model_refs: {refs}"
+
+            assert enriched_ref.get("display_name") == expected_display_name, (
+                f"Expected display_name={expected_display_name!r}, "
+                f"got {enriched_ref.get('display_name')!r}"
+            )
+            assert enriched_ref.get("description") == expected_description, (
+                f"Expected description={expected_description!r}, "
+                f"got {enriched_ref.get('description')!r}"
+            )
+
+            log.info(
+                "Model ref '%s' enriched with display_name=%r description=%r",
+                model_ref_name, enriched_ref.get("display_name"), enriched_ref.get("description"),
+            )
+
+        finally:
+            _delete_cr("maassubscription", subscription_name, namespace=maas_ns)
+            _delete_cr("maasmodelref", model_ref_name, namespace=model_ns)
             _delete_sa(sa_name, namespace=sa_ns)
 
 

--- a/test/e2e/tests/test_subscription_list_endpoints.py
+++ b/test/e2e/tests/test_subscription_list_endpoints.py
@@ -33,6 +33,7 @@ from test_helper import (
     SIMULATOR_SUBSCRIPTION,
     TIMEOUT,
     TLS_VERIFY,
+    _apply_cr,
     _create_api_key,
     _create_sa_token,
     _create_test_auth_policy,


### PR DESCRIPTION
## Summary

Add `display_name` and `description` fields to `ModelRefInfo` in `GET /v1/subscriptions`, populated from the `openshift.io/display-name` and `openshift.io/description` annotations on the corresponding `MaaSModelRef` CR.

Jira: https://issues.redhat.com/browse/RHOAIENG-62490

## Description

The `GET /subscriptions` response previously returned model refs with only `name`, `namespace`, `token_rate_limits`, and `billing_rate`. UI consumers had to make an additional `GET /v1/models` call to resolve human-readable model metadata.

Key changes:
- Add `DisplayName` and `Description` (`omitempty`) to `ModelRefInfo` in `types.go`
- Inject `MaaSModelRefLister` into `Selector`; `buildModelIndex()` builds a single `namespace/name → unstructured` map once per `loadSubscriptions()` call to avoid repeated `List()` calls per model ref
- Pass `MaaSModelRefLister` to `NewSelector` in `cmd/main.go` (already available in `ClusterConfig`)
- Update `openapi3.yaml` `ModelRefInfo` schema with the two new fields
- Enrichment is read-path only — no controller changes required; `MaaSModelRef` annotations are already written by the controller
- Fails gracefully (fields are empty) when the model lister is `nil`, `List()` errors, or the model ref is not yet in the informer cache — no impact on existing consumers

## How it was tested

- **Unit tests**: 3 new tests in `handler_test.go` covering the happy path, nil lister (graceful degradation), and model-not-found (graceful degradation). All 16 `maas-api` packages pass.
- **E2E test**: New `test_model_ref_display_name_and_description_enriched` in `test_subscription_list_endpoints.py` creates a `MaaSModelRef` with annotations on the cluster, creates a subscription pointing to it, calls `GET /v1/subscriptions`, and hard-asserts `display_name` and `description` match the annotations.
- **Schema validation**: Extended `_validate_subscription_info_schema` to type-check `display_name` and `description` on model refs when present, covering all existing e2e subscription list tests.
- **Build**: `go build ./...` passes cleanly.
- Also tested on the clusterbot cluster, here are the before and after test results - 

BEFORE — quay.io/opendatahub/maas-api:latest
```
"model_refs": [
  {
    "name": "facebook-opt-125m-simulated",
    "namespace": "llm",
    "token_rate_limits": [{"limit": 100, "window": "1m"}]
  }
]
```
AFTER — quay.io/chkulkar/maas-api:[RHOAIENG-62490](https://redhat.atlassian.net/browse/RHOAIENG-62490)
```
"model_refs": [
  {
    "name": "facebook-opt-125m-simulated",
    "namespace": "llm",
    "display_name": "Facebook OPT 125M (Simulated)",
    "description": "A simulated OPT-125M model for free-tier testing",
    "token_rate_limits": [{"limit": 100, "window": "1m"}]
  }
]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Subscription list endpoints now enrich model references with display names and descriptions sourced from model resource metadata.

* **Documentation**
  * Updated API specification to document display name and description fields in subscription model reference responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->