### PR TITLE
docs: add observability to basic install path

### DIFF
--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -37,6 +37,7 @@ Use this platform to streamline the deployment of your models, monitor usage, an
 - **[Prerequisites](install/prerequisites.md)** - Requirements and database setup
 - **[Platform Setup](install/platform-setup.md)** - Install ODH/RHOAI with MaaS
 - **[MaaS Setup](install/maas-setup.md)** - Gateway AuthPolicy and policies
+- **[Enable Observability](install/maas-setup.md#enable-observability-recommended)** - Metrics, dashboards, and usage tracking
 - **[Validation](install/validation.md)** - Verify your deployment
 
 ### 🔄 Migration

--- a/docs/content/install/maas-setup.md
+++ b/docs/content/install/maas-setup.md
@@ -268,6 +268,73 @@ After creating the database Secret and Gateways, create or update your DataScien
 !!! tip "Troubleshooting"
     If components do not become ready, run `kubectl describe datasciencecluster default-dsc` to inspect conditions and events.
 
+## Enable Observability (Recommended)
+
+Observability provides metrics, dashboards, and usage tracking for MaaS. While not strictly required for basic inference, enabling it is **strongly recommended** because:
+
+- **Tenant status checks** rely on metrics pipelines — without them, some status conditions may report incomplete data.
+- **Rate limiting visibility** (who is being throttled, token consumption per user/model) requires Limitador metrics to be scraped.
+- **Dashboards and showback** will have no data without the prerequisites below.
+
+If you skip this step, MaaS will still serve inference requests, but you will have no visibility into usage, rate limiting, or model performance. You can enable observability later by following the [full Observability guide](../advanced-administration/observability.md).
+
+### Quick Setup
+
+Two platform prerequisites must be configured before MaaS metrics flow into Prometheus:
+
+**1. Enable User Workload Monitoring** (cluster admin required)
+
+```bash
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+data:
+  config.yaml: |
+    enableUserWorkload: true
+EOF
+```
+
+Verify:
+
+```bash
+kubectl get pods -n openshift-user-workload-monitoring
+# Expected: prometheus-user-workload-0 and prometheus-user-workload-1 in Running state
+```
+
+**2. Enable Kuadrant Observability**
+
+```bash
+kubectl patch kuadrant kuadrant -n kuadrant-system --type=merge \
+  -p '{"spec":{"observability":{"enable":true}}}'
+```
+
+Verify:
+
+```bash
+kubectl get podmonitor -n kuadrant-system
+# Expected: kuadrant-limitador-monitor should be listed
+```
+
+**3. (Optional) Deploy ServiceMonitors and Dashboards**
+
+For additional metrics (Authorino auth evaluation, gateway latency, model inference) and Grafana dashboards:
+
+```bash
+# Deploy ServiceMonitors for MaaS components
+./scripts/observability/install-observability.sh
+
+# Deploy Grafana dashboards (requires a Grafana instance)
+./scripts/observability/install-grafana-dashboards.sh
+```
+
+For the full observability stack configuration, including Grafana setup, metric details, and PromQL queries, see the [Observability guide](../advanced-administration/observability.md).
+
+!!! info "RHOAI users"
+    For Red Hat OpenShift AI, also refer to the [RHOAI Observability documentation](https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.4/html/managing_openshift_ai/managing-observability_managing-rhoai) for platform-level monitoring configuration.
+
 ## Next steps
 
 * **Deploy models.** See [Model Setup (On Cluster)](model-setup.md) for sample model deployments.

--- a/docs/content/install/platform-setup.md
+++ b/docs/content/install/platform-setup.md
@@ -462,4 +462,5 @@ Install the platform operator (ODH or RHOAI) and initialize the platform with DS
 ## Next Steps
 
 1. [Install MaaS Components](maas-setup.md) - Database, Gateways, and Configure DataScienceCluster
-2. [Deploy a Model](../configuration-and-management/model-setup.md) - Deploy your first model
+2. [Enable Observability](maas-setup.md#enable-observability-recommended) - Configure metrics, dashboards, and usage tracking (recommended)
+3. [Deploy a Model](../configuration-and-management/model-setup.md) - Deploy your first model

--- a/docs/content/install/prerequisites.md
+++ b/docs/content/install/prerequisites.md
@@ -42,11 +42,17 @@ component enabled (KServe) and properly configured for deploying models with
 
 A specific requirement for MaaS v0.2.0+ is to set up RHOAI Model Serving with Red Hat Connectivity Link (RHCL) v1.3 or later.
 
-## Optional: Observability Prerequisites
+## Observability Prerequisites (Recommended)
 
-If you plan to use MaaS dashboards, showback, or usage metrics, additional platform configuration is required:
+Observability is **strongly recommended** for all MaaS installations. Without it, you will have no visibility into token consumption, rate limiting, or model performance, and some Tenant status conditions may report incomplete data.
 
 - **User Workload Monitoring** — Required for Prometheus to scrape metrics from MaaS components
 - **Kuadrant Observability** — Required for rate-limiting and usage metrics (e.g., `authorized_calls`, `limited_calls`)
 
-See [Observability Prerequisites](../advanced-administration/observability.md#prerequisites) for detailed configuration steps.
+Configuration steps are included in the [MaaS Setup guide](maas-setup.md#enable-observability-recommended). For the full reference, see [Observability](../advanced-administration/observability.md).
+
+!!! warning "What happens if you skip observability"
+    - Dashboards and showback will have **no data**
+    - Rate-limiting metrics (`authorized_hits`, `limited_calls`) will **not** be scraped
+    - Token consumption per user/model will **not** be visible
+    - You can enable observability later, but metrics are only collected from the point of enablement onward

--- a/docs/content/quickstart.md
+++ b/docs/content/quickstart.md
@@ -131,6 +131,36 @@ kubectl get pods -n ${APP_NS}
 
 For detailed validation and troubleshooting, see the [Validation Guide](install/validation.md).
 
+## Enable Observability
+
+After the core deployment is running, enable observability to get usage metrics, rate-limiting visibility, and dashboards. Without this step, MaaS functions normally but you will have no visibility into token consumption, rate limiting, or model performance.
+
+**Minimum setup** (two commands):
+
+```bash
+# 1. Enable User Workload Monitoring (cluster admin required)
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+data:
+  config.yaml: |
+    enableUserWorkload: true
+EOF
+
+# 2. Enable Kuadrant observability
+kubectl patch kuadrant kuadrant -n kuadrant-system --type=merge \
+  -p '{"spec":{"observability":{"enable":true}}}'
+```
+
+For the full observability setup — including ServiceMonitors, Grafana dashboards, and PromQL queries — see:
+
+- [Observability Prerequisites and Setup](install/maas-setup.md#enable-observability-recommended) in the install guide
+- [Full Observability Guide](advanced-administration/observability.md) for detailed configuration
+- [RHOAI Observability](https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.4/html/managing_openshift_ai/managing-observability_managing-rhoai) for RHOAI-specific monitoring
+
 ## Next Steps
 
 After deployment, proceed to [Model Setup (On Cluster)](install/model-setup.md) to deploy sample models, then [Validation](install/validation.md) to test and verify your deployment.


### PR DESCRIPTION
Include observability enablement steps in the main installation flow so that users following the basic setup docs are guided to configure metrics, dashboards, and usage tracking. The prerequisites page, MaaS setup guide, quickstart, platform setup next-steps, and documentation index now all reference observability as a recommended step with clear tradeoffs if skipped. Cross-links to the install script, full observability guide, and RHOAI observability docs are provided.

Closes [RHOAIENG-60435](https://redhat.atlassian.net/browse/RHOAIENG-60435)

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive observability setup guides with recommended configuration steps across installation and quick-start documentation
  * Elevated observability from optional to recommended in prerequisites
  * Included quick-start instructions for enabling monitoring and optional dashboard deployment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->