### PR TITLE
ci: harden promotion workflows with conflict pre-check and rich summaries

### DIFF
--- a/.github/workflows/promote-main-to-stable.yml
+++ b/.github/workflows/promote-main-to-stable.yml
@@ -5,8 +5,8 @@
 #
 # This workflow:
 #   1. Checks if stable is behind main
-#   2. Creates a PR from main -> stable if there are new changes
-#   3. Reuses an existing open PR if one already exists
+#   2. Verifies there are no merge conflicts (strict — fails on any conflict)
+#   3. Creates/updates a PR from main → stable only if merge is clean
 
 name: Promote Main to Stable
 
@@ -25,7 +25,7 @@ env:
 
 jobs:
   promote:
-    name: Create Promotion PR
+    name: Promote main to stable
     runs-on: ubuntu-latest
 
     steps:
@@ -40,9 +40,8 @@ jobs:
           git config user.name "${{ env.GH_USER_NAME }}"
           git config user.email "${{ env.GH_USER_EMAIL }}"
 
-      - name: Promote main to stable
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check for new commits
+        id: check
         run: |
           git fetch origin main stable
 
@@ -50,30 +49,86 @@ jobs:
           if [ "$DIFF_COUNT" -eq 0 ]; then
             echo "stable is already up to date with main. Nothing to promote."
             echo "## Promote Main to Stable" >> "$GITHUB_STEP_SUMMARY"
-            echo "stable is already up to date with main. No PR needed." >> "$GITHUB_STEP_SUMMARY"
+            echo "stable is already up to date with main. No changes to merge." >> "$GITHUB_STEP_SUMMARY"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           echo "Found $DIFF_COUNT commit(s) to promote from main to stable."
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+          echo "diff_count=$DIFF_COUNT" >> "$GITHUB_OUTPUT"
 
-          COMMIT_LOG=$(git log --oneline origin/stable..origin/main --no-merges | head -30)
-          BODY="Automated promotion of **${DIFF_COUNT} commit(s)** from \`main\` to \`stable\`."
-          BODY="${BODY}"$'\n\n'"\`\`\`"$'\n'"${COMMIT_LOG}"$'\n'"\`\`\`"
+      - name: Check for merge conflicts
+        if: steps.check.outputs.skip != 'true'
+        run: |
+          git checkout origin/stable
 
-          EXISTING_PR=$(gh pr list --base stable --head main --state open --json number --jq '.[0].number // empty')
+          if ! git merge --no-commit --no-ff origin/main; then
+            echo "::error::Merge conflicts detected between main and stable."
+            echo "## Promote Main to Stable — FAILED" >> "$GITHUB_STEP_SUMMARY"
+            echo "### Merge conflicts detected" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "The following files have conflicts:" >> "$GITHUB_STEP_SUMMARY"
+            echo '````' >> "$GITHUB_STEP_SUMMARY"
+            git diff --name-only --diff-filter=U >> "$GITHUB_STEP_SUMMARY"
+            echo '````' >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "Please resolve conflicts manually before re-running this workflow." >> "$GITHUB_STEP_SUMMARY"
+            git merge --abort
+            exit 1
+          fi
+
+          git merge --abort || true
+
+      - name: Create or update promotion PR
+        if: steps.check.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DIFF_COUNT: ${{ steps.check.outputs.diff_count }}
+        run: |
+          set -euo pipefail
+
+          COMMIT_LOG=$(git log --oneline origin/stable..origin/main --no-merges | head -50)
+
+          BODY="## Promotion: main → stable"
+          BODY="${BODY}"$'\n\n'"Automated promotion of **${DIFF_COUNT} commit(s)** from \`main\` to \`stable\`."
+          BODY="${BODY}"$'\n\n'"| Detail | Value |"
+          BODY="${BODY}"$'\n'"| --- | --- |"
+          BODY="${BODY}"$'\n'"| Promotion | \`main\` → \`stable\` |"
+          BODY="${BODY}"$'\n'"| Commits to merge | **${DIFF_COUNT}** |"
+          BODY="${BODY}"$'\n'"| Conflict check | ✅ Passed |"
+          BODY="${BODY}"$'\n\n'"### Commits included"
+          BODY="${BODY}"$'\n\n'"\`\`\`\`"$'\n'"${COMMIT_LOG}"$'\n'"\`\`\`\`"
+          BODY="${BODY}"$'\n\n'"---"
+          BODY="${BODY}"$'\n'"⚠️ **Merge this PR with a merge commit** (do not squash or rebase)."
+
+          EXISTING_PR=$(gh pr list --base stable --head main --state open --json number,url --jq '.[0] // empty')
 
           if [ -n "$EXISTING_PR" ]; then
