### PR TITLE
fix: update ODH version in scripts to get up-to-date TLS feature

### DIFF
--- a/.github/hack/install-odh.sh
+++ b/.github/hack/install-odh.sh
@@ -8,7 +8,8 @@
 #   OPERATOR_CATALOG - Custom catalog image (optional). When unset, uses community-operators.
 #                      Set to e.g. quay.io/opendatahub/opendatahub-operator-catalog:latest for custom builds.
 #   OPERATOR_CHANNEL   - Subscription channel (default: fast-3)
-#   OPERATOR_STARTING_CSV - Pin Subscription startingCSV (default: opendatahub-operator.v3.4.0-ea.1). Set to "-" to omit.
+#   OPERATOR_STARTING_CSV - Pin Subscription startingCSV (optional). When unset,
+#                           follow the channel head (latest in fast-3 by default).
 #   OPERATOR_INSTALL_PLAN_APPROVAL - Manual (default) or Automatic; use "-" to omit.
 #     Manual: blocks auto-upgrades; this script auto-approves only the first InstallPlan so install does not stall.
 #   OPERATOR_IMAGE   - Custom operator image to patch into CSV (optional)
@@ -124,9 +125,9 @@ else
   channel="${OPERATOR_CHANNEL:-fast-3}"
 fi
 
-# Pin to ODH 3.4 EA1 unless overridden (omit with OPERATOR_STARTING_CSV=- to follow channel head)
-starting_csv="${OPERATOR_STARTING_CSV:-opendatahub-operator.v3.4.0-ea.1}"
-[[ "$starting_csv" == "-" ]] && starting_csv=""
+# Follow the configured channel head by default unless OPERATOR_STARTING_CSV
+# explicitly pins a CSV.
+starting_csv="${OPERATOR_STARTING_CSV:-}"
 
 # Manual = no auto-upgrades; install_olm_operator still approves the first InstallPlan programmatically
 plan_approval="${OPERATOR_INSTALL_PLAN_APPROVAL:-Manual}"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -203,7 +203,7 @@ ENVIRONMENT VARIABLES:
   MAAS_CONTROLLER_IMAGE     Custom MaaS controller container image
   OPERATOR_CATALOG          Custom operator catalog
   OPERATOR_IMAGE            Custom operator image
-  OPERATOR_STARTING_CSV     ODH Subscription startingCSV (default: opendatahub-operator.v3.4.0-ea.1; "-" to omit)
+  OPERATOR_STARTING_CSV     ODH Subscription startingCSV (optional; when unset, follows the channel head)
   OPERATOR_INSTALL_PLAN_APPROVAL  ODH Subscription OLM approval (default: Manual — no auto-upgrades; first InstallPlan is auto-approved by the script)
   OPERATOR_TYPE             Operator type (rhoai/odh)
   EXTERNAL_OIDC            Enable external OIDC on maas-api (true/false)
@@ -1045,9 +1045,9 @@ install_primary_operator() {
         channel="${OPERATOR_CHANNEL:-fast-3}"
       fi
 
-      # Pin to ODH 3.4 EA1 unless overridden (omit with OPERATOR_STARTING_CSV=-)
-      local odh_starting_csv="${OPERATOR_STARTING_CSV:-opendatahub-operator.v3.4.0-ea.1}"
-      [[ "$odh_starting_csv" == "-" ]] && odh_starting_csv=""
+      # Follow the configured channel head by default unless OPERATOR_STARTING_CSV
+      # explicitly pins a CSV.
+      local odh_starting_csv="${OPERATOR_STARTING_CSV:-}"
 
       # Manual = no auto-upgrades; install_olm_operator auto-approves the first InstallPlan only
       local odh_plan_approval="${OPERATOR_INSTALL_PLAN_APPROVAL:-Manual}"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
https://redhat.atlassian.net/browse/RHOAIENG-65190

## Description
<!--- Describe your changes in detail -->
Updating ODH version to the latest released version to get up-to-date TLS feature, as well as any possible features coming up in the future.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Deployed MaaS with the scripts and saw EnvoyFilter created correctly, independently from LLMInferenceService.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Modified operator installation to follow the latest available version from the configured channel by default, instead of pinning to a specific release. Explicit version selection remains available for deployments requiring specific releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->