### PR TITLE
fix: use tiny-gpt2 URI for premium simulator in CI

### DIFF
--- a/docs/samples/models/simulator-premium/model.yaml
+++ b/docs/samples/models/simulator-premium/model.yaml
@@ -4,7 +4,7 @@ metadata:
   name: simulated-premium
 spec:
   model:
-    uri: hf://facebook/opt-125m
+    uri: hf://sshleifer/tiny-gpt2 # ~2MB test model, simulator ignores it anyway
     name: facebook/opt-125m
   replicas: 1
   router: 


### PR DESCRIPTION
## Summary

- Change `docs/samples/models/simulator-premium/model.yaml` storage URI from `hf://facebook/opt-125m` to `hf://sshleifer/tiny-gpt2`, matching the free simulator.
- `llm-d-inference-sim` does not use real weights; the full HF download caused premium `LLMInferenceService` init to exceed the 300s deploy wait in Konflux E2E.

## Test plan

- [ ] Re-run `maas-group-test-g5vll-e2e-maas-openshift` (or local `prow_run_smoke_test.sh`) and confirm `premium-simulated-simulated-premium` reaches Ready within `LLMIS_TIMEOUT`.

## Risk analysis

- **Risk rating:** 1
- **Why:** Sample-only change; served model name and simulator args unchanged. Lowers deploy time for premium tier smoke tests with no runtime behavior change for inference.