### PR TITLE
chore: restrict /lgtm to approvers and add CODEOWNERS for review assignment

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @opendatahub-io/model-as-a-service-maintainers

--- a/OWNERS
+++ b/OWNERS
@@ -6,13 +6,5 @@ approvers:
 reviewers:
   - chaitanya1731
   - jland-redhat
-  - dmytro-zaharnytskyi
-  - SB159
   - ishitasequeira
-  - yu-teo
-  - mynhardtburger
-  - somya-bhatnagar
-  - liangwen12year
-  - ryancham715
   - jrhyness
-  - EgorLu


### PR DESCRIPTION
## Summary
- Restricts `/lgtm` and `/approve` permissions to core maintainers only.
- Adds GitHub CODEOWNERS for automatic reviewer assignment from the broader team.

## Description
- Narrows the `OWNERS` `reviewers` list to match `approvers` (chaitanya1731, jland-redhat, ishitasequeira, jrhyness), ensuring only these 4 can issue `/lgtm` and `/approve` via Prow.
- Introduces `.github/CODEOWNERS` pointing to `@opendatahub-io/model-as-a-service-maintainers` (15 members) so GitHub automatically requests reviews from team members on every PR.
- The broader team retains full ability to review and comment on PRs but cannot add Prow merge-gating labels.

## How it was tested
- Verified `opendatahub-io/model-as-a-service-maintainers` team exists and has 15 members via GitHub API.
- Confirmed CODEOWNERS syntax is valid for GitHub's code review assignment.

## Risk analysis
- **Risk rating**: 1
- **Why**: No runtime code changes. Only affects PR workflow permissions. Easily reversible if the team needs broader `/lgtm` access restored.


Made with [Cursor](https://cursor.com)