### PR TITLE
feat: scope extproc inference routes

### DIFF
--- a/deployment/base/payload-processing/manager/envoy-filter.yaml
+++ b/deployment/base/payload-processing/manager/envoy-filter.yaml
@@ -25,7 +25,7 @@ spec:
           name: envoy.filters.http.ext_proc.bbr-pre
           typed_config:
             "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
-            failure_mode_allow: false
+            failure_mode_allow: true
             allow_mode_override: true
             processing_mode:
               request_header_mode: "SEND"
@@ -64,3 +64,40 @@ spec:
             grpc_service:
               envoy_grpc:
                 cluster_name: outbound|9004||payload-processing.openshift-ingress.svc.cluster.local
+    # Disable ext_proc on non-inference routes (maas-api /v1/models).
+    # Route name follows Istio's Gateway API naming: <namespace>.<httproute-name>.<rule-index>
+    - applyTo: HTTP_ROUTE
+      match:
+        context: GATEWAY
+        routeConfiguration:
+          vhost:
+            route:
+              name: "PLACEHOLDER.maas-api-route.0"
+      patch:
+        operation: MERGE
+        value:
+          typed_per_filter_config:
+            envoy.filters.http.ext_proc.bbr-pre:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExtProcPerRoute
+              disabled: true
+            envoy.filters.http.ext_proc.bbr:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExtProcPerRoute
+              disabled: true
+    # Disable ext_proc on non-inference routes (maas-api /maas-api/*).
+    - applyTo: HTTP_ROUTE
+      match:
+        context: GATEWAY
+        routeConfiguration:
+          vhost:
+            route:
+              name: "PLACEHOLDER.maas-api-route.1"
+      patch:
+        operation: MERGE
+        value:
+          typed_per_filter_config:
+            envoy.filters.http.ext_proc.bbr-pre:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExtProcPerRoute
+              disabled: true
+            envoy.filters.http.ext_proc.bbr:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExtProcPerRoute
+              disabled: true

--- a/deployment/base/payload-processing/manager/envoy-filter.yaml
+++ b/deployment/base/payload-processing/manager/envoy-filter.yaml
@@ -80,9 +80,6 @@ spec:
             envoy.filters.http.ext_proc.bbr-pre:
               "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExtProcPerRoute
               disabled: true
-            envoy.filters.http.ext_proc.bbr:
-              "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExtProcPerRoute
-              disabled: true
     # Disable ext_proc on non-inference routes (maas-api /maas-api/*).
     - applyTo: HTTP_ROUTE
       match:
@@ -96,8 +93,5 @@ spec:
         value:
           typed_per_filter_config:
             envoy.filters.http.ext_proc.bbr-pre:
-              "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExtProcPerRoute
-              disabled: true
-            envoy.filters.http.ext_proc.bbr:
               "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExtProcPerRoute
               disabled: true

--- a/maas-controller/pkg/platform/tenantreconcile/params.go
+++ b/maas-controller/pkg/platform/tenantreconcile/params.go
@@ -315,24 +315,14 @@ func patchPayloadProcessingEnvoyFilter(log logr.Logger, r *unstructured.Unstruct
 		configPatches[i] = patch
 	}
 
