### PR TITLE
fix: fixing unit test for cleanup Job

### DIFF
--- a/.github/workflows/maas-controller-ci.yml
+++ b/.github/workflows/maas-controller-ci.yml
@@ -2,8 +2,6 @@ name: MaaS Controller
 
 on:
   pull_request:
-    paths:
-      - 'maas-controller/**'
 
 permissions:
   actions: read

--- a/deployment/base/maas-controller/default/params.env
+++ b/deployment/base/maas-controller/default/params.env
@@ -1,4 +1,3 @@
 maas-api-image=quay.io/opendatahub/maas-api:latest
 maas-controller-image=quay.io/opendatahub/maas-controller:latest
 payload-processing-image=quay.io/opendatahub/odh-ai-gateway-payload-processing:odh-stable
-maas-api-key-cleanup-image=registry.redhat.io/ubi9/ubi-minimal:9.7

--- a/deployment/base/maas-controller/rbac/clusterrole.yaml
+++ b/deployment/base/maas-controller/rbac/clusterrole.yaml
@@ -103,12 +103,8 @@ rules:
   resources:
   - cronjobs
   verbs:
-  - create
   - delete
   - get
-  - list
-  - patch
-  - watch
 - apiGroups:
   - config.openshift.io
   resources:

--- a/docs/content/configuration-and-management/api-key-administration.md
+++ b/docs/content/configuration-and-management/api-key-administration.md
@@ -50,6 +50,8 @@ Use the bulk revoke endpoint to revoke all keys for the affected user, then noti
 
 Expired ephemeral keys are automatically deleted from the database by a **background cleanup loop** inside the maas-api process. By default it runs every 15 minutes (`CLEANUP_INTERVAL_MINUTES=15`). This prevents unbounded accumulation of expired short-lived credentials.
 
+When upgrading from releases that used the external `maas-api-key-cleanup` CronJob, the Tenant reconciler automatically removes that CronJob and its `maas-api-cleanup-restrict` NetworkPolicy on the next platform reconcile.
+
 ### How It Works
 
 1. On startup, maas-api starts a goroutine that periodically invokes the cleanup logic

--- a/docs/content/configuration-and-management/api-key-administration.md
+++ b/docs/content/configuration-and-management/api-key-administration.md
@@ -48,12 +48,12 @@ Use the bulk revoke endpoint to revoke all keys for the affected user, then noti
 
 ## Ephemeral Key Cleanup
 
-Expired ephemeral keys are automatically deleted from the database by a **CronJob** (`maas-api-key-cleanup`) that runs every 15 minutes. This prevents unbounded accumulation of expired short-lived credentials.
+Expired ephemeral keys are automatically deleted from the database by a **background cleanup loop** inside the maas-api process. By default it runs every 15 minutes (`CLEANUP_INTERVAL_MINUTES=15`). This prevents unbounded accumulation of expired short-lived credentials.
 
 ### How It Works
 
-1. The CronJob sends `POST /internal/v1/api-keys/cleanup` to the maas-api Service
-2. The endpoint deletes ephemeral keys that expired **more than 30 minutes ago** (grace period)
+1. On startup, maas-api starts a goroutine that periodically invokes the cleanup logic
+2. Cleanup deletes ephemeral keys that expired **more than 30 minutes ago** (grace period)
 3. Regular (non-ephemeral) keys are **never** deleted by cleanup — they remain until manually revoked
 
 ### Grace Period
@@ -62,28 +62,23 @@ A 30-minute grace period after expiration ensures that recently-expired keys are
 
 ### Security
 
-The cleanup endpoint is cluster-internal only:
+The cleanup logic runs in-process within maas-api. The `/internal/v1/api-keys/cleanup` HTTP endpoint remains available for manual triggers but is cluster-internal only:
 
 - It is registered under `/internal/v1/` and is **not exposed** on the external Service or Route
-- A `NetworkPolicy` (`maas-api-cleanup-restrict`) restricts cleanup pods to communicate only with `maas-api:8080` and DNS
-- No authentication is required on the endpoint itself — access control is enforced at the network layer
+- No authentication is required on the endpoint itself — access control is enforced at the network layer (cluster-internal only)
 
 ### Troubleshooting Cleanup
 
-**Check CronJob status:**
+**Check cleanup interval configuration:**
 
 ```bash
-oc get cronjob maas-api-key-cleanup -n <namespace>
-oc get jobs -n <namespace> -l app=maas-api-cleanup --sort-by=.metadata.creationTimestamp
+oc get deploy maas-api -n <namespace> -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="CLEANUP_INTERVAL_MINUTES")].value}{"\n"}'
 ```
 
-**View cleanup logs:**
+**View cleanup activity in maas-api logs:**
 
 ```bash
-# Latest CronJob run
-oc logs job/$(oc get jobs -n <namespace> -l app=maas-api-cleanup \
-  --sort-by=.metadata.creationTimestamp -o jsonpath='{.items[-1].metadata.name}') \
-  -n <namespace>
+oc logs deploy/maas-api -n <namespace> | grep -i cleanup
 ```
 
 **Manually trigger cleanup** (from an allowed pod or via oc exec):

