### PR TITLE
feat: limitador metrics in DSC's monitoring stack

### DIFF
--- a/deployment/base/maas-controller/rbac/clusterrole.yaml
+++ b/deployment/base/maas-controller/rbac/clusterrole.yaml
@@ -231,6 +231,7 @@ rules:
   - monitoring.coreos.com
   resources:
   - podmonitors
+  - servicemonitors
   verbs:
   - create
   - delete

--- a/maas-controller/pkg/controller/maas/self_deployment_controller.go
+++ b/maas-controller/pkg/controller/maas/self_deployment_controller.go
@@ -24,7 +24,9 @@ import (
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -84,6 +86,9 @@ func (r *LifecycleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			return ctrl.Result{}, err
 		} else if res != nil {
 			return *res, nil
+		}
+		if err := r.ensureLimitadorServiceMonitor(ctx); err != nil {
+			return ctrl.Result{}, err
 		}
 		if err := r.stripLegacyCleanupFinalizer(ctx, log, req.NamespacedName); err != nil {
 			return ctrl.Result{}, err
@@ -272,6 +277,67 @@ func tenantReferencesConfig(tenant *maasv1alpha1.Tenant, ct *maasv1alpha1.Config
 		}
 	}
 	return false
+}
+
+// ensureLimitadorServiceMonitor creates or updates the Limitador ServiceMonitor in the operator namespace.
+// This ServiceMonitor ensures metrics are scraped from the Limitador pod and get to the DSC's monitoring stack.
+// TODO: move the ServiceMonitor to the monitoring namespace (opendatahub/redahat-ods-monitoring).
+// If the ServiceMonitor CRD is not available, this is a no-op (allows running without the monitoring stack).
+// TODO: need to set the overall status of MaaS to Degraded if COO is missing.
+func (r *LifecycleReconciler) ensureLimitadorServiceMonitor(ctx context.Context) error {
+	var cfg maasv1alpha1.Config
+	if err := r.Get(ctx, client.ObjectKey{Name: maasv1alpha1.ConfigInstanceName}, &cfg); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
+	sm := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "monitoring.coreos.com/v1",
+			"kind":       "ServiceMonitor",
+			"metadata": map[string]any{
+				"name":      "limitador-metrics",
+				"namespace": r.DeploymentNS,
+				"labels": map[string]any{
+					"app":                              "limitador",
+					"monitoring.opendatahub.io/scrape": "true",
+				},
+			},
+			"spec": map[string]any{
+				"endpoints": []any{
+					map[string]any{
+						"interval": "30s",
+						"path":     "/metrics",
+						"port":     "http",
+					},
+				},
+				"namespaceSelector": map[string]any{
+					"any": true,
+				},
+				"selector": map[string]any{
+					"matchLabels": map[string]any{
+						"app": "limitador",
+					},
+				},
+			},
+		},
+	}
+
+	if err := controllerutil.SetOwnerReference(&cfg, sm, r.Scheme); err != nil {
+		return fmt.Errorf("set owner reference on ServiceMonitor: %w", err)
+	}
+
+	if err := r.Patch(ctx, sm, client.Apply, client.ForceOwnership, client.FieldOwner("maas-controller")); err != nil {
+		// If ServiceMonitor CRD is not installed, skip creation (monitoring stack is optional)
+		if apierrors.IsNotFound(err) || apimeta.IsNoMatchError(err) {
+			return nil
+		}
+		return fmt.Errorf("apply ServiceMonitor: %w", err)
+	}
+
+	return nil
 }
 
 // SetupWithManager registers the controller to watch only the maas-controller Deployment.

--- a/maas-controller/pkg/controller/maas/tenant_controller.go
+++ b/maas-controller/pkg/controller/maas/tenant_controller.go
@@ -79,7 +79,7 @@ type TenantReconciler struct {
 // +kubebuilder:rbac:groups=networking.istio.io,resources=envoyfilters,verbs=get;list;watch;create;patch;delete
 // +kubebuilder:rbac:groups=telemetry.istio.io,resources=telemetries,verbs=get;list;watch;create;patch;delete
 // +kubebuilder:rbac:groups=batch,resources=cronjobs,verbs=get;list;watch;create;patch;delete
-// +kubebuilder:rbac:groups=monitoring.coreos.com,resources=podmonitors,verbs=get;list;watch;create;patch;delete
+// +kubebuilder:rbac:groups=monitoring.coreos.com,resources=podmonitors;servicemonitors,verbs=get;list;watch;create;patch;delete
 // +kubebuilder:rbac:groups=perses.dev,resources=persesdashboards;persesdatasources,verbs=get;list;watch;create;patch;delete
 
 // clusterroles/clusterrolebindings: TenantReconciler SSA-applies the maas-api and payload-processing-reader


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
With this change, MaaS creates a ServiceMonitor that makes the OTEL collector of DSC monitoring to scrape metrics from limitador service and store them in the DSC-specific Prometheus instance.

This way, we don't rely on users to enable observability in Kuadrant and on setting up user workload monitoring (UWM). The metrics would get out of the box (assuming the DSC monitoring stack with metrics is configured) to the ODH/RHOAI's metric store.

Adjusting the usage dashboard would be posted separately.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested manually

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic reconciliation and management of a ServiceMonitor so limitador service metrics are created and kept up to date.

* **Chores**
  * Updated cluster permissions to allow creation and management of ServiceMonitor resources for collecting service metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->