-	// Patches 2 and 3 disable ext_proc on non-inference routes (maas-api-route rules 0 and 1).
+	// Patches 2 and 3 disable ext_proc on non-inference routes.
 	// Route name uses Istio's Gateway API convention: <namespace>.<httproute-name>.<rule-index>.
 	for i := 2; i < 4; i++ {
-		patch, ok := configPatches[i].(map[string]any)
-		if !ok {
-			return fmt.Errorf("EnvoyFilter configPatches[%d] is not an object", i)
+		if err := unstructured.SetNestedField(configPatches[i].(map[string]any),
+			fmt.Sprintf("%s.%s.%d", params.AppNamespace, MaaSAPIRouteName, i-2),
+			"match", "routeConfiguration", "vhost", "route", "name"); err != nil {
+			return fmt.Errorf("write configPatches[%d] route name: %w", i, err)
 		}
-
-		routeNamePath := []string{"match", "routeConfiguration", "vhost", "route", "name"}
-		routeName, _, _ := unstructured.NestedString(patch, routeNamePath...)
-		if routeName != "" && strings.Contains(routeName, "PLACEHOLDER.") {
-			newRouteName := strings.Replace(routeName, "PLACEHOLDER.", params.AppNamespace+".", 1)
-			if err := unstructured.SetNestedField(patch, newRouteName, routeNamePath...); err != nil {
-				return fmt.Errorf("write configPatches[%d] route name: %w", i, err)
-			}
-		}
-
-		configPatches[i] = patch
 	}
 
 	if err := unstructured.SetNestedSlice(r.Object, configPatches, "spec", "configPatches"); err != nil {

--- a/maas-controller/pkg/platform/tenantreconcile/params.go
+++ b/maas-controller/pkg/platform/tenantreconcile/params.go
@@ -318,7 +318,11 @@ func patchPayloadProcessingEnvoyFilter(log logr.Logger, r *unstructured.Unstruct
 	// Patches 2 and 3 disable ext_proc on non-inference routes.
 	// Route name uses Istio's Gateway API convention: <namespace>.<httproute-name>.<rule-index>.
 	for i := 2; i < 4; i++ {
-		if err := unstructured.SetNestedField(configPatches[i].(map[string]any),
+		patch, ok := configPatches[i].(map[string]any)
+		if !ok {
+			return fmt.Errorf("EnvoyFilter configPatches[%d] is not an object", i)
+		}
+		if err := unstructured.SetNestedField(patch,
 			fmt.Sprintf("%s.%s.%d", params.AppNamespace, MaaSAPIRouteName, i-2),
 			"match", "routeConfiguration", "vhost", "route", "name"); err != nil {
 			return fmt.Errorf("write configPatches[%d] route name: %w", i, err)

--- a/maas-controller/pkg/platform/tenantreconcile/params.go
+++ b/maas-controller/pkg/platform/tenantreconcile/params.go
@@ -290,8 +290,8 @@ func patchPayloadProcessingEnvoyFilter(log logr.Logger, r *unstructured.Unstruct
 	if err != nil {
 		return fmt.Errorf("read EnvoyFilter configPatches: %w", err)
 	}
-	if !found || len(configPatches) < 2 {
-		return fmt.Errorf("EnvoyFilter configPatches: expected at least 2 entries, got %d", len(configPatches))
+	if !found || len(configPatches) < 4 {
+		return fmt.Errorf("EnvoyFilter configPatches: expected at least 4 entries, got %d", len(configPatches))
 	}
 
 	clusterByIndex := []string{beforeCluster, afterCluster}
@@ -310,6 +310,26 @@ func patchPayloadProcessingEnvoyFilter(log logr.Logger, r *unstructured.Unstruct
 		clusterPath := []string{"patch", "value", "typed_config", "grpc_service", "envoy_grpc", "cluster_name"}
 		if err := unstructured.SetNestedField(patch, clusterName, clusterPath...); err != nil {
 			return fmt.Errorf("write configPatches[%d] grpc cluster_name: %w", i, err)
+		}
+
+		configPatches[i] = patch
+	}
+
+	// Patches 2 and 3 disable ext_proc on non-inference routes (maas-api-route rules 0 and 1).
+	// Route name uses Istio's Gateway API convention: <namespace>.<httproute-name>.<rule-index>.
+	for i := 2; i < 4; i++ {
+		patch, ok := configPatches[i].(map[string]any)
+		if !ok {
+			return fmt.Errorf("EnvoyFilter configPatches[%d] is not an object", i)
+		}
+
+		routeNamePath := []string{"match", "routeConfiguration", "vhost", "route", "name"}
+		routeName, _, _ := unstructured.NestedString(patch, routeNamePath...)
+		if routeName != "" && strings.Contains(routeName, "PLACEHOLDER.") {
+			newRouteName := strings.Replace(routeName, "PLACEHOLDER.", params.AppNamespace+".", 1)
+			if err := unstructured.SetNestedField(patch, newRouteName, routeNamePath...); err != nil {
+				return fmt.Errorf("write configPatches[%d] route name: %w", i, err)
+			}
 		}
 
 		configPatches[i] = patch

--- a/maas-controller/pkg/platform/tenantreconcile/params_test.go
+++ b/maas-controller/pkg/platform/tenantreconcile/params_test.go
@@ -1,6 +1,7 @@
 package tenantreconcile
 
 import (
+	"fmt"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -165,11 +166,12 @@ func TestApplyPlatformParamsWithRenderedOverlay(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, params.GatewayName, firstTargetRef["name"])
 
-	// Verify dual-stage filter chain: configPatches[0]=INSERT_BEFORE, configPatches[1]=INSERT_AFTER.
+	// Verify dual-stage filter chain: configPatches[0]=INSERT_BEFORE, configPatches[1]=INSERT_AFTER,
+	// plus per-route disable patches: configPatches[2] and [3]=MERGE on maas-api-route rules.
 	configPatches, found, err := unstructured.NestedSlice(payloadEnvoyFilter.Object, "spec", "configPatches")
 	require.NoError(t, err)
 	require.True(t, found)
-	require.Len(t, configPatches, 2, "expected two configPatches (INSERT_BEFORE + INSERT_AFTER)")
+	require.Len(t, configPatches, 4, "expected four configPatches (INSERT_BEFORE + INSERT_AFTER + 2x MERGE)")
 
 	wantAnchor := wasmpluginAnchorName(params.GatewayNamespace, params.GatewayName)
 	wantBeforeCluster := grpcClusterName(PayloadPreProcessingName, params.GatewayNamespace, 9004)
@@ -177,7 +179,7 @@ func TestApplyPlatformParamsWithRenderedOverlay(t *testing.T) {
 	wantOps := []string{"INSERT_BEFORE", "INSERT_AFTER"}
 	wantClusters := []string{wantBeforeCluster, wantAfterCluster}
 
-	for i, raw := range configPatches {
+	for i, raw := range configPatches[:2] {
 		cp, ok := raw.(map[string]any)
 		require.True(t, ok, "configPatches[%d] should be a map", i)
 
@@ -189,6 +191,26 @@ func TestApplyPlatformParamsWithRenderedOverlay(t *testing.T) {
 
 		cluster, _, _ := unstructured.NestedString(cp, "patch", "value", "typed_config", "grpc_service", "envoy_grpc", "cluster_name")
 		assert.Equal(t, wantClusters[i], cluster, "configPatches[%d] grpc cluster_name", i)
+	}
+
+	// Verify per-route ext_proc disable on maas-api-route rules 0 and 1.
+	for i := 2; i < 4; i++ {
+		cp, ok := configPatches[i].(map[string]any)
+		require.True(t, ok, "configPatches[%d] should be a map", i)
+
+		op, _, _ := unstructured.NestedString(cp, "patch", "operation")
+		assert.Equal(t, "MERGE", op, "configPatches[%d] operation", i)
+
+		routeName, _, _ := unstructured.NestedString(cp, "match", "routeConfiguration", "vhost", "route", "name")
+		wantRouteName := fmt.Sprintf("%s.%s.%d", params.AppNamespace, MaaSAPIRouteName, i-2)
+		assert.Equal(t, wantRouteName, routeName, "configPatches[%d] route name", i)
+
+		for _, filterName := range []string{"envoy.filters.http.ext_proc.bbr-pre", "envoy.filters.http.ext_proc.bbr"} {
+			disabled, found, err := unstructured.NestedBool(cp, "patch", "value", "typed_per_filter_config", filterName, "disabled")
+			require.NoError(t, err, "configPatches[%d] %s disabled field", i, filterName)
+			require.True(t, found, "configPatches[%d] %s disabled field should exist", i, filterName)
+			assert.True(t, disabled, "configPatches[%d] %s should be disabled", i, filterName)
+		}
 	}
 
 	// Verify payload-pre-processing Deployment and Service are present and namespaced correctly.

--- a/maas-controller/pkg/platform/tenantreconcile/params_test.go
+++ b/maas-controller/pkg/platform/tenantreconcile/params_test.go
@@ -205,12 +205,10 @@ func TestApplyPlatformParamsWithRenderedOverlay(t *testing.T) {
 		wantRouteName := fmt.Sprintf("%s.%s.%d", params.AppNamespace, MaaSAPIRouteName, i-2)
 		assert.Equal(t, wantRouteName, routeName, "configPatches[%d] route name", i)
 
-		for _, filterName := range []string{"envoy.filters.http.ext_proc.bbr-pre", "envoy.filters.http.ext_proc.bbr"} {
-			disabled, found, err := unstructured.NestedBool(cp, "patch", "value", "typed_per_filter_config", filterName, "disabled")
-			require.NoError(t, err, "configPatches[%d] %s disabled field", i, filterName)
-			require.True(t, found, "configPatches[%d] %s disabled field should exist", i, filterName)
-			assert.True(t, disabled, "configPatches[%d] %s should be disabled", i, filterName)
-		}
+		disabled, found, err := unstructured.NestedBool(cp, "patch", "value", "typed_per_filter_config", "envoy.filters.http.ext_proc.bbr-pre", "disabled")
+		require.NoError(t, err, "configPatches[%d] bbr-pre disabled field", i)
+		require.True(t, found, "configPatches[%d] bbr-pre disabled field should exist", i)
+		assert.True(t, disabled, "configPatches[%d] bbr-pre should be disabled", i)
 	}
 
 	// Verify payload-pre-processing Deployment and Service are present and namespaced correctly.


### PR DESCRIPTION
## Description

  Scopes the pre-auth ext_proc filter (`bbr-pre`) to inference  routes only. Non-inference routes (`/v1/models`,
 `/maas-api/*`) now bypass body-based model extraction via per-route `ExtProcPerRoute` disable in the EnvoyFilter. Also sets `failure_mode_allow: true` on the pre-auth filter as a safety net.

Addresses [RHOAIENG-66113](https://redhat.atlassian.net/browse/RHOAIENG-66113) and [RHOAIENG-63901](https://redhat.atlassian.net/browse/RHOAIENG-63901)

  ---

  ## Changes

  | File | What |                                              
  |------|------|
  | `envoy-filter.yaml` | Add 2 `HTTP_ROUTE` configPatches     
  disabling `bbr-pre` on `maas-api-route` rules;               
  `failure_mode_allow: true` on pre-auth |                   
  | `params.go` | Patch route name placeholder with tenant     
  namespace at reconcile time |                                
  | `params_test.go` | Assert 4 configPatches, verify route  
  names and disable config |                                   
                                                             
  ---                                                                                                                                                        
                                                             
  ## Merge criteria                                          

  - [x] The commits are squashed in a cohesive manner and have 
  meaningful messages.
  - [x] Testing instructions have been added in the PR body.   
  - [x] The developer has manually tested the changes and    
  verified that the changes work.       

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Updates**
  * Modified payload processing to gracefully continue when external processor errors occur
  * Extended route configuration patching to support additional route configurations

* **Tests**
  * Enhanced test coverage to validate expanded configuration structure for payload processing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->