--- a/docs/content/reference/maas-api-overview.md
+++ b/docs/content/reference/maas-api-overview.md
@@ -44,12 +44,12 @@ All endpoints except `/health` require authentication via the `Authorization: Be
 
 ### Internal Endpoints (Cluster-Only)
 
-These endpoints are registered under `/internal/v1/` and are **not exposed** on the external Service or Route. They are called by internal components (Authorino, CronJob) and protected by NetworkPolicy.
+These endpoints are registered under `/internal/v1/` and are **not exposed** on the external Service or Route. They are called by internal components (Authorino, maas-api in-process cleanup) and protected by NetworkPolicy where applicable.
 
 | Method | Path | Called By | Description |
 |--------|------|-----------|-------------|
 | POST | `/internal/v1/api-keys/validate` | Authorino | Validate an API key (hash lookup, status/expiry check). Returns user identity and subscription for the gateway. |
-| POST | `/internal/v1/api-keys/cleanup` | CronJob `maas-api-key-cleanup` | Delete expired ephemeral keys (30-minute grace period). Returns `{"deletedCount": N, "message": "..."}`. |
+| POST | `/internal/v1/api-keys/cleanup` | maas-api background cleanup (manual trigger via `oc exec` also supported) | Delete expired ephemeral keys (30-minute grace period). Returns `{"deletedCount": N, "message": "..."}`. |
 | POST | `/internal/v1/subscriptions/select` | Authorino | Select the appropriate subscription for a request based on user groups and optional explicit selection. |
 
 ---

--- a/docs/content/user-guide/api-key-management.md
+++ b/docs/content/user-guide/api-key-management.md
@@ -230,7 +230,7 @@ curl -sS -X POST "${MAAS_API_URL}/maas-api/v1/api-keys" \
   -d '{"ephemeral": true, "expiresIn": "30m"}' | jq .
 ```
 
