### PR TITLE
docs: document cert-manager as install prerequisite

### DIFF
--- a/docs/content/install/platform-setup.md
+++ b/docs/content/install/platform-setup.md
@@ -15,6 +15,7 @@ You need a Red Hat OpenShift cluster version 4.19.9 or later. Older OpenShift ve
 
 This section walks through the installation of the required Operators:
 
+* cert-manager
 * LeaderWorkerSet
 * Kuadrant (or RHCL)
 * Platform operator (ODH or RHOAI)
@@ -24,6 +25,79 @@ This section walks through the installation of the required Operators:
 
     - **ODH**: Refer to [Kuadrant documentation](https://docs.kuadrant.io)
     - **RHOAI**: Refer to [Red Hat documentation](https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed)
+
+## Install cert-manager
+
+cert-manager handles TLS certificate lifecycle for webhooks and service-to-service
+communication. It must be installed before LeaderWorkerSet and other operators that
+rely on cert-manager-issued webhook certificates.
+
+!!! note "Automated install"
+    The `deploy.sh` script installs cert-manager automatically. Follow these steps only
+    if you are installing the platform manually.
+
+=== "OpenShift (OperatorHub)"
+
+    Install the Red Hat cert-manager Operator from the built-in OperatorHub:
+
+    ```yaml
+    kubectl apply -f - <<EOF
+    apiVersion: v1
+    kind: Namespace
+    metadata:
+      name: cert-manager-operator
+    ---
+    apiVersion: operators.coreos.com/v1
+    kind: OperatorGroup
+    metadata:
+      name: cert-manager-operator
+      namespace: cert-manager-operator
+    ---
+    apiVersion: operators.coreos.com/v1alpha1
+    kind: Subscription
+    metadata:
+      name: openshift-cert-manager-operator
+      namespace: cert-manager-operator
+    spec:
+      channel: stable-v1
+      installPlanApproval: Automatic
+      name: openshift-cert-manager-operator
+      source: redhat-operators
+      sourceNamespace: openshift-marketplace
+    EOF
+    ```
+
+    Wait for the subscription to install successfully:
+
+    ```shell
+    kubectl wait --for=jsonpath='{.status.state}'=AtLatestKnown subscription/openshift-cert-manager-operator -n cert-manager-operator --timeout=300s
+    ```
+
+=== "Upstream Kubernetes"
+
+    Install cert-manager v1.12 or later using the upstream manifests:
+
+    ```shell
+    kubectl apply -f https://github.com/cert-manager/cert-manager/releases/latest/download/cert-manager.yaml
+    ```
+
+### Verification
+
+Check that cert-manager pods are running:
+
+```shell
+kubectl get pods -n cert-manager
+```
+
+```
+NAME                                      READY   STATUS    RESTARTS   AGE
+cert-manager-7f8d4dc55c-abc12             1/1     Running   0          60s
+cert-manager-cainjector-5f44b5b5f-def34   1/1     Running   0          60s
+cert-manager-webhook-6b7b8d6c7d-ghi56     1/1     Running   0          60s
+```
+
+All three pods (`cert-manager`, `cert-manager-cainjector`, `cert-manager-webhook`) must
+be `Running` before proceeding to the next step.
 
 ## Install LeaderWorkerSet API
 

--- a/docs/content/install/prerequisites.md
+++ b/docs/content/install/prerequisites.md
@@ -28,6 +28,30 @@ The following tools are used across the installation guides:
 * `kustomize` — used for Gateway AuthPolicy (MaaS Components)
 * `envsubst` — used for policy templates (MaaS Components)
 
+## Cluster Prerequisites
+
+### cert-manager
+
+cert-manager is **required** for TLS certificate provisioning across the MaaS platform.
+It must be installed before LeaderWorkerSet and other operators that depend on webhook
+certificates. The automated `deploy.sh` script installs cert-manager automatically; if
+you follow the manual install path, install it as the first step in
+[Platform Setup](platform-setup.md#install-cert-manager).
+
+* **ODH (OpenShift):** Install the `openshift-cert-manager-operator` from OperatorHub
+  (`redhat-operators` catalog, `stable-v1` channel).
+* **Upstream Kubernetes:** Install [cert-manager](https://cert-manager.io/docs/installation/)
+  v1.12 or later.
+
+To verify cert-manager is running:
+
+```shell
+kubectl get pods -n cert-manager
+```
+
+All pods (`cert-manager`, `cert-manager-cainjector`, `cert-manager-webhook`) must be
+`Running` before proceeding.
+
 ## Requirements for Open Data Hub project
 
 MaaS requires Open Data Hub version 3.0 or later, with the Model Serving component

--- a/docs/content/install/validation.md
+++ b/docs/content/install/validation.md
@@ -5,6 +5,26 @@ This guide provides instructions for validating and testing your MaaS Platform d
 !!! note "Prerequisite"
     At least one model must be deployed to validate the installation. See [Model Setup (On Cluster)](model-setup.md) to deploy sample models.
 
+## Prerequisite Check: cert-manager
+
+Before validating MaaS, confirm that cert-manager is installed and running. cert-manager
+provisions the TLS certificates used by webhooks and service-to-service communication.
+
+```bash
+# Verify cert-manager pods are running
+kubectl get pods -n cert-manager
+```
+
+All three pods (`cert-manager`, `cert-manager-cainjector`, `cert-manager-webhook`) must
+show `Running` status. If the namespace or pods are missing, install cert-manager before
+proceeding — see [Platform Setup](platform-setup.md#install-cert-manager).
+
+You can also confirm the cert-manager CRDs are established:
+
+```bash
+kubectl get crd certificates.cert-manager.io
+```
+
 ## Manual Validation (Recommended)
 
 Follow these steps to validate your deployment and understand each component:

--- a/docs/content/quickstart.md
+++ b/docs/content/quickstart.md
@@ -9,6 +9,7 @@ This guide provides quickstart instructions for deploying the MaaS Platform infr
 
 - **OpenShift cluster** (4.19.9+) with kubectl/oc access
       - **Recommended** 16 vCPUs, 32GB RAM, 100GB storage
+- **cert-manager**: Required for TLS certificate provisioning. The `deploy.sh` script installs it automatically; for manual installs see [Platform Setup](install/platform-setup.md#install-cert-manager).
 - **ODH/RHOAI requirements**:
       - RHOAI 3.0 +
       - ODH 3.0 +

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -24,7 +24,7 @@ Automated deployment script for OpenShift clusters supporting both operator-base
 
 **What it does:**
 - Validates configuration and prerequisites
-- Installs optional operators (cert-manager, LeaderWorkerSet) with auto-detection
+- Installs required operators (cert-manager, LeaderWorkerSet) with auto-detection
 - Installs rate limiter (RHCL or upstream Kuadrant)
 - Installs primary operator (RHOAI or ODH) or deploys via kustomize
 - Applies custom resources (DSC, DSCI)
@@ -49,6 +49,7 @@ Automated deployment script for OpenShift clusters supporting both operator-base
 
 **Requirements:**
 - OpenShift cluster (4.19.9+)
+- **cert-manager** — installed automatically by the script; required for TLS certificate provisioning (webhook certs, service-to-service TLS). See [Platform Setup](../docs/content/install/platform-setup.md#install-cert-manager) if installing manually.
 - `oc` CLI installed and logged in
 - `kubectl` installed
 - `jq` installed
@@ -319,6 +320,7 @@ All scripts require:
 - `jq` for JSON parsing
 - `kustomize` for manifest generation
 - Access to an OpenShift or Kubernetes cluster
+- **cert-manager** installed on the cluster (for TLS certificate provisioning)
 - Appropriate RBAC permissions (cluster-admin recommended)
 
 ## Environment Variables

--- a/scripts/validate-deployment.sh
+++ b/scripts/validate-deployment.sh
@@ -248,6 +248,42 @@ if [ -n "$REQUESTED_MODEL" ]; then
 fi
 
 # ==========================================
+# 0. Prerequisite Checks
+# ==========================================
+print_header "0️⃣ Prerequisite Checks"
+
+# Check cert-manager
+print_check "cert-manager"
+if kubectl get namespace cert-manager &>/dev/null; then
+    CERT_MANAGER_PODS=$(kubectl get pods -n cert-manager --no-headers 2>/dev/null | grep -c "Running" || echo "0")
+    if [ "$CERT_MANAGER_PODS" -ge 3 ]; then
+        print_success "cert-manager has $CERT_MANAGER_PODS running pod(s)"
+    elif [ "$CERT_MANAGER_PODS" -gt 0 ]; then
+        print_warning "cert-manager has only $CERT_MANAGER_PODS running pod(s) (expected 3)" "Check: kubectl get pods -n cert-manager"
+    else
+        print_fail "No cert-manager pods running" "cert-manager is required for TLS certificate provisioning" "Install cert-manager: see docs/content/install/platform-setup.md#install-cert-manager"
+    fi
+elif kubectl get namespace cert-manager-operator &>/dev/null; then
+    # OpenShift cert-manager operator uses a different namespace
+    CERT_MANAGER_PODS=$(kubectl get pods -n cert-manager-operator --no-headers 2>/dev/null | grep -c "Running" || echo "0")
+    if [ "$CERT_MANAGER_PODS" -gt 0 ]; then
+        print_success "cert-manager operator has $CERT_MANAGER_PODS running pod(s)"
+    else
+        print_fail "No cert-manager operator pods running" "cert-manager is required for TLS certificate provisioning" "Check: kubectl get pods -n cert-manager-operator"
+    fi
+else
+    print_fail "cert-manager not found" "Neither cert-manager nor cert-manager-operator namespace exists" "Install cert-manager: see docs/content/install/platform-setup.md#install-cert-manager"
+fi
+
+# Check cert-manager CRDs
+print_check "cert-manager CRDs"
+if kubectl get crd certificates.cert-manager.io &>/dev/null; then
+    print_success "cert-manager CRDs are established"
+else
+    print_fail "cert-manager CRDs not found" "certificates.cert-manager.io CRD is missing" "Install cert-manager before proceeding with MaaS deployment"
+fi
+
+# ==========================================
 # 1. Component Status Checks
 # ==========================================
 print_header "1️⃣ Component Status Checks"


### PR DESCRIPTION
Add cert-manager to the install prerequisites, platform-setup guide, quickstart, and validation docs so that administrators are explicitly informed about the requirement before hitting TLS or webhook failures mid-install. The validation script now checks for cert-manager pods and CRDs as part of a new prerequisite-checks phase.

Closes [RHOAIENG-60434](https://redhat.atlassian.net/browse/RHOAIENG-60434)

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
