### PR TITLE
chore: add nextProtos to TLS

### DIFF
--- a/docs/content/configuration-and-management/model-listing-flow.md
+++ b/docs/content/configuration-and-management/model-listing-flow.md
@@ -67,6 +67,7 @@ The maas-api deployment supports the following environment variable to control a
 | Variable | Description | Default | Constraints |
 |----------|-------------|---------|-------------|
 | `ACCESS_CHECK_TIMEOUT_SECONDS` | Timeout in seconds for each model access validation probe during `GET /v1/models`. Models that do not respond within this window are excluded from the response (fail-closed). | `15` | Must be ≥ 1 |
+| `DISCOVERY_ENABLE_HTTP2` | Enable HTTP/2 ALPN negotiation on the TLS client used for model discovery probes. Only enable if all model backends support HTTP/2. | `false` | `true` or `false` |
 
 !!! tip "When to increase"
     If models are missing from `GET /v1/models` responses and maas-api logs show probe timeouts, increase `ACCESS_CHECK_TIMEOUT_SECONDS` to give slower backends more time to respond. This is common when model endpoints have cold-start latency or are under heavy load.

--- a/maas-api/cmd/main.go
+++ b/maas-api/cmd/main.go
@@ -233,7 +233,7 @@ func registerHandlers(
 		log.Info("Resolved gateway internal host for access probes", "host", gatewayInternalHost)
 	}
 
-	modelManager, err := models.NewManager(log, cfg.AccessCheckTimeoutSeconds, gatewayInternalHost)
+	modelManager, err := models.NewManager(log, cfg.AccessCheckTimeoutSeconds, gatewayInternalHost, cfg.DiscoveryEnableHTTP2)
 	if err != nil {
 		log.Fatal("Failed to create model manager", "error", err)
 	}

--- a/maas-api/cmd/server.go
+++ b/maas-api/cmd/server.go
@@ -52,6 +52,7 @@ func buildTLSConfig(cfg *config.Config) (*tls.Config, error) {
 	return &tls.Config{
 		Certificates: []tls.Certificate{tlsCert},
 		MinVersion:   cfg.TLS.MinVersion.Value(),
+		NextProtos:   []string{"h2", "http/1.1"},
 	}, nil
 }
 

