### PR TITLE
feat: add source field to ModelRefInfo in subscription response

### DIFF
--- a/maas-api/internal/subscription/selector.go
+++ b/maas-api/internal/subscription/selector.go
@@ -298,9 +298,10 @@ func (s *Selector) enrichModelRefs(refs []ModelRefInfo, index map[string]*unstru
 				refs[i].Description = annotations[constant.AnnotationDescription]
 			}
 			kind, _, _ := unstructured.NestedString(u.Object, "spec", "modelRef", "kind")
-			if kind == "ExternalModel" {
+			switch kind {
+			case "ExternalModel":
 				refs[i].Source = "external"
-			} else if kind != "" {
+			case "LLMInferenceService":
 				refs[i].Source = "internal"
 			}
 		}

--- a/maas-api/internal/subscription/selector.go
+++ b/maas-api/internal/subscription/selector.go
@@ -297,6 +297,12 @@ func (s *Selector) enrichModelRefs(refs []ModelRefInfo, index map[string]*unstru
 				refs[i].DisplayName = annotations[constant.AnnotationDisplayName]
 				refs[i].Description = annotations[constant.AnnotationDescription]
 			}
+			kind, _, _ := unstructured.NestedString(u.Object, "spec", "modelRef", "kind")
+			if kind == "ExternalModel" {
+				refs[i].Source = "external"
+			} else if kind != "" {
+				refs[i].Source = "internal"
+			}
 		}
 	}
 }

--- a/maas-api/internal/subscription/selector_test.go
+++ b/maas-api/internal/subscription/selector_test.go
@@ -883,3 +883,86 @@ func createSubscriptionWithTRLPStatus(name string, groups []string, phase string
 	}
 	return obj
 }
+
+func createMaaSModelRef(name, namespace, kind string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "maas.opendatahub.io/v1alpha1",
+			"kind":       "MaaSModelRef",
+			"metadata": map[string]any{
+				"name":      name,
+				"namespace": namespace,
+			},
+			"spec": map[string]any{
+				"modelRef": map[string]any{
+					"kind": kind,
+					"name": name,
+				},
+			},
+		},
+	}
+}
+
+func TestEnrichModelRefsSource(t *testing.T) {
+	tests := []struct {
+		name           string
+		modelRefKind   string
+		expectedSource string
+	}{
+		{
+			name:           "ExternalModel kind maps to external",
+			modelRefKind:   "ExternalModel",
+			expectedSource: "external",
+		},
+		{
+			name:           "LLMInferenceService kind maps to internal",
+			modelRefKind:   "LLMInferenceService",
+			expectedSource: "internal",
+		},
+		{
+			name:           "empty kind leaves source empty",
+			modelRefKind:   "",
+			expectedSource: "",
+		},
+		{
+			name:           "unknown kind leaves source empty",
+			modelRefKind:   "SomeNewKind",
+			expectedSource: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			log := logger.New(false)
+
+			sub := createSubscription("test-sub", []string{"g1"}, nil, 1, defaultTestTokenRateLimit, "", "")
+
+			modelRef := createMaaSModelRef("test-model", "", tt.modelRefKind)
+			modelLister := &fakeModelLister{items: []*unstructured.Unstructured{modelRef}}
+
+			lister := &fakeLister{subscriptions: []*unstructured.Unstructured{sub}}
+			selector := subscription.NewSelector(log, lister, modelLister)
+
+			accessible, err := selector.GetAllAccessible([]string{"g1"}, "")
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			if len(accessible) == 0 {
+				t.Fatal("Expected at least one accessible subscription")
+			}
+
+			found := false
+			for _, ref := range accessible[0].ModelRefs {
+				if ref.Name == "test-model" {
+					found = true
+					if ref.Source != tt.expectedSource {
+						t.Errorf("Expected source %q, got %q", tt.expectedSource, ref.Source)
+					}
+				}
+			}
+			if !found {
+				t.Fatal("test-model not found in model refs")
+			}
+		})
+	}
+}

--- a/maas-api/internal/subscription/types.go
+++ b/maas-api/internal/subscription/types.go
@@ -57,6 +57,7 @@ type ModelRefInfo struct {
 	Namespace       string           `json:"-"`
 	DisplayName     string           `json:"display_name,omitempty"`
 	Description     string           `json:"description,omitempty"`
+	Source          string           `json:"source,omitempty"`
 	TokenRateLimits []TokenRateLimit `json:"token_rate_limits,omitempty"`
 	BillingRate     *BillingRate     `json:"billing_rate,omitempty"`
 }

--- a/maas-api/openapi3.yaml
+++ b/maas-api/openapi3.yaml
@@ -843,6 +843,13 @@ components:
                     type: string
                     description: Description from the openshift.io/description annotation on the MaaSModelRef
                     example: A free-tier model for general use
+                source:
+                    type: string
+                    description: "Classification of the model: internal (on-cluster) or external (third-party API)"
+                    enum:
+                        - internal
+                        - external
+                    example: internal
                 token_rate_limits:
                     type: array
                     items:


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Derive internal/external classification from MaaSModelRef.spec.modelRef.kind (ExternalModel → external, LLMInferenceService → internal) and populate it in the enrichModelRefs step. Updates OpenAPI spec accordingly.

Ref: [RHOAIENG-62495](https://redhat.atlassian.net/browse/RHOAIENG-62495)

<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Model references in API responses now include a new optional "source" property with values "internal" or "external".
* **Documentation**
  * API schema updated to document the new "source" field and its allowed values.
* **Tests**
  * New tests validate that the "source" field is populated correctly for internal, external, and unknown model kinds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->