### PR TITLE
chore: pin payload-processing to upstream commit and add bump workflow

### DIFF
--- a/.github/scripts/update-payload-processing.sh
+++ b/.github/scripts/update-payload-processing.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# Update pinned ai-gateway-payload-processing commit and image tag references.
+#
+# Usage: ./.github/scripts/update-payload-processing.sh <commit>
+# Example: ./.github/scripts/update-payload-processing.sh 36614760abfa1b3fb2b521a89097bdaf6e0693b5
+
+set -euo pipefail
+
+if [ $# -lt 1 ]; then
+    echo "Error: commit argument required"
+    echo "Usage: $0 <commit>"
+    exit 1
+fi
+
+COMMIT="$1"
+if ! [[ "$COMMIT" =~ ^[0-9a-f]{40}$ ]]; then
+    echo "Error: commit must be a 40-character lowercase hex SHA"
+    exit 1
+fi
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+IMAGE="quay.io/opendatahub/odh-ai-gateway-payload-processing:${COMMIT}"
+
+echo "Updating payload-processing pin to ${COMMIT}"
+echo "Image: ${IMAGE}"
+echo ""
+
+PARAMS_FILES=(
+    "deployment/overlays/odh/params.env"
+    "deployment/base/maas-controller/default/params.env"
+)
+for file in "${PARAMS_FILES[@]}"; do
+    path="${PROJECT_ROOT}/${file}"
+    if [ -f "$path" ]; then
+        sed -i "s#^payload-processing-image=.*#payload-processing-image=${IMAGE}#" "$path"
+        echo "  - ${file}"
+    fi
+done
+
+KUSTOMIZATION="${PROJECT_ROOT}/deployment/base/payload-processing/manager/kustomization.yaml"
+if [ -f "$KUSTOMIZATION" ]; then
+    sed -i "s/\(newTag: \).*/\1${COMMIT}/" "$KUSTOMIZATION"
+    echo "  - deployment/base/payload-processing/manager/kustomization.yaml"
+fi
+
+CONSTANTS="${PROJECT_ROOT}/maas-controller/pkg/platform/tenantreconcile/constants.go"
+if [ -f "$CONSTANTS" ]; then
+    sed -i "s#DefaultPayloadProcessingImage  = \".*\"#DefaultPayloadProcessingImage  = \"${IMAGE}\"#" "$CONSTANTS"
+    echo "  - maas-controller/pkg/platform/tenantreconcile/constants.go"
+fi
+
+LOCAL_DEPLOY="${PROJECT_ROOT}/test/e2e/scripts/local-deploy.sh"
+if [ -f "$LOCAL_DEPLOY" ]; then
+    sed -i "s#BBR_IMAGE=\"\${BBR_IMAGE:-quay.io/opendatahub/odh-ai-gateway-payload-processing:.*}\"#BBR_IMAGE=\"\${BBR_IMAGE:-${IMAGE}}\"#" "$LOCAL_DEPLOY"
+    echo "  - test/e2e/scripts/local-deploy.sh"
+fi
+
+echo ""
+echo "Payload-processing pin update complete."
+cd "$PROJECT_ROOT"
+git diff --stat \
+    deployment/overlays/odh/params.env \
+    deployment/base/maas-controller/default/params.env \
+    deployment/base/payload-processing/manager/kustomization.yaml \
+    maas-controller/pkg/platform/tenantreconcile/constants.go \
+    test/e2e/scripts/local-deploy.sh 2>/dev/null || true

--- a/.github/workflows/update-payload-processing.yml
+++ b/.github/workflows/update-payload-processing.yml
@@ -105,12 +105,9 @@ jobs:
             deployment/base/payload-processing/manager/kustomization.yaml \
             maas-controller/pkg/platform/tenantreconcile/constants.go \
             test/e2e/scripts/local-deploy.sh
-          git commit -m "$(cat <<EOF
-chore: update payload-processing pin to ${SHORT}
-
-Bump ai-gateway-payload-processing from ${CURRENT:0:12} to ${SHORT}.
-EOF
-)"
+          git commit \
+            -m "chore: update payload-processing pin to ${SHORT}" \
+            -m "Bump ai-gateway-payload-processing from ${CURRENT:0:12} to ${SHORT}."
           git push --force-with-lease origin "$BRANCH"
 
           COMMIT_URL="https://github.com/${UPSTREAM_REPO}/commit/${LATEST}"

