### PR TITLE
fix: stop subscription description falling back to displayName

### DIFF
--- a/.github/workflows/openapi-validation.yml
+++ b/.github/workflows/openapi-validation.yml
@@ -112,8 +112,9 @@ jobs:
           git fetch origin "$BASE_REF"
           git show "origin/$BASE_REF:maas-api/openapi3.yaml" > base-spec.yaml
 
-          # Run breaking change detection (--warn-ignore suppresses acknowledged warnings)
+          # Run breaking change detection (--err-ignore / --warn-ignore suppress acknowledged changes)
           oasdiff breaking base-spec.yaml maas-api/openapi3.yaml \
+            --err-ignore maas-api/oasdiff-err-ignore.txt \
             --warn-ignore maas-api/oasdiff-warn-ignore.txt > breaking-changes.txt || true
 
           # Check if actual breaking changes were detected.

--- a/maas-api/internal/subscription/handler_test.go
+++ b/maas-api/internal/subscription/handler_test.go
@@ -1061,8 +1061,8 @@ func TestListSubscriptions_MultipleAccessible(t *testing.T) {
 		found[s.SubscriptionIDHeader] = s.SubscriptionDescription
 	}
 
-	if desc, ok := found["free-sub"]; !ok || desc != "Free Tier" {
-		t.Errorf("expected free-sub with description 'Free Tier' (fallback from display-name), got %q", desc)
+	if desc, ok := found["free-sub"]; !ok || desc != "" {
+		t.Errorf("expected free-sub with empty description (no fallback), got %q", desc)
 	}
 	if desc, ok := found["premium-sub"]; !ok || desc != "High limits for production" {
 		t.Errorf("expected premium-sub with description 'High limits for production', got %q", desc)
@@ -1201,16 +1201,16 @@ func TestListSubscriptions_DescriptionFallback(t *testing.T) {
 	if byID["with-description-only"].SubscriptionDescription != "Description Only" {
 		t.Errorf("expected description 'Description Only', got %q", byID["with-description-only"].SubscriptionDescription)
 	}
-	// Display-name falls back to subscription_description when no description
-	if byID["with-display-name-only"].SubscriptionDescription != "Display Name Only" {
-		t.Errorf("expected description fallback to display-name, got %q", byID["with-display-name-only"].SubscriptionDescription)
+	// Display-name only: description should be empty (no fallback)
+	if byID["with-display-name-only"].SubscriptionDescription != "" {
+		t.Errorf("expected empty description (no fallback), got %q", byID["with-display-name-only"].SubscriptionDescription)
 	}
 	if byID["with-display-name-only"].DisplayName != "Display Name Only" {
 		t.Errorf("expected display_name 'Display Name Only', got %q", byID["with-display-name-only"].DisplayName)
 	}
-	// No annotations: falls back to name
-	if byID["no-annotations"].SubscriptionDescription != "no-annotations" {
-		t.Errorf("expected name fallback, got %q", byID["no-annotations"].SubscriptionDescription)
+	// No annotations: description should be empty (no fallback)
+	if byID["no-annotations"].SubscriptionDescription != "" {
+		t.Errorf("expected empty description (no fallback), got %q", byID["no-annotations"].SubscriptionDescription)
 	}
 }
 

--- a/maas-api/internal/subscription/handler_test.go
+++ b/maas-api/internal/subscription/handler_test.go
@@ -1152,7 +1152,7 @@ func TestListSubscriptionsForModel_UnknownModel(t *testing.T) {
 	}
 }
 
-func TestListSubscriptions_DescriptionFallback(t *testing.T) {
+func TestListSubscriptions_DescriptionNoFallback(t *testing.T) {
 	lister := &mockLister{subscriptions: []*unstructured.Unstructured{
 		createTestSubscriptionWithAnnotations("both-annotations", []string{"free-users"}, []string{"m"}, map[string]string{
 			"openshift.io/display-name": "My Display Name",

--- a/maas-api/internal/subscription/selector.go
+++ b/maas-api/internal/subscription/selector.go
@@ -697,20 +697,13 @@ func (s *Selector) ListAccessibleForModel(username string, groups []string, mode
 
 // toSubscriptionInfo converts internal subscription to a list response item.
 func toSubscriptionInfo(sub *subscription) SubscriptionInfo {
-	desc := sub.Description
-	if desc == "" {
-		desc = sub.DisplayName
-	}
-	if desc == "" {
-		desc = sub.Name
-	}
 	modelRefs := sub.ModelRefs
 	if modelRefs == nil {
 		modelRefs = []ModelRefInfo{}
 	}
 	info := SubscriptionInfo{
 		SubscriptionIDHeader:    sub.Name,
-		SubscriptionDescription: desc,
+		SubscriptionDescription: sub.Description,
 		DisplayName:             sub.DisplayName,
 		Priority:                sub.Priority,
 		ModelRefs:               modelRefs,
@@ -723,20 +716,13 @@ func toSubscriptionInfo(sub *subscription) SubscriptionInfo {
 
 // ResponseToSubscriptionInfo converts a SelectResponse to a SubscriptionInfo.
 func ResponseToSubscriptionInfo(sub *SelectResponse) SubscriptionInfo {
-	desc := sub.Description
-	if desc == "" {
-		desc = sub.DisplayName
-	}
-	if desc == "" {
-		desc = sub.Name
-	}
 	modelRefs := sub.ModelRefs
 	if modelRefs == nil {
 		modelRefs = []ModelRefInfo{}
 	}
 	return SubscriptionInfo{
 		SubscriptionIDHeader:    sub.Name,
-		SubscriptionDescription: desc,
+		SubscriptionDescription: sub.Description,
 		DisplayName:             sub.DisplayName,
 		Priority:                sub.Priority,
 		ModelRefs:               modelRefs,

--- a/maas-api/oasdiff-err-ignore.txt
+++ b/maas-api/oasdiff-err-ignore.txt
@@ -1,0 +1,10 @@
+# Acknowledged breaking changes (errors) — document reason and PR link for each entry.
+#
+# Format: each line must contain the HTTP method, path, and change description.
+# See https://github.com/oasdiff/oasdiff/blob/main/docs/BREAKING-CHANGES.md
+
+# PR #966: subscription_description is now optional (can be empty string).
+# The field was previously required and used a fallback chain (description → display-name → name).
+# Now it returns only the openshift.io/description annotation value, which may be unset.
+GET /v1/subscriptions the response property `items/subscription_description` became optional for the status `200`
+GET /v1/model/{model-id}/subscriptions the response property `items/subscription_description` became optional for the status `200`

--- a/maas-api/openapi3.yaml
+++ b/maas-api/openapi3.yaml
@@ -817,7 +817,7 @@ components:
                     example: premium
                 subscription_description:
                     type: string
-                    description: Human-readable description (from description annotation, falls back to display-name, then name)
+                    description: Human-readable description from the openshift.io/description annotation. May be empty if not set.
                     example: Premium Plan
                 display_name:
                     type: string
@@ -850,7 +850,6 @@ components:
                         env: production
             required:
                 - subscription_id_header
-                - subscription_description
                 - priority
                 - model_refs
 


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
Remove the `description→displayName→name` fallback chain in `toSubscriptionInfo` and `ResponseToSubscriptionInfo`. When no description annotation is set, return empty string and let the frontend decide what to display. 

Resolves [RHOAIENG-66621](https://redhat.atlassian.net/browse/RHOAIENG-66621)
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Subscription descriptions now reflect only the `openshift.io/description` annotation and no longer fall back to other fields when it’s missing.
* **Documentation**
  * Updated OpenAPI documentation: `subscription_description` may be empty and is no longer marked as required.
* **Tests**
  * Adjusted subscription listing tests to validate the new “no fallback” behavior, including renamed/repurposed coverage.
* **Chores**
  * Updated OpenAPI diff validation to acknowledge the documented API change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->