### PR TITLE
feat: add GET /v1/api-keys/config endpoint for API key limits

### DIFF
--- a/maas-api/cmd/main.go
+++ b/maas-api/cmd/main.go
@@ -220,6 +220,7 @@ func registerHandlers(ctx context.Context, log *logger.Logger, router *gin.Engin
 
 	// API Key routes - Complete CRUD for hash-based key architecture
 	apiKeyRoutes := v1Routes.Group("/api-keys", tokenHandler.ExtractUserInfo())
+	apiKeyRoutes.GET("/config", apiKeyHandler.GetAPIKeyConfig)         // Get API key limits
 	apiKeyRoutes.POST("", apiKeyHandler.CreateAPIKey)                  // Create hash-based key
 	apiKeyRoutes.POST("/search", apiKeyHandler.SearchAPIKeys)          // Search keys with filtering, sorting, and pagination
 	apiKeyRoutes.POST("/bulk-revoke", apiKeyHandler.BulkRevokeAPIKeys) // Bulk revoke keys

--- a/maas-api/internal/api_keys/handler.go
+++ b/maas-api/internal/api_keys/handler.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
+	"github.com/opendatahub-io/models-as-a-service/maas-api/internal/constant"
 	"github.com/opendatahub-io/models-as-a-service/maas-api/internal/logger"
 	"github.com/opendatahub-io/models-as-a-service/maas-api/internal/subscription"
 	"github.com/opendatahub-io/models-as-a-service/maas-api/internal/token"
@@ -38,7 +39,7 @@ type Handler struct {
 func (h *Handler) GetAPIKeyConfig(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{
 		"max_expiration_days":      h.service.GetMaxExpirationDays(),
-		"ephemeral_max_expiration": "1h",
+		"ephemeral_max_expiration": constant.DefaultEphemeralKeyMaxExpiration.String(),
 	})
 }
 

--- a/maas-api/internal/api_keys/handler.go
+++ b/maas-api/internal/api_keys/handler.go
@@ -35,6 +35,13 @@ type Handler struct {
 	adminChecker AdminChecker
 }
 
+func (h *Handler) GetAPIKeyConfig(c *gin.Context) {
+	c.JSON(http.StatusOK, gin.H{
+		"max_expiration_days":      h.service.GetMaxExpirationDays(),
+		"ephemeral_max_expiration": "1h",
+	})
+}
+
 func NewHandler(log *logger.Logger, service *Service, adminChecker AdminChecker) *Handler {
 	if log == nil {
 		log = logger.Production()

--- a/maas-api/internal/api_keys/handler_test.go
+++ b/maas-api/internal/api_keys/handler_test.go
@@ -1512,7 +1512,7 @@ func TestCreateEphemeralAPIKey(t *testing.T) {
 		var response map[string]string
 		err := json.Unmarshal(w.Body.Bytes(), &response)
 		require.NoError(t, err)
-		assert.Contains(t, response["error"], "cannot exceed 1 hour")
+		assert.Contains(t, response["error"], "cannot exceed 1h0m0s")
 	})
 }
 

--- a/maas-api/internal/api_keys/service.go
+++ b/maas-api/internal/api_keys/service.go
@@ -35,6 +35,13 @@ type Service struct {
 	subSelector SubscriptionSelector
 }
 
+func (s *Service) GetMaxExpirationDays() int {
+	if s.config.APIKeyMaxExpirationDays > 0 {
+		return s.config.APIKeyMaxExpirationDays
+	}
+	return constant.DefaultAPIKeyMaxExpirationDays
+}
+
 func NewService(store MetadataStore, cfg *config.Config, sub SubscriptionSelector) *Service {
 	return NewServiceWithLogger(store, cfg, sub, logger.Production())
 }

--- a/maas-api/internal/api_keys/service.go
+++ b/maas-api/internal/api_keys/service.go
@@ -36,7 +36,7 @@ type Service struct {
 }
 
 func (s *Service) GetMaxExpirationDays() int {
-	if s.config.APIKeyMaxExpirationDays > 0 {
+	if s.config != nil && s.config.APIKeyMaxExpirationDays > 0 {
 		return s.config.APIKeyMaxExpirationDays
 	}
 	return constant.DefaultAPIKeyMaxExpirationDays
@@ -94,10 +94,7 @@ func (s *Service) CreateAPIKey(
 	}
 
 	// Compute max expiration days once from config-or-default (CWE-613 mitigation).
-	maxDays := constant.DefaultAPIKeyMaxExpirationDays
-	if s.config != nil && s.config.APIKeyMaxExpirationDays > 0 {
-		maxDays = s.config.APIKeyMaxExpirationDays
-	}
+	maxDays := s.GetMaxExpirationDays()
 	maxRegularDuration := time.Duration(maxDays) * 24 * time.Hour
 
 	// Default expiration if not provided

--- a/maas-api/internal/api_keys/service.go
+++ b/maas-api/internal/api_keys/service.go
@@ -103,8 +103,7 @@ func (s *Service) CreateAPIKey(
 	// Default expiration if not provided
 	if expiresIn == nil {
 		if ephemeral {
-			// Ephemeral keys default to 1 hour
-			d := 1 * time.Hour
+			d := constant.DefaultEphemeralKeyMaxExpiration
 			expiresIn = &d
 		} else {
 			// Regular keys default to max expiration days
@@ -118,10 +117,8 @@ func (s *Service) CreateAPIKey(
 
 	// Validate against maximum expiration limit (always enforced)
 	if ephemeral {
-		// Ephemeral keys have a strict 1-hour maximum to prevent abuse
-		maxEphemeralDuration := 1 * time.Hour
-		if *expiresIn > maxEphemeralDuration {
-			return nil, fmt.Errorf("ephemeral key expiration (%v) cannot exceed 1 hour: %w", *expiresIn, ErrExpirationExceedsMax)
+		if *expiresIn > constant.DefaultEphemeralKeyMaxExpiration {
+			return nil, fmt.Errorf("ephemeral key expiration (%v) cannot exceed %v: %w", *expiresIn, constant.DefaultEphemeralKeyMaxExpiration, ErrExpirationExceedsMax)
 		}
 	} else if *expiresIn > maxRegularDuration {
 		// Regular keys always enforce max expiration (config or default)

--- a/maas-api/internal/api_keys/service_test.go
+++ b/maas-api/internal/api_keys/service_test.go
@@ -713,7 +713,7 @@ func TestEphemeralKeyExpiration(t *testing.T) {
 			name:        "ExceedsOneHourLimit",
 			expiresIn:   2 * time.Hour,
 			expectedErr: api_keys.ErrExpirationExceedsMax,
-			errContains: "cannot exceed 1 hour",
+			errContains: "cannot exceed 1h0m0s",
 		},
 		{
 			name:        "ZeroExpiration",

--- a/maas-api/internal/constant/const.go
+++ b/maas-api/internal/constant/const.go
@@ -21,6 +21,9 @@ const (
 	// DefaultAPIKeyMaxExpirationDays is the default maximum allowed expiration for API keys.
 	DefaultAPIKeyMaxExpirationDays = 90
 
+	// DefaultEphemeralKeyMaxExpiration is the maximum allowed expiration for ephemeral API keys.
+	DefaultEphemeralKeyMaxExpiration = 1 * time.Hour
+
 	// DefaultSARCacheMaxSize is the maximum number of entries in the SAR admin-check cache.
 	DefaultSARCacheMaxSize = 8192
 

--- a/maas-api/openapi3.yaml
+++ b/maas-api/openapi3.yaml
@@ -465,6 +465,32 @@ paths:
                                 error:
                                     message: "Access denied: you can only bulk revoke your own API keys"
                                     type: forbidden
+    /v1/api-keys/config:
+        get:
+            tags:
+                - api-keys-v2
+            summary: Get API key configuration limits
+            description: |
+                Returns the API key limits that apply when creating keys.
+                Useful for clients (e.g. Dashboard) that need to display valid ranges
+                for expiration without requiring admin access to the Tenant CR.
+            operationId: api-keys#get-config
+            responses:
+                "200":
+                    description: OK response.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ApiKeyConfig'
+                            example:
+                                max_expiration_days: 90
+                                ephemeral_max_expiration: "1h"
+                "401":
+                    description: Unauthorized. Missing or invalid Authorization header.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ErrorResponse'
     /v1/api-keys/{id}:
         get:
             tags:
@@ -879,6 +905,22 @@ components:
                         - per_token
             required:
                 - name
+
+        # API Key configuration limits
+        ApiKeyConfig:
+            type: object
+            properties:
+                max_expiration_days:
+                    type: integer
+                    description: Maximum expiration in days for regular API keys
+                    example: 90
+                ephemeral_max_expiration:
+                    type: string
+                    description: Maximum expiration for ephemeral API keys
+                    example: "1h"
+            required:
+                - max_expiration_days
+                - ephemeral_max_expiration
 
         # API Key metadata
         ApiKey:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Expose max_expiration_days and ephemeral_max_expiration so the Dashboard can display valid ranges when creating keys without needing admin access to the Tenant CR.

Ref: [RHOAIENG-56625](https://redhat.atlassian.net/browse/RHOAIENG-56625)
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an authenticated endpoint: `GET /v1/api-keys/config`, returning API key expiration limits (`max_expiration_days` and `ephemeral_max_expiration`).
* **Documentation**
  * Updated the OpenAPI specification to include `GET /v1/api-keys/config` and its response schema.
* **Bug Fixes / UX**
  * Standardized ephemeral API key expiration defaults and validation to the same 1-hour maximum.
  * Improved validation error wording and updated related tests to match the duration format (e.g., `1h0m0s`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->