### PR TITLE
ci: harden promote-stable-to-rhoai merge step

### DIFF
--- a/.github/workflows/promote-stable-to-rhoai.yml
+++ b/.github/workflows/promote-stable-to-rhoai.yml
@@ -80,11 +80,12 @@ jobs:
             exit 1
           fi
 
-          git merge --abort
+          git merge --abort || true
 
       - name: Merge stable into rhoai
         if: steps.check.outputs.skip != 'true'
         run: |
+          set -euo pipefail
           git checkout rhoai
           git reset --hard origin/rhoai
 


### PR DESCRIPTION
## Summary

Follow-up to #926 — addresses review feedback from @ishitasequeira.

## Description

- Add `set -euo pipefail` to the "Merge stable into rhoai" step to ensure any silent command failure aborts execution before `git push` can run against bad state.
- Guard the dry-run `git merge --abort` with `|| true` to prevent spurious "no merge in progress" errors if the conflict path already aborted the merge.

## How it was tested

- Verified workflow syntax is valid
- Logic reviewed: `set -euo pipefail` catches unset variables (`-u`), pipe failures (`-o pipefail`), and non-zero exits (`-e`) before the push step
- `|| true` only applies to the abort after a successful dry-run merge, which is the only path that reaches it

## Risk analysis

- **Risk rating**: 1
- **Why**: Minimal change (2 lines) in a CI workflow that only runs on-demand. Adds strictly defensive behavior — cannot introduce regressions.

Ref: [RHOAIENG-63731](https://redhat.atlassian.net/browse/RHOAIENG-63731)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved merge conflict handling resilience in CI/CD workflows to prevent error masking during cleanup operations, ensuring clearer failure diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->