-            if ! echo "$BODY" | gh pr edit "$EXISTING_PR" --body-file -; then
-              echo "::error::Failed to update existing promotion PR #${EXISTING_PR}"
-              exit 1
-            fi
-            echo "Updated existing promotion PR #${EXISTING_PR}"
+            PR_NUMBER=$(echo "$EXISTING_PR" | jq -r '.number')
+            PR_URL=$(echo "$EXISTING_PR" | jq -r '.url')
+            echo "$BODY" | gh pr edit "$PR_NUMBER" --body-file -
+            echo "Updated existing promotion PR #${PR_NUMBER}"
           else
-            if ! echo "$BODY" | gh pr create --base stable --head main \
+            PR_URL=$(echo "$BODY" | gh pr create --base stable --head main \
               --title "chore: promote main to stable" \
-              --body-file -; then
-              echo "::error::Failed to create promotion PR"
-              exit 1
-            fi
-            echo "Created new promotion PR"
+              --body-file - | tail -n1)
+            PR_NUMBER="${PR_URL##*/}"
+            [[ "$PR_NUMBER" =~ ^[0-9]+$ ]] || { echo "::error::Failed to parse PR number from: $PR_URL"; exit 1; }
+            echo "Created new promotion PR #${PR_NUMBER}"
           fi
+
+          echo "## Promote Main to Stable — PR Created" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "**PR:** [#${PR_NUMBER}](${PR_URL})" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Detail | Value |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|--------|-------|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Promotion | \`main\` → \`stable\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Commits to merge | **${DIFF_COUNT}** |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Conflict check | ✅ Passed |" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "### Commits included" >> "$GITHUB_STEP_SUMMARY"
+          echo '````' >> "$GITHUB_STEP_SUMMARY"
+          echo "$COMMIT_LOG" >> "$GITHUB_STEP_SUMMARY"
+          echo '````' >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/promote-stable-to-rhoai.yml
+++ b/.github/workflows/promote-stable-to-rhoai.yml
@@ -1,6 +1,6 @@
 # Promote Stable to RHOAI Workflow
 #
-# Merges the stable branch into rhoai directly with a merge commit.
+# Creates a promotional PR to merge stable into rhoai.
 # Triggered on-demand only via workflow_dispatch.
 #
 # To enable scheduled promotions in the future, uncomment the schedule block below.
@@ -8,7 +8,7 @@
 # This workflow:
 #   1. Checks if rhoai is behind stable
 #   2. Verifies there are no merge conflicts (strict — fails on any conflict)
-#   3. Merges stable into rhoai with a merge commit and pushes
+#   3. Creates/updates a PR from stable → rhoai only if merge is clean
 
 name: Promote Stable to RHOAI
 
@@ -18,7 +18,8 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
+  pull-requests: write
 
 env:
   GH_USER_NAME: github-actions[bot]
@@ -26,14 +27,13 @@ env:
 
 jobs:
   promote:
-    name: Merge stable into rhoai
+    name: Promote stable to rhoai
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
-          ref: rhoai
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -71,9 +71,9 @@ jobs:
             echo "### Merge conflicts detected" >> "$GITHUB_STEP_SUMMARY"
             echo "" >> "$GITHUB_STEP_SUMMARY"
             echo "The following files have conflicts:" >> "$GITHUB_STEP_SUMMARY"
-            echo '```' >> "$GITHUB_STEP_SUMMARY"
+            echo '````' >> "$GITHUB_STEP_SUMMARY"
             git diff --name-only --diff-filter=U >> "$GITHUB_STEP_SUMMARY"
