### PR TITLE
feat: add token consumption time-series chart to Prometheus usage das…

### DIFF
--- a/deployment/components/observability/observability/dashboards/usage-dashboard.yaml
+++ b/deployment/components/observability/observability/dashboards/usage-dashboard.yaml
@@ -54,11 +54,17 @@ spec:
           title: Token Consumption
         items:
           - content:
-              $ref: '#/spec/panels/tokenConsumptionByUser'
-            height: 12
+              $ref: '#/spec/panels/tokenConsumptionOverTime'
+            height: 10
             width: 24
             x: 0
             'y': 0
+          - content:
+              $ref: '#/spec/panels/tokenConsumptionByUser'
+            height: 8
+            width: 24
+            x: 0
+            'y': 10
   panels:
     activeUsers:
       kind: Panel
@@ -163,6 +169,47 @@ spec:
                       )
                     ) or vector(1)
                   seriesNameFormat: Success Rate
+    tokenConsumptionOverTime:
+      kind: Panel
+      spec:
+        display:
+          name: Token consumption
+          description: >-
+            Tokens over time by model or subscription.
+            View by drives chart sum by (${view_by:raw}).
+            Table always shows full model x subscription detail.
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              position: bottom
+              mode: table
+              values: []
+            visual:
+              display: line
+              lineWidth: 3
+              areaOpacity: 1
+              connectNulls: true
+              stack: all
+              showPoints: always
+              pointRadius: 6
+            yAxis:
+              min: 0
+              format:
+                unit: decimal
+        queries:
+          - kind: TimeSeriesQuery
+            spec:
+              plugin:
+                kind: PrometheusTimeSeriesQuery
+                spec:
+                  datasource:
+                    kind: PrometheusDatasource
+                    name: kuadrant-prometheus-datasource
+                  query: >-
+                    round(sum by (${view_by:raw}) (increase(authorized_hits{user!="",
+                    user=~"$user", subscription=~"$subscription",
+                    model=~"$model"}[30m])))
     tokenConsumptionByUser:
       kind: Panel
       spec:
@@ -425,3 +472,19 @@ spec:
             labelName: model
             matchers:
               - 'authorized_hits{model!=""}'
+    - kind: ListVariable
+      spec:
+        allowAllValue: false
+        allowMultiple: false
+        defaultValue: model
+        display:
+          name: View by
+        name: view_by
+        plugin:
+          kind: StaticListVariable
+          spec:
+            values:
+              - value: model
+                label: By model
+              - value: subscription
+                label: By subscription


### PR DESCRIPTION
## Summary
- Add a stacked area `TimeSeriesChart` panel (`tokenConsumptionOverTime`) to the Prometheus-based Usage dashboard, showing token consumption over time via `increase(authorized_hits{...}[30m])`
- Add a `view_by` static list variable ("By model" / "By subscription") that drives `sum by (${view_by:raw})` grouping in the chart
- Update the "Token Consumption" grid layout to place the new chart (24×10) above the existing table (24×8)

## Test plan
- [x] Deployed dashboard to dev cluster (`opendatahub` namespace) — `PersesDashboard` reconciled successfully
- [x] Validated `kuadrant-prometheus-datasource` (`PersesDatasource`) reconciled successfully
- [x] Verified PromQL query returns real data via Thanos Querier (both port 9091 unscoped and 9092 namespace-scoped)
- [x] Generated inference traffic and confirmed non-zero `increase()` values
- [x] Confirmed `view_by` variable toggles between `model` and `subscription` grouping


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Token Consumption" section to the usage dashboard with a time-series chart showing consumption trends.
  * Added a detailed breakdown table beneath the chart and a new grouping option to view consumption "By model" or "By subscription" (default: model).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->