### PR TITLE
chore: add isManaged check for all resources managed by maas-controller

### DIFF
--- a/maas-controller/pkg/controller/maas/annotations.go
+++ b/maas-controller/pkg/controller/maas/annotations.go
@@ -16,10 +16,15 @@ limitations under the License.
 
 package maas
 
-import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/opendatahub-io/models-as-a-service/maas-controller/pkg/platform/tenantreconcile"
+)
 
 // ManagedByODHOperator is used to denote if a resource/component should be reconciled - when missing or true, reconcile.
-const ManagedByODHOperator = "opendatahub.io/managed"
+// This aliases tenantreconcile.AnnotationManaged so there is a single canonical definition.
+const ManagedByODHOperator = tenantreconcile.AnnotationManaged
 
 // isManaged reports whether obj has explicitly opted out of maas or opendatahub controller management.
 func isManaged(obj metav1.Object) bool {

--- a/maas-controller/pkg/platform/tenantreconcile/constants.go
+++ b/maas-controller/pkg/platform/tenantreconcile/constants.go
@@ -23,6 +23,12 @@ func isOptionalAPIGroup(group string) bool {
 }
 
 const (
+	// AnnotationManaged is the opt-out annotation key used by the ODH operator and MaaS
+	// controller. Resources annotated with this key set to "false" are skipped on both
+	// the write (create/update) and delete paths. This is the single source of truth;
+	// other packages that need the same key must reference this constant.
+	AnnotationManaged = "opendatahub.io/managed"
+
 	// ComponentName is the ODH component label key suffix (app.opendatahub.io/<name>).
 	// This is the DSC component identifier, not a standalone CR kind.
 	ComponentName = "modelsasservice"

--- a/maas-controller/pkg/platform/tenantreconcile/postrender.go
+++ b/maas-controller/pkg/platform/tenantreconcile/postrender.go
@@ -30,7 +30,7 @@ func PostRender(ctx context.Context, log logr.Logger, tenant *maasv1alpha1.Tenan
 
 		// Skip resources with opendatahub.io/managed: false annotation
 		annotations := resource.GetAnnotations()
-		if annotations != nil && annotations["opendatahub.io/managed"] == "false" {
+		if annotations != nil && annotations[AnnotationManaged] == "false" {
 			log.V(2).Info("Skipping resource due to opendatahub.io/managed=false annotation",
 				"kind", resource.GetKind(), "name", resource.GetName(), "namespace", resource.GetNamespace())
 			continue
@@ -105,7 +105,7 @@ func setManagedFalseAnnotation(resources []unstructured.Unstructured) {
 			if ann == nil {
 				ann = make(map[string]string)
 			}
-			ann["opendatahub.io/managed"] = "false"
+			ann[AnnotationManaged] = "false"
 			r.SetAnnotations(ann)
 			return
 		}

--- a/maas-controller/pkg/reconciler/externalmodel/reconciler.go
+++ b/maas-controller/pkg/reconciler/externalmodel/reconciler.go
@@ -227,11 +227,26 @@ func (r *Reconciler) deleteIfExists(ctx context.Context, log logr.Logger, kind, 
 		}
 		return fmt.Errorf("failed to get %s %s/%s: %w", kind, namespace, name, err)
 	}
+	if !isManaged(obj) {
+		log.Info("Resource opted out of management, skipping deletion", "kind", kind, "name", name, "namespace", namespace)
+		return nil
+	}
 	log.Info("Deleting resource", "kind", kind, "name", name)
 	if err := r.Delete(ctx, obj); err != nil && !apierrors.IsNotFound(err) {
 		return fmt.Errorf("failed to delete %s %s/%s: %w", kind, namespace, name, err)
 	}
 	return nil
+}
+
+// isManaged reports whether obj has opted into maas/opendatahub controller management.
+// When the annotation is absent or any value other than "false", the resource is managed.
+// Only an explicit opendatahub.io/managed=false opts the resource out.
+func isManaged(obj metav1.Object) bool {
+	val, ok := obj.GetAnnotations()[tenantreconcile.AnnotationManaged]
+	if !ok {
+		return true
+	}
+	return val != "false"
 }
 
 // applyService creates or updates a Service.
@@ -244,6 +259,10 @@ func (r *Reconciler) applyService(ctx context.Context, log logr.Logger, desired 
 	}
 	if err != nil {
 		return err
+	}
+	if !isManaged(existing) {
+		log.Info("Service opted out of management, skipping update", "name", existing.Name, "namespace", existing.Namespace)
+		return nil
 	}
 	specChanged := !equality.Semantic.DeepEqual(existing.Spec, desired.Spec)
 	ownerChanged := !equality.Semantic.DeepEqual(existing.OwnerReferences, desired.OwnerReferences)
@@ -270,6 +289,10 @@ func (r *Reconciler) applyUnstructured(ctx context.Context, log logr.Logger, des
 	if err != nil {
 		return err
 	}
+	if !isManaged(existing) {
+		log.Info("Resource opted out of management, skipping update", "kind", existing.GetKind(), "name", existing.GetName(), "namespace", existing.GetNamespace())
+		return nil
+	}
 	desired.SetResourceVersion(existing.GetResourceVersion())
 	log.Info("Updating resource", "kind", desired.GetKind(), "name", desired.GetName())
 	return r.Update(ctx, desired)
@@ -285,6 +308,10 @@ func (r *Reconciler) applyHTTPRoute(ctx context.Context, log logr.Logger, desire
 	}
 	if err != nil {
 		return err
+	}
+	if !isManaged(existing) {
+		log.Info("HTTPRoute opted out of management, skipping update", "name", existing.Name, "namespace", existing.Namespace)
+		return nil
 	}
 	existing.Spec = desired.Spec
 	existing.Labels = desired.Labels

--- a/maas-controller/pkg/reconciler/externalmodel/reconciler_test.go
+++ b/maas-controller/pkg/reconciler/externalmodel/reconciler_test.go
@@ -1,0 +1,347 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package externalmodel
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	maasv1alpha1 "github.com/opendatahub-io/models-as-a-service/maas-controller/api/maas/v1alpha1"
+	"github.com/opendatahub-io/models-as-a-service/maas-controller/pkg/platform/tenantreconcile"
+)
+
+var testScheme = runtime.NewScheme()
+
+func init() {
+	utilruntime.Must(clientgoscheme.AddToScheme(testScheme))
+	utilruntime.Must(gatewayapiv1.Install(testScheme))
+	utilruntime.Must(maasv1alpha1.AddToScheme(testScheme))
+}
+
+// newTestExternalModel creates a minimal ExternalModel for reconciler tests.
+func newTestExternalModel(name, ns, endpoint string, annotations map[string]string) *maasv1alpha1.ExternalModel {
+	em := &maasv1alpha1.ExternalModel{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   ns,
+			Annotations: annotations,
+		},
+		Spec: maasv1alpha1.ExternalModelSpec{
+			Provider:    "openai",
+			Endpoint:    endpoint,
+			TargetModel: name,
+		},
+	}
+	// TypeMeta is needed for setUnstructuredOwner to build a correct OwnerReference.
+	em.APIVersion = maasv1alpha1.GroupVersion.String()
+	em.Kind = "ExternalModel"
+	return em
+}
+
+// TestManagedAnnotation_Service verifies that an existing Service with
+// opendatahub.io/managed=false is not updated by the ExternalModel reconciler.
+func TestManagedAnnotation_Service(t *testing.T) {
+	const (
+		name                 = "gpt-4o"
+		ns                   = "llm"
+		endpoint             = "api.openai.com"
+		sentinelExternalName = "sentinel.example.com"
+	)
+
+	tests := []struct {
+		testName        string
+		annotations     map[string]string
+		wantSpecChanged bool
+	}{
+		{
+			testName:        "annotation absent: controller updates",
+			annotations:     nil,
+			wantSpecChanged: true,
+		},
+		{
+			testName:        "opendatahub.io/managed=false: controller skips update",
+			annotations:     map[string]string{tenantreconcile.AnnotationManaged: "false"},
+			wantSpecChanged: false,
+		},
+		{
+			testName:        "opendatahub.io/managed=true: controller updates",
+			annotations:     map[string]string{tenantreconcile.AnnotationManaged: "true"},
+			wantSpecChanged: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.testName, func(t *testing.T) {
+			existingSvc := &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        name,
+					Namespace:   ns,
+					Annotations: tc.annotations,
+				},
+				Spec: corev1.ServiceSpec{
+					Type:         corev1.ServiceTypeExternalName,
+					ExternalName: sentinelExternalName,
+				},
+			}
+
+			em := newTestExternalModel(name, ns, endpoint, nil)
+			c := fake.NewClientBuilder().WithScheme(testScheme).WithObjects(em, existingSvc).Build()
+			r := &Reconciler{Client: c, Scheme: testScheme, Log: ctrl.Log}
+
+			_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: name, Namespace: ns}})
+			require.NoError(t, err)
+
+			got := &corev1.Service{}
+			require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: name, Namespace: ns}, got))
+
+			if tc.wantSpecChanged {
+				assert.Equal(t, endpoint, got.Spec.ExternalName, "expected Service ExternalName to be updated to endpoint")
+			} else {
+				assert.Equal(t, sentinelExternalName, got.Spec.ExternalName, "expected Service ExternalName to be unchanged (managed=false opt-out)")
+			}
+		})
+	}
+}
+
+// TestManagedAnnotation_ServiceEntry verifies that an existing ServiceEntry with
+// opendatahub.io/managed=false is not updated by the ExternalModel reconciler.
+func TestManagedAnnotation_ServiceEntry(t *testing.T) {
+	const (
+		name             = "gpt-4o"
+		ns               = "llm"
+		endpoint         = "api.openai.com"
+		sentinelEndpoint = "sentinel.example.com"
+	)
+
+	tests := []struct {
+		testName        string
+		annotations     map[string]string
+		wantSpecChanged bool
+	}{
+		{
+			testName:        "annotation absent: controller updates",
+			annotations:     nil,
+			wantSpecChanged: true,
+		},
+		{
+			testName:        "opendatahub.io/managed=false: controller skips update",
+			annotations:     map[string]string{tenantreconcile.AnnotationManaged: "false"},
+			wantSpecChanged: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.testName, func(t *testing.T) {
+			existingSE := &unstructured.Unstructured{}
+			existingSE.SetGroupVersionKind(schema.GroupVersionKind{Group: "networking.istio.io", Version: "v1", Kind: "ServiceEntry"})
+			existingSE.SetName(name)
+			existingSE.SetNamespace(ns)
+			existingSE.SetAnnotations(tc.annotations)
+			_ = unstructured.SetNestedStringSlice(existingSE.Object, []string{sentinelEndpoint}, "spec", "hosts")
+
+			em := newTestExternalModel(name, ns, endpoint, nil)
+			c := fake.NewClientBuilder().WithScheme(testScheme).WithObjects(em, existingSE).Build()
+			r := &Reconciler{Client: c, Scheme: testScheme, Log: ctrl.Log}
+
+			_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: name, Namespace: ns}})
+			require.NoError(t, err)
+
+			got := &unstructured.Unstructured{}
+			got.SetGroupVersionKind(schema.GroupVersionKind{Group: "networking.istio.io", Version: "v1", Kind: "ServiceEntry"})
+			require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: name, Namespace: ns}, got))
+
+			hosts, _, _ := unstructured.NestedStringSlice(got.Object, "spec", "hosts")
+			if tc.wantSpecChanged {
+				assert.Equal(t, []string{endpoint}, hosts, "expected ServiceEntry hosts to be updated to endpoint")
+			} else {
+				require.Len(t, hosts, 1)
+				assert.Equal(t, sentinelEndpoint, hosts[0], "expected ServiceEntry hosts to be unchanged (managed=false opt-out)")
+			}
+		})
+	}
+}
+
+// TestManagedAnnotation_HTTPRoute verifies that an existing HTTPRoute with
+// opendatahub.io/managed=false is not updated by the ExternalModel reconciler.
+func TestManagedAnnotation_HTTPRoute(t *testing.T) {
+	const (
+		name     = "gpt-4o"
+		ns       = "llm"
+		endpoint = "api.openai.com"
+	)
+
+	sentinelParentName := gatewayapiv1.ObjectName("sentinel-gateway")
+
+	tests := []struct {
+		testName        string
+		annotations     map[string]string
+		wantSpecChanged bool
+	}{
+		{
+			testName:        "annotation absent: controller updates",
+			annotations:     nil,
+			wantSpecChanged: true,
+		},
+		{
+			testName:        "opendatahub.io/managed=false: controller skips update",
+			annotations:     map[string]string{tenantreconcile.AnnotationManaged: "false"},
+			wantSpecChanged: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.testName, func(t *testing.T) {
+			existingHR := &gatewayapiv1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        name,
+					Namespace:   ns,
+					Annotations: tc.annotations,
+				},
+				Spec: gatewayapiv1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapiv1.CommonRouteSpec{
+						ParentRefs: []gatewayapiv1.ParentReference{
+							{Name: sentinelParentName},
+						},
+					},
+				},
+			}
+
+			em := newTestExternalModel(name, ns, endpoint, nil)
+			c := fake.NewClientBuilder().WithScheme(testScheme).WithObjects(em, existingHR).Build()
+			r := &Reconciler{Client: c, Scheme: testScheme, Log: ctrl.Log, GatewayName: "maas-default-gateway", GatewayNamespace: "openshift-ingress"}
+
+			_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: name, Namespace: ns}})
+			require.NoError(t, err)
+
+			got := &gatewayapiv1.HTTPRoute{}
+			require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: name, Namespace: ns}, got))
+
+			if tc.wantSpecChanged {
+				require.Len(t, got.Spec.ParentRefs, 1)
+				assert.Equal(t, gatewayapiv1.ObjectName("maas-default-gateway"), got.Spec.ParentRefs[0].Name,
+					"expected HTTPRoute parent to be updated to configured gateway")
+			} else {
+				require.Len(t, got.Spec.ParentRefs, 1)
+				assert.Equal(t, sentinelParentName, got.Spec.ParentRefs[0].Name,
+					"expected HTTPRoute parent to be unchanged (managed=false opt-out)")
+			}
+		})
+	}
+}
+
+// TestManagedAnnotation_DestinationRule_DeletePath verifies that an existing DestinationRule with
+// opendatahub.io/managed=false is NOT deleted when the ExternalModel switches to TLS=false.
+// (deleteIfExists is called to remove the stale DestinationRule when TLS is disabled.)
+func TestManagedAnnotation_DestinationRule_DeletePath(t *testing.T) {
+	const (
+		name     = "gpt-4o"
+		ns       = "llm"
+		endpoint = "vllm.internal"
+	)
+
+	tests := []struct {
+		testName    string
+		annotations map[string]string
+		wantDeleted bool
+	}{
+		{
+			testName:    "annotation absent: controller deletes stale DestinationRule",
+			annotations: nil,
+			wantDeleted: true,
+		},
+		{
+			testName:    "opendatahub.io/managed=true: controller deletes stale DestinationRule",
+			annotations: map[string]string{tenantreconcile.AnnotationManaged: "true"},
+			wantDeleted: true,
+		},
+		{
+			testName:    "opendatahub.io/managed=false: controller must not delete opted-out DestinationRule",
+			annotations: map[string]string{tenantreconcile.AnnotationManaged: "false"},
+			wantDeleted: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.testName, func(t *testing.T) {
+			// Pre-populate a stale DestinationRule (left over from when TLS was enabled).
+			existingDR := &unstructured.Unstructured{}
+			existingDR.SetGroupVersionKind(schema.GroupVersionKind{Group: "networking.istio.io", Version: "v1", Kind: "DestinationRule"})
+			existingDR.SetName(name)
+			existingDR.SetNamespace(ns)
+			existingDR.SetAnnotations(tc.annotations)
+
+			// ExternalModel has tls=false annotation so the reconciler calls deleteIfExists on the DR.
+			em := newTestExternalModel(name, ns, endpoint, map[string]string{annotationTLS: "false"})
+			c := fake.NewClientBuilder().WithScheme(testScheme).WithObjects(em, existingDR).Build()
+			r := &Reconciler{Client: c, Scheme: testScheme, Log: ctrl.Log}
+
+			_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: name, Namespace: ns}})
+			require.NoError(t, err)
+
+			got := &unstructured.Unstructured{}
+			got.SetGroupVersionKind(schema.GroupVersionKind{Group: "networking.istio.io", Version: "v1", Kind: "DestinationRule"})
+			getErr := c.Get(context.Background(), types.NamespacedName{Name: name, Namespace: ns}, got)
+
+			if tc.wantDeleted {
+				assert.True(t, apierrors.IsNotFound(getErr),
+					"expected DestinationRule to be deleted, but it still exists (err: %v)", getErr)
+			} else {
+				assert.NoError(t, getErr,
+					"expected DestinationRule to survive (managed=false opt-out), but got error: %v", getErr)
+			}
+		})
+	}
+}
+
+// TestIsManaged verifies the isManaged helper function covers all edge cases.
+func TestIsManaged(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		want        bool
+	}{
+		{name: "nil annotations", annotations: nil, want: true},
+		{name: "empty annotations", annotations: map[string]string{}, want: true},
+		{name: "other annotations only", annotations: map[string]string{"other.io/key": "value"}, want: true},
+		{name: "managed=false opts out", annotations: map[string]string{tenantreconcile.AnnotationManaged: "false"}, want: false},
+		{name: "managed=true is managed", annotations: map[string]string{tenantreconcile.AnnotationManaged: "true"}, want: true},
+		{name: "managed=1 is managed (only 'false' opts out)", annotations: map[string]string{tenantreconcile.AnnotationManaged: "1"}, want: true},
+		{name: "managed=FALSE (uppercase) is managed", annotations: map[string]string{tenantreconcile.AnnotationManaged: "FALSE"}, want: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			obj := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Annotations: tc.annotations}}
+			assert.Equal(t, tc.want, isManaged(obj))
+		})
+	}
+}