-            echo '```' >> "$GITHUB_STEP_SUMMARY"
+            echo '````' >> "$GITHUB_STEP_SUMMARY"
             echo "" >> "$GITHUB_STEP_SUMMARY"
             echo "Please resolve conflicts manually before re-running this workflow." >> "$GITHUB_STEP_SUMMARY"
             git merge --abort
@@ -82,26 +82,55 @@ jobs:
 
           git merge --abort || true
 
-      - name: Merge stable into rhoai
+      - name: Create or update promotion PR
         if: steps.check.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DIFF_COUNT: ${{ steps.check.outputs.diff_count }}
         run: |
           set -euo pipefail
-          git checkout rhoai
-          git reset --hard origin/rhoai
 
-          DIFF_COUNT="${{ steps.check.outputs.diff_count }}"
-          COMMIT_LOG=$(git log --oneline origin/rhoai..origin/stable --no-merges | head -30)
+          COMMIT_LOG=$(git log --oneline origin/rhoai..origin/stable --no-merges | head -50)
 
-          git merge --no-ff origin/stable \
-            -m "chore: promote stable to rhoai ($DIFF_COUNT commits)"
+          BODY="## Promotion: stable → rhoai"
+          BODY="${BODY}"$'\n\n'"Automated promotion of **${DIFF_COUNT} commit(s)** from \`stable\` to \`rhoai\`."
+          BODY="${BODY}"$'\n\n'"| Detail | Value |"
+          BODY="${BODY}"$'\n'"| --- | --- |"
+          BODY="${BODY}"$'\n'"| Promotion | \`stable\` → \`rhoai\` |"
+          BODY="${BODY}"$'\n'"| Commits to merge | **${DIFF_COUNT}** |"
+          BODY="${BODY}"$'\n'"| Conflict check | ✅ Passed |"
+          BODY="${BODY}"$'\n\n'"### Commits included"
+          BODY="${BODY}"$'\n\n'"\`\`\`\`"$'\n'"${COMMIT_LOG}"$'\n'"\`\`\`\`"
+          BODY="${BODY}"$'\n\n'"---"
+          BODY="${BODY}"$'\n'"⚠️ **Merge this PR with a merge commit** (do not squash or rebase)."
 
-          git push origin rhoai
+          EXISTING_PR=$(gh pr list --base rhoai --head stable --state open --json number,url --jq '.[0] // empty')
 
