### PR TITLE
fix: replace Total Errors with Total Rate Limited

### DIFF
--- a/deployment/components/observability/observability/dashboards/usage-dashboard.yaml
+++ b/deployment/components/observability/observability/dashboards/usage-dashboard.yaml
@@ -29,7 +29,7 @@ spec:
             x: 5
             'y': 0
           - content:
-              $ref: '#/spec/panels/totalErrors'
+              $ref: '#/spec/panels/totalRateLimited'
             height: 5
             width: 5
             x: 10
@@ -316,12 +316,12 @@ spec:
                       or
                       0 * sum by (user, subscription, model) (increase(authorized_hits{user!="", user=~"$user", subscription=~"$subscription", model=~"$model"}[$__range]))
                     )
-    totalErrors:
+    totalRateLimited:
       kind: Panel
       spec:
         display:
           description: Total rate-limited requests over the selected time window.
-          name: Total Errors
+          name: Total Rate Limited
         plugin:
           kind: StatChart
           spec:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Using the term 'error' is misleading since this counts only requests that have been rejected due to rate limit (code 429).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested manually.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * The Usage dashboard Overview now links to and displays the rate-limited metric instead of the error metric. The panel label has been updated from “Total Errors” to “Total Rate Limited” so the Overview accurately reflects rate-limiting data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->