### PR TITLE
fix: remove namespace field from model refs in GET /subscriptions response

### DIFF
--- a/.github/workflows/openapi-validation.yml
+++ b/.github/workflows/openapi-validation.yml
@@ -112,8 +112,9 @@ jobs:
           git fetch origin "$BASE_REF"
           git show "origin/$BASE_REF:maas-api/openapi3.yaml" > base-spec.yaml
 
-          # Run breaking change detection
-          oasdiff breaking base-spec.yaml maas-api/openapi3.yaml > breaking-changes.txt || true
+          # Run breaking change detection (--warn-ignore suppresses acknowledged warnings)
+          oasdiff breaking base-spec.yaml maas-api/openapi3.yaml \
+            --warn-ignore maas-api/oasdiff-warn-ignore.txt > breaking-changes.txt || true
 
           # Check if actual breaking changes were detected.
           # oasdiff outputs "No changes detected" when specs are identical, and

--- a/maas-api/internal/subscription/types.go
+++ b/maas-api/internal/subscription/types.go
@@ -54,7 +54,7 @@ type SubscriptionInfo struct {
 // ModelRefInfo represents a model reference with its rate limits.
 type ModelRefInfo struct {
 	Name            string           `json:"name"`
-	Namespace       string           `json:"namespace,omitempty"`
+	Namespace       string           `json:"-"`
 	DisplayName     string           `json:"display_name,omitempty"`
 	Description     string           `json:"description,omitempty"`
 	TokenRateLimits []TokenRateLimit `json:"token_rate_limits,omitempty"`

--- a/maas-api/oasdiff-warn-ignore.txt
+++ b/maas-api/oasdiff-warn-ignore.txt
@@ -1,0 +1,9 @@
+# Acknowledged breaking changes — document reason and PR link for each entry.
+#
+# Format: each line must contain the HTTP method, path, and change description.
+# See https://github.com/oasdiff/oasdiff/blob/main/docs/BREAKING-CHANGES.md
+
+# PR #915: Remove namespace from model refs in GET /subscriptions response.
+# The namespace field exposed internal cluster topology not relevant to API consumers.
+GET /v1/subscriptions removed the optional property `items/model_refs/items/namespace` from the response with the `200` status
+GET /v1/model/{model-id}/subscriptions removed the optional property `items/model_refs/items/namespace` from the response with the `200` status

--- a/maas-api/openapi3.yaml
+++ b/maas-api/openapi3.yaml
@@ -835,10 +835,6 @@ components:
                     type: string
                     description: Name of the MaaSModelRef
                     example: free-model-ref
-                namespace:
-                    type: string
-                    description: Namespace where the MaaSModelRef lives
-                    example: llm
                 display_name:
                     type: string
                     description: Human-readable display name from the openshift.io/display-name annotation on the MaaSModelRef

--- a/test/e2e/tests/test_subscription_list_endpoints.py
+++ b/test/e2e/tests/test_subscription_list_endpoints.py
@@ -180,6 +180,7 @@ class TestListSubscriptions:
             assert len(test_sub["model_refs"]) >= 1, "Expected at least 1 model_ref"
             ref = test_sub["model_refs"][0]
             assert ref["name"] == MODEL_REF, f"Expected model_ref name '{MODEL_REF}', got '{ref['name']}'"
+            assert "namespace" not in ref, f"model_ref should not expose namespace: {ref}"
 
             # Validate token_rate_limits if present
             if "token_rate_limits" in ref and ref["token_rate_limits"]:

--- a/test/e2e/tests/test_subscription_list_endpoints.py
+++ b/test/e2e/tests/test_subscription_list_endpoints.py
@@ -67,6 +67,7 @@ def _validate_subscription_info_schema(sub):
     for ref in sub["model_refs"]:
         assert "name" in ref, f"model_ref missing name: {ref}"
         assert isinstance(ref["name"], str), "model_ref name must be string"
+        assert "namespace" not in ref, f"model_ref should not expose namespace: {ref}"
         # display_name and description are optional (omitempty) but must be strings when present
         if "display_name" in ref:
             assert isinstance(ref["display_name"], str), \
@@ -180,7 +181,6 @@ class TestListSubscriptions:
             assert len(test_sub["model_refs"]) >= 1, "Expected at least 1 model_ref"
             ref = test_sub["model_refs"][0]
             assert ref["name"] == MODEL_REF, f"Expected model_ref name '{MODEL_REF}', got '{ref['name']}'"
-            assert "namespace" not in ref, f"model_ref should not expose namespace: {ref}"
 
             # Validate token_rate_limits if present
             if "token_rate_limits" in ref and ref["token_rate_limits"]:


### PR DESCRIPTION
## Summary

- Remove the `namespace` (project) field from `ModelRefInfo` in the GET /subscriptions API response
- The field exposed internal cluster metadata that platform consumers do not need

## Breaking Change

Removes the `namespace` field from `modelRefs` objects in the `GET /v1/subscriptions` response. This field exposed internal cluster topology (which namespace a MaaSModelRef lives in) which is not relevant to API consumers and could leak implementation details. Clients should use `name` to identify model refs.

- **Impact**: Clients parsing `namespace` from subscription model refs will receive `undefined`/missing field instead
- **Migration**: Remove any client-side references to `modelRefs[].namespace` — use `modelRefs[].name` to identify model refs
- **Reason**: Defense in depth — internal namespace metadata should not be exposed in public API responses

## Changes

- **`maas-api/internal/subscription/types.go`**: Change `ModelRefInfo.Namespace` JSON tag from `"namespace,omitempty"` to `"-"` — excluded from JSON serialization, still available internally for model matching in the subscription selector
- **`maas-api/openapi3.yaml`**: Remove `namespace` property from the model ref schema
- **`test/e2e/tests/test_subscription_list_endpoints.py`**: Add assertion that no model ref in the response contains a `namespace` field

## Test plan

- [x] `ModelRefInfo.Namespace` still populated internally from MaaSSubscription CRD spec
- [x] Model matching in `selector.go` still works (uses Go struct field, not JSON)
- [x] E2E test asserts `namespace` absent from response
- [ ] `go build ./...` passes
- [ ] `go test ./internal/subscription/...` passes
- [ ] E2E: GET /subscriptions returns model refs without `namespace`

Ref: [RHAISTRAT-1547](https://redhat.atlassian.net/browse/RHAISTRAT-1547)
https://redhat.atlassian.net/browse/RHOAIENG-62491

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Model reference objects in subscription API responses no longer include the namespace field.

* **Documentation**
  * API schema updated to remove the namespace property from model reference definitions and clarify name examples.

* **Tests**
  * End-to-end tests strengthened to verify model reference responses do not expose a namespace field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->