### PR DESCRIPTION
## Description

Audits all resource types reconciled by `maas-controller` to confirm the `opendatahub.io/managed=false` opt-out annotation is respected on both the write (create/update) and delete paths.

## How Has This Been Tested?

New unit tests in `pkg/reconciler/externalmodel/reconciler_test.go` cover the added behaviour:

- `TestManagedAnnotation_Service` — write-path opt-out: pre-existing Service with `managed=false` keeps its sentinel `ExternalName` after reconcile.
- `TestManagedAnnotation_ServiceEntry` — write-path opt-out: pre-existing ServiceEntry spec is untouched.
- `TestManagedAnnotation_HTTPRoute` — write-path opt-out: pre-existing HTTPRoute parent ref is untouched.
- `TestManagedAnnotation_DestinationRule_DeletePath` — delete-path opt-out: stale DestinationRule with `managed=false` survives the TLS→no-TLS transition that would otherwise call `deleteIfExists`.
- `TestIsManaged` — unit-tests the helper across all edge cases (nil annotations, absent key, `false`, `true`, other values, case-sensitivity).

Each test includes the three-way table `absent / managed=false / managed=true` to confirm the positive and negative cases.
https://redhat.atlassian.net/browse/RHOAIENG-60911

## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Resources can now opt-out of automatic management by setting the `opendatahub.io/managed=false` annotation. When applied, the controller will skip updates and deletions for annotated resources.

* **Tests**
  * Added comprehensive test coverage for opt-out annotation behavior across service management, gateway routing, and resource lifecycle operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->