### PR TITLE
docs: add DeepWiki badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # ODH - Models as a Service with Policy Management
 
-[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/opendatahub-io/models-as-a-service)
-
 Our goal is to create a comprehensive platform for **Models as a Service** with real-time policy management.
 
 > [!IMPORTANT]
@@ -162,6 +160,8 @@ MAAS_API_IMAGE=quay.io/myuser/maas-api:pr-123 \
 - [Authorino Caching Configuration](docs/content/configuration-and-management/authorino-caching.md) - Cache tuning for metadata and authorization
 
 Online Documentation: [https://opendatahub-io.github.io/models-as-a-service/](https://opendatahub-io.github.io/models-as-a-service/)
+
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/opendatahub-io/models-as-a-service)
 
 ## 🤝 Contributing
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ODH - Models as a Service with Policy Management
 
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/opendatahub-io/models-as-a-service)
+
 Our goal is to create a comprehensive platform for **Models as a Service** with real-time policy management.
 
 > [!IMPORTANT]


### PR DESCRIPTION
## Summary
- Adds the official DeepWiki badge to the README, linking to https://deepwiki.com/opendatahub-io/models-as-a-service
- This signals DeepWiki to prioritize weekly auto-refreshes of the documentation index for this repo
- This directly supports the Slack MaaS tech support efforts and generally makes MaaS' documentation more accessible to LLMs.

## Why
The MaaS DeepWiki index was last refreshed on Feb 19, 2026 and is over 3 months stale. Adding the badge enables automatic weekly refreshes ([source](https://x.com/itsandrewgao/status/1927108352061898853)).

## Risk analysis
- **Risk rating:** 0
- **Why:** Documentation-only change — adds a badge image to the README with no runtime impact.

## Test plan
- [x] Verify badge renders correctly on GitHub
- [x] Verify badge links to https://deepwiki.com/opendatahub-io/models-as-a-service

## Followup
- After ~1 week, confirm DeepWiki index timestamp has updated

Ref: [RHOAIENG-65100](https://redhat.atlassian.net/browse/RHOAIENG-65100)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an "Ask DeepWiki" badge link to the README, positioned immediately after the Online Documentation link and before the Contributing section to increase visibility and provide quicker access for readers. This is a documentation-only, low-impact change with no functional or behavioral effects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->