--- a/maas-api/internal/config/config.go
+++ b/maas-api/internal/config/config.go
@@ -79,6 +79,10 @@ type Config struct {
 
 	MetricsPort int
 
+	// DiscoveryEnableHTTP2 enables HTTP/2 ALPN negotiation on the TLS client used
+	// by model discovery probes. Default: false (HTTP/1.1 only).
+	DiscoveryEnableHTTP2 bool
+
 	// OTELEndpoint is the OTLP gRPC endpoint for trace export (e.g., "localhost:4317").
 	// Tracing is disabled when empty.
 	OTELEndpoint string
@@ -104,6 +108,7 @@ func Load() *Config {
 	sarCacheMaxSize, _ := env.GetInt("SAR_CACHE_MAX_SIZE", constant.DefaultSARCacheMaxSize)
 	lastUsedDebounceSecs, _ := env.GetInt("LAST_USED_DEBOUNCE_SECS", 60)
 	metricsPort, _ := env.GetInt("METRICS_PORT", constant.DefaultMetricsPort)
+	discoveryEnableHTTP2, _ := env.GetBool("DISCOVERY_ENABLE_HTTP2", false)
 	otelInsecure, _ := env.GetBool("OTEL_EXPORTER_OTLP_INSECURE", false)
 	otelSampleRate := 1.0
 	if rateStr := env.GetString("OTEL_TRACES_SAMPLE_RATE", ""); rateStr != "" {
@@ -139,6 +144,7 @@ func Load() *Config {
 		SARCacheMaxSize:           sarCacheMaxSize,
 		LastUsedDebounceSecs:      lastUsedDebounceSecs,
 		MetricsPort:               metricsPort,
+		DiscoveryEnableHTTP2:      discoveryEnableHTTP2,
 		OTELEndpoint:              env.GetString("OTEL_EXPORTER_OTLP_ENDPOINT", ""),
 		OTELInsecure:              otelInsecure,
 		OTELSampleRate:            otelSampleRate,

--- a/maas-api/internal/handlers/models_test.go
+++ b/maas-api/internal/handlers/models_test.go
@@ -349,7 +349,7 @@ func TestListingModels(t *testing.T) { //nolint:maintidx // table-driven test wi
 	}
 	router, _ := fixtures.SetupTestServer(t, config)
 
-	modelMgr, errMgr := models.NewManager(testLogger, 15, "")
+	modelMgr, errMgr := models.NewManager(testLogger, 15, "", false)
 	require.NoError(t, errMgr)
 
 	// Set up test fixtures
@@ -464,7 +464,7 @@ func TestListingModelsWithSubscriptionHeader(t *testing.T) {
 	}
 	router, _ := fixtures.SetupTestServer(t, config)
 
-	modelMgr, errMgr := models.NewManager(testLogger, 15, "")
+	modelMgr, errMgr := models.NewManager(testLogger, 15, "", false)
 	require.NoError(t, errMgr)
 
 	_, cleanup := fixtures.StubTokenProviderAPIs(t)
@@ -692,7 +692,7 @@ func TestListModels_ReturnAllModels(t *testing.T) {
 		},
 	}
 
-	modelMgr, err := models.NewManager(testLogger, 15, "")
+	modelMgr, err := models.NewManager(testLogger, 15, "", false)
 	require.NoError(t, err)
 
 	subscriptionSelector := subscription.NewSelector(testLogger, subscriptionLister, nil, nil)
@@ -881,7 +881,7 @@ func TestListModels_DeduplicationBySubscription(t *testing.T) {
 		},
 	}
 
-	modelMgr, err := models.NewManager(testLogger, 15, "")
+	modelMgr, err := models.NewManager(testLogger, 15, "", false)
 	require.NoError(t, err)
 
 	subscriptionSelector := subscription.NewSelector(testLogger, subscriptionLister, nil, nil)
@@ -999,7 +999,7 @@ func TestListModels_DifferentModelRefsWithSameModelID(t *testing.T) {
 		},
 	}
 
-	modelMgr, err := models.NewManager(testLogger, 15, "")
+	modelMgr, err := models.NewManager(testLogger, 15, "", false)
 	require.NoError(t, err)
 
 	subscriptionSelector := subscription.NewSelector(testLogger, subscriptionLister, nil, nil)
@@ -1106,7 +1106,7 @@ func TestListModels_DifferentModelRefsWithSameURLAndModelID(t *testing.T) {
 		},
 	}
 
-	modelMgr, err := models.NewManager(testLogger, 15, "")
+	modelMgr, err := models.NewManager(testLogger, 15, "", false)
 	require.NoError(t, err)
 
 	subscriptionSelector := subscription.NewSelector(testLogger, subscriptionLister, nil, nil)
@@ -1212,7 +1212,7 @@ func TestListModels_DifferentModelRefsWithSameModelIDAndDifferentSubscriptions(t
 		},
 	}
 
-	modelMgr, err := models.NewManager(testLogger, 15, "")
+	modelMgr, err := models.NewManager(testLogger, 15, "", false)
 	require.NoError(t, err)
 
 	subscriptionSelector := subscription.NewSelector(testLogger, subscriptionLister, nil, nil)
@@ -1305,7 +1305,7 @@ func TestListModels_ExternalModelUsesModelRefName(t *testing.T) {
 		},
 	}
 
-	modelMgr, err := models.NewManager(testLogger, 15, "")
+	modelMgr, err := models.NewManager(testLogger, 15, "", false)
 	require.NoError(t, err)
 
 	subscriptionSelector := subscription.NewSelector(testLogger, &fakeSubscriptionLister{}, lister, nil)

--- a/maas-api/internal/models/discovery.go
+++ b/maas-api/internal/models/discovery.go
@@ -140,7 +140,7 @@ func BuildClusterTLSConfigFromPath(log *logger.Logger, caPath string) (*tls.Conf
 		if os.IsNotExist(err) {
 			log.Debug("Kubernetes service account CA not found, using system root CAs only",
 				"path", caPath)
-			return &tls.Config{MinVersion: tls.VersionTLS12, RootCAs: caCertPool, NextProtos: []string{"h2", "http/1.1"}}, nil
+			return &tls.Config{MinVersion: tls.VersionTLS12, RootCAs: caCertPool}, nil
 		}
 		return nil, fmt.Errorf("failed to read CA certificate: %w", err)
 	}