-Expired ephemeral keys are automatically cleaned up by a CronJob. See [API Key Administration](../configuration-and-management/api-key-administration.md#ephemeral-key-cleanup) for details.
+Expired ephemeral keys are automatically cleaned up by a background process in maas-api. See [API Key Administration](../configuration-and-management/api-key-administration.md#ephemeral-key-cleanup) for details.
 
 ---
 

--- a/maas-api/cmd/main.go
+++ b/maas-api/cmd/main.go
@@ -246,7 +246,7 @@ func registerHandlers(ctx context.Context, log *logger.Logger, router *gin.Engin
 	apiKeyRoutes.GET("/:id", apiKeyHandler.GetAPIKey)                  // Get specific key
 	apiKeyRoutes.DELETE("/:id", apiKeyHandler.RevokeAPIKey)            // Revoke specific key
 
-	// Internal routes (no auth required - called by Authorino / CronJob)
+	// Internal routes (no auth required - called by Authorino / in-process cleanup)
 	internalRoutes := router.Group("/internal/v1")
 	internalRoutes.POST("/api-keys/validate", apiKeyHandler.ValidateAPIKeyHandler)
 	internalRoutes.POST("/api-keys/cleanup", apiKeyHandler.CleanupExpiredEphemeralKeys) // TODO: consider remove endpoint if not public access

--- a/maas-api/internal/api_keys/handler.go
+++ b/maas-api/internal/api_keys/handler.go
@@ -469,7 +469,7 @@ func (h *Handler) SearchAPIKeys(c *gin.Context) {
 // TODO: cleanup unless we wanna keep /cleanup endpoint
 // CleanupExpiredEphemeralKeys handles POST /internal/v1/api-keys/cleanup
 // Deletes expired ephemeral API keys. Called by in-process cleanup and the internal endpoint.
-// Access is restricted at the network level via NetworkPolicy.
+// Cluster-internal only; not exposed on the external Service or Route.
 func (h *Handler) CleanupExpiredEphemeralKeys(c *gin.Context) {
 	count, err := h.service.CleanupExpiredEphemeral(c.Request.Context())
 	if err != nil {

--- a/maas-api/internal/api_keys/handler.go
+++ b/maas-api/internal/api_keys/handler.go
@@ -468,7 +468,7 @@ func (h *Handler) SearchAPIKeys(c *gin.Context) {
 
 // TODO: cleanup unless we wanna keep /cleanup endpoint
 // CleanupExpiredEphemeralKeys handles POST /internal/v1/api-keys/cleanup
-// Deletes expired ephemeral API keys. Called by CronJob.
+// Deletes expired ephemeral API keys. Called by in-process cleanup and the internal endpoint.
 // Access is restricted at the network level via NetworkPolicy.
 func (h *Handler) CleanupExpiredEphemeralKeys(c *gin.Context) {
 	count, err := h.service.CleanupExpiredEphemeral(c.Request.Context())

--- a/maas-api/internal/api_keys/service.go
+++ b/maas-api/internal/api_keys/service.go
@@ -297,7 +297,7 @@ func (s *Service) BulkRevokeAPIKeys(ctx context.Context, username string) (int, 
 
 // TODO: cleanup unless we wanna keep /cleanup endpoint
 // CleanupExpiredEphemeral deletes expired ephemeral keys from storage.
-// Called by the internal cleanup endpoint (CronJob).
+// Called by the internal cleanup endpoint and in-process background cleanup.
 func (s *Service) CleanupExpiredEphemeral(ctx context.Context) (int64, error) {
 	count, err := s.store.DeleteExpiredEphemeral(ctx)
 	if err != nil {

--- a/maas-controller/pkg/controller/maas/tenant_controller.go
+++ b/maas-controller/pkg/controller/maas/tenant_controller.go
@@ -69,6 +69,7 @@ type TenantReconciler struct {
 // +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;patch;delete
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;patch;delete
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;create;patch;delete
+// +kubebuilder:rbac:groups=batch,resources=cronjobs,verbs=get;delete
 // +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=httproutes,verbs=get;list;watch;create;patch;delete
 // +kubebuilder:rbac:groups=config.openshift.io,resources=authentications,verbs=get;list;watch
 // +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch
@@ -78,7 +79,6 @@ type TenantReconciler struct {
 // +kubebuilder:rbac:groups=networking.istio.io,resources=destinationrules,verbs=get;list;watch;create;patch;delete
 // +kubebuilder:rbac:groups=networking.istio.io,resources=envoyfilters,verbs=get;list;watch;create;patch;delete
 // +kubebuilder:rbac:groups=telemetry.istio.io,resources=telemetries,verbs=get;list;watch;create;patch;delete
-// +kubebuilder:rbac:groups=batch,resources=cronjobs,verbs=get;list;watch;create;patch;delete
 // +kubebuilder:rbac:groups=monitoring.coreos.com,resources=podmonitors,verbs=get;list;watch;create;patch;delete
 // +kubebuilder:rbac:groups=perses.dev,resources=persesdashboards;persesdatasources,verbs=get;list;watch;create;patch;delete
 

--- a/maas-controller/pkg/platform/tenantreconcile/constants.go
+++ b/maas-controller/pkg/platform/tenantreconcile/constants.go
@@ -40,14 +40,12 @@ const (
 
 	DefaultMaaSAPIImage            = "quay.io/opendatahub/maas-api:latest"
 	DefaultPayloadProcessingImage  = "quay.io/opendatahub/odh-ai-gateway-payload-processing:odh-stable"
-	DefaultMaaSAPIKeyCleanupImage  = "registry.redhat.io/ubi9/ubi-minimal:9.7"
 	DefaultAPIKeyMaxExpirationDays = "90"
 
 	GatewayDefaultAuthPolicyName                  = "gateway-default-auth"
 	GatewayTokenRateLimitDefaultDenyPolicyName    = "gateway-default-deny"
 	MaaSAPIAuthPolicyName                         = "maas-api-auth-policy"
 	MaaSAPIRouteName                              = "maas-api-route"
-	MaaSAPIKeyCleanupCronJobName                  = "maas-api-key-cleanup" //nolint:gosec // Kubernetes resource name, not a credential
 	GatewayDestinationRuleName                    = "maas-api-backend-tls"
 	TelemetryPolicyName                           = "maas-telemetry"
 	IstioTelemetryName                            = "latency-per-subscription"
@@ -75,7 +73,6 @@ const (
 var (
 	GVKDeployment           = schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}
 	GVKHTTPRoute            = schema.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1", Kind: "HTTPRoute"}
-	GVKCronJob              = schema.GroupVersionKind{Group: "batch", Version: "v1", Kind: "CronJob"}
 	GVKAuthPolicy           = schema.GroupVersionKind{Group: "kuadrant.io", Version: "v1", Kind: "AuthPolicy"}
 	GVKTokenRateLimitPolicy = schema.GroupVersionKind{Group: "kuadrant.io", Version: "v1alpha1", Kind: "TokenRateLimitPolicy"}
 	GVKDestinationRule      = schema.GroupVersionKind{Group: "networking.istio.io", Version: "v1", Kind: "DestinationRule"}

--- a/maas-controller/pkg/platform/tenantreconcile/constants.go
+++ b/maas-controller/pkg/platform/tenantreconcile/constants.go
@@ -47,6 +47,8 @@ const (
 	MaaSAPIAuthPolicyName                         = "maas-api-auth-policy"
 	MaaSAPIRouteName                              = "maas-api-route"
 	GatewayDestinationRuleName                    = "maas-api-backend-tls"
+	LegacyMaaSAPIKeyCleanupCronJobName            = "maas-api-key-cleanup" //nolint:gosec // Kubernetes resource name, not a credential
+	LegacyMaaSAPICleanupNetworkPolicyName         = "maas-api-cleanup-restrict"
 	TelemetryPolicyName                           = "maas-telemetry"
 	IstioTelemetryName                            = "latency-per-subscription"
 	MaaSAPIDeploymentName                         = "maas-api"
@@ -72,6 +74,8 @@ const (
 // GVKs used for post-render and readiness (mirrors opendatahub-operator/pkg/cluster/gvk selections).
 var (
 	GVKDeployment           = schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}
+	GVKCronJob              = schema.GroupVersionKind{Group: "batch", Version: "v1", Kind: "CronJob"}
+	GVKNetworkPolicy        = schema.GroupVersionKind{Group: "networking.k8s.io", Version: "v1", Kind: "NetworkPolicy"}
 	GVKHTTPRoute            = schema.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1", Kind: "HTTPRoute"}
 	GVKAuthPolicy           = schema.GroupVersionKind{Group: "kuadrant.io", Version: "v1", Kind: "AuthPolicy"}
 	GVKTokenRateLimitPolicy = schema.GroupVersionKind{Group: "kuadrant.io", Version: "v1alpha1", Kind: "TokenRateLimitPolicy"}

--- a/maas-controller/pkg/platform/tenantreconcile/params.go
+++ b/maas-controller/pkg/platform/tenantreconcile/params.go
@@ -22,7 +22,6 @@ type PlatformParams struct {
 
 	MaaSAPIImage           string
 	PayloadProcessingImage string
-	MaaSAPIKeyCleanupImage string
 
 	APIKeyMaxExpirationDays string
 }
@@ -37,7 +36,6 @@ func BuildPlatformParams(tenant *maasv1alpha1.Tenant, appNamespace, clusterAudie
 		ClusterAudience:         clusterAudience,
 		MaaSAPIImage:            firstNonEmpty(os.Getenv("RELATED_IMAGE_ODH_MAAS_API_IMAGE"), DefaultMaaSAPIImage),
 		PayloadProcessingImage:  firstNonEmpty(os.Getenv("RELATED_IMAGE_ODH_AI_GATEWAY_PAYLOAD_PROCESSING_IMAGE"), DefaultPayloadProcessingImage),
-		MaaSAPIKeyCleanupImage:  firstNonEmpty(os.Getenv("RELATED_IMAGE_UBI_MINIMAL_IMAGE"), DefaultMaaSAPIKeyCleanupImage),
 		APIKeyMaxExpirationDays: resolveAPIKeyMaxExpirationDays(tenant),
 	}
 }
@@ -72,10 +70,6 @@ func applyPlatformParams(log logr.Logger, resources []unstructured.Unstructured,
 			}
 		case gvk == GVKDeployment && name == PayloadProcessingName:
 			if err := patchPayloadProcessingDeployment(log, r, params); err != nil {
-				return err
-			}
-		case gvk == GVKCronJob && name == MaaSAPIKeyCleanupCronJobName:
-			if err := patchCleanupCronJobImage(log, r, params); err != nil {
 				return err
 			}
 		case gvk == GVKHTTPRoute && name == MaaSAPIRouteName:
@@ -133,14 +127,6 @@ func patchPayloadProcessingDeployment(log logr.Logger, r *unstructured.Unstructu
 	log.V(4).Info("Patching payload-processing image", "image", params.PayloadProcessingImage)
 	if err := setContainerImage(r, "payload-processing", params.PayloadProcessingImage); err != nil {
 		return fmt.Errorf("patch payload-processing image: %w", err)
-	}
-	return nil
-}
-
-func patchCleanupCronJobImage(log logr.Logger, r *unstructured.Unstructured, params PlatformParams) error {
-	log.V(4).Info("Patching cleanup CronJob image", "image", params.MaaSAPIKeyCleanupImage)
-	if err := setCronJobContainerImage(r, "cleanup", params.MaaSAPIKeyCleanupImage); err != nil {
-		return fmt.Errorf("patch cleanup CronJob image: %w", err)
 	}
 	return nil
 }
@@ -314,21 +300,6 @@ func setOrAddEnvVar(r *unstructured.Unstructured, containerName, envName, envVal
 		cm["env"] = envSlice
 		containers[i] = cm
 		return unstructured.SetNestedSlice(r.Object, containers, "spec", "template", "spec", "containers")
-	}
-	return fmt.Errorf("container %q not found", containerName)
-}
-
-func setCronJobContainerImage(r *unstructured.Unstructured, containerName, image string) error {
-	containers, found, err := unstructured.NestedSlice(r.Object, "spec", "jobTemplate", "spec", "template", "spec", "containers")
-	if err != nil || !found {
-		return errors.New("containers not found")
-	}
-	for i, c := range containers {
-		if cm, ok := c.(map[string]any); ok && cm["name"] == containerName {
-			cm["image"] = image
-			containers[i] = cm
-			return unstructured.SetNestedSlice(r.Object, containers, "spec", "jobTemplate", "spec", "template", "spec", "containers")
-		}
 	}
 	return fmt.Errorf("container %q not found", containerName)
 }

--- a/maas-controller/pkg/platform/tenantreconcile/params_test.go
+++ b/maas-controller/pkg/platform/tenantreconcile/params_test.go
@@ -18,7 +18,6 @@ func TestBuildPlatformParams(t *testing.T) {
 	t.Run("if values are not set for optional fields, fall back to defaults", func(t *testing.T) {
 		t.Setenv("RELATED_IMAGE_ODH_MAAS_API_IMAGE", "")
 		t.Setenv("RELATED_IMAGE_ODH_AI_GATEWAY_PAYLOAD_PROCESSING_IMAGE", "")
-		t.Setenv("RELATED_IMAGE_UBI_MINIMAL_IMAGE", "")
 
 		tenant := &maasv1alpha1.Tenant{
 			Spec: maasv1alpha1.TenantSpec{
@@ -37,14 +36,12 @@ func TestBuildPlatformParams(t *testing.T) {
 		assert.Equal(t, "https://kubernetes.default.svc", got.ClusterAudience)
 		assert.Equal(t, DefaultMaaSAPIImage, got.MaaSAPIImage)
 		assert.Equal(t, DefaultPayloadProcessingImage, got.PayloadProcessingImage)
-		assert.Equal(t, DefaultMaaSAPIKeyCleanupImage, got.MaaSAPIKeyCleanupImage)
 		assert.Equal(t, DefaultAPIKeyMaxExpirationDays, got.APIKeyMaxExpirationDays)
 	})
 
 	t.Run("if values are set for optional fields, they should prevail", func(t *testing.T) {
 		t.Setenv("RELATED_IMAGE_ODH_MAAS_API_IMAGE", "quay.io/example/maas-api:test")
 		t.Setenv("RELATED_IMAGE_ODH_AI_GATEWAY_PAYLOAD_PROCESSING_IMAGE", "quay.io/example/payload:test")
-		t.Setenv("RELATED_IMAGE_UBI_MINIMAL_IMAGE", "quay.io/example/cleanup:test")
 
 		maxExpirationDays := int32(45)
 		tenant := &maasv1alpha1.Tenant{
@@ -67,7 +64,6 @@ func TestBuildPlatformParams(t *testing.T) {
 		assert.Equal(t, "cluster-audience", got.ClusterAudience)
 		assert.Equal(t, "quay.io/example/maas-api:test", got.MaaSAPIImage)
 		assert.Equal(t, "quay.io/example/payload:test", got.PayloadProcessingImage)
-		assert.Equal(t, "quay.io/example/cleanup:test", got.MaaSAPIKeyCleanupImage)
 		assert.Equal(t, "45", got.APIKeyMaxExpirationDays)
 	})
 }
@@ -81,7 +77,6 @@ func TestApplyPlatformParamsWithRenderedOverlay(t *testing.T) {
 		ClusterAudience:         "openshift-custom",
 		MaaSAPIImage:            "quay.io/example/maas-api:test",
 		PayloadProcessingImage:  "quay.io/example/payload:test",
-		MaaSAPIKeyCleanupImage:  "quay.io/example/cleanup:test",
 		APIKeyMaxExpirationDays: "45",
 	}
 
@@ -93,13 +88,11 @@ func TestApplyPlatformParamsWithRenderedOverlay(t *testing.T) {
 	assert.Equal(t, params.GatewayNamespace, requireEnvVarValue(t, maasAPIDeployment, "maas-api", "GATEWAY_NAMESPACE"))
 	assert.Equal(t, params.GatewayName, requireEnvVarValue(t, maasAPIDeployment, "maas-api", "GATEWAY_NAME"))
 	assert.Equal(t, params.APIKeyMaxExpirationDays, requireEnvVarValue(t, maasAPIDeployment, "maas-api", "API_KEY_MAX_EXPIRATION_DAYS"))
+	assert.Equal(t, "15", requireEnvVarValue(t, maasAPIDeployment, "maas-api", "CLEANUP_INTERVAL_MINUTES"))
 
 	payloadDeployment := requireResource(t, resources, GVKDeployment, PayloadProcessingName)
 	assert.Equal(t, params.GatewayNamespace, payloadDeployment.GetNamespace())
 	assert.Equal(t, params.PayloadProcessingImage, requireContainerImage(t, payloadDeployment, "spec", "template", "spec", "containers"))
-
-	cleanupCronJob := requireResource(t, resources, GVKCronJob, MaaSAPIKeyCleanupCronJobName)
-	assert.Equal(t, params.MaaSAPIKeyCleanupImage, requireContainerImage(t, cleanupCronJob, "spec", "jobTemplate", "spec", "template", "spec", "containers"))
 
 	httpRoute := requireResource(t, resources, GVKHTTPRoute, MaaSAPIRouteName)
 	parentRefs, found, err := unstructured.NestedSlice(httpRoute.Object, "spec", "parentRefs")

--- a/maas-controller/pkg/platform/tenantreconcile/pipeline.go
+++ b/maas-controller/pkg/platform/tenantreconcile/pipeline.go
@@ -83,6 +83,10 @@ func RunPlatform(
 		return nil, fmt.Errorf("apply: %w", err)
 	}
 
+	if err := PruneLegacyCleanupResources(ctx, log, c, appNs); err != nil {
+		return nil, fmt.Errorf("prune legacy cleanup resources: %w", err)
+	}
+
 	ready, detail, err := MaasAPIDeploymentReady(ctx, c, appNs)
 	if err != nil {
 		return nil, fmt.Errorf("deployment status: %w", err)

--- a/maas-controller/pkg/platform/tenantreconcile/prune.go
+++ b/maas-controller/pkg/platform/tenantreconcile/prune.go
@@ -1,0 +1,63 @@
+package tenantreconcile
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// PruneLegacyCleanupResources removes ephemeral-key cleanup operands dropped from the
+// platform overlay in #934. ApplyRendered is SSA-only and does not prune resources
+// removed from manifests; this runs after apply so upgrades converge automatically.
+func PruneLegacyCleanupResources(ctx context.Context, log logr.Logger, c client.Client, appNs string) error {
+	legacy := []struct {
+		gvk  schema.GroupVersionKind
+		kind string
+		name string
+	}{
+		{gvk: GVKCronJob, kind: "CronJob", name: LegacyMaaSAPIKeyCleanupCronJobName},
+		{gvk: GVKNetworkPolicy, kind: "NetworkPolicy", name: LegacyMaaSAPICleanupNetworkPolicyName},
+	}
+	for _, resource := range legacy {
+		if err := deleteLegacyResourceIfExists(ctx, log, c, resource.kind, resource.name, appNs, resource.gvk); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func deleteLegacyResourceIfExists(ctx context.Context, log logr.Logger, c client.Client, kind, name, namespace string, gvk schema.GroupVersionKind) error {
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(gvk)
+	if err := c.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, obj); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("get legacy %s %s/%s: %w", kind, namespace, name, err)
+	}
+	if !isManagedForPrune(obj) {
+		log.V(1).Info("Skipping legacy resource prune: opted out of management",
+			"kind", kind, "name", name, "namespace", namespace)
+		return nil
+	}
+	log.Info("Deleting legacy platform resource", "kind", kind, "name", name, "namespace", namespace)
+	if err := c.Delete(ctx, obj); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("delete legacy %s %s/%s: %w", kind, namespace, name, err)
+	}
+	return nil
+}
+
+func isManagedForPrune(obj metav1.Object) bool {
+	ann := obj.GetAnnotations()
+	if ann != nil && ann[AnnotationManaged] == "false" {
+		return false
+	}
+	return true
+}

--- a/maas-controller/pkg/platform/tenantreconcile/prune_test.go
+++ b/maas-controller/pkg/platform/tenantreconcile/prune_test.go
@@ -1,0 +1,66 @@
+package tenantreconcile
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestPruneLegacyCleanupResources(t *testing.T) {
+	t.Run("deletes legacy CronJob and NetworkPolicy", func(t *testing.T) {
+		appNs := "tenant-ns"
+		cronJob := newLegacyResource(GVKCronJob, LegacyMaaSAPIKeyCleanupCronJobName, appNs, nil)
+		networkPolicy := newLegacyResource(GVKNetworkPolicy, LegacyMaaSAPICleanupNetworkPolicyName, appNs, nil)
+
+		c := fake.NewClientBuilder().WithObjects(cronJob, networkPolicy).Build()
+		require.NoError(t, PruneLegacyCleanupResources(context.Background(), logr.Discard(), c, appNs))
+
+		assertNotFound(t, c, GVKCronJob, LegacyMaaSAPIKeyCleanupCronJobName, appNs)
+		assertNotFound(t, c, GVKNetworkPolicy, LegacyMaaSAPICleanupNetworkPolicyName, appNs)
+	})
+
+	t.Run("no-op when legacy resources are absent", func(t *testing.T) {
+		c := fake.NewClientBuilder().Build()
+		require.NoError(t, PruneLegacyCleanupResources(context.Background(), logr.Discard(), c, "tenant-ns"))
+	})
+
+	t.Run("skips resources with opendatahub.io/managed=false", func(t *testing.T) {
+		appNs := "tenant-ns"
+		cronJob := newLegacyResource(GVKCronJob, LegacyMaaSAPIKeyCleanupCronJobName, appNs, map[string]string{
+			AnnotationManaged: "false",
+		})
+
+		c := fake.NewClientBuilder().WithObjects(cronJob).Build()
+		require.NoError(t, PruneLegacyCleanupResources(context.Background(), logr.Discard(), c, appNs))
+
+		obj := &unstructured.Unstructured{}
+		obj.SetGroupVersionKind(GVKCronJob)
+		require.NoError(t, c.Get(context.Background(), client.ObjectKey{Name: LegacyMaaSAPIKeyCleanupCronJobName, Namespace: appNs}, obj))
+	})
+}
+
+func newLegacyResource(gvk schema.GroupVersionKind, name, namespace string, annotations map[string]string) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(gvk)
+	obj.SetName(name)
+	obj.SetNamespace(namespace)
+	if annotations != nil {
+		obj.SetAnnotations(annotations)
+	}
+	return obj
+}
+
+func assertNotFound(t *testing.T, c client.Client, gvk schema.GroupVersionKind, name, namespace string) {
+	t.Helper()
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(gvk)
+	err := c.Get(context.Background(), client.ObjectKey{Name: name, Namespace: namespace}, obj)
+	require.True(t, apierrors.IsNotFound(err))
+}

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -550,14 +550,12 @@ main() {
     local cm_maas_api_image="${MAAS_API_IMAGE:-quay.io/opendatahub/maas-api:${default_tag}}"
     local cm_maas_controller_image="${MAAS_CONTROLLER_IMAGE:-quay.io/opendatahub/maas-controller:${default_tag}}"
     local cm_payload_processing_image="quay.io/opendatahub/odh-ai-gateway-payload-processing:odh-stable"
-    local cm_cleanup_image="registry.redhat.io/ubi9/ubi-minimal:9.7"
 
     log_info "  Ensuring maas-parameters ConfigMap..."
     kubectl create configmap maas-parameters -n "$NAMESPACE" \
       --from-literal="maas-api-image=${cm_maas_api_image}" \
       --from-literal="maas-controller-image=${cm_maas_controller_image}" \
       --from-literal="payload-processing-image=${cm_payload_processing_image}" \
-      --from-literal="maas-api-key-cleanup-image=${cm_cleanup_image}" \
       --dry-run=client -o yaml | kubectl apply -f - || {
       log_error "Failed to create/update maas-parameters ConfigMap"
       return 1

--- a/test/e2e/scripts/local-deploy.sh
+++ b/test/e2e/scripts/local-deploy.sh
@@ -1097,7 +1097,6 @@ cat > "$TEMP_DIR/params.env" <<EOF
 maas-api-image=${MAAS_API_IMAGE}
 maas-controller-image=${MAAS_CONTROLLER_IMAGE}
 payload-processing-image=${BBR_IMAGE}
-maas-api-key-cleanup-image=docker.io/curlimages/curl:latest
 EOF
 
 # Create a live maas-parameters ConfigMap with image values consumed by

--- a/test/e2e/tests/test_api_keys.py
+++ b/test/e2e/tests/test_api_keys.py
@@ -883,18 +883,17 @@ class TestAPIKeyRevocationE2E:
 
 
 class TestEphemeralKeyCleanup:
-    """Tests for ephemeral API key cleanup (CronJob + internal endpoint).
+    """Tests for ephemeral API key cleanup (in-process + internal endpoint).
 
     Validates that:
     - Ephemeral keys can be created with short expiration
-    - The cleanup CronJob exists and is correctly configured
+    - maas-api is configured with CLEANUP_INTERVAL_MINUTES
     - Triggering cleanup does not delete active (non-expired) ephemeral keys
     - Cleanup returns a well-formed response with deletedCount
 
     The cleanup endpoint (POST /internal/v1/api-keys/cleanup) is cluster-internal
-    and not exposed on the public Route. These tests trigger it via the CronJob
-    mechanism (kubectl create job --from=cronjob/maas-api-key-cleanup) or via
-    oc exec into the maas-api pod.
+    and not exposed on the public Route. These tests trigger it via oc exec into
+    the maas-api pod.
 
     Environment Variables:
     - DEPLOYMENT_NAMESPACE: Namespace where maas-api is deployed (default: opendatahub)
@@ -904,87 +903,36 @@ class TestEphemeralKeyCleanup:
     def deployment_namespace(self) -> str:
         return os.environ.get("DEPLOYMENT_NAMESPACE", "opendatahub")
 
-    def test_cronjob_exists_and_configured(self, deployment_namespace: str):
-        """Verify the maas-api-key-cleanup CronJob exists with expected configuration."""
+    def test_cleanup_interval_configured(self, deployment_namespace: str):
+        """Verify maas-api Deployment has CLEANUP_INTERVAL_MINUTES configured."""
         import subprocess as sp
 
         result = sp.run(
-            ["oc", "get", "cronjob", "maas-api-key-cleanup",
+            ["oc", "get", "deploy", "maas-api",
              "-n", deployment_namespace, "-o", "json"],
             capture_output=True, text=True,
         )
         if result.returncode != 0:
             pytest.skip(
-                f"CronJob maas-api-key-cleanup not found in {deployment_namespace}: "
+                f"Deployment maas-api not found in {deployment_namespace}: "
                 f"{result.stderr.strip()}"
             )
 
         import json as _json
-        cj = _json.loads(result.stdout)
-        spec = cj["spec"]
-
-        # Verify schedule (every 15 minutes)
-        assert spec["schedule"] == "*/15 * * * *", \
-            f"Expected schedule '*/15 * * * *', got '{spec['schedule']}'"
-
-        # Verify concurrency policy
-        assert spec["concurrencyPolicy"] == "Forbid", \
-            "CronJob should use Forbid concurrency policy"
-
-        # Verify the curl command targets the internal cleanup endpoint
-        containers = spec["jobTemplate"]["spec"]["template"]["spec"]["containers"]
-        assert len(containers) >= 1
-        container_spec = containers[0]
-        # Command is in the 'command' field (shell script via /bin/sh -c)
-        cmd_parts = container_spec.get("command", [])
-        cmd_str = " ".join(cmd_parts)
-        assert "/internal/v1/api-keys/cleanup" in cmd_str, \
-            f"CronJob command should target cleanup endpoint, got: {cmd_str}"
-
-        # Verify security context (non-root, read-only fs)
-        sec_ctx = container_spec.get("securityContext", {})
-        assert sec_ctx.get("runAsNonRoot", False) is True, \
-            "Cleanup container should run as non-root"
-        assert sec_ctx.get("readOnlyRootFilesystem", False) is True, \
-            "Cleanup container should have read-only root filesystem"
-
-        print(f"[cleanup] CronJob validated: schedule={spec['schedule']}, "
-              f"concurrency={spec['concurrencyPolicy']}")
-
-    def test_cleanup_networkpolicy_exists(self, deployment_namespace: str):
-        """Verify the cleanup NetworkPolicy exists and restricts cleanup pod access."""
-        import subprocess as sp
-
-        result = sp.run(
-            ["oc", "get", "networkpolicy", "maas-api-cleanup-restrict",
-             "-n", deployment_namespace, "-o", "json"],
-            capture_output=True, text=True,
+        deploy = _json.loads(result.stdout)
+        containers = deploy["spec"]["template"]["spec"]["containers"]
+        maas_api_container = next(
+            (c for c in containers if c.get("name") == "maas-api"),
+            containers[0] if containers else {},
         )
-        if result.returncode != 0:
-            pytest.skip(
-                f"NetworkPolicy maas-api-cleanup-restrict not found in "
-                f"{deployment_namespace}: {result.stderr.strip()}"
-            )
+        env_vars = {e["name"]: e.get("value") for e in maas_api_container.get("env", []) if "name" in e}
 
-        import json as _json
-        np = _json.loads(result.stdout)
-        spec = np["spec"]
+        assert "CLEANUP_INTERVAL_MINUTES" in env_vars, \
+            "maas-api should have CLEANUP_INTERVAL_MINUTES env var"
+        assert env_vars["CLEANUP_INTERVAL_MINUTES"] == "15", \
+            f"Expected CLEANUP_INTERVAL_MINUTES=15, got {env_vars['CLEANUP_INTERVAL_MINUTES']!r}"
 
-        # Verify it targets cleanup pods
-        selector = spec.get("podSelector", {}).get("matchLabels", {})
-        assert selector.get("app") == "maas-api-cleanup", \
-            f"NetworkPolicy should target app=maas-api-cleanup, got: {selector}"
-
-        # Verify policy types include both Egress and Ingress
-        policy_types = spec.get("policyTypes", [])
-        assert "Egress" in policy_types, "NetworkPolicy should control egress"
-        assert "Ingress" in policy_types, "NetworkPolicy should control ingress"
-
-        # Verify ingress is blocked (empty list)
-        assert spec.get("ingress") == [] or spec.get("ingress") is None, \
-            "Cleanup pods should have no inbound traffic"
-
-        print("[cleanup] NetworkPolicy validated: cleanup pods restricted to maas-api egress only")
+        print(f"[cleanup] Deployment validated: CLEANUP_INTERVAL_MINUTES={env_vars['CLEANUP_INTERVAL_MINUTES']}")
 
     def test_create_ephemeral_key(self, api_keys_base_url: str, headers: dict):
         """Create an ephemeral key and verify it appears in search with includeEphemeral."""
@@ -1072,7 +1020,7 @@ class TestEphemeralKeyCleanup:
         print(f"[cleanup] Created ephemeral key for survival test: id={key_id}")
 
         # Trigger cleanup via oc exec into maas-api pod
-        # This calls the internal endpoint directly, same as the CronJob does
+        # This calls the internal endpoint directly, same as in-process cleanup does
         get_pod = sp.run(
             ["oc", "get", "pods", "-n", deployment_namespace,
              "-l", "app.kubernetes.io/name=maas-api",


### PR DESCRIPTION
A few cleanup items were missed in [934](https://github.com/opendatahub-io/models-as-a-service/pull/934/changes) inside of the controller, so I have update those as well as some minor documentation misses.

Also updated the `maas-controller` workflow to run everytime since it is relatively quick to run the unit test (and such as in this case) changes that are external to the controller codebase can effect the controller. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated ephemeral API key cleanup docs to reflect automatic in-process cleanup by maas-api (default interval: 15 minutes, configurable via CLEANUP_INTERVAL_MINUTES) and revised troubleshooting instructions.

* **Tests**
  * Adjusted end-to-end tests to validate in-process cleanup configuration on maas-api and to trigger cleanup via the internal endpoint.

* **Chores**
  * Deployment params and install scripts simplified (removed external cleanup image param); CI workflow trigger loosened to run for more PRs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->