--- a/.github/workflows/update-payload-processing.yml
+++ b/.github/workflows/update-payload-processing.yml
@@ -1,0 +1,166 @@
+# Update Payload Processing Pin
+#
+# Fetches the latest commit from opendatahub-io/ai-gateway-payload-processing
+# and opens a PR to update the pinned commit and image tag in this repository.
+#
+# Usage:
+#   1. Go to Actions > Update Payload Processing > Run workflow
+#   2. Optionally override the upstream branch (default: main)
+
+name: Update Payload Processing
+
+on:
+  workflow_dispatch:
+    inputs:
+      upstream_branch:
+        description: 'Upstream branch to track (default: main)'
+        required: false
+        default: main
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+env:
+  GH_USER_NAME: github-actions[bot]
+  GH_USER_EMAIL: github-actions[bot]@users.noreply.github.com
+  UPSTREAM_REPO: opendatahub-io/ai-gateway-payload-processing
+
+jobs:
+  update:
+    name: Update payload-processing pin
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure Git
+        run: |
+          git config user.name "${{ env.GH_USER_NAME }}"
+          git config user.email "${{ env.GH_USER_EMAIL }}"
+
+      - name: Resolve current and latest commits
+        id: commits
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          UPSTREAM_BRANCH: ${{ inputs.upstream_branch || 'main' }}
+        run: |
+          set -euo pipefail
+
+          IMAGE="$(grep '^payload-processing-image=' deployment/overlays/odh/params.env | cut -d= -f2-)"
+          CURRENT="${IMAGE##*:}"
+          if ! [[ "$CURRENT" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::Invalid current commit in deployment/overlays/odh/params.env payload-processing-image: '$CURRENT'"
+            exit 1
+          fi
+
+          LATEST="$(gh api "repos/${UPSTREAM_REPO}/commits/${UPSTREAM_BRANCH}" --jq .sha)"
+          if ! [[ "$LATEST" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::Failed to resolve latest commit from ${UPSTREAM_REPO}@${UPSTREAM_BRANCH}"
+            exit 1
+          fi
+
+          echo "current=${CURRENT}" >> "$GITHUB_OUTPUT"
+          echo "latest=${LATEST}" >> "$GITHUB_OUTPUT"
+          echo "upstream_branch=${UPSTREAM_BRANCH}" >> "$GITHUB_OUTPUT"
+
+          if [ "$CURRENT" = "$LATEST" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "Payload-processing pin is already up to date (${CURRENT})."
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "Updating payload-processing pin: ${CURRENT} -> ${LATEST}"
+          fi
+
+      - name: Update pin
+        if: steps.commits.outputs.skip != 'true'
+        env:
+          LATEST: ${{ steps.commits.outputs.latest }}
+        run: |
+          chmod +x .github/scripts/update-payload-processing.sh
+          .github/scripts/update-payload-processing.sh "$LATEST"
+
+      - name: Create or update PR
+        if: steps.commits.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CURRENT: ${{ steps.commits.outputs.current }}
+          LATEST: ${{ steps.commits.outputs.latest }}
+          UPSTREAM_BRANCH: ${{ steps.commits.outputs.upstream_branch }}
+        run: |
+          set -euo pipefail
+
+          SHORT="${LATEST:0:12}"
+          BRANCH="chore/update-payload-processing-${SHORT}"
+          IMAGE="quay.io/opendatahub/odh-ai-gateway-payload-processing:${LATEST}"
+
+          git checkout -b "$BRANCH"
+          git add deployment/overlays/odh/params.env \
+            deployment/base/maas-controller/default/params.env \
+            deployment/base/payload-processing/manager/kustomization.yaml \
+            maas-controller/pkg/platform/tenantreconcile/constants.go \
+            test/e2e/scripts/local-deploy.sh
+          git commit -m "$(cat <<EOF
+chore: update payload-processing pin to ${SHORT}
+
+Bump ai-gateway-payload-processing from ${CURRENT:0:12} to ${SHORT}.
+EOF
+)"
+          git push --force-with-lease origin "$BRANCH"
+
+          COMMIT_URL="https://github.com/${UPSTREAM_REPO}/commit/${LATEST}"
+          COMPARE_URL="https://github.com/${UPSTREAM_REPO}/compare/${CURRENT}...${LATEST}"
+
+          BODY="## Update payload-processing pin"
+          BODY="${BODY}"$'\n\n'"Automated bump of the pinned [\`ai-gateway-payload-processing\`](https://github.com/${UPSTREAM_REPO}) commit and image tag."
+          BODY="${BODY}"$'\n\n'"| Detail | Value |"
+          BODY="${BODY}"$'\n'"| --- | --- |"
+          BODY="${BODY}"$'\n'"| Previous commit | [\`${CURRENT}\`](https://github.com/${UPSTREAM_REPO}/commit/${CURRENT}) |"
+          BODY="${BODY}"$'\n'"| New commit | [\`${LATEST}\`](${COMMIT_URL}) |"
+          BODY="${BODY}"$'\n'"| Upstream branch | \`${UPSTREAM_BRANCH}\` |"
+          BODY="${BODY}"$'\n'"| Image tag | \`${IMAGE}\` |"
+          BODY="${BODY}"$'\n\n'"[View upstream changes](${COMPARE_URL})"
+
+          EXISTING_PR="$(gh pr list --head "$BRANCH" --state open --json number,url --jq '.[0] // empty')"
+          if [ -n "$EXISTING_PR" ]; then
+            PR_NUMBER="$(echo "$EXISTING_PR" | jq -r '.number')"
+            PR_URL="$(echo "$EXISTING_PR" | jq -r '.url')"
+            echo "$BODY" | gh pr edit "$PR_NUMBER" --title "chore: update payload-processing pin to ${SHORT}" --body-file -
+            echo "Updated existing PR #${PR_NUMBER}"
+          else
+            PR_URL="$(echo "$BODY" | gh pr create \
+              --base main \
+              --head "$BRANCH" \
+              --title "chore: update payload-processing pin to ${SHORT}" \
+              --body-file -)"
+            PR_NUMBER="${PR_URL##*/}"
+            echo "Created PR #${PR_NUMBER}"
+          fi
+
+          {
+            echo "## Payload-processing pin updated"
+            echo ""
+            echo "**PR:** [#${PR_NUMBER}](${PR_URL})"
+            echo ""
+            echo "| Detail | Value |"
+            echo "| --- | --- |"
+            echo "| Previous | \`${CURRENT}\` |"
+            echo "| New | \`${LATEST}\` |"
+            echo "| Image | \`${IMAGE}\` |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Summary (already up to date)
+        if: steps.commits.outputs.skip == 'true'
+        env:
+          CURRENT: ${{ steps.commits.outputs.current }}
+        run: |
+          {
+            echo "## Payload-processing pin up to date"
+            echo ""
+            echo "No changes needed. Current pin: \`${CURRENT}\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/deployment/base/maas-controller/default/params.env
+++ b/deployment/base/maas-controller/default/params.env
@@ -1,4 +1,4 @@
 maas-api-image=quay.io/opendatahub/maas-api:latest
 maas-controller-image=quay.io/opendatahub/maas-controller:latest
-payload-processing-image=quay.io/opendatahub/odh-ai-gateway-payload-processing:odh-stable
+payload-processing-image=quay.io/opendatahub/odh-ai-gateway-payload-processing:36614760abfa1b3fb2b521a89097bdaf6e0693b5
 maas-api-key-cleanup-image=registry.redhat.io/ubi9/ubi-minimal:9.7

--- a/deployment/base/payload-processing/manager/kustomization.yaml
+++ b/deployment/base/payload-processing/manager/kustomization.yaml
@@ -10,4 +10,4 @@ resources:
 images:
   - name: payload-processing
     newName: quay.io/opendatahub/odh-ai-gateway-payload-processing
-    newTag: odh-stable
+    newTag: 36614760abfa1b3fb2b521a89097bdaf6e0693b5

--- a/deployment/overlays/odh/params.env
+++ b/deployment/overlays/odh/params.env
@@ -1,6 +1,6 @@
 maas-api-image=quay.io/opendatahub/maas-api:odh-stable
 maas-controller-image=quay.io/opendatahub/maas-controller:odh-stable
-payload-processing-image=quay.io/opendatahub/odh-ai-gateway-payload-processing:odh-stable
+payload-processing-image=quay.io/opendatahub/odh-ai-gateway-payload-processing:36614760abfa1b3fb2b521a89097bdaf6e0693b5
 maas-api-key-cleanup-image=registry.redhat.io/ubi9/ubi-minimal:9.7
 payload-processing-replicas=1
 gateway-namespace=openshift-ingress

--- a/docs/content/install/external-model-setup.md
+++ b/docs/content/install/external-model-setup.md
@@ -60,8 +60,9 @@ kubectl apply -f ${PROJECT_DIR}/deployment/base/payload-processing/manager/desti
 kubectl apply -f ${PROJECT_DIR}/deployment/base/payload-processing/manager/envoy-filter.yaml
 
 # Deployment (substitute the image placeholder)
+PAYLOAD_PROCESSING_IMAGE="${PAYLOAD_PROCESSING_IMAGE:-$(grep '^payload-processing-image=' "${PROJECT_DIR}/deployment/overlays/odh/params.env" | cut -d= -f2-)}"
 cat ${PROJECT_DIR}/deployment/base/payload-processing/manager/deployment.yaml | \
-  sed 's|image: payload-processing|image: quay.io/opendatahub/odh-ai-gateway-payload-processing:odh-stable|' | \
+  sed "s|image: payload-processing|image: ${PAYLOAD_PROCESSING_IMAGE}|" | \
   kubectl apply -f -
 
 # Verify

--- a/maas-controller/pkg/platform/tenantreconcile/constants.go
+++ b/maas-controller/pkg/platform/tenantreconcile/constants.go
@@ -39,7 +39,7 @@ const (
 	LabelTenantNamespace = "maas.opendatahub.io/tenant-namespace"
 
 	DefaultMaaSAPIImage            = "quay.io/opendatahub/maas-api:latest"
-	DefaultPayloadProcessingImage  = "quay.io/opendatahub/odh-ai-gateway-payload-processing:odh-stable"
+	DefaultPayloadProcessingImage  = "quay.io/opendatahub/odh-ai-gateway-payload-processing:36614760abfa1b3fb2b521a89097bdaf6e0693b5"
 	DefaultMaaSAPIKeyCleanupImage  = "registry.redhat.io/ubi9/ubi-minimal:9.7"
 	DefaultAPIKeyMaxExpirationDays = "90"
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -549,7 +549,7 @@ main() {
     [[ "${DEV_MODE:-false}" == "true" ]] && default_tag="latest"
     local cm_maas_api_image="${MAAS_API_IMAGE:-quay.io/opendatahub/maas-api:${default_tag}}"
     local cm_maas_controller_image="${MAAS_CONTROLLER_IMAGE:-quay.io/opendatahub/maas-controller:${default_tag}}"
-    local cm_payload_processing_image="quay.io/opendatahub/odh-ai-gateway-payload-processing:odh-stable"
+    local cm_payload_processing_image="${PAYLOAD_PROCESSING_IMAGE:-$(get_odh_overlay_param payload-processing-image 2>/dev/null || echo "quay.io/opendatahub/odh-ai-gateway-payload-processing:36614760abfa1b3fb2b521a89097bdaf6e0693b5")}"
     local cm_cleanup_image="registry.redhat.io/ubi9/ubi-minimal:9.7"
 
     log_info "  Ensuring maas-parameters ConfigMap..."

--- a/test/e2e/scripts/LOCAL-DEPLOY.md
+++ b/test/e2e/scripts/LOCAL-DEPLOY.md
@@ -41,10 +41,12 @@ No other repos need to be cloned. The script auto-clones what it needs.
 
 > **How BBR works**: The BBR (payload-processing) **deployment manifests** (Deployment, Service,
 > EnvoyFilter) live inside this repo at `deployment/base/payload-processing/`. This is the same
-> as OpenShift — the MaaS kustomize overlay includes BBR. On Apple Silicon, the pre-built quay.io
-> image is x86-only, so the script **auto-clones** `ai-gateway-payload-processing` to
-> `../ai-gateway-payload-processing` and builds an arm64 image locally. On x86, the pre-built
-> image is used directly.
+> as OpenShift — the MaaS kustomize overlay includes BBR. The image tag and upstream source commit
+> are pinned in `deployment/overlays/odh/params.env` (`payload-processing-image`); override locally
+> with `BBR_IMAGE` or `PAYLOAD_PROCESSING_COMMIT`. On Apple Silicon, the pre-built quay.io image is
+> x86-only, so the script **auto-clones** `ai-gateway-payload-processing` to
+> `../ai-gateway-payload-processing`, checks out the pinned commit, and builds an arm64 image locally.
+> On x86, the pre-built image is used directly.
 
 ## What Gets Deployed
 

--- a/test/e2e/scripts/local-deploy.sh
+++ b/test/e2e/scripts/local-deploy.sh
@@ -15,6 +15,8 @@
 #   KUADRANT_VERSION     - Kuadrant Helm chart version (default: 1.3.1)
 #   MAAS_NAMESPACE       - MaaS deployment namespace (default: maas-system)
 #   GATEWAY_NAMESPACE    - Gateway namespace (default: istio-system)
+#   BBR_IMAGE            - Payload-processing image (default: see params.env pin)
+#   PAYLOAD_PROCESSING_COMMIT - Upstream repo commit for local BBR builds (default: BBR_IMAGE tag)
 
 set -euo pipefail
 
@@ -34,7 +36,9 @@ SUBSCRIPTION_NAMESPACE="models-as-a-service"
 
 MAAS_API_IMAGE="${MAAS_API_IMAGE:-quay.io/opendatahub/maas-api:latest}"
 MAAS_CONTROLLER_IMAGE="${MAAS_CONTROLLER_IMAGE:-quay.io/opendatahub/maas-controller:latest}"
-BBR_IMAGE="${BBR_IMAGE:-quay.io/opendatahub/odh-ai-gateway-payload-processing:odh-stable}"
+
+BBR_IMAGE="${BBR_IMAGE:-quay.io/opendatahub/odh-ai-gateway-payload-processing:36614760abfa1b3fb2b521a89097bdaf6e0693b5}"
+PAYLOAD_PROCESSING_COMMIT="${PAYLOAD_PROCESSING_COMMIT:-${BBR_IMAGE##*:}}"
 
 # Path to BBR repo (for arm64 image builds)
 BBR_REPO="${BBR_REPO:-$(cd "$PROJECT_ROOT/../ai-gateway-payload-processing" 2>/dev/null && pwd || echo "")}"
@@ -73,6 +77,24 @@ step() {
 ok()   { echo -e "  ${GREEN}✓${NC} $1"; }
 warn() { echo -e "  ${YELLOW}!${NC} $1"; }
 fail() { echo -e "  ${RED}✗${NC} $1" >&2; }
+
+ensure_bbr_repo() {
+  if [[ -z "${BBR_REPO:-}" || ! -d "$BBR_REPO" ]]; then
+    BBR_REPO="$PROJECT_ROOT/../ai-gateway-payload-processing"
+  fi
+  if [[ ! -d "$BBR_REPO/.git" ]]; then
+    echo "  Cloning ai-gateway-payload-processing..."
+    gh repo clone opendatahub-io/ai-gateway-payload-processing "$BBR_REPO"
+  fi
+  local current
+  current="$(git -C "$BBR_REPO" rev-parse HEAD 2>/dev/null || echo "")"
+  if [[ "$current" != "$PAYLOAD_PROCESSING_COMMIT" ]]; then
+    echo "  Checking out payload-processing commit ${PAYLOAD_PROCESSING_COMMIT:0:12}..."
+    git -C "$BBR_REPO" fetch origin "$PAYLOAD_PROCESSING_COMMIT" --depth 1 2>/dev/null \
+      || git -C "$BBR_REPO" fetch origin
+    git -C "$BBR_REPO" checkout "$PAYLOAD_PROCESSING_COMMIT"
+  fi
+}
 
 # ─── Argument parsing ───────────────────────────────────────────────────────
 
@@ -300,14 +322,7 @@ if [[ "$ACTION" == "rebuild" ]]; then
   fi
   kubectl config use-context "kind-${KIND_CLUSTER_NAME}" &>/dev/null
 
-  # Ensure BBR repo is available
-  if [[ -z "$BBR_REPO" || ! -d "$BBR_REPO" ]]; then
-    BBR_REPO="$PROJECT_ROOT/../ai-gateway-payload-processing"
-    if [[ ! -d "$BBR_REPO" ]]; then
-      echo "  Cloning ai-gateway-payload-processing..."
-      gh repo clone opendatahub-io/ai-gateway-payload-processing "$BBR_REPO" -- --depth 1 2>&1 | tail -1
-    fi
-  fi
+  ensure_bbr_repo
 
   case "$REBUILD_COMPONENT" in
     bbr|payload-processing)
@@ -1060,14 +1075,7 @@ if [[ "$ARCH" == "arm64" ]]; then
         -t "$MAAS_CONTROLLER_IMAGE" . 2>&1 | tail -3)
     kind load docker-image "$MAAS_CONTROLLER_IMAGE" --name "$KIND_CLUSTER_NAME"
 
-    # Auto-clone BBR repo if not present
-    if [[ -z "$BBR_REPO" || ! -d "$BBR_REPO" ]]; then
-      BBR_REPO="$PROJECT_ROOT/../ai-gateway-payload-processing"
-      if [[ ! -d "$BBR_REPO" ]]; then
-        echo "  Cloning ai-gateway-payload-processing..."
-        gh repo clone opendatahub-io/ai-gateway-payload-processing "$BBR_REPO" -- --depth 1 2>&1 | tail -1
-      fi
-    fi
+    ensure_bbr_repo
 
     echo "  Building payload-processing (BBR)..."
     (cd "$BBR_REPO" && \


### PR DESCRIPTION
Replace the floating odh-stable image tag with commit SHA 36614760abfa1b3fb2b521a89097bdaf6e0693b5 across params.env, kustomize, and controller defaults. Add a scheduled GitHub Action and update script to open PRs when ai-gateway-payload-processing moves forward.

Local deploy and deploy.sh now override the pin via BBR_IMAGE / PAYLOAD_PROCESSING_IMAGE, matching how other component images are set.


On demand workflow example:

https://github.com/jland-redhat/models-as-a-service/actions/runs/27237376331

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated workflow to track and pin the payload-processing component to specific commit tags and open/update PRs when updates are needed.

* **Chores**
  * Switched deployment configs and defaults from rolling tags to commit-based image tags.
  * Enhanced deploy scripts to accept configurable environment overrides with sensible fallbacks and consistent repo checkout behavior.

* **Documentation**
  * Updated install and local-deploy docs to document configurable image/versioning and platform-specific build behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->