@@ -155,7 +155,6 @@ func BuildClusterTLSConfigFromPath(log *logger.Logger, caPath string) (*tls.Conf
 	return &tls.Config{
 		RootCAs:    caCertPool,
 		MinVersion: tls.VersionTLS12,
-		NextProtos: []string{"h2", "http/1.1"},
 	}, nil
 }
 

--- a/maas-api/internal/models/discovery.go
+++ b/maas-api/internal/models/discovery.go
@@ -140,7 +140,7 @@ func BuildClusterTLSConfigFromPath(log *logger.Logger, caPath string) (*tls.Conf
 		if os.IsNotExist(err) {
 			log.Debug("Kubernetes service account CA not found, using system root CAs only",
 				"path", caPath)
-			return &tls.Config{MinVersion: tls.VersionTLS12, RootCAs: caCertPool}, nil
+			return &tls.Config{MinVersion: tls.VersionTLS12, RootCAs: caCertPool, NextProtos: []string{"h2", "http/1.1"}}, nil
 		}
 		return nil, fmt.Errorf("failed to read CA certificate: %w", err)
 	}
@@ -155,6 +155,7 @@ func BuildClusterTLSConfigFromPath(log *logger.Logger, caPath string) (*tls.Conf
 	return &tls.Config{
 		RootCAs:    caCertPool,
 		MinVersion: tls.VersionTLS12,
+		NextProtos: []string{"h2", "http/1.1"},
 	}, nil
 }
 

