### PR TITLE
feat: add subscription filter to POST /api-keys/search

### DIFF
--- a/maas-api/internal/api_keys/handler_test.go
+++ b/maas-api/internal/api_keys/handler_test.go
@@ -414,6 +414,64 @@ func TestSearchAPIKeys_StatusFilter(t *testing.T) {
 	})
 }
 
+func TestSearchAPIKeys_SubscriptionFilter(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	store := NewMockStore()
+	cfg := &config.Config{}
+	service := NewServiceWithLogger(store, cfg, fixedSubSelector{}, logger.Development())
+	handler := NewHandler(logger.Development(), service, newMockAdminChecker())
+
+	ctx := context.Background()
+	testUser := &token.UserContext{
+		Username: "test-user",
+		Groups:   []string{"system:authenticated"},
+	}
+
+	err := store.AddKey(ctx, testUser.Username, "key-sub-a", "hash-a", "Key A", "", []string{"system:authenticated"}, "subscription-a", nil, false)
+	require.NoError(t, err)
+	err = store.AddKey(ctx, testUser.Username, "key-sub-b", "hash-b", "Key B", "", []string{"system:authenticated"}, "subscription-b", nil, false)
+	require.NoError(t, err)
+
+	t.Run("FilterBySubscription", func(t *testing.T) {
+		requestBody := `{"filters": {"subscription": "subscription-a"}}`
+
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest(http.MethodPost, "/v1/api-keys/search", nil)
+		c.Request.Header.Set("Content-Type", "application/json")
+		c.Request.Body = io.NopCloser(strings.NewReader(requestBody))
+		c.Set("user", testUser)
+
+		handler.SearchAPIKeys(c)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		var response SearchAPIKeysResponse
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		require.NoError(t, err)
+		assert.Len(t, response.Data, 1)
+		assert.Equal(t, "subscription-a", response.Data[0].Subscription)
+	})
+
+	t.Run("NoFilterReturnsAll", func(t *testing.T) {
+		requestBody := `{}`
+
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest(http.MethodPost, "/v1/api-keys/search", nil)
+		c.Request.Header.Set("Content-Type", "application/json")
+		c.Request.Body = io.NopCloser(strings.NewReader(requestBody))
+		c.Set("user", testUser)
+
+		handler.SearchAPIKeys(c)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		var response SearchAPIKeysResponse
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		require.NoError(t, err)
+		assert.Len(t, response.Data, 2, "should return all keys when no subscription filter")
+	})
+}
+
 func TestSearchAPIKeys_Sorting(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	store := NewMockStore()

--- a/maas-api/internal/api_keys/store_mock.go
+++ b/maas-api/internal/api_keys/store_mock.go
@@ -334,6 +334,18 @@ func (m *MockStore) Search(
 	now := time.Now().UTC()
 	allKeys := m.filterKeys(username, filters.Status, includeEphemeral, now)
 
+	// Filter by subscription
+	if filters.Subscription != nil && *filters.Subscription != "" {
+		sub := strings.TrimSpace(*filters.Subscription)
+		filtered := allKeys[:0]
+		for _, k := range allKeys {
+			if k.Subscription == sub {
+				filtered = append(filtered, k)
+			}
+		}
+		allKeys = filtered
+	}
+
 	// Sort keys
 	sort.Slice(allKeys, func(i, j int) bool {
 		return compareKeys(allKeys[i], allKeys[j], sortParams.By, sortParams.Order)

--- a/maas-api/internal/api_keys/store_postgres.go
+++ b/maas-api/internal/api_keys/store_postgres.go
@@ -234,6 +234,13 @@ func (s *PostgresStore) Search(
 		whereClauses = append(whereClauses, fmt.Sprintf("(%s) IN (%s)", effectiveStatusExpr, strings.Join(placeholders, ",")))
 	}
 
+	// Filter by subscription name
+	if filters.Subscription != nil && *filters.Subscription != "" {
+		whereClauses = append(whereClauses, fmt.Sprintf("subscription = $%d", argPos))
+		args = append(args, strings.TrimSpace(*filters.Subscription))
+		argPos++
+	}
+
 	// Build final WHERE clause
 	whereClause := ""
 	if len(whereClauses) > 0 {

--- a/maas-api/internal/api_keys/types.go
+++ b/maas-api/internal/api_keys/types.go
@@ -88,6 +88,9 @@ type SearchFilters struct {
 	HasExpiration *bool `json:"hasExpiration,omitempty"` // true = expiring, false = permanent
 	HasBeenUsed   *bool `json:"hasBeenUsed,omitempty"`   // true = used, false = never used
 
+	// Subscription filter
+	Subscription *string `json:"subscription,omitempty"` // Filter by bound subscription name
+
 	// Ephemeral key filter
 	IncludeEphemeral *bool `json:"includeEphemeral,omitempty"` // Include ephemeral keys in results (default: false)
 }

--- a/test/e2e/tests/test_api_keys.py
+++ b/test/e2e/tests/test_api_keys.py
@@ -1352,3 +1352,137 @@ class TestAPIKeySubscriptionPhases:
             _delete_cr("maasauthpolicy", auth_name, namespace=ns)
             _delete_sa(sa_name, namespace=MODEL_NAMESPACE)
             _wait_reconcile()
+
+
+class TestAPIKeySubscriptionFilter:
+    """Tests for POST /api-keys/search subscription filter.
+
+    Verifies that the subscription filter scopes search results to keys
+    bound to a specific subscription, and that omitting it returns all keys.
+    """
+
+    def test_search_filters_by_subscription(self, api_keys_base_url: str, headers: dict):
+        """Search with subscription filter returns only keys bound to that subscription."""
+        sub_a = SIMULATOR_SUBSCRIPTION
+        sub_b = f"e2e-filter-sub-{os.urandom(4).hex()}"
+        ns = _ns()
+        sa_name = f"e2e-filter-sa-{os.urandom(4).hex()}"
+
+        key_ids_a = []
+        key_ids_b = []
+        try:
+            # Set up a second subscription so we can create keys bound to it
+            oc_token = _create_sa_token(sa_name, namespace=MODEL_NAMESPACE)
+            sa_user = _sa_to_user(sa_name, namespace=MODEL_NAMESPACE)
+            _create_test_auth_policy(f"{sub_b}-auth", MODEL_REF, users=[sa_user])
+            _create_test_subscription(sub_b, MODEL_REF, users=[sa_user])
+            _wait_for_maas_subscription_phase(sub_b, namespace=ns)
+
+            # Create 2 keys bound to sub_a (the default simulator subscription)
+            for i in range(2):
+                r = requests.post(
+                    api_keys_base_url,
+                    headers=headers,
+                    json={"name": f"e2e-filter-a-{i}", "subscription": sub_a},
+                    timeout=TIMEOUT,
+                    verify=TLS_VERIFY,
+                )
+                assert r.status_code in (200, 201), f"Failed to create key for {sub_a}: {r.text}"
+                key_ids_a.append(r.json()["id"])
+
+            # Create 1 key bound to sub_b
+            r_b = requests.post(
+                api_keys_base_url,
+                headers={"Authorization": f"Bearer {oc_token}", "Content-Type": "application/json"},
+                json={"name": "e2e-filter-b-0", "subscription": sub_b},
+                timeout=TIMEOUT,
+                verify=TLS_VERIFY,
+            )
+            assert r_b.status_code in (200, 201), f"Failed to create key for {sub_b}: {r_b.text}"
+            key_ids_b.append(r_b.json()["id"])
+
+            # Search with subscription filter for sub_b
+            r_search = requests.post(
+                f"{api_keys_base_url}/search",
+                headers={"Authorization": f"Bearer {oc_token}", "Content-Type": "application/json"},
+                json={
+                    "filters": {"status": ["active"], "subscription": sub_b},
+                    "pagination": {"limit": 50, "offset": 0},
+                },
+                timeout=TIMEOUT,
+                verify=TLS_VERIFY,
+            )
+            assert r_search.status_code == 200, f"Search failed: {r_search.status_code} {r_search.text}"
+            items = r_search.json().get("items") or r_search.json().get("data") or []
+            result_ids = [item["id"] for item in items]
+
+            # sub_b key should be present
+            for kid in key_ids_b:
+                assert kid in result_ids, (
+                    f"Key {kid} (subscription={sub_b}) should appear in filtered results"
+                )
+
+            # sub_a keys should NOT be present
+            for kid in key_ids_a:
+                assert kid not in result_ids, (
+                    f"Key {kid} (subscription={sub_a}) should NOT appear when filtering by {sub_b}"
+                )
+
+            log.info("subscription filter correctly scoped search results")
+
+        finally:
+            # Cleanup: revoke created keys
+            for kid in key_ids_a:
+                requests.delete(f"{api_keys_base_url}/{kid}", headers=headers, timeout=TIMEOUT, verify=TLS_VERIFY)
+            for kid in key_ids_b:
+                requests.delete(
+                    f"{api_keys_base_url}/{kid}",
+                    headers={"Authorization": f"Bearer {oc_token}", "Content-Type": "application/json"},
+                    timeout=TIMEOUT, verify=TLS_VERIFY,
+                )
+            _delete_cr("maassubscription", sub_b, namespace=ns)
+            _delete_cr("maasauthpolicy", f"{sub_b}-auth", namespace=ns)
+            _delete_sa(sa_name, namespace=MODEL_NAMESPACE)
+            _wait_reconcile()
+
+    def test_search_without_subscription_returns_all(self, api_keys_base_url: str, headers: dict):
+        """Search without subscription filter returns keys across all subscriptions."""
+        key_ids = []
+        try:
+            # Create keys with explicit subscription binding
+            for i in range(2):
+                r = requests.post(
+                    api_keys_base_url,
+                    headers=headers,
+                    json={"name": f"e2e-nofilter-{i}", "subscription": SIMULATOR_SUBSCRIPTION},
+                    timeout=TIMEOUT,
+                    verify=TLS_VERIFY,
+                )
+                assert r.status_code in (200, 201), f"Failed to create key: {r.text}"
+                key_ids.append(r.json()["id"])
+
+            # Search without subscription filter
+            r_search = requests.post(
+                f"{api_keys_base_url}/search",
+                headers=headers,
+                json={
+                    "filters": {"status": ["active"]},
+                    "pagination": {"limit": 50, "offset": 0},
+                },
+                timeout=TIMEOUT,
+                verify=TLS_VERIFY,
+            )
+            assert r_search.status_code == 200, f"Search failed: {r_search.status_code} {r_search.text}"
+            items = r_search.json().get("items") or r_search.json().get("data") or []
+            result_ids = [item["id"] for item in items]
+
+            for kid in key_ids:
+                assert kid in result_ids, (
+                    f"Key {kid} should appear in unfiltered search results"
+                )
+
+            log.info("unfiltered search returns all keys (no regression)")
+
+        finally:
+            for kid in key_ids:
+                requests.delete(f"{api_keys_base_url}/{kid}", headers=headers, timeout=TIMEOUT, verify=TLS_VERIFY)

--- a/test/e2e/tests/test_api_keys.py
+++ b/test/e2e/tests/test_api_keys.py
@@ -1363,26 +1363,34 @@ class TestAPIKeySubscriptionFilter:
 
     def test_search_filters_by_subscription(self, api_keys_base_url: str, headers: dict):
         """Search with subscription filter returns only keys bound to that subscription."""
-        sub_a = SIMULATOR_SUBSCRIPTION
-        sub_b = f"e2e-filter-sub-{os.urandom(4).hex()}"
+        sub_a = f"e2e-filter-sub-a-{os.urandom(4).hex()}"
+        sub_b = f"e2e-filter-sub-b-{os.urandom(4).hex()}"
         ns = _ns()
         sa_name = f"e2e-filter-sa-{os.urandom(4).hex()}"
 
         key_ids_a = []
         key_ids_b = []
         try:
-            # Set up a second subscription so we can create keys bound to it
+            # Create one SA authorized for both subscriptions so that
+            # exclusion in search results is attributable to the subscription
+            # filter, not user-scoping.
             oc_token = _create_sa_token(sa_name, namespace=MODEL_NAMESPACE)
             sa_user = _sa_to_user(sa_name, namespace=MODEL_NAMESPACE)
+            sa_headers = {"Authorization": f"Bearer {oc_token}", "Content-Type": "application/json"}
+
+            _create_test_auth_policy(f"{sub_a}-auth", MODEL_REF, users=[sa_user])
+            _create_test_subscription(sub_a, MODEL_REF, users=[sa_user])
+            _wait_for_maas_subscription_phase(sub_a, namespace=ns)
+
             _create_test_auth_policy(f"{sub_b}-auth", MODEL_REF, users=[sa_user])
             _create_test_subscription(sub_b, MODEL_REF, users=[sa_user])
             _wait_for_maas_subscription_phase(sub_b, namespace=ns)
 
-            # Create 2 keys bound to sub_a (the default simulator subscription)
+            # Create 2 keys bound to sub_a
             for i in range(2):
                 r = requests.post(
                     api_keys_base_url,
-                    headers=headers,
+                    headers=sa_headers,
                     json={"name": f"e2e-filter-a-{i}", "subscription": sub_a},
                     timeout=TIMEOUT,
                     verify=TLS_VERIFY,
@@ -1393,7 +1401,7 @@ class TestAPIKeySubscriptionFilter:
             # Create 1 key bound to sub_b
             r_b = requests.post(
                 api_keys_base_url,
-                headers={"Authorization": f"Bearer {oc_token}", "Content-Type": "application/json"},
+                headers=sa_headers,
                 json={"name": "e2e-filter-b-0", "subscription": sub_b},
                 timeout=TIMEOUT,
                 verify=TLS_VERIFY,
@@ -1401,10 +1409,10 @@ class TestAPIKeySubscriptionFilter:
             assert r_b.status_code in (200, 201), f"Failed to create key for {sub_b}: {r_b.text}"
             key_ids_b.append(r_b.json()["id"])
 
-            # Search with subscription filter for sub_b
+            # Search with subscription filter for sub_b — same principal
             r_search = requests.post(
                 f"{api_keys_base_url}/search",
-                headers={"Authorization": f"Bearer {oc_token}", "Content-Type": "application/json"},
+                headers=sa_headers,
                 json={
                     "filters": {"status": ["active"], "subscription": sub_b},
                     "pagination": {"limit": 50, "offset": 0},
@@ -1422,7 +1430,8 @@ class TestAPIKeySubscriptionFilter:
                     f"Key {kid} (subscription={sub_b}) should appear in filtered results"
                 )
 
-            # sub_a keys should NOT be present
+            # sub_a keys should NOT be present — since the same user owns
+            # both, exclusion proves the subscription filter works.
             for kid in key_ids_a:
                 assert kid not in result_ids, (
                     f"Key {kid} (subscription={sub_a}) should NOT appear when filtering by {sub_b}"
@@ -1431,17 +1440,12 @@ class TestAPIKeySubscriptionFilter:
             log.info("subscription filter correctly scoped search results")
 
         finally:
-            # Cleanup: revoke created keys
-            for kid in key_ids_a:
-                requests.delete(f"{api_keys_base_url}/{kid}", headers=headers, timeout=TIMEOUT, verify=TLS_VERIFY)
-            for kid in key_ids_b:
-                requests.delete(
-                    f"{api_keys_base_url}/{kid}",
-                    headers={"Authorization": f"Bearer {oc_token}", "Content-Type": "application/json"},
-                    timeout=TIMEOUT, verify=TLS_VERIFY,
-                )
+            for kid in key_ids_a + key_ids_b:
+                requests.delete(f"{api_keys_base_url}/{kid}", headers=sa_headers, timeout=TIMEOUT, verify=TLS_VERIFY)
             _delete_cr("maassubscription", sub_b, namespace=ns)
             _delete_cr("maasauthpolicy", f"{sub_b}-auth", namespace=ns)
+            _delete_cr("maassubscription", sub_a, namespace=ns)
+            _delete_cr("maasauthpolicy", f"{sub_a}-auth", namespace=ns)
             _delete_sa(sa_name, namespace=MODEL_NAMESPACE)
             _wait_reconcile()
 


### PR DESCRIPTION
## Summary

- Add optional `subscription` filter to POST /api-keys/search so users can scope results to a specific subscription

## Changes

- **`maas-api/internal/api_keys/types.go`**: Add `Subscription *string` to `SearchFilters`
- **`maas-api/internal/api_keys/store_postgres.go`**: Add `subscription = $N` WHERE clause when filter is provided
- **`maas-api/internal/api_keys/store_mock.go`**: Add subscription filtering to mock store's `Search()`
- **`maas-api/internal/api_keys/handler_test.go`**: Add `TestSearchAPIKeys_SubscriptionFilter` with two subtests: filter by subscription returns scoped results, no filter returns all keys

## Usage

```json
POST /v1/api-keys/search
{
  "filters": {
    "subscription": "my-subscription-name"
  }
}
```

## Test plan

- [x] Unit test: filter by subscription returns only matching keys
- [x] Unit test: no filter returns all keys (backward compatible)
- [ ] `go build ./...` passes
- [ ] `go test ./internal/api_keys/...` passes

Ref: [RHAISTRAT-1547](https://redhat.atlassian.net/browse/RHAISTRAT-1547)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added subscription filtering to API key search, letting users narrow results to keys bound to a specific subscription.

* **Tests**
  * Added unit and end-to-end tests covering subscription-based search behavior to ensure correct filtering and overall search results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->