-          echo "## Promote Stable to RHOAI — SUCCESS" >> "$GITHUB_STEP_SUMMARY"
+          if [ -n "$EXISTING_PR" ]; then
+            PR_NUMBER=$(echo "$EXISTING_PR" | jq -r '.number')
+            PR_URL=$(echo "$EXISTING_PR" | jq -r '.url')
+            echo "$BODY" | gh pr edit "$PR_NUMBER" --body-file -
+            echo "Updated existing promotion PR #${PR_NUMBER}"
+          else
+            PR_URL=$(echo "$BODY" | gh pr create --base rhoai --head stable \
+              --title "chore: promote stable to rhoai" \
+              --body-file - | tail -n1)
+            PR_NUMBER="${PR_URL##*/}"
+            [[ "$PR_NUMBER" =~ ^[0-9]+$ ]] || { echo "::error::Failed to parse PR number from: $PR_URL"; exit 1; }
+            echo "Created new promotion PR #${PR_NUMBER}"
+          fi
+
+          echo "## Promote Stable to RHOAI — PR Created" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "Merged **$DIFF_COUNT commit(s)** from \`stable\` into \`rhoai\`." >> "$GITHUB_STEP_SUMMARY"
+          echo "**PR:** [#${PR_NUMBER}](${PR_URL})" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Detail | Value |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|--------|-------|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Promotion | \`stable\` → \`rhoai\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Commits to merge | **${DIFF_COUNT}** |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Conflict check | ✅ Passed |" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "### Commits included" >> "$GITHUB_STEP_SUMMARY"
-          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          echo '````' >> "$GITHUB_STEP_SUMMARY"
           echo "$COMMIT_LOG" >> "$GITHUB_STEP_SUMMARY"
-          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          echo '````' >> "$GITHUB_STEP_SUMMARY"

--- a/docs/content/contributing/release-strategy.md
+++ b/docs/content/contributing/release-strategy.md
@@ -16,21 +16,25 @@ The release flow moves code through four stages, each mapped to a branch and env
 
 ## How Promotion Works
 
-Promotions between branches are automated via GitHub Actions workflows. The main → stable promotion creates a PR for review, while the stable → rhoai promotion merges directly (since stable is already validated).
+Promotions between branches are automated via GitHub Actions workflows that create PRs. Both workflows perform a strict merge conflict pre-check and will **not** create a PR if conflicts exist — conflicts must be resolved manually before re-running.
 
 ### Stream to Lake (`main` → `stable`)
 
 - **Schedule:** Every Sunday at midnight UTC (also available on-demand)
 - **Workflow:** `promote-main-to-stable.yml`
-- A PR is created from `main` to `stable` listing all new commits
+- Performs a dry-run merge to verify no conflicts exist
+- Creates a PR from `main` to `stable` listing all new commits
 - If an open promotion PR already exists, it is updated in place
+- **Must be merged with a merge commit** (no squash or rebase)
 
 ### Lake to RHOAI (`stable` → `rhoai`)
 
 - **Trigger:** On-demand only (via `workflow_dispatch`)
 - **Workflow:** `promote-stable-to-rhoai.yml`
-- Merges `stable` into `rhoai` directly with a merge commit (`--no-ff`)
-- **Strict conflict policy:** the workflow fails without making any changes if merge conflicts exist; conflicts must be resolved manually before re-running
+- Performs a dry-run merge to verify no conflicts exist
+- Creates a PR from `stable` to `rhoai` listing all new commits
+- If an open promotion PR already exists, it is updated in place
+- **Must be merged with a merge commit** (no squash or rebase)
 - A cron schedule can be enabled in the workflow once the release strategy matures
 
 ### RHOAI to Ocean (`rhoai` → downstream)


### PR DESCRIPTION
## Summary

Rewrite both branch promotion workflows to add strict merge conflict pre-checks and rich GitHub step summaries with PR links and commit metadata.

Ref: [RHOAIENG-63950](https://redhat.atlassian.net/browse/RHOAIENG-63950)

## Description

Both `promote-main-to-stable` and `promote-stable-to-rhoai` workflows now:

- Perform a **dry-run merge** (`git merge --no-commit --no-ff`) before creating any PR
- **Fail immediately** with a clear list of conflicting files if merge conflicts exist
- Only create/update a PR if the merge is guaranteed to be clean
- Display a **rich step summary** in the GitHub Actions UI with:
  - PR link at the top for quick access
  - Metadata table (commit count, promotion direction)
  - Full list of commits included in the promotion
- Include a reminder to merge with a merge commit (no squash/rebase)
- Use `set -euo pipefail` in the PR creation step for safety
- Move `${{ }}` interpolation to `env:` block (CWE-94 prevention)
- Harden PR number extraction with `tail -n1` + numeric assertion
- Use 4-backtick fences for robustness

Also updates `docs/content/contributing/release-strategy.md` to document the new behavior.

## How it was tested

- Workflow syntax validated
- Both workflows tested end-to-end in fork (main→stable and stable→rhoai promotions)
- Verified step summary renders correctly with PR link, table, and commit list
- Previous iteration tested: https://github.com/chaitanya1731/models-as-a-service/actions/runs/26180802720

## Risk analysis

- **Risk rating**: 2
- **Why**: Only affects CI promotion workflows (workflow_dispatch + weekly cron). Does not touch application code. The conflict check is additive safety. Tested in fork.