--- a/maas-api/internal/models/discovery.go
+++ b/maas-api/internal/models/discovery.go
@@ -66,7 +66,7 @@ type Manager struct {
 // gatewayInternalHost, when non-empty, routes all probe TCP connections to this
 // cluster-internal address while preserving the original URL hostname for TLS SNI
 // and the Host header, so gateway routing and Authorino auth work identically.
-func NewManager(log *logger.Logger, accessCheckTimeoutSeconds int, gatewayInternalHost string) (*Manager, error) {
+func NewManager(log *logger.Logger, accessCheckTimeoutSeconds int, gatewayInternalHost string, enableHTTP2 bool) (*Manager, error) {
 	if log == nil {
 		return nil, errors.New("log is required")
 	}
@@ -75,7 +75,7 @@ func NewManager(log *logger.Logger, accessCheckTimeoutSeconds int, gatewayIntern
 		timeout = time.Duration(accessCheckTimeoutSeconds) * time.Second
 	}
 
-	tlsConfig, err := BuildClusterTLSConfigFromPath(log, kubeServiceAccountCAPath)
+	tlsConfig, err := BuildClusterTLSConfigFromPath(log, kubeServiceAccountCAPath, enableHTTP2)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build TLS config: %w", err)
 	}
@@ -115,7 +115,7 @@ func NewManager(log *logger.Logger, accessCheckTimeoutSeconds int, gatewayIntern
 // the default Kubernetes service account CA path. It is a convenience wrapper around
 // BuildClusterTLSConfigFromPath.
 func BuildClusterTLSConfig(log *logger.Logger) (*tls.Config, error) {
-	return BuildClusterTLSConfigFromPath(log, kubeServiceAccountCAPath)
+	return BuildClusterTLSConfigFromPath(log, kubeServiceAccountCAPath, false)
 }
 
 // BuildClusterTLSConfigFromPath creates a TLS config for cluster-internal communication.
@@ -125,7 +125,7 @@ func BuildClusterTLSConfig(log *logger.Logger) (*tls.Config, error) {
 //
 // If caPath does not exist, system root CAs are used alone (development/out-of-cluster mode).
 // If caPath exists but cannot be read or parsed, an error is returned to prevent insecure fallback.
-func BuildClusterTLSConfigFromPath(log *logger.Logger, caPath string) (*tls.Config, error) {
+func BuildClusterTLSConfigFromPath(log *logger.Logger, caPath string, enableHTTP2 bool) (*tls.Config, error) {
 	if log == nil {
 		return nil, errors.New("log is required")
 	}
@@ -140,22 +140,25 @@ func BuildClusterTLSConfigFromPath(log *logger.Logger, caPath string) (*tls.Conf
 		if os.IsNotExist(err) {
 			log.Debug("Kubernetes service account CA not found, using system root CAs only",
 				"path", caPath)
-			return &tls.Config{MinVersion: tls.VersionTLS12, RootCAs: caCertPool}, nil
+		} else {
+			return nil, fmt.Errorf("failed to read CA certificate: %w", err)
 		}
-		return nil, fmt.Errorf("failed to read CA certificate: %w", err)
+	} else {
+		if !caCertPool.AppendCertsFromPEM(caCert) {
+			return nil, errors.New("failed to parse Kubernetes service account CA certificate")
+		}
+		log.Debug("Using system root CAs with Kubernetes service account CA appended",
+			"path", caPath)
 	}
 
-	if !caCertPool.AppendCertsFromPEM(caCert) {
-		return nil, errors.New("failed to parse Kubernetes service account CA certificate")
-	}
-
-	log.Debug("Using system root CAs with Kubernetes service account CA appended",
-		"path", caPath)
-
-	return &tls.Config{
+	tlsCfg := &tls.Config{
 		RootCAs:    caCertPool,
 		MinVersion: tls.VersionTLS12,
-	}, nil
+	}
+	if enableHTTP2 {
+		tlsCfg.NextProtos = []string{"h2", "http/1.1"}
+	}
+	return tlsCfg, nil
 }
 
 // FilterModelsByAccess returns only models the user can access by probing each model's

--- a/maas-api/internal/models/discovery_test.go
+++ b/maas-api/internal/models/discovery_test.go
@@ -126,6 +126,26 @@ func TestBuildClusterTLSConfigFromPath(t *testing.T) {
 		assert.Equal(t, uint16(tls.VersionTLS12), tlsConfig.MinVersion)
 		assert.NotNil(t, tlsConfig.RootCAs)
 	})
+
+	t.Run("sets NextProtos when HTTP/2 is enabled", func(t *testing.T) {
+		log := logger.New(true)
+
+		tlsConfig, err := models.BuildClusterTLSConfigFromPath(log, "/nonexistent/ca.crt", true)
+		require.NoError(t, err)
+		require.NotNil(t, tlsConfig)
+
+		assert.Equal(t, []string{"h2", "http/1.1"}, tlsConfig.NextProtos)
+	})
+
+	t.Run("does not set NextProtos when HTTP/2 is disabled", func(t *testing.T) {
+		log := logger.New(true)
+
+		tlsConfig, err := models.BuildClusterTLSConfigFromPath(log, "/nonexistent/ca.crt", false)
+		require.NoError(t, err)
+		require.NotNil(t, tlsConfig)
+
+		assert.Nil(t, tlsConfig.NextProtos)
+	})
 }
 
 // selfSignedCertPEM generates a minimal self-signed CA certificate in PEM format for use in tests.

--- a/maas-api/internal/models/discovery_test.go
+++ b/maas-api/internal/models/discovery_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestNewManager(t *testing.T) {
 	t.Run("returns error when logger is nil", func(t *testing.T) {
-		manager, err := models.NewManager(nil, 15, "")
+		manager, err := models.NewManager(nil, 15, "", false)
 		require.Error(t, err)
 		assert.Nil(t, manager)
 		assert.Contains(t, err.Error(), "log is required")
@@ -31,7 +31,7 @@ func TestNewManager(t *testing.T) {
 	t.Run("creates manager successfully with valid logger", func(t *testing.T) {
 		log := logger.New(true)
 
-		manager, err := models.NewManager(log, 15, "")
+		manager, err := models.NewManager(log, 15, "", false)
 		require.NoError(t, err)
 		assert.NotNil(t, manager)
 	})
@@ -63,7 +63,7 @@ func TestBuildClusterTLSConfig(t *testing.T) {
 
 func TestBuildClusterTLSConfigFromPath(t *testing.T) {
 	t.Run("returns error when logger is nil", func(t *testing.T) {
-		tlsConfig, err := models.BuildClusterTLSConfigFromPath(nil, "/nonexistent")
+		tlsConfig, err := models.BuildClusterTLSConfigFromPath(nil, "/nonexistent", false)
 		require.Error(t, err)
 		assert.Nil(t, tlsConfig)
 	})
@@ -71,7 +71,7 @@ func TestBuildClusterTLSConfigFromPath(t *testing.T) {
 	t.Run("uses system root CAs when CA file is absent", func(t *testing.T) {
 		log := logger.New(true)
 
-		tlsConfig, err := models.BuildClusterTLSConfigFromPath(log, "/nonexistent/ca.crt")
+		tlsConfig, err := models.BuildClusterTLSConfigFromPath(log, "/nonexistent/ca.crt", false)
 		require.NoError(t, err)
 		require.NotNil(t, tlsConfig)
 
@@ -89,7 +89,7 @@ func TestBuildClusterTLSConfigFromPath(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, f.Close())
 
-		tlsConfig, err := models.BuildClusterTLSConfigFromPath(log, f.Name())
+		tlsConfig, err := models.BuildClusterTLSConfigFromPath(log, f.Name(), false)
 		require.Error(t, err)
 		assert.Nil(t, tlsConfig)
 		assert.Contains(t, err.Error(), "failed to parse")
@@ -103,7 +103,7 @@ func TestBuildClusterTLSConfigFromPath(t *testing.T) {
 		require.NoError(t, os.WriteFile(caPath, []byte("placeholder"), 0o000))
 		t.Cleanup(func() { _ = os.Chmod(caPath, 0o644) })
 
-		tlsConfig, err := models.BuildClusterTLSConfigFromPath(log, caPath)
+		tlsConfig, err := models.BuildClusterTLSConfigFromPath(log, caPath, false)
 		require.Error(t, err)
 		assert.Nil(t, tlsConfig)
 	})
@@ -118,7 +118,7 @@ func TestBuildClusterTLSConfigFromPath(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, f.Close())
 
-		tlsConfig, err := models.BuildClusterTLSConfigFromPath(log, f.Name())
+		tlsConfig, err := models.BuildClusterTLSConfigFromPath(log, f.Name(), false)
 		require.NoError(t, err)
 		require.NotNil(t, tlsConfig)
 

--- a/maas-controller/cmd/manager/main.go
+++ b/maas-controller/cmd/manager/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
 	stderrors "errors"
 	"flag"
 	"fmt"
@@ -813,9 +814,16 @@ func main() {
 	}
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
-		Scheme:                 scheme,
-		Cache:                  cacheOpts,
-		Metrics:                metricsserver.Options{BindAddress: metricsAddr},
+		Scheme: scheme,
+		Cache:  cacheOpts,
+		Metrics: metricsserver.Options{
+			BindAddress: metricsAddr,
+			TLSOpts: []func(*tls.Config){
+				func(c *tls.Config) {
+					c.NextProtos = []string{"h2", "http/1.1"}
+				},
+			},
+		},
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "maas-controller.models-as-a-service.opendatahub.io",

--- a/test/e2e/tests/test_models_endpoint.py
+++ b/test/e2e/tests/test_models_endpoint.py
@@ -384,40 +384,24 @@ class TestModelsEndpoint:
 
             # Test: GET /v1/models WITH x-maas-subscription header using K8s token
             # Expected: Returns models from simulator-subscription only
-            # Poll until models appear — gateway policy and subscription metadata
-            # propagation can lag behind CR readiness.
             log.info("Testing: GET /v1/models with K8s token and explicit subscription header: simulator-subscription")
             url = f"{_maas_api_url()}/v1/models"
-            request_headers = {
-                "Authorization": f"Bearer {sa_token}",  # K8s token, not API key
-                "x-maas-subscription": SIMULATOR_SUBSCRIPTION,
-            }
-            deadline = time.time() + 120
-            r = None
-            models = []
-            while time.time() < deadline:
-                r = _request_with_gateway_retry(
-                    requests.get,
-                    url,
-                    headers=request_headers,
-                )
-                if r.status_code == 200:
-                    data = r.json()
-                    models = data.get("data") or []
-                    if len(models) > 0:
-                        break
-                    log.info(f"Models not yet propagated, got {len(models)} entries")
-                else:
-                    log.info(f"Waiting for /v1/models HTTP 200; got {r.status_code}")
-                time.sleep(5)
+            r = _request_with_gateway_retry(
+                requests.get,
+                url,
+                headers={
+                    "Authorization": f"Bearer {sa_token}",  # K8s token, not API key
+                    "x-maas-subscription": SIMULATOR_SUBSCRIPTION,
+                },
+            )
 
-            assert r is not None, "Expected /v1/models response, got none"
             assert r.status_code == 200, f"Expected 200 with explicit subscription header, got {r.status_code}: {r.text}"
 
             # Validate response structure
             data = r.json()
             assert data.get("object") == "list", f"Expected object='list', got {data.get('object')}"
             assert "data" in data, "Response missing 'data' field"
+            models = data.get("data", []) if data.get("data") is not None else []
 
             # Should have at least one model from simulator-subscription
             assert len(models) > 0, f"Expected at least one model in response, got {len(models)}. Data was: {data.get('data')}"

--- a/test/e2e/tests/test_models_endpoint.py
+++ b/test/e2e/tests/test_models_endpoint.py
@@ -384,24 +384,40 @@ class TestModelsEndpoint:
 
             # Test: GET /v1/models WITH x-maas-subscription header using K8s token
             # Expected: Returns models from simulator-subscription only
+            # Poll until models appear — gateway policy and subscription metadata
+            # propagation can lag behind CR readiness.
             log.info("Testing: GET /v1/models with K8s token and explicit subscription header: simulator-subscription")
             url = f"{_maas_api_url()}/v1/models"
-            r = _request_with_gateway_retry(
-                requests.get,
-                url,
-                headers={
-                    "Authorization": f"Bearer {sa_token}",  # K8s token, not API key
-                    "x-maas-subscription": SIMULATOR_SUBSCRIPTION,
-                },
-            )
+            request_headers = {
+                "Authorization": f"Bearer {sa_token}",  # K8s token, not API key
+                "x-maas-subscription": SIMULATOR_SUBSCRIPTION,
+            }
+            deadline = time.time() + 120
+            r = None
+            models = []
+            while time.time() < deadline:
+                r = _request_with_gateway_retry(
+                    requests.get,
+                    url,
+                    headers=request_headers,
+                )
+                if r.status_code == 200:
+                    data = r.json()
+                    models = data.get("data") or []
+                    if len(models) > 0:
+                        break
+                    log.info(f"Models not yet propagated, got {len(models)} entries")
+                else:
+                    log.info(f"Waiting for /v1/models HTTP 200; got {r.status_code}")
+                time.sleep(5)
 
+            assert r is not None, "Expected /v1/models response, got none"
             assert r.status_code == 200, f"Expected 200 with explicit subscription header, got {r.status_code}: {r.text}"
 
             # Validate response structure
             data = r.json()
             assert data.get("object") == "list", f"Expected object='list', got {data.get('object')}"
             assert "data" in data, "Response missing 'data' field"
-            models = data.get("data", []) if data.get("data") is not None else []
 
             # Should have at least one model from simulator-subscription
             assert len(models) > 0, f"Expected at least one model in response, got {len(models)}. Data was: {data.get('data')}"


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-61392

## Description
To address the required changes as per Jira issue:
1. `maas-api/cmd/server.go`: Adds `NextProtos: ["h2", "http/1.1"]` to the `maas-api` server's TLS config, enabling HTTP/2 for inbound connections.
2. `maas-controller/cmd/manager/main.go`: Adds `NextProtos` via TLSOpts on the controller-runtime metrics server. Currently requires `SecureServing: true` to take effect, but pre-staged for when it's enabled.
3. `maas-api/internal/models/discovery.go`: Makes `HTTP/2` on the model discovery probe client configurable via `DISCOVERY_ENABLE_HTTP2` (defaults to false). The main reason why we had to add a new `env var` is because adding `NextProtos` unconditionally to the client-side TLS config would break model probes if backends don't properly support HTTP/2, causing /v1/models to **silently** return **empty results**.
4. `docs/content/configuration-and-management/model-listing-flow.md`: Documents the new env var in the existing configuration table.
5. Additiona lunit tests: Updated all callers of NewManager and BuildClusterTLSConfigFromPath to pass the new parameter. Also, added two new subtests verifying `NextProtos` is set when HTTP/2 is enabled and absent when disabled.

## How Has This Been Tested?
Unit tests pass

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional HTTP/2 support for model discovery probes.
  * Added the `DISCOVERY_ENABLE_HTTP2` configuration setting, defaulting to disabled.
  * Enabled HTTP/2 and HTTP/1.1 negotiation for the controller metrics server.

* **Documentation**
  * Documented the new discovery HTTP/2 configuration option, including valid values and default behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->