### PR TITLE
fix: restore --dev flag in deploy script argument parser

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -330,6 +330,10 @@ parse_arguments() {
         POSTGRES_CONNECTION="$2"
         shift 2
         ;;
+      --dev)
+        DEV_MODE="true"
+        shift
+        ;;
       --help|-h)
         show_help
         exit 0
@@ -524,8 +528,10 @@ main() {
     # Ensure maas-parameters ConfigMap exists with image defaults before the
     # controller starts; maas-controller reads these via configMapKeyRef
     # (RELATED_IMAGE_* env vars).
-    local cm_maas_api_image="${MAAS_API_IMAGE:-quay.io/opendatahub/maas-api:latest}"
-    local cm_maas_controller_image="${MAAS_CONTROLLER_IMAGE:-quay.io/opendatahub/maas-controller:latest}"
+    local default_tag="odh-stable"
+    [[ "${DEV_MODE:-false}" == "true" ]] && default_tag="latest"
+    local cm_maas_api_image="${MAAS_API_IMAGE:-quay.io/opendatahub/maas-api:${default_tag}}"
+    local cm_maas_controller_image="${MAAS_CONTROLLER_IMAGE:-quay.io/opendatahub/maas-controller:${default_tag}}"
     local cm_payload_processing_image="quay.io/opendatahub/odh-ai-gateway-payload-processing:odh-stable"
     local cm_cleanup_image="registry.redhat.io/ubi9/ubi-minimal:9.7"
 


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-64574

## Summary

- Restore the `--dev)` case in `parse_arguments()` — removed accidentally in #864
- Update default image tag from `:latest` to `:odh-stable` when `--dev` is not passed

## Context

PR #896 added `--dev` flag support to `deploy.sh`. PR #864 (refactor of Tenant reconciler params.env) subsequently removed the `--dev)` case from `parse_arguments()` while keeping the `DEV_MODE` variable and help text. This causes `deploy.sh --dev` to fail with "Unknown option: --dev".

## Risk analysis

- **Risk rating:** 1
- **Why:** Single-file script change restoring a flag parser case that was accidentally removed. The `DEV_MODE` variable, help text, and consuming code already exist — only the argument parser entry was missing.

## Test plan

- [x] `deploy.sh --dev --dry-run` — no longer errors with "Unknown option"
- [x] `DEV_MODE` correctly set to `true` when `--dev` is passed
- [x] Default (no `--dev`) uses `:odh-stable` image tags
- [x] `--dev` switches to `:latest` image tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)