### PR TITLE
chore: remove reviewers from OWNERS to disable prow auto-assignment

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -3,8 +3,3 @@ approvers:
   - jland-redhat
   - ishitasequeira
   - jrhyness
-reviewers:
-  - chaitanya1731
-  - jland-redhat
-  - ishitasequeira
-  - jrhyness


### PR DESCRIPTION
## Summary
- Removes `reviewers` section from OWNERS to stop Prow blunderbuss from auto-assigning reviewers.
- Reviewer assignment is now handled by `.github/CODEOWNERS` + GitHub team code review assignment settings.

## Description
- With the `reviewers` list present, Prow's blunderbuss plugin auto-assigns reviewers from OWNERS, duplicating the CODEOWNERS-based assignment.
- By removing `reviewers`, only the `model-as-a-service-maintainers` GitHub team (via CODEOWNERS) handles review assignment.
- The `approvers` list remains unchanged — these 4 people retain `/lgtm` and `/approve` permissions for Tide merge gating.

## How it was tested
- Verified approvers can still `/lgtm` and `/approve` (approvers implicitly have `/lgtm` in Prow).
- Confirmed CODEOWNERS auto-assignment works via test PR #930.

## Risk analysis
- **Risk rating**: 1
- **Why**: No runtime code changes. Only affects PR review assignment workflow. Approvers retain full merge-gating authority.


Made with [Cursor](https://cursor.com)