### PR TITLE
test: add multitenancy phase 1 e2e coverage (RHOAIENG-67709)

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -44,14 +44,28 @@ pytest tests/<file>.py -v
 | `test_namespace_scoping.py` | Namespace wiring |
 | `test_external_models.py` | External model refs |
 | `test_tenant.py` | `default-tenant` (subscription namespace): Ready/phase, optional payload-processing (gateway namespace), user CRs not owned by Tenant |
+| `test_aitenant_lifecycle.py` | `AITenant` bootstrap create/delete; reserved namespace rejection |
+| `test_tenant_namespace_discovery.py` | Multi-tenant namespace discovery (S1), webhooks (S6); smoke enables `ENABLE_TENANT_NAMESPACE_DISCOVERY=true` by default |
+| `test_gateway_scoped_authpolicy.py` | Gateway-scoped `maas-gateway-auth` (S10 / #912); runs in default CI |
+| `test_multi_tenant_integration.py` | Multi-tenant lifecycle and coexistence scenarios; smoke enables tenant namespace discovery by default |
+| `test_multi_tenant_maas_api.py` | Per-tenant `maas-api` infrastructure (S24); gated by `ENABLE_S24_E2E=true` |
+| `test_tenant_auth_isolation.py` | Tenant-scoped API-key/OIDC isolation (S4); gated by `ENABLE_S4_E2E=true` and tenant API URLs |
+| `test_tenant_subscription_isolation.py` | Tenant-scoped subscription listing/selection (S4); gated by `ENABLE_S4_E2E=true` and tenant API URLs |
+| `test_tenant_rate_limit_isolation.py` | Tenant-scoped rate-limit isolation (S4); gated by `ENABLE_S4_E2E=true` and tenant API URLs |
 | `test_config_tenant.py` | Cluster `Config/default`: anchor present, owner refs on Tenant and `maas-controller` Deployment (skips if Config CRD missing) |
 
-Other modules (for example `test_external_oidc.py`, `test_subscription_list_endpoints.py`) are not in the default Prow pytest list—run them explicitly or use `smoke.sh`, which executes all tests under `tests/`.
+Modules outside the explicit smoke list (for example `test_subscription_list_endpoints.py`) can be run directly or via `smoke.sh`, which executes all tests under `tests/`.
 
 **Skips:** `test_tenant.py` and `test_config_tenant.py` skip the whole module when the needed CRD or object is absent (partial cluster or older bundle). Neither module deletes Config or exercises DSC disable; that stays in operator or manual teardown.
 
 ## CI
 
-CI runs `./test/e2e/scripts/prow_run_smoke_test.sh`: pytest on `test_api_keys.py`, `test_namespace_scoping.py`, `test_negative_security.py`, `test_subscription.py`, `test_models_endpoint.py`, `test_external_models.py`, `test_tenant.py`, `test_config_tenant.py`, then deployment validation; reports under `ARTIFACT_DIR` when set.
+CI runs `./test/e2e/scripts/prow_run_smoke_test.sh`: pytest on the default smoke modules listed above (including `test_aitenant_lifecycle.py`, `test_tenant_namespace_discovery.py`, `test_gateway_scoped_authpolicy.py`, `test_multi_tenant_integration.py`, and the gated S24/S4 modules), then deployment validation; reports under `ARTIFACT_DIR` when set.
+
+Multi-tenancy discovery tests run by default in `prow_run_smoke_test.sh`, which sets `ENABLE_TENANT_NAMESPACE_DISCOVERY=true` unless explicitly overridden and patches maas-controller before pytest. If set to `false`, `test_tenant_namespace_discovery.py` and `test_multi_tenant_integration.py` skip. When discovery is enabled, `test_namespace_scoping.py` skips (dormant-mode assumptions).
+
+The dormant-mode regression inside `test_tenant_namespace_discovery.py` mutates controller flags and only runs when `ENABLE_TENANT_DISCOVERY_DORMANT_E2E=true`.
+
+The S24/S4 suites are in the smoke list but intentionally skip until their backing implementation is present in the deployed build. Enable them with `ENABLE_S24_E2E=true` or `ENABLE_S4_E2E=true` plus `MAAS_API_BASE_URL_TENANT_A`, `MAAS_API_BASE_URL_TENANT_B`, `TENANT_A_NAMESPACE`, and `TENANT_B_NAMESPACE`.
 
 External OIDC runs require `EXTERNAL_OIDC=true` and `OIDC_ISSUER_URL`, `OIDC_TOKEN_URL`, `OIDC_CLIENT_ID`, `OIDC_USERNAME`, `OIDC_PASSWORD` per your deploy/test setup.

--- a/test/e2e/scripts/prow_run_smoke_test.sh
+++ b/test/e2e/scripts/prow_run_smoke_test.sh
@@ -52,7 +52,7 @@
 #   DEPLOYMENT_NAMESPACE - Namespace of MaaS API and controller (default: opendatahub)
 #   MAAS_SUBSCRIPTION_NAMESPACE - Namespace of MaaS CRs and Tenant CR (default: models-as-a-service)
 #   ENABLE_TENANT_NAMESPACE_DISCOVERY - Patch maas-controller with discovery flag before pytest (default: true)
-#   AITENANT_NAMESPACE - Namespace for AITenant CRs (default: redhat-ai-gateway-infra)
+#   AITENANT_NAMESPACE - Namespace for AITenant CRs (default: ai-tenants)
 #   GATEWAY_NAMESPACE - Namespace for payload-processing deployment checks (default: openshift-ingress)
 #   MODEL_NAMESPACE - Namespace of models and MaaSModelRefs (default: llm)
 #
@@ -113,7 +113,7 @@ GATEWAY_PROGRAMMED_TIMEOUT="${GATEWAY_PROGRAMMED_TIMEOUT:-600}"
 OIDC_READINESS_STRICT="${OIDC_READINESS_STRICT:-false}"
 # Multi-tenancy Phase 1: patch maas-controller for tenant namespace discovery E2E.
 ENABLE_TENANT_NAMESPACE_DISCOVERY="${ENABLE_TENANT_NAMESPACE_DISCOVERY:-true}"
-AITENANT_NAMESPACE="${AITENANT_NAMESPACE:-redhat-ai-gateway-infra}"
+AITENANT_NAMESPACE="${AITENANT_NAMESPACE:-ai-tenants}"
 
 # Artifact collection: OpenShift CI provides ARTIFACT_DIR (docs.ci.openshift.org/docs/architecture/step-registry).
 # Files written here are collected to artifacts/<job>/<step>/ in Prow. Fallbacks: ARTIFACTS, LOG_DIR, or local reports.
@@ -514,7 +514,8 @@ wait_for_auth_policies_enforced() {
 validate_deployment() {
     echo "Deployment Validation"
     echo "Using controller namespace: $DEPLOYMENT_NAMESPACE"
-    echo "Using maas-api namespace: redhat-ai-gateway-infra"
+    echo "Using maas-api namespace: $DEPLOYMENT_NAMESPACE"
+    echo "Using AITenant namespace: $AITENANT_NAMESPACE"
 
     if [ "$SKIP_VALIDATION" = false ]; then
         # maas-api deploys to operator namespace (opendatahub for ODH, redhat-ods-applications for RHOAI)

--- a/test/e2e/scripts/prow_run_smoke_test.sh
+++ b/test/e2e/scripts/prow_run_smoke_test.sh
@@ -51,6 +51,8 @@
 #   OIDC_READINESS_STRICT - When true, exit before pytest if the OIDC readiness probe times out.
 #   DEPLOYMENT_NAMESPACE - Namespace of MaaS API and controller (default: opendatahub)
 #   MAAS_SUBSCRIPTION_NAMESPACE - Namespace of MaaS CRs and Tenant CR (default: models-as-a-service)
+#   ENABLE_TENANT_NAMESPACE_DISCOVERY - Patch maas-controller with discovery flag before pytest (default: true)
+#   AITENANT_NAMESPACE - Namespace for AITenant CRs (default: redhat-ai-gateway-infra)
 #   GATEWAY_NAMESPACE - Namespace for payload-processing deployment checks (default: openshift-ingress)
 #   MODEL_NAMESPACE - Namespace of models and MaaSModelRefs (default: llm)
 #
@@ -109,6 +111,9 @@ export INGRESS_MODE
 GATEWAY_PROGRAMMED_TIMEOUT="${GATEWAY_PROGRAMMED_TIMEOUT:-600}"
 # OIDC readiness gate: by default do not block pytest if Keycloak/Authorino still returns 401
 OIDC_READINESS_STRICT="${OIDC_READINESS_STRICT:-false}"
+# Multi-tenancy Phase 1: patch maas-controller for tenant namespace discovery E2E.
+ENABLE_TENANT_NAMESPACE_DISCOVERY="${ENABLE_TENANT_NAMESPACE_DISCOVERY:-true}"
+AITENANT_NAMESPACE="${AITENANT_NAMESPACE:-redhat-ai-gateway-infra}"
 
 # Artifact collection: OpenShift CI provides ARTIFACT_DIR (docs.ci.openshift.org/docs/architecture/step-registry).
 # Files written here are collected to artifacts/<job>/<step>/ in Prow. Fallbacks: ARTIFACTS, LOG_DIR, or local reports.
@@ -161,6 +166,45 @@ apply_default_oidc_for_keycloak() {
     export OIDC_USERNAME="${OIDC_USERNAME:-alice_lead}"
     export OIDC_PASSWORD="${OIDC_PASSWORD:-letmein}"
     echo "OIDC for e2e (Keycloak tenant-a defaults): issuer=${OIDC_ISSUER_URL}"
+}
+
+# Patch maas-controller to enable tenant namespace discovery for MT S1/S27 E2E.
+enable_tenant_namespace_discovery_for_e2e() {
+    [[ "${ENABLE_TENANT_NAMESPACE_DISCOVERY}" == "true" ]] || return 0
+
+    echo "Enabling --enable-tenant-namespace-discovery on maas-controller..."
+    if ! oc get deployment maas-controller -n "$DEPLOYMENT_NAMESPACE" &>/dev/null; then
+        echo "❌ ERROR: maas-controller not found in ${DEPLOYMENT_NAMESPACE}; cannot enable tenant namespace discovery"
+        return 1
+    fi
+
+    local args_json
+    args_json="$(oc get deployment maas-controller -n "$DEPLOYMENT_NAMESPACE" -o jsonpath='{.spec.template.spec.containers[0].args}' 2>/dev/null || echo '[]')"
+    if echo "$args_json" | grep -q 'enable-tenant-namespace-discovery'; then
+        echo "✅ maas-controller already has tenant namespace discovery enabled"
+    elif [[ -z "$args_json" || "$args_json" == "<no value>" ]]; then
+        oc patch deployment maas-controller -n "$DEPLOYMENT_NAMESPACE" --type=json -p='[
+          {"op": "add", "path": "/spec/template/spec/containers/0/args", "value": ["--enable-tenant-namespace-discovery=true"]}
+        ]' || {
+            echo "❌ ERROR: failed to initialize maas-controller args for tenant namespace discovery"
+            return 1
+        }
+    else
+        oc patch deployment maas-controller -n "$DEPLOYMENT_NAMESPACE" --type=json -p='[
+          {"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--enable-tenant-namespace-discovery=true"}
+        ]' || {
+            echo "❌ ERROR: failed to patch maas-controller for tenant namespace discovery"
+            return 1
+        }
+    fi
+
+    if ! echo "$args_json" | grep -q 'enable-tenant-namespace-discovery'; then
+        oc rollout status deployment/maas-controller -n "$DEPLOYMENT_NAMESPACE" --timeout=180s || {
+            echo "❌ ERROR: maas-controller rollout failed after discovery patch"
+            return 1
+        }
+        echo "✅ maas-controller patched with --enable-tenant-namespace-discovery=true"
+    fi
 }
 
 require_external_oidc_config() {
@@ -604,6 +648,10 @@ run_e2e_tests() {
     export DEPLOYMENT_NAMESPACE
     export MAAS_SUBSCRIPTION_NAMESPACE
     export GATEWAY_NAMESPACE="${GATEWAY_NAMESPACE:-openshift-ingress}"
+    export GATEWAY_NAME="${GATEWAY_NAME:-maas-default-gateway}"
+    export AITENANT_NAMESPACE
+    export ENABLE_TENANT_NAMESPACE_DISCOVERY
+    enable_tenant_namespace_discovery_for_e2e || exit 1
     # Skip TLS verification in CI (self-signed certs)
     export E2E_SKIP_TLS_VERIFY=true
     # Set MODEL_NAME explicitly - maas-api /v1/models currently only lists MaaSModelRefs
@@ -738,7 +786,7 @@ run_e2e_tests() {
         fi
     fi
 
-    # Run all e2e tests
+    # Run the default smoke e2e tests
     if ! PYTHONPATH="$test_dir:${PYTHONPATH:-}" pytest \
         -v --maxfail=5 --disable-warnings \
         --junitxml="$xml" \
@@ -752,6 +800,13 @@ run_e2e_tests() {
         "$test_dir/tests/test_external_models.py" \
         "$test_dir/tests/test_tenant.py" \
         "$test_dir/tests/test_aitenant_lifecycle.py" \
+        "$test_dir/tests/test_tenant_namespace_discovery.py" \
+        "$test_dir/tests/test_gateway_scoped_authpolicy.py" \
+        "$test_dir/tests/test_multi_tenant_integration.py" \
+        "$test_dir/tests/test_multi_tenant_maas_api.py" \
+        "$test_dir/tests/test_tenant_auth_isolation.py" \
+        "$test_dir/tests/test_tenant_subscription_isolation.py" \
+        "$test_dir/tests/test_tenant_rate_limit_isolation.py" \
         "$test_dir/tests/test_config_tenant.py" \
         "$test_dir/tests/test_external_oidc.py" ; then
         echo "❌ ERROR: E2E tests failed"

--- a/test/e2e/tests/conftest.py
+++ b/test/e2e/tests/conftest.py
@@ -8,6 +8,39 @@ import requests
 # TLS verification flag - set E2E_SKIP_TLS_VERIFY=true to disable cert verification
 TLS_VERIFY = os.environ.get("E2E_SKIP_TLS_VERIFY", "").lower() != "true"
 
+# When using port-forward (GATEWAY_HOST=127.0.0.1:PORT), set GATEWAY_ROUTE_HOST to the
+# real route hostname so OpenShift gateway routing matches the Host header.
+_GATEWAY_ROUTE_HOST = os.environ.get("GATEWAY_ROUTE_HOST", "")
+
+
+def _maybe_inject_gateway_route_host(method, url, kwargs):
+    if not _GATEWAY_ROUTE_HOST:
+        return kwargs
+    url_str = str(url)
+    if "127.0.0.1" in url_str or "localhost" in url_str:
+        headers = dict(kwargs.get("headers") or {})
+        headers.setdefault("Host", _GATEWAY_ROUTE_HOST)
+        kwargs["headers"] = headers
+    return kwargs
+
+
+if _GATEWAY_ROUTE_HOST:
+    _orig_request = requests.api.request
+
+    def _request(method, url, **kwargs):
+        kwargs = _maybe_inject_gateway_route_host(method, url, kwargs)
+        return _orig_request(method, url, **kwargs)
+
+    requests.api.request = _request
+
+    _orig_session_request = requests.Session.request
+
+    def _session_request(self, method, url, **kwargs):
+        kwargs = _maybe_inject_gateway_route_host(method, url, kwargs)
+        return _orig_session_request(self, method, url, **kwargs)
+
+    requests.Session.request = _session_request
+
 
 @pytest.fixture(scope="session")
 def gateway_host() -> str:
@@ -43,8 +76,13 @@ def _verify_gateway_dns(gateway_host: str):
     early instead of producing cryptic ConnectionError stack traces
     in every test.
     """
+    host_port = gateway_host.rsplit(":", 1)
+    if len(host_port) == 2 and host_port[1].isdigit():
+        host, port = host_port[0], int(host_port[1])
+    else:
+        host, port = gateway_host, None
     try:
-        socket.getaddrinfo(gateway_host, None)
+        socket.getaddrinfo(host, port or 0)
     except socket.gaierror:
         pytest.skip(
             f"Gateway hostname '{gateway_host}' does not resolve "

--- a/test/e2e/tests/multitenancy_helpers.py
+++ b/test/e2e/tests/multitenancy_helpers.py
@@ -1,0 +1,763 @@
+"""Shared helpers for multi-tenancy Phase 1 E2E tests (S1 / S11 / S6)."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import time
+import uuid
+from typing import Any, Optional
+
+import pytest
+import requests
+
+from test_helper import (
+    MODEL_NAMESPACE,
+    MODEL_REF,
+    TIMEOUT,
+    TLS_VERIFY,
+    _apply_cr,
+    _delete_cr,
+    _ns,
+    _wait_reconcile,
+)
+
+AITENANT_CRD = "aitenants.maas.opendatahub.io"
+AITENANT_KIND = "aitenant"
+TENANT_CR_NAME = "default-tenant"
+
+LABEL_AI_GATEWAY_TENANT = "ai-gateway.opendatahub.io/tenant"
+LABEL_MANAGED_BY_AITENANT = "maas.opendatahub.io/managed-by-aitenant"
+LABEL_TENANT_NAME = "maas.opendatahub.io/tenant-name"
+LABEL_TENANT_NAMESPACE = "maas.opendatahub.io/tenant-namespace"
+
+FINALIZER_SUBSCRIPTION = "maas.opendatahub.io/subscription-cleanup"
+FINALIZER_AUTHPOLICY = "maas.opendatahub.io/authpolicy-cleanup"
+
+GATEWAY_AUTH_POLICY_NAME = "maas-gateway-auth"
+
+AITENANT_NAMESPACE = os.environ.get("AITENANT_NAMESPACE", "redhat-ai-gateway-infra")
+GATEWAY_NAMESPACE = os.environ.get("GATEWAY_NAMESPACE", "openshift-ingress")
+DEFAULT_GATEWAY_NAME = os.environ.get("GATEWAY_NAME", "maas-default-gateway")
+AITENANT_GATEWAY_CLASS_NAME = os.environ.get("AITENANT_GATEWAY_CLASS_NAME", "openshift-default")
+DEPLOYMENT_NAMESPACE = os.environ.get("DEPLOYMENT_NAMESPACE", "opendatahub")
+OC_TIMEOUT = int(os.environ.get("E2E_OC_TIMEOUT", "60"))
+
+DISCOVERY_ARG = "--enable-tenant-namespace-discovery=true"
+
+
+def _oc_bin() -> str:
+    path = shutil.which("oc")
+    if not path:
+        raise RuntimeError("`oc` binary not found in PATH")
+    return path
+
+
+def _oc_run(args, *, input_text: Optional[str] = None, timeout: Optional[int] = None):
+    return subprocess.run(
+        [_oc_bin(), *args],
+        input=input_text,
+        capture_output=True,
+        text=True,
+        timeout=OC_TIMEOUT if timeout is None else timeout,
+        check=False,
+    )
+
+
+def _oc_output_not_found(result) -> bool:
+    combined = (result.stderr or "") + (result.stdout or "")
+    return "(NotFound)" in combined or "not found" in combined.lower()
+
+
+def env_bool(name: str, default: bool = False) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.lower() in {"1", "true", "yes", "y", "on"}
+
+
+def _apply(obj: dict) -> None:
+    result = _oc_run(["apply", "-f", "-"], input_text=json.dumps(obj))
+    if result.returncode != 0:
+        raise RuntimeError(f"`oc apply` failed: {result.stderr.strip() or result.stdout.strip()}")
+
+
+def _create_expect_failure(obj: dict) -> str:
+    result = _oc_run(["create", "-f", "-"], input_text=json.dumps(obj))
+    combined = (result.stderr or "") + (result.stdout or "")
+    if result.returncode == 0:
+        raise AssertionError(f"`oc create` unexpectedly succeeded: {combined}")
+    return combined
+
+
+def _delete(kind: str, name: str, namespace: Optional[str] = None, *, timeout: str = "60s") -> None:
+    args = ["delete", kind, name, "--ignore-not-found", f"--timeout={timeout}"]
+    if namespace:
+        args.extend(["-n", namespace])
+    result = _oc_run(args, timeout=OC_TIMEOUT + 30)
+    if result.returncode != 0:
+        raise RuntimeError(f"`oc {' '.join(args)}` failed: {result.stderr.strip() or result.stdout.strip()}")
+
+
+def delete_best_effort(kind: str, name: str, namespace: Optional[str] = None, *, timeout: str = "60s") -> None:
+    try:
+        _delete(kind, name, namespace, timeout=timeout)
+    except Exception as exc:  # noqa: BLE001
+        print(f"[cleanup] failed to delete {kind}/{name}: {exc}")
+
+
+def get_json_or_none(kind: str, name: str, namespace: Optional[str] = None) -> Optional[dict]:
+    args = ["get", kind, name, "-o", "json"]
+    if namespace:
+        args.extend(["-n", namespace])
+    result = _oc_run(args)
+    if result.returncode == 0:
+        return json.loads(result.stdout)
+    if _oc_output_not_found(result):
+        return None
+    raise RuntimeError(f"`oc {' '.join(args)}` failed: {result.stderr.strip() or result.stdout.strip()}")
+
+
+def list_json(kind: str, namespace: Optional[str] = None, *, labels: Optional[str] = None) -> list[dict]:
+    args = ["get", kind, "-o", "json"]
+    if namespace:
+        args.extend(["-n", namespace])
+    if labels:
+        args.extend(["-l", labels])
+    result = _oc_run(args)
+    if result.returncode == 0:
+        return json.loads(result.stdout).get("items") or []
+    if _oc_output_not_found(result):
+        return []
+    raise RuntimeError(f"`oc {' '.join(args)}` failed: {result.stderr.strip() or result.stdout.strip()}")
+
+
+def wait_for_json(
+    kind: str,
+    name: str,
+    namespace: Optional[str] = None,
+    *,
+    predicate=None,
+    timeout: int = 180,
+    interval: int = 5,
+) -> dict:
+    deadline = time.time() + timeout
+    last_obj = None
+    while time.time() < deadline:
+        obj = get_json_or_none(kind, name, namespace)
+        if obj is not None:
+            last_obj = obj
+            if predicate is None or predicate(obj):
+                return obj
+        time.sleep(interval)
+    raise AssertionError(
+        f"{kind}/{name} in {namespace or '<cluster>'} did not satisfy condition. Last object: {last_obj}"
+    )
+
+
+def wait_for_not_found(
+    kind: str,
+    name: str,
+    namespace: Optional[str] = None,
+    *,
+    timeout: int = 120,
+    interval: int = 5,
+) -> None:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if get_json_or_none(kind, name, namespace) is None:
+            return
+        time.sleep(interval)
+    raise AssertionError(f"{kind}/{name} in {namespace or '<cluster>'} still exists")
+
+
+def wait_for_finalizer(
+    kind: str,
+    name: str,
+    namespace: str,
+    finalizer: str,
+    *,
+    present: bool = True,
+    timeout: int = 120,
+    interval: int = 5,
+) -> dict:
+    def _predicate(obj: dict) -> bool:
+        finalizers = obj.get("metadata", {}).get("finalizers") or []
+        return (finalizer in finalizers) if present else (finalizer not in finalizers)
+
+    return wait_for_json(kind, name, namespace, predicate=_predicate, timeout=timeout, interval=interval)
+
+
+def wait_for_status_phase(
+    kind: str,
+    name: str,
+    namespace: str,
+    *,
+    expected_phase: Optional[str | tuple[str, ...]] = None,
+    timeout: int = 120,
+    interval: int = 5,
+) -> dict:
+    def _predicate(obj: dict) -> bool:
+        phase = (obj.get("status") or {}).get("phase")
+        if expected_phase is None:
+            return bool(phase)
+        if isinstance(expected_phase, tuple):
+            return phase in expected_phase
+        return phase == expected_phase
+
+    return wait_for_json(kind, name, namespace, predicate=_predicate, timeout=timeout, interval=interval)
+
+
+def wait_for_deployment_available(name: str, namespace: str = DEPLOYMENT_NAMESPACE, *, timeout: int = 180) -> dict:
+    def _predicate(obj: dict) -> bool:
+        status = obj.get("status") or {}
+        if status.get("availableReplicas", 0) < 1:
+            return False
+        for condition in status.get("conditions") or []:
+            if condition.get("type") == "Available" and condition.get("status") == "True":
+                return True
+        return False
+
+    return wait_for_json("deployment", name, namespace, predicate=_predicate, timeout=timeout)
+
+
+def wait_for_annotation_contains(
+    kind: str,
+    name: str,
+    namespace: str,
+    annotation: str,
+    expected_values: list[str],
+    *,
+    timeout: int = 180,
+    interval: int = 5,
+) -> list[str]:
+    last_values: list[str] = []
+
+    def _predicate(obj: dict) -> bool:
+        nonlocal last_values
+        annotations = obj.get("metadata", {}).get("annotations") or {}
+        last_values = parse_annotation_list(annotations.get(annotation, ""))
+        return all(value in last_values for value in expected_values)
+
+    wait_for_json(kind, name, namespace, predicate=_predicate, timeout=timeout, interval=interval)
+    return last_values
+
+
+def controller_has_tenant_namespace_discovery() -> bool:
+    result = _oc_run(["get", "deployment", "maas-controller", "-n", DEPLOYMENT_NAMESPACE, "-o", "json"])
+    if result.returncode != 0:
+        return False
+    deployment = json.loads(result.stdout)
+    containers = deployment.get("spec", {}).get("template", {}).get("spec", {}).get("containers") or []
+    if not containers:
+        return False
+    args = containers[0].get("args") or []
+    return DISCOVERY_ARG in args or "--enable-tenant-namespace-discovery" in args
+
+
+def patch_controller_tenant_namespace_discovery(*, enabled: bool = True) -> None:
+    """Patch maas-controller Deployment to enable or disable tenant namespace discovery."""
+    result = _oc_run(["get", "deployment", "maas-controller", "-n", DEPLOYMENT_NAMESPACE, "-o", "json"])
+    if result.returncode != 0:
+        raise RuntimeError(f"failed to read maas-controller deployment: {result.stderr.strip()}")
+
+    deployment = json.loads(result.stdout)
+    containers = deployment["spec"]["template"]["spec"]["containers"]
+    args = list(containers[0].get("args") or [])
+    args = [a for a in args if not a.startswith("--enable-tenant-namespace-discovery")]
+    if enabled:
+        args.append(DISCOVERY_ARG)
+    containers[0]["args"] = args
+
+    patch = json.dumps(deployment)
+    apply_result = _oc_run(["apply", "-f", "-"], input_text=patch)
+    if apply_result.returncode != 0:
+        raise RuntimeError(
+            f"failed to patch maas-controller deployment: {apply_result.stderr.strip() or apply_result.stdout.strip()}"
+        )
+
+    rollout = _oc_run(
+        ["rollout", "status", f"deployment/maas-controller", "-n", DEPLOYMENT_NAMESPACE, "--timeout=180s"],
+        timeout=200,
+    )
+    if rollout.returncode != 0:
+        raise RuntimeError(f"maas-controller rollout failed: {rollout.stderr.strip() or rollout.stdout.strip()}")
+
+
+def require_tenant_namespace_discovery():
+    if os.environ.get("ENABLE_TENANT_NAMESPACE_DISCOVERY", "").lower() == "true":
+        if not controller_has_tenant_namespace_discovery():
+            pytest.fail(
+                "ENABLE_TENANT_NAMESPACE_DISCOVERY=true but maas-controller is missing "
+                f"{DISCOVERY_ARG}; patch the deployment or run prow with multitenancy setup"
+            )
+        return
+    if not controller_has_tenant_namespace_discovery():
+        pytest.skip(
+            f"maas-controller does not have {DISCOVERY_ARG}; "
+            "set ENABLE_TENANT_NAMESPACE_DISCOVERY=true and patch the deployment to run multi-tenancy E2E"
+        )
+
+
+def require_s27_blocked_story_enabled(story: str) -> None:
+    env_name = f"ENABLE_{story.upper()}_E2E"
+    if not env_bool(env_name):
+        pytest.skip(f"{story} E2E is present but gated until the backing story lands; set {env_name}=true")
+
+
+def require_aitenant_crd():
+    result = _oc_run(["get", "crd", AITENANT_CRD])
+    if result.returncode != 0:
+        if _oc_output_not_found(result):
+            if env_bool("ENABLE_TENANT_NAMESPACE_DISCOVERY"):
+                pytest.fail(f"Missing CRD {AITENANT_CRD}; multi-tenancy discovery E2E cannot run")
+            pytest.skip(f"Missing CRD {AITENANT_CRD}; AITenant tests are not applicable")
+        pytest.fail(f"`oc get crd {AITENANT_CRD}` failed: {result.stderr.strip() or result.stdout.strip()}")
+
+
+def new_discovery_case(*, use_default_gateway: bool = False) -> dict[str, str]:
+    suffix = uuid.uuid4().hex[:8]
+    tenant_name = f"e2e-mt-{suffix}"
+    return {
+        "suffix": suffix,
+        "tenant_ns": f"e2e-mt-{suffix}",
+        "tenant_label_name": tenant_name,
+        "gateway_name": DEFAULT_GATEWAY_NAME if use_default_gateway else tenant_name,
+        "policy_name": f"e2e-policy-{suffix}",
+        "subscription_name": f"e2e-sub-{suffix}",
+    }
+
+
+def new_named_tenant_case(prefix: str) -> dict[str, str]:
+    """Create a stable-ish tenant case with a caller-provided DNS-safe prefix."""
+    suffix = uuid.uuid4().hex[:6]
+    tenant_name = f"{prefix}-{suffix}"
+    return {
+        "suffix": suffix,
+        "tenant_ns": f"{tenant_name}-ns",
+        "tenant_label_name": tenant_name,
+        "gateway_name": tenant_name,
+        "policy_name": f"{tenant_name}-policy",
+        "subscription_name": f"{tenant_name}-sub",
+    }
+
+
+def admin_subject() -> str:
+    whoami = _oc_run(["whoami"])
+    if whoami.returncode == 0 and whoami.stdout.strip():
+        return whoami.stdout.strip()
+    return "system:authenticated"
+
+
+def ensure_namespace(name: str, *, labels: Optional[dict[str, str]] = None) -> None:
+    result = _oc_run(["create", "namespace", name])
+    if result.returncode != 0 and "AlreadyExists" not in (result.stderr or "") and "already exists" not in (result.stderr or "").lower():
+        raise RuntimeError(f"failed to create namespace {name}: {result.stderr.strip() or result.stdout.strip()}")
+    if labels:
+        patch = {"metadata": {"labels": labels}}
+        patch_result = _oc_run(["patch", "namespace", name, "--type=merge", "-p", json.dumps(patch)])
+        if patch_result.returncode != 0:
+            raise RuntimeError(f"failed to label namespace {name}: {patch_result.stderr.strip()}")
+
+
+def apply_discovery_labels(namespace: str, tenant_label_name: str) -> None:
+    ensure_namespace(namespace)
+    patch = {
+        "metadata": {
+            "labels": {
+                LABEL_AI_GATEWAY_TENANT: tenant_label_name,
+                LABEL_MANAGED_BY_AITENANT: "true",
+                LABEL_TENANT_NAME: tenant_label_name,
+                LABEL_TENANT_NAMESPACE: namespace,
+            }
+        }
+    }
+    result = _oc_run(["patch", "namespace", namespace, "--type=merge", "-p", json.dumps(patch)])
+    if result.returncode != 0:
+        raise RuntimeError(f"failed to apply discovery labels to {namespace}: {result.stderr.strip()}")
+
+
+def remove_discovery_labels(namespace: str) -> None:
+    patch = {
+        "metadata": {
+            "labels": {
+                LABEL_AI_GATEWAY_TENANT: None,
+                LABEL_MANAGED_BY_AITENANT: None,
+                LABEL_TENANT_NAME: None,
+                LABEL_TENANT_NAMESPACE: None,
+            }
+        }
+    }
+    result = _oc_run(["patch", "namespace", namespace, "--type=merge", "-p", json.dumps(patch)])
+    if result.returncode != 0:
+        raise RuntimeError(f"failed to remove discovery labels from {namespace}: {result.stderr.strip()}")
+
+
+def apply_tenant_cr(
+    namespace: str,
+    gateway_name: str,
+    *,
+    gateway_namespace: str = GATEWAY_NAMESPACE,
+    external_oidc: Optional[dict[str, str]] = None,
+) -> None:
+    spec: dict[str, Any] = {
+        "gatewayRef": {
+            "name": gateway_name,
+            "namespace": gateway_namespace,
+        }
+    }
+    if external_oidc:
+        spec["externalOIDC"] = external_oidc
+    _apply(
+        {
+            "apiVersion": "maas.opendatahub.io/v1alpha1",
+            "kind": "Tenant",
+            "metadata": {"name": TENANT_CR_NAME, "namespace": namespace},
+            "spec": spec,
+        }
+    )
+
+
+def apply_gateway_fixture(gateway_name: str, *, fixture_label: str) -> None:
+    _apply(
+        {
+            "apiVersion": "gateway.networking.k8s.io/v1",
+            "kind": "Gateway",
+            "metadata": {
+                "name": gateway_name,
+                "namespace": GATEWAY_NAMESPACE,
+                "labels": {"e2e.maas.opendatahub.io/fixture": fixture_label},
+            },
+            "spec": {
+                "gatewayClassName": AITENANT_GATEWAY_CLASS_NAME,
+                "listeners": [{"name": "http", "port": 80, "protocol": "HTTP"}],
+            },
+        }
+    )
+
+
+def apply_aitenant(case: dict[str, str]) -> None:
+    _apply(
+        {
+            "apiVersion": "maas.opendatahub.io/v1alpha1",
+            "kind": "AITenant",
+            "metadata": {"name": case["tenant_label_name"], "namespace": AITENANT_NAMESPACE},
+            "spec": {
+                "tenantNamespace": {"name": case["tenant_ns"]},
+                "gateway": {"name": case["gateway_name"]},
+                "rbac": {
+                    "admins": [{"kind": "User", "name": admin_subject()}],
+                },
+            },
+        }
+    )
+
+
+def aitenant_ready(obj: dict) -> bool:
+    status = obj.get("status") or {}
+    if status.get("phase") != "Active":
+        return False
+    return any(
+        cond.get("type") == "Ready" and cond.get("status") == "True"
+        for cond in status.get("conditions") or []
+    )
+
+
+def bootstrap_aitenant_tenant(case: dict[str, str], *, use_default_gateway: bool = False) -> None:
+    if not use_default_gateway:
+        apply_gateway_fixture(case["gateway_name"], fixture_label=case["tenant_label_name"])
+    apply_aitenant(case)
+    wait_for_json(AITENANT_KIND, case["tenant_label_name"], AITENANT_NAMESPACE, predicate=aitenant_ready)
+    wait_for_json("tenant", TENANT_CR_NAME, case["tenant_ns"])
+
+
+def apply_maas_auth_policy(name: str, namespace: str, model_ref: str = MODEL_REF, model_namespace: str = MODEL_NAMESPACE) -> None:
+    _apply_cr(
+        {
+            "apiVersion": "maas.opendatahub.io/v1alpha1",
+            "kind": "MaaSAuthPolicy",
+            "metadata": {"name": name, "namespace": namespace},
+            "spec": {
+                "modelRefs": [{"name": model_ref, "namespace": model_namespace}],
+                "subjects": {"groups": [{"name": "system:authenticated"}]},
+            },
+        }
+    )
+
+
+def apply_maas_subscription(
+    name: str,
+    namespace: str,
+    model_ref: str = MODEL_REF,
+    model_namespace: str = MODEL_NAMESPACE,
+    *,
+    token_limit: int = 100,
+    window: str = "1m",
+    groups: Optional[list[str]] = None,
+    users: Optional[list[str]] = None,
+    priority: Optional[int] = None,
+) -> None:
+    owner: dict[str, Any] = {}
+    if users:
+        owner["users"] = users
+    owner["groups"] = [{"name": group} for group in (groups or ["system:authenticated"])]
+    spec: dict[str, Any] = {
+        "owner": owner,
+        "modelRefs": [
+            {
+                "name": model_ref,
+                "namespace": model_namespace,
+                "tokenRateLimits": [{"limit": token_limit, "window": window}],
+            }
+        ],
+    }
+    if priority is not None:
+        spec["priority"] = int(priority)
+    _apply_cr(
+        {
+            "apiVersion": "maas.opendatahub.io/v1alpha1",
+            "kind": "MaaSSubscription",
+            "metadata": {"name": name, "namespace": namespace},
+            "spec": spec,
+        }
+    )
+
+
+def delete_maas_auth_policy(name: str, namespace: str) -> None:
+    _delete_cr("MaaSAuthPolicy", name, namespace)
+
+
+def delete_maas_subscription(name: str, namespace: str) -> None:
+    _delete_cr("MaaSSubscription", name, namespace)
+
+
+def delete_namespace_best_effort(name: str) -> None:
+    delete_best_effort("namespace", name, timeout="90s")
+
+
+def get_cr_annotation(kind: str, name: str, namespace: str, key: str) -> str:
+    obj = get_json_or_none(kind, name, namespace)
+    if not obj:
+        return ""
+    annotations = obj.get("metadata", {}).get("annotations") or {}
+    return annotations.get(key, "") or ""
+
+
+def parse_annotation_list(value: str) -> list[str]:
+    return [item.strip() for item in (value or "").split(",") if item.strip()]
+
+
+def deployment_env(name: str, namespace: str = DEPLOYMENT_NAMESPACE, *, container_name: str = "maas-api") -> dict[str, str]:
+    deployment = get_json_or_none("deployment", name, namespace)
+    if not deployment:
+        return {}
+    containers = deployment.get("spec", {}).get("template", {}).get("spec", {}).get("containers") or []
+    container = next((c for c in containers if c.get("name") == container_name), containers[0] if containers else {})
+    return {entry.get("name"): entry.get("value") for entry in container.get("env") or [] if entry.get("name")}
+
+
+def http_route_parent_refs(name: str, namespace: str = DEPLOYMENT_NAMESPACE) -> list[dict]:
+    route = get_json_or_none("httproute", name, namespace)
+    if not route:
+        return []
+    return ((route.get("spec") or {}).get("parentRefs") or [])
+
+
+def http_route_backend_refs(name: str, namespace: str = DEPLOYMENT_NAMESPACE) -> list[dict]:
+    route = get_json_or_none("httproute", name, namespace)
+    if not route:
+        return []
+    refs: list[dict] = []
+    for rule in (route.get("spec") or {}).get("rules") or []:
+        refs.extend(rule.get("backendRefs") or [])
+    return refs
+
+
+def per_tenant_maas_api_names(tenant_name: str) -> dict[str, str]:
+    return {
+        "deployment": f"maas-api-{tenant_name}",
+        "service": f"maas-api-{tenant_name}",
+        "httproute": f"maas-api-{tenant_name}-route",
+        "authpolicy": f"maas-api-{tenant_name}-auth",
+    }
+
+
+def get_gateway_authpolicy(namespace: str = GATEWAY_NAMESPACE, name: str = GATEWAY_AUTH_POLICY_NAME) -> Optional[dict]:
+    return get_json_or_none("authpolicy", name, namespace)
+
+
+def get_gateway_authpolicy_issuer(namespace: str = GATEWAY_NAMESPACE, name: str = GATEWAY_AUTH_POLICY_NAME) -> str:
+    """Return OIDC issuerUrl from the gateway-scoped maas-gateway-auth policy (#912)."""
+    ap = get_gateway_authpolicy(namespace, name)
+    if not ap:
+        return ""
+    auth_rules = ((ap.get("spec") or {}).get("defaults") or {}).get("rules", {}).get("authentication") or {}
+    oidc = auth_rules.get("oidc-identities") or {}
+    jwt = oidc.get("jwt") or {}
+    return jwt.get("issuerUrl") or ""
+
+
+def get_gateway_authpolicy_target_ref(namespace: str = GATEWAY_NAMESPACE, name: str = GATEWAY_AUTH_POLICY_NAME) -> dict:
+    ap = get_gateway_authpolicy(namespace, name)
+    if not ap:
+        return {}
+    return (ap.get("spec") or {}).get("targetRef") or {}
+
+
+def assert_no_per_model_authpolicy(model_ref: str, model_namespace: str = MODEL_NAMESPACE) -> None:
+    """Gateway-only mode (#912) must not create maas-auth-{model} policies."""
+    ap = get_json_or_none("authpolicy", f"maas-auth-{model_ref}", model_namespace)
+    assert ap is None, f"legacy per-model AuthPolicy maas-auth-{model_ref} should not exist in gateway-only mode"
+
+
+def get_kuadrant_authpolicy_issuer(model_ref: str, model_namespace: str = MODEL_NAMESPACE) -> str:
+    """Deprecated alias: OIDC now lives on maas-gateway-auth, not per-model policies."""
+    _ = (model_ref, model_namespace)
+    return get_gateway_authpolicy_issuer()
+
+
+def auth_can_create_maassubscription(subject: str, namespace: str) -> bool:
+    result = _oc_run(
+        [
+            "auth",
+            "can-i",
+            "create",
+            "maassubscriptions",
+            "-n",
+            namespace,
+            f"--as={subject}",
+        ]
+    )
+    return result.returncode == 0 and result.stdout.strip() == "yes"
+
+
+def cleanup_discovery_case(case: dict[str, str], *, delete_gateway: bool = True) -> None:
+    delete_best_effort(AITENANT_KIND, case["tenant_label_name"], AITENANT_NAMESPACE)
+    delete_maas_auth_policy(case["policy_name"], case["tenant_ns"])
+    delete_maas_subscription(case["subscription_name"], case["tenant_ns"])
+    delete_namespace_best_effort(case["tenant_ns"])
+    if delete_gateway and case["gateway_name"] != DEFAULT_GATEWAY_NAME:
+        delete_best_effort("gateway", case["gateway_name"], GATEWAY_NAMESPACE)
+
+
+def legacy_default_namespace() -> str:
+    return _ns()
+
+
+def tenant_api_base_url(slot: str) -> str:
+    """Return a tenant maas-api base URL from explicit E2E env vars.
+
+    Accepted env names for slot "TENANT_A":
+    - MAAS_API_BASE_URL_TENANT_A
+    - GATEWAY_HOST_TENANT_A (converted to https://host/maas-api unless INSECURE_HTTP=true)
+    """
+    normalized = slot.upper().replace("-", "_")
+    explicit = os.environ.get(f"MAAS_API_BASE_URL_{normalized}")
+    if explicit:
+        return explicit.rstrip("/")
+    host = os.environ.get(f"GATEWAY_HOST_{normalized}")
+    if host:
+        scheme = "http" if env_bool("INSECURE_HTTP") else "https"
+        return f"{scheme}://{host}/maas-api"
+    return ""
+
+
+def require_tenant_api_base_urls(*slots: str) -> dict[str, str]:
+    urls = {slot: tenant_api_base_url(slot) for slot in slots}
+    missing = [slot for slot, url in urls.items() if not url]
+    if missing:
+        needed = ", ".join(f"MAAS_API_BASE_URL_{slot.upper().replace('-', '_')}" for slot in missing)
+        pytest.fail(f"tenant maas-api URLs not configured; set {needed}")
+    return urls
+
+
+def bearer_headers(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+
+
+def create_api_key_at(base_url: str, oc_token: str, name: str, *, subscription: Optional[str] = None) -> requests.Response:
+    body: dict[str, str] = {"name": name}
+    if subscription:
+        body["subscription"] = subscription
+    return requests.post(
+        f"{base_url}/v1/api-keys",
+        headers=bearer_headers(oc_token),
+        json=body,
+        timeout=TIMEOUT,
+        verify=TLS_VERIFY,
+    )
+
+
+def get_api_key_at(base_url: str, oc_token: str, key_id: str) -> requests.Response:
+    return requests.get(
+        f"{base_url}/v1/api-keys/{key_id}",
+        headers=bearer_headers(oc_token),
+        timeout=TIMEOUT,
+        verify=TLS_VERIFY,
+    )
+
+
+def search_api_keys_at(
+    base_url: str,
+    oc_token: str,
+    *,
+    subscription: Optional[str] = None,
+    status: Optional[list[str]] = None,
+) -> requests.Response:
+    filters: dict[str, Any] = {"status": status or ["active"]}
+    if subscription:
+        filters["subscription"] = subscription
+    return requests.post(
+        f"{base_url}/v1/api-keys/search",
+        headers=bearer_headers(oc_token),
+        json={
+            "filters": filters,
+            "sort": {"by": "created_at", "order": "desc"},
+            "pagination": {"limit": 50, "offset": 0},
+        },
+        timeout=TIMEOUT,
+        verify=TLS_VERIFY,
+    )
+
+
+def validate_api_key_at(base_url: str, api_key: str) -> requests.Response:
+    return requests.post(
+        f"{base_url}/internal/v1/api-keys/validate",
+        json={"key": api_key},
+        timeout=TIMEOUT,
+        verify=TLS_VERIFY,
+    )
+
+
+def select_subscription_at(
+    base_url: str,
+    api_key: str,
+    username: str,
+    groups: list[str],
+    *,
+    requested_subscription: Optional[str] = None,
+    requested_model: Optional[str] = None,
+) -> requests.Response:
+    payload: dict[str, Any] = {"username": username, "groups": groups}
+    if requested_subscription:
+        payload["requestedSubscription"] = requested_subscription
+    if requested_model:
+        payload["requestedModel"] = requested_model
+    return requests.post(
+        f"{base_url}/internal/v1/subscriptions/select",
+        headers={"Authorization": f"Bearer {api_key}"},
+        json=payload,
+        timeout=TIMEOUT,
+        verify=TLS_VERIFY,
+    )
+
+
+def list_subscriptions_at(base_url: str, api_key: str) -> requests.Response:
+    return requests.get(
+        f"{base_url}/v1/subscriptions",
+        headers=bearer_headers(api_key),
+        timeout=TIMEOUT,
+        verify=TLS_VERIFY,
+    )

--- a/test/e2e/tests/multitenancy_helpers.py
+++ b/test/e2e/tests/multitenancy_helpers.py
@@ -92,6 +92,17 @@ def env_bool(name: str, default: bool = False) -> bool:
     return value.lower() in {"1", "true", "yes", "y", "on"}
 
 
+def external_oidc_from_env() -> Optional[dict[str, str]]:
+    """Return the deployed OIDC config used by the default tenant, when enabled."""
+    issuer = os.environ.get("OIDC_ISSUER_URL", "")
+    if not env_bool("EXTERNAL_OIDC") or not issuer:
+        return None
+    return {
+        "issuerUrl": issuer,
+        "clientId": os.environ.get("OIDC_CLIENT_ID", "test-client"),
+    }
+
+
 def redact_sensitive(value: Any, *, max_length: int = 300) -> str:
     """Return a short string safe enough for CI assertion messages."""
     text = str(value)
@@ -460,6 +471,8 @@ def apply_tenant_cr(
             "namespace": gateway_namespace,
         }
     }
+    if external_oidc is None and gateway_name == DEFAULT_GATEWAY_NAME:
+        external_oidc = external_oidc_from_env()
     if external_oidc:
         spec["externalOIDC"] = external_oidc
     _apply(
@@ -491,18 +504,23 @@ def apply_gateway_fixture(gateway_name: str, *, fixture_label: str) -> None:
 
 
 def apply_aitenant(case: dict[str, str]) -> None:
+    spec: dict[str, Any] = {
+        "tenantNamespace": {"name": case["tenant_ns"]},
+        "gateway": {"name": case["gateway_name"]},
+        "rbac": {
+            "admins": [{"kind": "User", "name": admin_subject()}],
+        },
+    }
+    oidc = external_oidc_from_env()
+    if oidc:
+        spec["oidc"] = oidc
+
     _apply(
         {
             "apiVersion": "maas.opendatahub.io/v1alpha1",
             "kind": "AITenant",
             "metadata": {"name": case["tenant_label_name"], "namespace": AITENANT_NAMESPACE},
-            "spec": {
-                "tenantNamespace": {"name": case["tenant_ns"]},
-                "gateway": {"name": case["gateway_name"]},
-                "rbac": {
-                    "admins": [{"kind": "User", "name": admin_subject()}],
-                },
-            },
+            "spec": spec,
         }
     )
 

--- a/test/e2e/tests/multitenancy_helpers.py
+++ b/test/e2e/tests/multitenancy_helpers.py
@@ -39,7 +39,7 @@ FINALIZER_AUTHPOLICY = "maas.opendatahub.io/authpolicy-cleanup"
 
 GATEWAY_AUTH_POLICY_NAME = "maas-gateway-auth"
 
-AITENANT_NAMESPACE = os.environ.get("AITENANT_NAMESPACE", "redhat-ai-gateway-infra")
+AITENANT_NAMESPACE = os.environ.get("AITENANT_NAMESPACE", "ai-tenants")
 GATEWAY_NAMESPACE = os.environ.get("GATEWAY_NAMESPACE", "openshift-ingress")
 DEFAULT_GATEWAY_NAME = os.environ.get("GATEWAY_NAME", "maas-default-gateway")
 AITENANT_GATEWAY_CLASS_NAME = os.environ.get("AITENANT_GATEWAY_CLASS_NAME", "openshift-default")

--- a/test/e2e/tests/multitenancy_helpers.py
+++ b/test/e2e/tests/multitenancy_helpers.py
@@ -47,14 +47,18 @@ DEPLOYMENT_NAMESPACE = os.environ.get("DEPLOYMENT_NAMESPACE", "opendatahub")
 OC_TIMEOUT = int(os.environ.get("E2E_OC_TIMEOUT", "60"))
 
 DISCOVERY_ARG = "--enable-tenant-namespace-discovery=true"
+SENSITIVE_FIELD_PATTERN = (
+    r"password|passwd|pwd|secret|token|api[_-]?key|apikey|key|credential|authorization|cookie|session|dsn|uri|url"
+)
 SENSITIVE_FIELD_RE = re.compile(
-    r"(password|passwd|pwd|secret|token|api[_-]?key|apikey|key|credential|authorization|cookie|session|dsn|uri|url)",
+    rf"({SENSITIVE_FIELD_PATTERN})",
     re.IGNORECASE,
 )
 SENSITIVE_VALUE_PATTERNS = (
     re.compile(r"\bBearer\s+[A-Za-z0-9._~+/=-]+", re.IGNORECASE),
     re.compile(r"\bsk-oai-[A-Za-z0-9._-]+", re.IGNORECASE),
     re.compile(r"\bpostgres(?:ql)?://[^\s\"']+", re.IGNORECASE),
+    re.compile(r"\b[a-z][a-z0-9+.-]*://[^/\s:@\"'<>]+:[^@\s/\"'<>]+@[^\s\"'<>]+", re.IGNORECASE),
 )
 
 
@@ -94,13 +98,13 @@ def redact_sensitive(value: Any, *, max_length: int = 300) -> str:
     for pattern in SENSITIVE_VALUE_PATTERNS:
         text = pattern.sub("<redacted>", text)
     text = re.sub(
-        r'("(?:[^"]*(?:password|passwd|pwd|secret|token|api[_-]?key|apikey|key|credential|authorization|cookie|session)[^"]*)"\s*:\s*)"[^"]*"',
+        rf'("(?:[^"]*(?:{SENSITIVE_FIELD_PATTERN})[^"]*)"\s*:\s*)"[^"]*"',
         r'\1"<redacted>"',
         text,
         flags=re.IGNORECASE,
     )
     text = re.sub(
-        r"('(?:[^']*(?:password|passwd|pwd|secret|token|api[_-]?key|apikey|key|credential|authorization|cookie|session)[^']*)'\s*:\s*)'[^']*'",
+        rf"('(?:[^']*(?:{SENSITIVE_FIELD_PATTERN})[^']*)'\s*:\s*)'[^']*'",
         r"\1'<redacted>'",
         text,
         flags=re.IGNORECASE,

--- a/test/e2e/tests/multitenancy_helpers.py
+++ b/test/e2e/tests/multitenancy_helpers.py
@@ -58,7 +58,7 @@ SENSITIVE_VALUE_PATTERNS = (
     re.compile(r"\bBearer\s+[A-Za-z0-9._~+/=-]+", re.IGNORECASE),
     re.compile(r"\bsk-oai-[A-Za-z0-9._-]+", re.IGNORECASE),
     re.compile(r"\bpostgres(?:ql)?://[^\s\"']+", re.IGNORECASE),
-    re.compile(r"\b[a-z][a-z0-9+.-]*://[^/\s:@\"'<>]+:[^@\s/\"'<>]+@[^\s\"'<>]+", re.IGNORECASE),
+    re.compile(r"\b[a-z][a-z0-9+.-]*://[^/\s:@\"'<>]+(?::[^@\s/\"'<>]+)?@[^\s\"'<>]+", re.IGNORECASE),
 )
 
 
@@ -334,7 +334,7 @@ def patch_controller_tenant_namespace_discovery(*, enabled: bool = True) -> None
 
 
 def require_tenant_namespace_discovery():
-    if os.environ.get("ENABLE_TENANT_NAMESPACE_DISCOVERY", "").lower() == "true":
+    if env_bool("ENABLE_TENANT_NAMESPACE_DISCOVERY"):
         if not controller_has_tenant_namespace_discovery():
             pytest.fail(
                 "ENABLE_TENANT_NAMESPACE_DISCOVERY=true but maas-controller is missing "
@@ -395,7 +395,12 @@ def admin_subject() -> str:
     whoami = _oc_run(["whoami"])
     if whoami.returncode == 0 and whoami.stdout.strip():
         return whoami.stdout.strip()
-    return "system:authenticated"
+    raise RuntimeError(
+        "oc whoami failed: "
+        f"returncode={whoami.returncode} "
+        f"stdout={whoami.stdout.strip()!r} "
+        f"stderr={whoami.stderr.strip()!r}"
+    )
 
 
 def ensure_namespace(name: str, *, labels: Optional[dict[str, str]] = None) -> None:

--- a/test/e2e/tests/multitenancy_helpers.py
+++ b/test/e2e/tests/multitenancy_helpers.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import shutil
 import subprocess
 import time
@@ -46,6 +47,15 @@ DEPLOYMENT_NAMESPACE = os.environ.get("DEPLOYMENT_NAMESPACE", "opendatahub")
 OC_TIMEOUT = int(os.environ.get("E2E_OC_TIMEOUT", "60"))
 
 DISCOVERY_ARG = "--enable-tenant-namespace-discovery=true"
+SENSITIVE_FIELD_RE = re.compile(
+    r"(password|passwd|pwd|secret|token|api[_-]?key|apikey|key|credential|authorization|cookie|session|dsn|uri|url)",
+    re.IGNORECASE,
+)
+SENSITIVE_VALUE_PATTERNS = (
+    re.compile(r"\bBearer\s+[A-Za-z0-9._~+/=-]+", re.IGNORECASE),
+    re.compile(r"\bsk-oai-[A-Za-z0-9._-]+", re.IGNORECASE),
+    re.compile(r"\bpostgres(?:ql)?://[^\s\"']+", re.IGNORECASE),
+)
 
 
 def _oc_bin() -> str:
@@ -76,6 +86,39 @@ def env_bool(name: str, default: bool = False) -> bool:
     if value is None:
         return default
     return value.lower() in {"1", "true", "yes", "y", "on"}
+
+
+def redact_sensitive(value: Any, *, max_length: int = 300) -> str:
+    """Return a short string safe enough for CI assertion messages."""
+    text = str(value)
+    for pattern in SENSITIVE_VALUE_PATTERNS:
+        text = pattern.sub("<redacted>", text)
+    text = re.sub(
+        r'("(?:[^"]*(?:password|passwd|pwd|secret|token|api[_-]?key|apikey|key|credential|authorization|cookie|session)[^"]*)"\s*:\s*)"[^"]*"',
+        r'\1"<redacted>"',
+        text,
+        flags=re.IGNORECASE,
+    )
+    text = re.sub(
+        r"('(?:[^']*(?:password|passwd|pwd|secret|token|api[_-]?key|apikey|key|credential|authorization|cookie|session)[^']*)'\s*:\s*)'[^']*'",
+        r"\1'<redacted>'",
+        text,
+        flags=re.IGNORECASE,
+    )
+    if len(text) > max_length:
+        return f"{text[:max_length]}...<truncated>"
+    return text
+
+
+def redact_mapping(mapping: dict[str, Any]) -> dict[str, Any]:
+    return {
+        key: "<redacted>" if SENSITIVE_FIELD_RE.search(key) else value
+        for key, value in sorted(mapping.items())
+    }
+
+
+def response_summary(response: requests.Response, *, max_body: int = 300) -> str:
+    return f"status={response.status_code} body={redact_sensitive(response.text, max_length=max_body)}"
 
 
 def _apply(obj: dict) -> None:

--- a/test/e2e/tests/test_aitenant_lifecycle.py
+++ b/test/e2e/tests/test_aitenant_lifecycle.py
@@ -234,6 +234,16 @@ def _delete_aitenant(case):
     _wait_for_not_found(AITENANT_KIND, case["aitenant_name"], AITENANT_NAMESPACE)
 
 
+def _aitenant_failed_invalid_placement(obj):
+    status = obj.get("status") or {}
+    if status.get("phase") != "Failed":
+        return False
+    return any(
+        cond.get("type") == "Ready" and cond.get("reason") == "InvalidPlacement"
+        for cond in status.get("conditions") or []
+    )
+
+
 class TestAITenantLifecycle:
     # TODO: Add e2e coverage that Policies, Subscriptions, Models, and inference requests
     # work end-to-end in a newly created AITenant tenant namespace.
@@ -279,3 +289,39 @@ class TestAITenantLifecycle:
             _delete_best_effort(AITENANT_KIND, case["aitenant_name"], AITENANT_NAMESPACE)
             _delete_best_effort("gateway", case["gateway_name"], GATEWAY_NAMESPACE)
             _delete_best_effort("namespace", case["tenant_ns"], timeout="90s")
+
+    def test_aitenant_rejects_models_as_a_service_for_non_default_tenant(self):
+        """RHOAIENG-66836: non-default AITenant must not use models-as-a-service tenant namespace."""
+        suffix = uuid.uuid4().hex[:8]
+        aitenant_name = f"e2e-invalid-{suffix}"
+        reserved_ns = os.environ.get("MAAS_SUBSCRIPTION_NAMESPACE", "models-as-a-service")
+        gateway_name = aitenant_name
+
+        try:
+            _apply_gateway_fixture({"gateway_name": gateway_name, "aitenant_name": aitenant_name})
+            _apply(
+                {
+                    "apiVersion": "maas.opendatahub.io/v1alpha1",
+                    "kind": "AITenant",
+                    "metadata": {"name": aitenant_name, "namespace": AITENANT_NAMESPACE},
+                    "spec": {
+                        "tenantNamespace": {"name": reserved_ns, "create": True},
+                        "rbac": {"admins": [{"kind": "User", "name": _admin_subject()}]},
+                    },
+                }
+            )
+            aitenant = _wait_for_json(
+                AITENANT_KIND,
+                aitenant_name,
+                AITENANT_NAMESPACE,
+                predicate=_aitenant_failed_invalid_placement,
+                timeout=120,
+            )
+            ready = next(
+                (c for c in (aitenant.get("status") or {}).get("conditions") or [] if c.get("type") == "Ready"),
+                {},
+            )
+            assert ready.get("reason") == "InvalidPlacement"
+        finally:
+            _delete_best_effort(AITENANT_KIND, aitenant_name, AITENANT_NAMESPACE)
+            _delete_best_effort("gateway", gateway_name, GATEWAY_NAMESPACE)

--- a/test/e2e/tests/test_api_keys.py
+++ b/test/e2e/tests/test_api_keys.py
@@ -906,7 +906,7 @@ class TestEphemeralKeyCleanup:
         """Return the namespace where maas-api is deployed.
 
         Controlled by E2E_MAAS_API_DEPLOYMENT_NAMESPACE env var,
-        defaults to redhat-ai-gateway-infra.
+        defaults to DEPLOYMENT_NAMESPACE/opendatahub.
         """
         from test_helper import MAAS_API_DEPLOYMENT_NAMESPACE
         return MAAS_API_DEPLOYMENT_NAMESPACE

--- a/test/e2e/tests/test_gateway_scoped_authpolicy.py
+++ b/test/e2e/tests/test_gateway_scoped_authpolicy.py
@@ -1,0 +1,122 @@
+"""
+E2E tests for gateway-scoped AuthPolicy (MT S10 / #912).
+
+Validates that MaaSAuthPolicy reconciliation produces a singleton
+maas-gateway-auth policy targeting the Gateway (not per-model HTTPRoute policies).
+
+Runs in default CI (no tenant namespace discovery required).
+"""
+
+import json
+import uuid
+
+import pytest
+
+from multitenancy_helpers import (
+    DEFAULT_GATEWAY_NAME,
+    GATEWAY_AUTH_POLICY_NAME,
+    GATEWAY_NAMESPACE,
+    assert_no_per_model_authpolicy,
+    get_gateway_authpolicy,
+    get_gateway_authpolicy_target_ref,
+)
+from test_helper import (
+    MODEL_NAMESPACE,
+    MODEL_REF,
+    _create_test_auth_policy,
+    _delete_cr,
+    _wait_for_maas_auth_policy_phase,
+    _wait_reconcile,
+)
+
+
+def _gateway_auth_rego() -> str:
+    ap = get_gateway_authpolicy()
+    if not ap:
+        return ""
+    authorization = (
+        ((ap.get("spec") or {}).get("defaults") or {})
+        .get("rules", {})
+        .get("authorization")
+        or {}
+    )
+    membership = authorization.get("require-group-membership") or {}
+    return (membership.get("opa") or {}).get("rego") or ""
+
+
+class TestGatewayAuthPolicyStructure:
+    """S10: AuthPolicy targets Gateway; no legacy per-model policies."""
+
+    def test_target_ref_points_to_gateway(self):
+        """6.1: maas-gateway-auth targetRef must be Gateway, not HTTPRoute."""
+        ap = get_gateway_authpolicy()
+        assert ap is not None, (
+            f"{GATEWAY_AUTH_POLICY_NAME} must exist in {GATEWAY_NAMESPACE} after prow fixtures reconcile"
+        )
+
+        target = get_gateway_authpolicy_target_ref()
+        assert target.get("kind") == "Gateway", f"expected Gateway targetRef, got {target!r}"
+        assert target.get("group") == "gateway.networking.k8s.io"
+        assert target.get("name") == DEFAULT_GATEWAY_NAME
+        target_ns = target.get("namespace") or GATEWAY_NAMESPACE
+        assert target_ns == GATEWAY_NAMESPACE, f"expected gateway namespace {GATEWAY_NAMESPACE}, got {target_ns!r}"
+
+        conditions = (ap.get("status") or {}).get("conditions") or []
+        accepted = [c for c in conditions if c.get("type") == "Accepted"]
+        assert accepted and accepted[0].get("status") == "True", (
+            f"{GATEWAY_AUTH_POLICY_NAME} must be Accepted, got {conditions!r}"
+        )
+
+    def test_no_per_model_authpolicy_for_fixture_model(self):
+        """6.2: Gateway-only mode must not create maas-auth-{model} in model namespace."""
+        assert_no_per_model_authpolicy(MODEL_REF, MODEL_NAMESPACE)
+
+
+class TestGatewayAuthPolicyLifecycle:
+    """S10: Gateway auth is reconciled from MaaSAuthPolicy changes."""
+
+    def test_gateway_auth_embeds_model_allowlist(self):
+        """6.3: Aggregated subject allowlists appear in gateway auth rego."""
+        suffix = uuid.uuid4().hex[:8]
+        policy_name = f"e2e-gw-auth-{suffix}"
+        unique_group = f"e2e-gw-group-{suffix}"
+
+        try:
+            _create_test_auth_policy(policy_name, MODEL_REF, groups=[unique_group])
+            _wait_for_maas_auth_policy_phase(policy_name, timeout=120, require_auth_policies=False)
+
+            rego = _gateway_auth_rego()
+            assert unique_group in rego, (
+                f"expected gateway auth rego to include group {unique_group!r}"
+            )
+            assert_no_per_model_authpolicy(MODEL_REF, MODEL_NAMESPACE)
+        finally:
+            _delete_cr("maasauthpolicy", policy_name)
+            _wait_reconcile()
+
+    def test_only_one_gateway_authpolicy_named_maas_gateway_auth(self):
+        """6.2: Exactly one maas-gateway-auth exists in the gateway namespace."""
+        ap = get_gateway_authpolicy()
+        assert ap is not None
+
+        from multitenancy_helpers import _oc_run
+
+        result = _oc_run(
+            [
+                "get",
+                "authpolicy",
+                "-n",
+                GATEWAY_NAMESPACE,
+                "-l",
+                "app.kubernetes.io/part-of=maas-gateway-auth",
+                "-o",
+                "json",
+            ]
+        )
+        if result.returncode != 0:
+            pytest.fail(result.stderr.strip() or result.stdout.strip())
+
+        items = json.loads(result.stdout).get("items") or []
+        names = [item.get("metadata", {}).get("name") for item in items]
+        assert GATEWAY_AUTH_POLICY_NAME in names
+        assert len(items) == 1, f"expected one gateway auth policy, got {names!r}"

--- a/test/e2e/tests/test_helper.py
+++ b/test/e2e/tests/test_helper.py
@@ -14,7 +14,7 @@ Environment variables (all optional unless noted):
   - GATEWAY_HOST: Gateway hostname (required)
   - MAAS_API_BASE_URL: MaaS API URL (auto-derived from GATEWAY_HOST if not set)
   - MAAS_SUBSCRIPTION_NAMESPACE: MaaS CRs namespace (default: models-as-a-service)
-  - E2E_MAAS_API_DEPLOYMENT_NAMESPACE: Namespace where maas-api workloads run (default: redhat-ai-gateway-infra)
+  - E2E_MAAS_API_DEPLOYMENT_NAMESPACE: Namespace where maas-api workloads run (default: DEPLOYMENT_NAMESPACE/opendatahub)
   - E2E_TEST_TOKEN_SA_NAMESPACE, E2E_TEST_TOKEN_SA_NAME: SA token source for Prow
   - E2E_TIMEOUT: Request timeout in seconds (default: 45)
   - E2E_RECONCILE_WAIT: Wait time for reconciliation in seconds (default: 8)

--- a/test/e2e/tests/test_multi_tenant_integration.py
+++ b/test/e2e/tests/test_multi_tenant_integration.py
@@ -1,0 +1,170 @@
+"""
+Multi-tenant integration E2E scenarios for Phase 1.
+
+These tests compose the S1/S10/S11 behavior:
+  - Full tenant lifecycle from AITenant create to delete
+  - Default tenant reconciliation remains intact
+  - Same-named resources across tenant namespaces do not collide
+  - Namespace discovery label changes trigger reconciliation
+
+Requires maas-controller with --enable-tenant-namespace-discovery=true.
+"""
+
+import uuid
+
+import pytest
+
+from multitenancy_helpers import (
+    AITENANT_KIND,
+    AITENANT_NAMESPACE,
+    DEFAULT_GATEWAY_NAME,
+    FINALIZER_AUTHPOLICY,
+    FINALIZER_SUBSCRIPTION,
+    MODEL_NAMESPACE,
+    MODEL_REF,
+    TENANT_CR_NAME,
+    apply_discovery_labels,
+    apply_gateway_fixture,
+    apply_maas_auth_policy,
+    apply_maas_subscription,
+    apply_tenant_cr,
+    bootstrap_aitenant_tenant,
+    cleanup_discovery_case,
+    delete_best_effort,
+    delete_maas_auth_policy,
+    delete_maas_subscription,
+    ensure_namespace,
+    get_json_or_none,
+    legacy_default_namespace,
+    new_discovery_case,
+    remove_discovery_labels,
+    require_aitenant_crd,
+    require_tenant_namespace_discovery,
+    wait_for_annotation_contains,
+    wait_for_finalizer,
+    wait_for_json,
+    wait_for_not_found,
+    wait_for_status_phase,
+)
+from test_helper import _wait_reconcile
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _require_multitenancy_prerequisites():
+    require_tenant_namespace_discovery()
+    require_aitenant_crd()
+    wait_for_json("namespace", AITENANT_NAMESPACE, timeout=180, interval=5)
+
+
+class TestMultiTenantIntegration:
+    """S27 section 7 — multi-tenant integration scenarios."""
+
+    def test_full_tenant_lifecycle_create_to_delete(self):
+        """7.1: Full tenant lifecycle from create through policy/subscription reconcile to delete."""
+        case = new_discovery_case()
+        role_name = f"aitenant-{case['tenant_label_name']}-tenant-admin"
+        try:
+            apply_gateway_fixture(case["gateway_name"], fixture_label=case["tenant_label_name"])
+            bootstrap_aitenant_tenant(case)
+
+            tenant = wait_for_json("tenant", TENANT_CR_NAME, case["tenant_ns"], timeout=180)
+            assert tenant["spec"]["gatewayRef"]["name"] == case["gateway_name"]
+            assert get_json_or_none("role", role_name, case["tenant_ns"]) is not None
+
+            apply_maas_auth_policy(case["policy_name"], case["tenant_ns"])
+            apply_maas_subscription(case["subscription_name"], case["tenant_ns"])
+            wait_for_status_phase("maasauthpolicy", case["policy_name"], case["tenant_ns"], expected_phase="Active")
+            wait_for_status_phase(
+                "maassubscription",
+                case["subscription_name"],
+                case["tenant_ns"],
+                expected_phase=("Active", "Degraded"),
+            )
+
+            delete_best_effort(AITENANT_KIND, case["tenant_label_name"], AITENANT_NAMESPACE)
+            wait_for_not_found("tenant", TENANT_CR_NAME, case["tenant_ns"], timeout=180)
+            wait_for_not_found("role", role_name, case["tenant_ns"], timeout=180)
+
+            namespace = get_json_or_none("namespace", case["tenant_ns"])
+            assert namespace is not None
+            labels = namespace.get("metadata", {}).get("labels") or {}
+            assert labels.get("ai-gateway.opendatahub.io/tenant") is None
+            assert labels.get("maas.opendatahub.io/managed-by-aitenant") is None
+        finally:
+            cleanup_discovery_case(case)
+
+    def test_default_tenant_unaffected_by_multitenancy_enablement(self):
+        """7.2: Default tenant namespace still reconciles while discovery mode is enabled."""
+        ns = legacy_default_namespace()
+        suffix = uuid.uuid4().hex[:6]
+        policy_name = f"e2e-default-int-auth-{suffix}"
+        subscription_name = f"e2e-default-int-sub-{suffix}"
+        try:
+            apply_maas_auth_policy(policy_name, ns)
+            apply_maas_subscription(subscription_name, ns)
+            wait_for_status_phase("maasauthpolicy", policy_name, ns, expected_phase="Active")
+            wait_for_status_phase("maassubscription", subscription_name, ns, expected_phase=("Active", "Degraded"))
+        finally:
+            delete_maas_auth_policy(policy_name, ns)
+            delete_maas_subscription(subscription_name, ns)
+
+    def test_same_named_resources_across_tenants(self):
+        """7.3: Same-named MaaS resources in separate tenant namespaces both contribute safely."""
+        case_a = new_discovery_case(use_default_gateway=True)
+        case_b = new_discovery_case(use_default_gateway=True)
+        shared_policy = f"e2e-shared-int-policy-{case_a['suffix']}"
+        shared_sub = f"e2e-shared-int-sub-{case_a['suffix']}"
+        for case in (case_a, case_b):
+            case["policy_name"] = shared_policy
+            case["subscription_name"] = shared_sub
+
+        try:
+            for case in (case_a, case_b):
+                apply_discovery_labels(case["tenant_ns"], case["tenant_label_name"])
+                apply_tenant_cr(case["tenant_ns"], DEFAULT_GATEWAY_NAME)
+                apply_maas_auth_policy(shared_policy, case["tenant_ns"])
+                apply_maas_subscription(shared_sub, case["tenant_ns"])
+                wait_for_finalizer("maasauthpolicy", shared_policy, case["tenant_ns"], FINALIZER_AUTHPOLICY)
+                wait_for_finalizer("maassubscription", shared_sub, case["tenant_ns"], FINALIZER_SUBSCRIPTION)
+                wait_for_status_phase("maasauthpolicy", shared_policy, case["tenant_ns"], expected_phase="Active")
+
+            expected_subs = [f"{case_a['tenant_ns']}/{shared_sub}", f"{case_b['tenant_ns']}/{shared_sub}"]
+            wait_for_annotation_contains(
+                "tokenratelimitpolicy",
+                f"maas-trlp-{MODEL_REF}",
+                MODEL_NAMESPACE,
+                "maas.opendatahub.io/subscriptions",
+                expected_subs,
+            )
+        finally:
+            cleanup_discovery_case(case_a, delete_gateway=False)
+            cleanup_discovery_case(case_b, delete_gateway=False)
+
+    def test_tenant_namespace_label_change_triggers_reconciliation(self):
+        """7.4: Adding and removing discovery labels changes reconciliation behavior."""
+        case = new_discovery_case(use_default_gateway=True)
+        first_policy = case["policy_name"]
+        second_policy = f"e2e-label-return-{case['suffix']}"
+        try:
+            ensure_namespace(case["tenant_ns"])
+            apply_tenant_cr(case["tenant_ns"], DEFAULT_GATEWAY_NAME)
+            apply_maas_auth_policy(first_policy, case["tenant_ns"])
+            _wait_reconcile(10)
+            first = get_json_or_none("maasauthpolicy", first_policy, case["tenant_ns"])
+            assert first is not None
+            assert FINALIZER_AUTHPOLICY not in ((first.get("metadata") or {}).get("finalizers") or [])
+
+            apply_discovery_labels(case["tenant_ns"], case["tenant_label_name"])
+            wait_for_finalizer("maasauthpolicy", first_policy, case["tenant_ns"], FINALIZER_AUTHPOLICY)
+            wait_for_status_phase("maasauthpolicy", first_policy, case["tenant_ns"], expected_phase="Active")
+
+            remove_discovery_labels(case["tenant_ns"])
+            _wait_reconcile(10)
+            apply_maas_auth_policy(second_policy, case["tenant_ns"])
+            _wait_reconcile(10)
+            second = get_json_or_none("maasauthpolicy", second_policy, case["tenant_ns"])
+            assert second is not None
+            assert FINALIZER_AUTHPOLICY not in ((second.get("metadata") or {}).get("finalizers") or [])
+        finally:
+            delete_maas_auth_policy(second_policy, case["tenant_ns"])
+            cleanup_discovery_case(case, delete_gateway=False)

--- a/test/e2e/tests/test_multi_tenant_integration.py
+++ b/test/e2e/tests/test_multi_tenant_integration.py
@@ -24,7 +24,6 @@ from multitenancy_helpers import (
     MODEL_REF,
     TENANT_CR_NAME,
     apply_discovery_labels,
-    apply_gateway_fixture,
     apply_maas_auth_policy,
     apply_maas_subscription,
     apply_tenant_cr,
@@ -61,11 +60,10 @@ class TestMultiTenantIntegration:
 
     def test_full_tenant_lifecycle_create_to_delete(self):
         """7.1: Full tenant lifecycle from create through policy/subscription reconcile to delete."""
-        case = new_discovery_case()
+        case = new_discovery_case(use_default_gateway=True)
         role_name = f"aitenant-{case['tenant_label_name']}-tenant-admin"
         try:
-            apply_gateway_fixture(case["gateway_name"], fixture_label=case["tenant_label_name"])
-            bootstrap_aitenant_tenant(case)
+            bootstrap_aitenant_tenant(case, use_default_gateway=True)
 
             tenant = wait_for_json("tenant", TENANT_CR_NAME, case["tenant_ns"], timeout=180)
             assert tenant["spec"]["gatewayRef"]["name"] == case["gateway_name"]

--- a/test/e2e/tests/test_multi_tenant_maas_api.py
+++ b/test/e2e/tests/test_multi_tenant_maas_api.py
@@ -1,0 +1,134 @@
+"""
+E2E tests for per-tenant maas-api infrastructure (MT S24 / RHOAIENG-66483).
+
+These tests validate the expected Phase 1 contract once the per-tenant maas-api
+implementation is available:
+  - AITenant creates dedicated maas-api Deployment/Service/HTTPRoute/AuthPolicy
+  - TENANT_NAME is set on each maas-api Deployment
+  - HTTPRoutes attach to the tenant Gateway and route to the tenant Service
+  - Default and multiple tenant maas-api instances coexist
+
+Run with ENABLE_S24_E2E=true. The current mainline-compatible E2E smoke path
+does not enable this module until S24 lands.
+"""
+
+import pytest
+
+from multitenancy_helpers import (
+    DEPLOYMENT_NAMESPACE,
+    GATEWAY_NAMESPACE,
+    TENANT_CR_NAME,
+    bootstrap_aitenant_tenant,
+    cleanup_discovery_case,
+    deployment_env,
+    env_bool,
+    get_json_or_none,
+    http_route_backend_refs,
+    http_route_parent_refs,
+    new_named_tenant_case,
+    per_tenant_maas_api_names,
+    require_aitenant_crd,
+    wait_for_deployment_available,
+    wait_for_json,
+)
+
+
+pytestmark = pytest.mark.skipif(
+    not env_bool("ENABLE_S24_E2E"),
+    reason="S24 per-tenant maas-api E2E is gated; set ENABLE_S24_E2E=true once the backing implementation lands",
+)
+
+
+@pytest.fixture(scope="module")
+def tenant_cases():
+    require_aitenant_crd()
+    case_a = new_named_tenant_case("e2e-api-a")
+    case_b = new_named_tenant_case("e2e-api-b")
+    try:
+        for case in (case_a, case_b):
+            bootstrap_aitenant_tenant(case)
+        yield case_a, case_b
+    finally:
+        cleanup_discovery_case(case_a)
+        cleanup_discovery_case(case_b)
+
+
+def _tenant_name(case: dict[str, str]) -> str:
+    return case["tenant_label_name"]
+
+
+def _tenant_api_names(case: dict[str, str]) -> dict[str, str]:
+    return per_tenant_maas_api_names(_tenant_name(case))
+
+
+class TestPerTenantMaaSAPI:
+    """S27 section 2 — per-tenant maas-api infrastructure."""
+
+    def test_aitenant_creates_dedicated_maas_api_infrastructure(self, tenant_cases):
+        """2.1: AITenant creates dedicated maas-api Deployment, Service, HTTPRoute, and AuthPolicy."""
+        for case in tenant_cases:
+            names = _tenant_api_names(case)
+            deployment = wait_for_deployment_available(names["deployment"], DEPLOYMENT_NAMESPACE, timeout=240)
+            assert deployment["metadata"]["name"] == names["deployment"]
+
+            service = wait_for_json("service", names["service"], DEPLOYMENT_NAMESPACE, timeout=180)
+            assert service["metadata"]["name"] == names["service"]
+
+            route = wait_for_json("httproute", names["httproute"], DEPLOYMENT_NAMESPACE, timeout=180)
+            assert route["metadata"]["name"] == names["httproute"]
+
+            auth = wait_for_json("authpolicy", names["authpolicy"], DEPLOYMENT_NAMESPACE, timeout=180)
+            assert auth["metadata"]["name"] == names["authpolicy"]
+
+            tenant = wait_for_json("tenant", TENANT_CR_NAME, case["tenant_ns"], timeout=180)
+            assert tenant["spec"]["gatewayRef"]["name"] == case["gateway_name"]
+
+    def test_tenant_name_environment_variable_set(self, tenant_cases):
+        """2.2: TENANT_NAME env var identifies the tenant served by each maas-api Deployment."""
+        for case in tenant_cases:
+            names = _tenant_api_names(case)
+            env = deployment_env(names["deployment"], DEPLOYMENT_NAMESPACE)
+            assert env.get("TENANT_NAME") == _tenant_name(case), (
+                f"{names['deployment']} should set TENANT_NAME={_tenant_name(case)!r}, got {env!r}"
+            )
+
+    def test_service_routing_isolation(self, tenant_cases):
+        """2.3: Each tenant HTTPRoute points at that tenant's dedicated Service."""
+        service_names = set()
+        for case in tenant_cases:
+            names = _tenant_api_names(case)
+            service = get_json_or_none("service", names["service"], DEPLOYMENT_NAMESPACE)
+            assert service is not None
+            service_names.add(service["metadata"]["name"])
+
+            backend_refs = http_route_backend_refs(names["httproute"], DEPLOYMENT_NAMESPACE)
+            backend_names = {ref.get("name") for ref in backend_refs}
+            assert names["service"] in backend_names, (
+                f"{names['httproute']} should route to {names['service']}, got {backend_refs!r}"
+            )
+
+        assert len(service_names) == len(tenant_cases), f"expected isolated services, got {service_names!r}"
+
+    def test_httproute_tenant_attachment(self, tenant_cases):
+        """2.4: Tenant maas-api HTTPRoute attaches to the tenant Gateway."""
+        for case in tenant_cases:
+            names = _tenant_api_names(case)
+            parent_refs = http_route_parent_refs(names["httproute"], DEPLOYMENT_NAMESPACE)
+            assert any(
+                ref.get("name") == case["gateway_name"]
+                and (ref.get("namespace") or GATEWAY_NAMESPACE) == GATEWAY_NAMESPACE
+                for ref in parent_refs
+            ), f"{names['httproute']} parentRefs do not attach to {GATEWAY_NAMESPACE}/{case['gateway_name']}: {parent_refs!r}"
+
+    def test_default_and_multiple_tenants_coexist(self, tenant_cases):
+        """2.5: Default maas-api remains while multiple tenant maas-api instances exist."""
+        assert get_json_or_none("deployment", "maas-api", DEPLOYMENT_NAMESPACE) is not None
+        assert get_json_or_none("service", "maas-api", DEPLOYMENT_NAMESPACE) is not None
+        assert get_json_or_none("httproute", "maas-api-route", DEPLOYMENT_NAMESPACE) is not None
+
+        tenant_deployments = [
+            get_json_or_none("deployment", _tenant_api_names(case)["deployment"], DEPLOYMENT_NAMESPACE)
+            for case in tenant_cases
+        ]
+        assert all(deployment is not None for deployment in tenant_deployments)
+        assert len({deployment["metadata"]["name"] for deployment in tenant_deployments if deployment}) == len(tenant_cases)

--- a/test/e2e/tests/test_multi_tenant_maas_api.py
+++ b/test/e2e/tests/test_multi_tenant_maas_api.py
@@ -27,6 +27,7 @@ from multitenancy_helpers import (
     http_route_parent_refs,
     new_named_tenant_case,
     per_tenant_maas_api_names,
+    redact_mapping,
     require_aitenant_crd,
     wait_for_deployment_available,
     wait_for_json,
@@ -89,7 +90,7 @@ class TestPerTenantMaaSAPI:
             names = _tenant_api_names(case)
             env = deployment_env(names["deployment"], DEPLOYMENT_NAMESPACE)
             assert env.get("TENANT_NAME") == _tenant_name(case), (
-                f"{names['deployment']} should set TENANT_NAME={_tenant_name(case)!r}, got {env!r}"
+                f"{names['deployment']} should set TENANT_NAME={_tenant_name(case)!r}, got {redact_mapping(env)!r}"
             )
 
     def test_service_routing_isolation(self, tenant_cases):

--- a/test/e2e/tests/test_namespace_scoping.py
+++ b/test/e2e/tests/test_namespace_scoping.py
@@ -29,6 +29,7 @@ from typing import Optional
 import pytest
 import requests
 
+from multitenancy_helpers import controller_has_tenant_namespace_discovery
 from test_helper import (
     MODEL_NAMESPACE,
     MODEL_REF,
@@ -46,6 +47,20 @@ from test_helper import (
 )
 
 log = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _skip_when_tenant_discovery_enabled():
+    if os.environ.get("ENABLE_TENANT_NAMESPACE_DISCOVERY", "").lower() == "true":
+        pytest.skip(
+            "test_namespace_scoping validates single-tenant dormant mode; "
+            "skipped when ENABLE_TENANT_NAMESPACE_DISCOVERY=true"
+        )
+    if controller_has_tenant_namespace_discovery():
+        pytest.skip(
+            "maas-controller has tenant namespace discovery enabled; "
+            "these tests assume dormant single-namespace reconciliation"
+        )
 
 
 def _get_token():

--- a/test/e2e/tests/test_tenant_auth_isolation.py
+++ b/test/e2e/tests/test_tenant_auth_isolation.py
@@ -23,7 +23,9 @@ from multitenancy_helpers import (
     delete_maas_subscription,
     env_bool,
     get_api_key_at,
+    redact_sensitive,
     require_tenant_api_base_urls,
+    response_summary,
     search_api_keys_at,
     select_subscription_at,
     validate_api_key_at,
@@ -95,7 +97,7 @@ def tenant_api_keys(tenant_auth_setup):
             subscription=tenant_auth_setup["subscription"],
         )
         assert response.status_code in (200, 201), (
-            f"create key for {tenant['name']} failed: {response.status_code} {response.text}"
+            f"create key for {tenant['name']} failed: {response_summary(response)}"
         )
         created[key_name] = response.json()
     return created
@@ -111,7 +113,7 @@ class TestTenantAuthIsolation:
             tenant = tenant_auth_setup[tenant_key]
             key_id = tenant_api_keys[key_name]["id"]
             response = get_api_key_at(tenant["base_url"], oc_token, key_id)
-            assert response.status_code == 200, f"GET key in {tenant['name']} failed: {response.status_code} {response.text}"
+            assert response.status_code == 200, f"GET key in {tenant['name']} failed: {response_summary(response)}"
             data = response.json()
             if data.get("tenant") is not None:
                 assert data["tenant"] == tenant["name"]
@@ -122,7 +124,7 @@ class TestTenantAuthIsolation:
         response = validate_api_key_at(tenant_auth_setup["tenant_a"]["base_url"], tenant_api_keys["a"]["key"])
         assert response.status_code == 200
         data = response.json()
-        assert data.get("valid") is True, data
+        assert data.get("valid") is True, redact_sensitive(data)
         assert data.get("subscription") == tenant_auth_setup["subscription"]
 
     def test_api_key_rejected_cross_tenant(self, tenant_auth_setup, tenant_api_keys):
@@ -130,7 +132,7 @@ class TestTenantAuthIsolation:
         response = validate_api_key_at(tenant_auth_setup["tenant_b"]["base_url"], tenant_api_keys["a"]["key"])
         assert response.status_code == 200
         data = response.json()
-        assert data.get("valid") is False, data
+        assert data.get("valid") is False, redact_sensitive(data)
 
     def test_oidc_token_validation_per_tenant(self, tenant_env):
         """3.4: Tenant OIDC tokens are accepted only by their configured tenant endpoint."""
@@ -141,11 +143,11 @@ class TestTenantAuthIsolation:
 
         tenant_a, tenant_b = tenant_env
         response_a = search_api_keys_at(tenant_a["base_url"], token_a)
-        assert response_a.status_code != 401, f"Tenant A rejected its OIDC token: {response_a.status_code} {response_a.text}"
+        assert response_a.status_code != 401, f"Tenant A rejected its OIDC token: {response_summary(response_a)}"
 
         cross_response = search_api_keys_at(tenant_b["base_url"], token_a)
         assert cross_response.status_code in (401, 403), (
-            f"Tenant B should reject Tenant A OIDC token, got {cross_response.status_code}: {cross_response.text}"
+            f"Tenant B should reject Tenant A OIDC token: {response_summary(cross_response)}"
         )
 
     def test_api_key_list_scoped_to_tenant(self, tenant_auth_setup, tenant_api_keys):
@@ -156,7 +158,7 @@ class TestTenantAuthIsolation:
             oc_token,
             subscription=tenant_auth_setup["subscription"],
         )
-        assert response_a.status_code == 200, f"Tenant A search failed: {response_a.status_code} {response_a.text}"
+        assert response_a.status_code == 200, f"Tenant A search failed: {response_summary(response_a)}"
         ids_a = {item["id"] for item in response_a.json().get("data", [])}
         assert tenant_api_keys["a"]["id"] in ids_a
         assert tenant_api_keys["b"]["id"] not in ids_a
@@ -166,7 +168,7 @@ class TestTenantAuthIsolation:
             oc_token,
             subscription=tenant_auth_setup["subscription"],
         )
-        assert response_b.status_code == 200, f"Tenant B search failed: {response_b.status_code} {response_b.text}"
+        assert response_b.status_code == 200, f"Tenant B search failed: {response_summary(response_b)}"
         ids_b = {item["id"] for item in response_b.json().get("data", [])}
         assert tenant_api_keys["b"]["id"] in ids_b
         assert tenant_api_keys["a"]["id"] not in ids_b
@@ -183,5 +185,5 @@ class TestTenantAuthIsolation:
         )
         assert response.status_code == 200
         data = response.json()
-        assert data.get("error") is None, data
+        assert data.get("error") is None, redact_sensitive(data)
         assert data.get("namespace") == tenant_auth_setup["tenant_a"]["namespace"]

--- a/test/e2e/tests/test_tenant_auth_isolation.py
+++ b/test/e2e/tests/test_tenant_auth_isolation.py
@@ -1,0 +1,187 @@
+"""
+E2E tests for tenant-scoped authentication and API-key isolation (MT S4).
+
+This module requires two live tenant maas-api endpoints. Configure:
+  ENABLE_S4_E2E=true
+  MAAS_API_BASE_URL_TENANT_A / MAAS_API_BASE_URL_TENANT_B
+  TENANT_A_NAMESPACE / TENANT_B_NAMESPACE
+  TENANT_A_NAME / TENANT_B_NAME
+
+The backing S4 implementation is not enabled in the default smoke run.
+"""
+
+import os
+import uuid
+
+import pytest
+
+from multitenancy_helpers import (
+    apply_maas_auth_policy,
+    apply_maas_subscription,
+    create_api_key_at,
+    delete_maas_auth_policy,
+    delete_maas_subscription,
+    env_bool,
+    get_api_key_at,
+    require_tenant_api_base_urls,
+    search_api_keys_at,
+    select_subscription_at,
+    validate_api_key_at,
+    wait_for_status_phase,
+)
+from test_helper import MODEL_NAMESPACE, MODEL_REF, _get_cluster_token
+
+
+pytestmark = pytest.mark.skipif(
+    not env_bool("ENABLE_S4_E2E"),
+    reason="S4 tenant persistence E2E is gated; set ENABLE_S4_E2E=true once the backing implementation lands",
+)
+
+
+@pytest.fixture(scope="module")
+def tenant_env():
+    urls = require_tenant_api_base_urls("TENANT_A", "TENANT_B")
+    tenant_a = {
+        "slot": "TENANT_A",
+        "name": os.environ.get("TENANT_A_NAME", "tenant-a"),
+        "namespace": os.environ.get("TENANT_A_NAMESPACE", ""),
+        "base_url": urls["TENANT_A"],
+    }
+    tenant_b = {
+        "slot": "TENANT_B",
+        "name": os.environ.get("TENANT_B_NAME", "tenant-b"),
+        "namespace": os.environ.get("TENANT_B_NAMESPACE", ""),
+        "base_url": urls["TENANT_B"],
+    }
+    missing = [item["slot"] for item in (tenant_a, tenant_b) if not item["namespace"]]
+    if missing:
+        pytest.fail(f"tenant namespaces not configured; set {', '.join(f'{slot}_NAMESPACE' for slot in missing)}")
+    return tenant_a, tenant_b
+
+
+@pytest.fixture
+def tenant_auth_setup(tenant_env):
+    tenant_a, tenant_b = tenant_env
+    suffix = uuid.uuid4().hex[:6]
+    policy_name = f"e2e-auth-iso-{suffix}"
+    subscription_name = f"e2e-auth-iso-{suffix}"
+    try:
+        for tenant in tenant_env:
+            apply_maas_auth_policy(policy_name, tenant["namespace"])
+            apply_maas_subscription(subscription_name, tenant["namespace"])
+            wait_for_status_phase("maasauthpolicy", policy_name, tenant["namespace"], expected_phase="Active")
+            wait_for_status_phase("maassubscription", subscription_name, tenant["namespace"], expected_phase=("Active", "Degraded"))
+        yield {
+            "tenant_a": tenant_a,
+            "tenant_b": tenant_b,
+            "policy": policy_name,
+            "subscription": subscription_name,
+        }
+    finally:
+        for tenant in tenant_env:
+            delete_maas_auth_policy(policy_name, tenant["namespace"])
+            delete_maas_subscription(subscription_name, tenant["namespace"])
+
+
+@pytest.fixture
+def tenant_api_keys(tenant_auth_setup):
+    oc_token = _get_cluster_token()
+    created = {}
+    for key_name, tenant in (("a", tenant_auth_setup["tenant_a"]), ("b", tenant_auth_setup["tenant_b"])):
+        response = create_api_key_at(
+            tenant["base_url"],
+            oc_token,
+            f"e2e-auth-iso-{key_name}-{uuid.uuid4().hex[:6]}",
+            subscription=tenant_auth_setup["subscription"],
+        )
+        assert response.status_code in (200, 201), (
+            f"create key for {tenant['name']} failed: {response.status_code} {response.text}"
+        )
+        created[key_name] = response.json()
+    return created
+
+
+class TestTenantAuthIsolation:
+    """S27 section 3 — authentication tenant isolation."""
+
+    def test_api_key_creation_scoped_to_tenant(self, tenant_auth_setup, tenant_api_keys):
+        """3.1: API key metadata is scoped to the tenant that minted it."""
+        oc_token = _get_cluster_token()
+        for key_name, tenant_key in (("a", "tenant_a"), ("b", "tenant_b")):
+            tenant = tenant_auth_setup[tenant_key]
+            key_id = tenant_api_keys[key_name]["id"]
+            response = get_api_key_at(tenant["base_url"], oc_token, key_id)
+            assert response.status_code == 200, f"GET key in {tenant['name']} failed: {response.status_code} {response.text}"
+            data = response.json()
+            if data.get("tenant") is not None:
+                assert data["tenant"] == tenant["name"]
+            assert data.get("subscription") == tenant_auth_setup["subscription"]
+
+    def test_api_key_validates_against_correct_tenant(self, tenant_auth_setup, tenant_api_keys):
+        """3.2: API key validates on the tenant endpoint that minted it."""
+        response = validate_api_key_at(tenant_auth_setup["tenant_a"]["base_url"], tenant_api_keys["a"]["key"])
+        assert response.status_code == 200
+        data = response.json()
+        assert data.get("valid") is True, data
+        assert data.get("subscription") == tenant_auth_setup["subscription"]
+
+    def test_api_key_rejected_cross_tenant(self, tenant_auth_setup, tenant_api_keys):
+        """3.3: Tenant B rejects a key minted by Tenant A."""
+        response = validate_api_key_at(tenant_auth_setup["tenant_b"]["base_url"], tenant_api_keys["a"]["key"])
+        assert response.status_code == 200
+        data = response.json()
+        assert data.get("valid") is False, data
+
+    def test_oidc_token_validation_per_tenant(self, tenant_env):
+        """3.4: Tenant OIDC tokens are accepted only by their configured tenant endpoint."""
+        token_a = os.environ.get("OIDC_TOKEN_TENANT_A", "")
+        token_b = os.environ.get("OIDC_TOKEN_TENANT_B", "")
+        if not token_a or not token_b:
+            pytest.skip("OIDC_TOKEN_TENANT_A and OIDC_TOKEN_TENANT_B are required for per-tenant OIDC validation")
+
+        tenant_a, tenant_b = tenant_env
+        response_a = search_api_keys_at(tenant_a["base_url"], token_a)
+        assert response_a.status_code != 401, f"Tenant A rejected its OIDC token: {response_a.status_code} {response_a.text}"
+
+        cross_response = search_api_keys_at(tenant_b["base_url"], token_a)
+        assert cross_response.status_code in (401, 403), (
+            f"Tenant B should reject Tenant A OIDC token, got {cross_response.status_code}: {cross_response.text}"
+        )
+
+    def test_api_key_list_scoped_to_tenant(self, tenant_auth_setup, tenant_api_keys):
+        """3.5: API key search returns keys from the current tenant only."""
+        oc_token = _get_cluster_token()
+        response_a = search_api_keys_at(
+            tenant_auth_setup["tenant_a"]["base_url"],
+            oc_token,
+            subscription=tenant_auth_setup["subscription"],
+        )
+        assert response_a.status_code == 200, f"Tenant A search failed: {response_a.status_code} {response_a.text}"
+        ids_a = {item["id"] for item in response_a.json().get("data", [])}
+        assert tenant_api_keys["a"]["id"] in ids_a
+        assert tenant_api_keys["b"]["id"] not in ids_a
+
+        response_b = search_api_keys_at(
+            tenant_auth_setup["tenant_b"]["base_url"],
+            oc_token,
+            subscription=tenant_auth_setup["subscription"],
+        )
+        assert response_b.status_code == 200, f"Tenant B search failed: {response_b.status_code} {response_b.text}"
+        ids_b = {item["id"] for item in response_b.json().get("data", [])}
+        assert tenant_api_keys["b"]["id"] in ids_b
+        assert tenant_api_keys["a"]["id"] not in ids_b
+
+    def test_api_key_subscription_selection_uses_tenant_namespace(self, tenant_auth_setup, tenant_api_keys):
+        """3.x/4.x: Internal subscription selection reports the tenant-local subscription namespace."""
+        response = select_subscription_at(
+            tenant_auth_setup["tenant_a"]["base_url"],
+            tenant_api_keys["a"]["key"],
+            "e2e-auth-user",
+            ["system:authenticated"],
+            requested_subscription=tenant_auth_setup["subscription"],
+            requested_model=f"{MODEL_NAMESPACE}/{MODEL_REF}",
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data.get("error") is None, data
+        assert data.get("namespace") == tenant_auth_setup["tenant_a"]["namespace"]

--- a/test/e2e/tests/test_tenant_namespace_discovery.py
+++ b/test/e2e/tests/test_tenant_namespace_discovery.py
@@ -1,0 +1,395 @@
+"""
+E2E tests for tenant namespace discovery (MT S1 / RHOAIENG-62761).
+
+Validates maas-controller behavior when --enable-tenant-namespace-discovery=true:
+  - Labeled tenant namespaces are reconciled
+  - Unlabeled namespaces are ignored
+  - Label removal stops reconciliation
+  - Per-tenant OIDC from namespace-local Tenant/default-tenant
+  - Namespace-qualified policy contributor tracking
+  - Webhook rejects CRs without Tenant CR (MT S6 / RHOAIENG-62766)
+
+Requires:
+  - AITenant CRD (S11)
+  - maas-controller with --enable-tenant-namespace-discovery=true
+  - LLMInferenceService + MaaSModelRef for MODEL_REF in MODEL_NAMESPACE (prow fixtures)
+  - oc access
+
+Environment variables:
+  ENABLE_TENANT_NAMESPACE_DISCOVERY - when "true", require the controller discovery flag
+  See multitenancy_helpers.py and test_helper.py for namespace/gateway defaults.
+"""
+
+import os
+import uuid
+
+import pytest
+
+from multitenancy_helpers import (
+    AITENANT_NAMESPACE,
+    DEFAULT_GATEWAY_NAME,
+    FINALIZER_AUTHPOLICY,
+    FINALIZER_SUBSCRIPTION,
+    GATEWAY_AUTH_POLICY_NAME,
+    GATEWAY_NAMESPACE,
+    apply_discovery_labels,
+    apply_gateway_fixture,
+    apply_maas_auth_policy,
+    apply_maas_subscription,
+    apply_tenant_cr,
+    assert_no_per_model_authpolicy,
+    auth_can_create_maassubscription,
+    bootstrap_aitenant_tenant,
+    cleanup_discovery_case,
+    controller_has_tenant_namespace_discovery,
+    delete_maas_auth_policy,
+    delete_maas_subscription,
+    delete_namespace_best_effort,
+    ensure_namespace,
+    get_gateway_authpolicy,
+    get_gateway_authpolicy_issuer,
+    get_json_or_none,
+    legacy_default_namespace,
+    new_discovery_case,
+    patch_controller_tenant_namespace_discovery,
+    remove_discovery_labels,
+    require_aitenant_crd,
+    require_tenant_namespace_discovery,
+    wait_for_annotation_contains,
+    wait_for_finalizer,
+    wait_for_json,
+    wait_for_status_phase,
+    _create_expect_failure,
+    _oc_run,
+)
+from test_helper import MODEL_NAMESPACE, MODEL_REF, _wait_for_maas_auth_policy_phase, _wait_reconcile
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _require_multitenancy_prerequisites():
+    require_tenant_namespace_discovery()
+    require_aitenant_crd()
+    wait_for_json("namespace", AITENANT_NAMESPACE, timeout=180, interval=5)
+
+
+class TestTenantNamespaceDiscovery:
+    """S27 section 1 — tenant namespace discovery (S1 / PR #975)."""
+
+    def test_labeled_tenant_namespace_is_discovered(self):
+        """1.1: Controller discovers labeled tenant namespaces and reconciles CRs."""
+        case = new_discovery_case(use_default_gateway=True)
+        try:
+            apply_discovery_labels(case["tenant_ns"], case["tenant_label_name"])
+            apply_tenant_cr(case["tenant_ns"], DEFAULT_GATEWAY_NAME)
+            apply_maas_auth_policy(case["policy_name"], case["tenant_ns"])
+            apply_maas_subscription(case["subscription_name"], case["tenant_ns"])
+
+            wait_for_finalizer("maasauthpolicy", case["policy_name"], case["tenant_ns"], FINALIZER_AUTHPOLICY)
+            wait_for_finalizer("maassubscription", case["subscription_name"], case["tenant_ns"], FINALIZER_SUBSCRIPTION)
+            auth = wait_for_status_phase(
+                "maasauthpolicy",
+                case["policy_name"],
+                case["tenant_ns"],
+                expected_phase="Active",
+            )
+            sub = wait_for_status_phase(
+                "maassubscription",
+                case["subscription_name"],
+                case["tenant_ns"],
+                expected_phase=("Active", "Degraded"),
+            )
+            assert auth.get("status", {}).get("phase") == "Active"
+            assert sub.get("status", {}).get("phase") in ("Active", "Degraded")
+        finally:
+            cleanup_discovery_case(case, delete_gateway=False)
+
+    def test_label_removal_stops_reconciliation(self):
+        """1.2: Removing discovery labels stops new reconciliation activity."""
+        case = new_discovery_case(use_default_gateway=True)
+        try:
+            apply_discovery_labels(case["tenant_ns"], case["tenant_label_name"])
+            apply_tenant_cr(case["tenant_ns"], DEFAULT_GATEWAY_NAME)
+            apply_maas_auth_policy(case["policy_name"], case["tenant_ns"])
+            wait_for_finalizer("maasauthpolicy", case["policy_name"], case["tenant_ns"], FINALIZER_AUTHPOLICY)
+
+            remove_discovery_labels(case["tenant_ns"])
+            _wait_reconcile(10)
+
+            new_policy = f"e2e-post-label-{case['suffix']}"
+            apply_maas_auth_policy(new_policy, case["tenant_ns"])
+            _wait_reconcile(15)
+
+            obj = get_json_or_none("maasauthpolicy", new_policy, case["tenant_ns"])
+            assert obj is not None
+            finalizers = (obj.get("metadata") or {}).get("finalizers") or []
+            assert FINALIZER_AUTHPOLICY not in finalizers, (
+                "CR created after label removal should not receive controller finalizer"
+            )
+            assert not (obj.get("status") or {}).get("phase"), (
+                "CR created after label removal should not be reconciled"
+            )
+        finally:
+            delete_maas_auth_policy(f"e2e-post-label-{case['suffix']}", case["tenant_ns"])
+            cleanup_discovery_case(case, delete_gateway=False)
+
+    def test_unlabeled_namespace_ignored(self):
+        """1.3: CRs in namespaces without discovery labels are ignored (Tenant CR satisfies webhook)."""
+        suffix = uuid.uuid4().hex[:8]
+        unlabeled_ns = f"e2e-unlabeled-{suffix}"
+        policy_name = f"e2e-unlabeled-policy-{suffix}"
+        sub_name = f"e2e-unlabeled-sub-{suffix}"
+        try:
+            ensure_namespace(unlabeled_ns)
+            apply_tenant_cr(unlabeled_ns, DEFAULT_GATEWAY_NAME)
+            apply_maas_auth_policy(policy_name, unlabeled_ns)
+            apply_maas_subscription(sub_name, unlabeled_ns)
+            _wait_reconcile(15)
+
+            auth = get_json_or_none("maasauthpolicy", policy_name, unlabeled_ns)
+            sub = get_json_or_none("maassubscription", sub_name, unlabeled_ns)
+            assert auth is not None and sub is not None
+            assert not (auth.get("metadata") or {}).get("finalizers"), "unlabeled namespace auth policy should have no finalizers"
+            assert not (sub.get("metadata") or {}).get("finalizers"), "unlabeled namespace subscription should have no finalizers"
+            assert not (auth.get("status") or {}).get("phase")
+            assert not (sub.get("status") or {}).get("phase")
+        finally:
+            delete_maas_auth_policy(policy_name, unlabeled_ns)
+            delete_maas_subscription(sub_name, unlabeled_ns)
+            delete_namespace_best_effort(unlabeled_ns)
+
+    def test_dynamic_discovery_after_label_added(self):
+        """1.2 variant: Pre-existing CRs reconcile after namespace gains discovery labels."""
+        case = new_discovery_case(use_default_gateway=True)
+        try:
+            ensure_namespace(case["tenant_ns"])
+            apply_tenant_cr(case["tenant_ns"], DEFAULT_GATEWAY_NAME)
+            apply_maas_auth_policy(case["policy_name"], case["tenant_ns"])
+            _wait_reconcile(10)
+            before = get_json_or_none("maasauthpolicy", case["policy_name"], case["tenant_ns"])
+            assert before is not None
+            assert FINALIZER_AUTHPOLICY not in ((before.get("metadata") or {}).get("finalizers") or [])
+
+            apply_discovery_labels(case["tenant_ns"], case["tenant_label_name"])
+            wait_for_finalizer("maasauthpolicy", case["policy_name"], case["tenant_ns"], FINALIZER_AUTHPOLICY)
+            wait_for_status_phase(
+                "maasauthpolicy",
+                case["policy_name"],
+                case["tenant_ns"],
+                expected_phase="Active",
+            )
+        finally:
+            cleanup_discovery_case(case, delete_gateway=False)
+
+    def test_per_tenant_oidc_configuration(self):
+        """1.4: Gateway-scoped maas-gateway-auth issuerUrl reflects Tenant externalOIDC (#912)."""
+        if not os.environ.get("OIDC_ISSUER_URL"):
+            pytest.skip("OIDC_ISSUER_URL not set; per-tenant OIDC E2E requires external OIDC deploy")
+
+        issuer = os.environ["OIDC_ISSUER_URL"]
+        case = new_discovery_case(use_default_gateway=True)
+
+        try:
+            apply_discovery_labels(case["tenant_ns"], case["tenant_label_name"])
+            apply_tenant_cr(
+                case["tenant_ns"],
+                DEFAULT_GATEWAY_NAME,
+                external_oidc={"issuerUrl": issuer, "clientId": os.environ.get("OIDC_CLIENT_ID", "test-client")},
+            )
+            apply_maas_auth_policy(case["policy_name"], case["tenant_ns"])
+            _wait_for_maas_auth_policy_phase(case["policy_name"], namespace=case["tenant_ns"], timeout=180)
+
+            gw_auth = get_gateway_authpolicy()
+            assert gw_auth is not None, f"{GATEWAY_AUTH_POLICY_NAME} should exist in {GATEWAY_NAMESPACE}"
+            assert_no_per_model_authpolicy(MODEL_REF, MODEL_NAMESPACE)
+
+            live_issuer = get_gateway_authpolicy_issuer()
+            assert live_issuer.rstrip("/") == issuer.rstrip("/"), (
+                f"expected gateway AuthPolicy issuer {issuer}, got {live_issuer!r}"
+            )
+        finally:
+            cleanup_discovery_case(case, delete_gateway=False)
+
+    def test_namespace_qualified_collision_prevention(self):
+        """1.5: Same-named CRs in two tenant namespaces use namespace-qualified TRLP tracking."""
+        case_a = new_discovery_case(use_default_gateway=True)
+        case_b = new_discovery_case(use_default_gateway=True)
+        shared_policy_name = f"e2e-shared-policy-{case_a['suffix']}"
+        shared_sub_name = f"e2e-shared-sub-{case_a['suffix']}"
+        case_a["policy_name"] = shared_policy_name
+        case_a["subscription_name"] = shared_sub_name
+        case_b["policy_name"] = shared_policy_name
+        case_b["subscription_name"] = shared_sub_name
+
+        try:
+            for case in (case_a, case_b):
+                apply_discovery_labels(case["tenant_ns"], case["tenant_label_name"])
+                apply_tenant_cr(case["tenant_ns"], DEFAULT_GATEWAY_NAME)
+                apply_maas_auth_policy(shared_policy_name, case["tenant_ns"])
+                apply_maas_subscription(shared_sub_name, case["tenant_ns"])
+                wait_for_finalizer("maasauthpolicy", shared_policy_name, case["tenant_ns"], FINALIZER_AUTHPOLICY)
+                wait_for_finalizer("maassubscription", shared_sub_name, case["tenant_ns"], FINALIZER_SUBSCRIPTION)
+                _wait_for_maas_auth_policy_phase(shared_policy_name, namespace=case["tenant_ns"], timeout=120)
+
+            assert_no_per_model_authpolicy(MODEL_REF, MODEL_NAMESPACE)
+            assert get_gateway_authpolicy() is not None
+
+            expected_a_sub = f"{case_a['tenant_ns']}/{shared_sub_name}"
+            expected_b_sub = f"{case_b['tenant_ns']}/{shared_sub_name}"
+            sub_contributors = wait_for_annotation_contains(
+                "tokenratelimitpolicy",
+                f"maas-trlp-{MODEL_REF}",
+                MODEL_NAMESPACE,
+                "maas.opendatahub.io/subscriptions",
+                [expected_a_sub, expected_b_sub],
+            )
+
+            assert expected_a_sub in sub_contributors, f"missing {expected_a_sub} in {sub_contributors}"
+            assert expected_b_sub in sub_contributors, f"missing {expected_b_sub} in {sub_contributors}"
+        finally:
+            cleanup_discovery_case(case_a, delete_gateway=False)
+            cleanup_discovery_case(case_b, delete_gateway=False)
+
+    def test_tenant_admin_rbac_is_namespace_scoped(self):
+        """1.6: Tenant-admin RBAC from AITenant bootstrap is scoped to the tenant namespace."""
+        case = new_discovery_case()
+        sa_name = f"e2e-mt-rbac-{case['suffix']}"
+        role_name = f"aitenant-{case['tenant_label_name']}-tenant-admin"
+        other_ns = f"e2e-mt-other-{case['suffix']}"
+        try:
+            apply_gateway_fixture(case["gateway_name"], fixture_label=case["tenant_label_name"])
+            bootstrap_aitenant_tenant(case)
+
+            role = get_json_or_none("role", role_name, case["tenant_ns"])
+            binding = get_json_or_none("rolebinding", role_name, case["tenant_ns"])
+            assert role is not None, "tenant-admin Role should exist in tenant namespace"
+            assert binding is not None, "tenant-admin RoleBinding should exist in tenant namespace"
+            rules = role.get("rules") or []
+            assert any("maassubscriptions" in (rule.get("resources") or []) for rule in rules)
+
+            sa_result = _oc_run(["create", "sa", sa_name, "-n", case["tenant_ns"]])
+            if sa_result.returncode != 0 and "already exists" not in (sa_result.stderr or "").lower():
+                raise RuntimeError(sa_result.stderr.strip() or sa_result.stdout.strip())
+            rb_result = _oc_run(
+                [
+                    "create",
+                    "rolebinding",
+                    f"{sa_name}-binding",
+                    f"--role={role_name}",
+                    f"--serviceaccount={case['tenant_ns']}:{sa_name}",
+                    "-n",
+                    case["tenant_ns"],
+                ]
+            )
+            if rb_result.returncode != 0 and "already exists" not in (rb_result.stderr or "").lower():
+                raise RuntimeError(rb_result.stderr.strip() or rb_result.stdout.strip())
+
+            sa_user = f"system:serviceaccount:{case['tenant_ns']}:{sa_name}"
+            ensure_namespace(other_ns)
+            apply_tenant_cr(other_ns, DEFAULT_GATEWAY_NAME)
+
+            assert auth_can_create_maassubscription(sa_user, case["tenant_ns"]), (
+                f"tenant-admin SA should manage subscriptions in its tenant namespace"
+            )
+            assert not auth_can_create_maassubscription(sa_user, other_ns), (
+                f"tenant-admin SA should not manage subscriptions in another tenant namespace"
+            )
+        finally:
+            delete_namespace_best_effort(other_ns)
+            _oc_run(["delete", "rolebinding", f"{sa_name}-binding", "-n", case["tenant_ns"], "--ignore-not-found"])
+            _oc_run(["delete", "sa", sa_name, "-n", case["tenant_ns"], "--ignore-not-found"])
+            cleanup_discovery_case(case)
+
+
+class TestTenantWebhookValidation:
+    """S6 webhook — reject MaaSSubscription / MaaSAuthPolicy without Tenant CR (PR #942)."""
+
+    def test_maassubscription_rejected_without_tenant_cr(self):
+        suffix = uuid.uuid4().hex[:8]
+        ns = f"e2e-webhook-sub-{suffix}"
+        try:
+            ensure_namespace(ns)
+            output = _create_expect_failure(
+                {
+                    "apiVersion": "maas.opendatahub.io/v1alpha1",
+                    "kind": "MaaSSubscription",
+                    "metadata": {"name": f"e2e-webhook-sub-{suffix}", "namespace": ns},
+                    "spec": {
+                        "owner": {"groups": [{"name": "system:authenticated"}]},
+                        "modelRefs": [
+                            {
+                                "name": MODEL_REF,
+                                "namespace": MODEL_NAMESPACE,
+                                "tokenRateLimits": [{"limit": 1, "window": "1m"}],
+                            }
+                        ],
+                    },
+                }
+            )
+            assert "not enabled for MaaS tenant resources" in output or "denied" in output.lower()
+        finally:
+            delete_namespace_best_effort(ns)
+
+    def test_maasauthpolicy_rejected_without_tenant_cr(self):
+        suffix = uuid.uuid4().hex[:8]
+        ns = f"e2e-webhook-auth-{suffix}"
+        try:
+            ensure_namespace(ns)
+            output = _create_expect_failure(
+                {
+                    "apiVersion": "maas.opendatahub.io/v1alpha1",
+                    "kind": "MaaSAuthPolicy",
+                    "metadata": {"name": f"e2e-webhook-auth-{suffix}", "namespace": ns},
+                    "spec": {
+                        "modelRefs": [{"name": MODEL_REF, "namespace": MODEL_NAMESPACE}],
+                        "subjects": {"groups": [{"name": "system:authenticated"}]},
+                    },
+                }
+            )
+            assert "not enabled for MaaS tenant resources" in output or "denied" in output.lower()
+        finally:
+            delete_namespace_best_effort(ns)
+
+
+class TestTenantDiscoveryDormantMode:
+    """Verify dormant mode when discovery flag is disabled (regression guard)."""
+
+    def test_dormant_mode_ignores_labeled_namespace(self):
+        if os.environ.get("ENABLE_TENANT_DISCOVERY_DORMANT_E2E", "").lower() != "true":
+            pytest.skip("Dormant-mode test mutates controller flags; set ENABLE_TENANT_DISCOVERY_DORMANT_E2E=true")
+
+        if not controller_has_tenant_namespace_discovery():
+            pytest.skip("Controller already in dormant mode")
+
+        case = new_discovery_case(use_default_gateway=True)
+        policy_name = f"e2e-dormant-{case['suffix']}"
+        try:
+            apply_discovery_labels(case["tenant_ns"], case["tenant_label_name"])
+            apply_tenant_cr(case["tenant_ns"], DEFAULT_GATEWAY_NAME)
+
+            patch_controller_tenant_namespace_discovery(enabled=False)
+            apply_maas_auth_policy(policy_name, case["tenant_ns"])
+            _wait_reconcile(15)
+
+            obj = get_json_or_none("maasauthpolicy", policy_name, case["tenant_ns"])
+            assert obj is not None
+            assert FINALIZER_AUTHPOLICY not in ((obj.get("metadata") or {}).get("finalizers") or [])
+            assert not (obj.get("status") or {}).get("phase")
+        finally:
+            delete_maas_auth_policy(policy_name, case["tenant_ns"])
+            delete_namespace_best_effort(case["tenant_ns"])
+            patch_controller_tenant_namespace_discovery(enabled=True)
+
+
+class TestLegacyDefaultNamespaceStillWorks:
+    """Default tenant namespace continues to reconcile with discovery enabled."""
+
+    def test_models_as_a_service_namespace_reconciles(self):
+        ns = legacy_default_namespace()
+        suffix = uuid.uuid4().hex[:8]
+        policy_name = f"e2e-default-ns-{suffix}"
+        try:
+            apply_maas_auth_policy(policy_name, ns)
+            wait_for_finalizer("maasauthpolicy", policy_name, ns, FINALIZER_AUTHPOLICY)
+            wait_for_status_phase("maasauthpolicy", policy_name, ns, expected_phase="Active")
+        finally:
+            delete_maas_auth_policy(policy_name, ns)

--- a/test/e2e/tests/test_tenant_rate_limit_isolation.py
+++ b/test/e2e/tests/test_tenant_rate_limit_isolation.py
@@ -22,6 +22,7 @@ from multitenancy_helpers import (
     delete_maas_subscription,
     env_bool,
     require_tenant_api_base_urls,
+    response_summary,
     wait_for_status_phase,
 )
 from test_helper import (
@@ -88,14 +89,14 @@ def tenant_rate_limit_setup(tenant_env):
             f"e2e-rate-a-{suffix}",
             subscription=sub_a,
         )
-        assert key_a_response.status_code in (200, 201), key_a_response.text
+        assert key_a_response.status_code in (200, 201), response_summary(key_a_response)
         key_b_response = create_api_key_at(
             tenant_b["base_url"],
             oc_token,
             f"e2e-rate-b-{suffix}",
             subscription=sub_b,
         )
-        assert key_b_response.status_code in (200, 201), key_b_response.text
+        assert key_b_response.status_code in (200, 201), response_summary(key_b_response)
 
         yield {
             "tenant_a": tenant_a,
@@ -141,7 +142,7 @@ def _exhaust_until_429(api_base_url: str, api_key: str, *, attempts: int = 8) ->
         elif last.status_code == 429:
             return successes, last
         else:
-            raise AssertionError(f"unexpected inference status {last.status_code}: {last.text[:300]}")
+            raise AssertionError(f"unexpected inference response: {response_summary(last)}")
         time.sleep(0.1)
     assert last is not None
     return successes, last
@@ -154,9 +155,9 @@ class TestTenantRateLimitIsolation:
         """5.1: Tenant A's low quota is enforced on Tenant A traffic."""
         tenant_a = tenant_rate_limit_setup["tenant_a"]
         successes, response = _exhaust_until_429(tenant_a["base_url"], tenant_rate_limit_setup["key_a"])
-        assert successes > 0, f"Tenant A hit 429 before any successful inference: {response.text[:300]}"
+        assert successes > 0, f"Tenant A hit 429 before any successful inference: {response_summary(response)}"
         assert response.status_code == 429, (
-            f"expected Tenant A to hit rate limit, got {response.status_code} after {successes} successes: {response.text[:300]}"
+            f"expected Tenant A to hit rate limit after {successes} successes: {response_summary(response)}"
         )
 
     def test_independent_tenant_rate_limits(self, tenant_rate_limit_setup):
@@ -168,5 +169,5 @@ class TestTenantRateLimitIsolation:
 
         tenant_b_response = _inference_at(tenant_b["base_url"], tenant_rate_limit_setup["key_b"])
         assert tenant_b_response.status_code == 200, (
-            f"Tenant B should still have independent quota, got {tenant_b_response.status_code}: {tenant_b_response.text[:300]}"
+            f"Tenant B should still have independent quota: {response_summary(tenant_b_response)}"
         )

--- a/test/e2e/tests/test_tenant_rate_limit_isolation.py
+++ b/test/e2e/tests/test_tenant_rate_limit_isolation.py
@@ -1,0 +1,172 @@
+"""
+E2E tests for per-tenant rate-limit isolation (MT S4).
+
+Run with:
+  ENABLE_S4_E2E=true
+  MAAS_API_BASE_URL_TENANT_A / MAAS_API_BASE_URL_TENANT_B
+  TENANT_A_NAMESPACE / TENANT_B_NAMESPACE
+"""
+
+import os
+import time
+import uuid
+
+import pytest
+import requests
+
+from multitenancy_helpers import (
+    apply_maas_auth_policy,
+    apply_maas_subscription,
+    create_api_key_at,
+    delete_maas_auth_policy,
+    delete_maas_subscription,
+    env_bool,
+    require_tenant_api_base_urls,
+    wait_for_status_phase,
+)
+from test_helper import (
+    MODEL_NAME,
+    MODEL_NAMESPACE,
+    MODEL_PATH,
+    MODEL_REF,
+    TIMEOUT,
+    TLS_VERIFY,
+    _get_cluster_token,
+    _wait_for_token_rate_limit_policy,
+)
+
+
+pytestmark = pytest.mark.skipif(
+    not env_bool("ENABLE_S4_E2E"),
+    reason="S4 tenant rate-limit isolation E2E is gated; set ENABLE_S4_E2E=true once the backing implementation lands",
+)
+
+
+@pytest.fixture(scope="module")
+def tenant_env():
+    urls = require_tenant_api_base_urls("TENANT_A", "TENANT_B")
+    tenant_a = {
+        "slot": "TENANT_A",
+        "name": os.environ.get("TENANT_A_NAME", "tenant-a"),
+        "namespace": os.environ.get("TENANT_A_NAMESPACE", ""),
+        "base_url": urls["TENANT_A"],
+    }
+    tenant_b = {
+        "slot": "TENANT_B",
+        "name": os.environ.get("TENANT_B_NAME", "tenant-b"),
+        "namespace": os.environ.get("TENANT_B_NAMESPACE", ""),
+        "base_url": urls["TENANT_B"],
+    }
+    missing = [item["slot"] for item in (tenant_a, tenant_b) if not item["namespace"]]
+    if missing:
+        pytest.fail(f"tenant namespaces not configured; set {', '.join(f'{slot}_NAMESPACE' for slot in missing)}")
+    return tenant_a, tenant_b
+
+
+@pytest.fixture
+def tenant_rate_limit_setup(tenant_env):
+    suffix = uuid.uuid4().hex[:6]
+    tenant_a, tenant_b = tenant_env
+    policy_name = f"e2e-rate-iso-auth-{suffix}"
+    sub_a = f"e2e-rate-iso-a-{suffix}"
+    sub_b = f"e2e-rate-iso-b-{suffix}"
+    try:
+        for tenant in tenant_env:
+            apply_maas_auth_policy(policy_name, tenant["namespace"])
+            wait_for_status_phase("maasauthpolicy", policy_name, tenant["namespace"], expected_phase="Active")
+
+        apply_maas_subscription(sub_a, tenant_a["namespace"], token_limit=3, window="1m")
+        apply_maas_subscription(sub_b, tenant_b["namespace"], token_limit=100, window="1m")
+        wait_for_status_phase("maassubscription", sub_a, tenant_a["namespace"], expected_phase=("Active", "Degraded"))
+        wait_for_status_phase("maassubscription", sub_b, tenant_b["namespace"], expected_phase=("Active", "Degraded"))
+        _wait_for_token_rate_limit_policy(MODEL_REF, model_namespace=MODEL_NAMESPACE, timeout=120)
+
+        oc_token = _get_cluster_token()
+        key_a_response = create_api_key_at(
+            tenant_a["base_url"],
+            oc_token,
+            f"e2e-rate-a-{suffix}",
+            subscription=sub_a,
+        )
+        assert key_a_response.status_code in (200, 201), key_a_response.text
+        key_b_response = create_api_key_at(
+            tenant_b["base_url"],
+            oc_token,
+            f"e2e-rate-b-{suffix}",
+            subscription=sub_b,
+        )
+        assert key_b_response.status_code in (200, 201), key_b_response.text
+
+        yield {
+            "tenant_a": tenant_a,
+            "tenant_b": tenant_b,
+            "policy": policy_name,
+            "subscription_a": sub_a,
+            "subscription_b": sub_b,
+            "key_a": key_a_response.json()["key"],
+            "key_b": key_b_response.json()["key"],
+        }
+    finally:
+        for tenant in tenant_env:
+            delete_maas_auth_policy(policy_name, tenant["namespace"])
+        delete_maas_subscription(sub_a, tenant_a["namespace"])
+        delete_maas_subscription(sub_b, tenant_b["namespace"])
+
+
+def _gateway_base_from_api_url(api_base_url: str) -> str:
+    stripped = api_base_url.rstrip("/")
+    if stripped.endswith("/maas-api"):
+        return stripped[: -len("/maas-api")]
+    return stripped
+
+
+def _inference_at(api_base_url: str, api_key: str) -> requests.Response:
+    url = f"{_gateway_base_from_api_url(api_base_url)}{MODEL_PATH}/v1/completions"
+    return requests.post(
+        url,
+        headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
+        json={"model": MODEL_NAME, "prompt": "Hello", "max_tokens": 1},
+        timeout=TIMEOUT,
+        verify=TLS_VERIFY,
+    )
+
+
+def _exhaust_until_429(api_base_url: str, api_key: str, *, attempts: int = 8) -> tuple[int, requests.Response]:
+    successes = 0
+    last = None
+    for _ in range(attempts):
+        last = _inference_at(api_base_url, api_key)
+        if last.status_code == 200:
+            successes += 1
+        elif last.status_code == 429:
+            return successes, last
+        else:
+            raise AssertionError(f"unexpected inference status {last.status_code}: {last.text[:300]}")
+        time.sleep(0.1)
+    assert last is not None
+    return successes, last
+
+
+class TestTenantRateLimitIsolation:
+    """S27 section 5 — rate-limit isolation."""
+
+    def test_rate_limit_enforced_per_tenant(self, tenant_rate_limit_setup):
+        """5.1: Tenant A's low quota is enforced on Tenant A traffic."""
+        tenant_a = tenant_rate_limit_setup["tenant_a"]
+        successes, response = _exhaust_until_429(tenant_a["base_url"], tenant_rate_limit_setup["key_a"])
+        assert successes > 0, f"Tenant A hit 429 before any successful inference: {response.text[:300]}"
+        assert response.status_code == 429, (
+            f"expected Tenant A to hit rate limit, got {response.status_code} after {successes} successes: {response.text[:300]}"
+        )
+
+    def test_independent_tenant_rate_limits(self, tenant_rate_limit_setup):
+        """5.2: Exhausting Tenant A does not consume Tenant B's quota."""
+        tenant_a = tenant_rate_limit_setup["tenant_a"]
+        tenant_b = tenant_rate_limit_setup["tenant_b"]
+        successes, response = _exhaust_until_429(tenant_a["base_url"], tenant_rate_limit_setup["key_a"])
+        assert response.status_code == 429, f"Tenant A did not hit rate limit after {successes} successes"
+
+        tenant_b_response = _inference_at(tenant_b["base_url"], tenant_rate_limit_setup["key_b"])
+        assert tenant_b_response.status_code == 200, (
+            f"Tenant B should still have independent quota, got {tenant_b_response.status_code}: {tenant_b_response.text[:300]}"
+        )

--- a/test/e2e/tests/test_tenant_subscription_isolation.py
+++ b/test/e2e/tests/test_tenant_subscription_isolation.py
@@ -1,0 +1,153 @@
+"""
+E2E tests for tenant-scoped MaaSSubscription selection (MT S4/S5).
+
+Run with:
+  ENABLE_S4_E2E=true
+  MAAS_API_BASE_URL_TENANT_A / MAAS_API_BASE_URL_TENANT_B
+  TENANT_A_NAMESPACE / TENANT_B_NAMESPACE
+"""
+
+import os
+import uuid
+
+import pytest
+
+from multitenancy_helpers import (
+    apply_maas_subscription,
+    create_api_key_at,
+    delete_maas_subscription,
+    env_bool,
+    list_subscriptions_at,
+    require_tenant_api_base_urls,
+    select_subscription_at,
+    wait_for_status_phase,
+)
+from test_helper import MODEL_NAMESPACE, MODEL_REF, _get_cluster_token
+
+
+pytestmark = pytest.mark.skipif(
+    not env_bool("ENABLE_S4_E2E"),
+    reason="S4 tenant subscription isolation E2E is gated; set ENABLE_S4_E2E=true once the backing implementation lands",
+)
+
+
+@pytest.fixture(scope="module")
+def tenant_env():
+    urls = require_tenant_api_base_urls("TENANT_A", "TENANT_B")
+    tenant_a = {
+        "slot": "TENANT_A",
+        "name": os.environ.get("TENANT_A_NAME", "tenant-a"),
+        "namespace": os.environ.get("TENANT_A_NAMESPACE", ""),
+        "base_url": urls["TENANT_A"],
+    }
+    tenant_b = {
+        "slot": "TENANT_B",
+        "name": os.environ.get("TENANT_B_NAME", "tenant-b"),
+        "namespace": os.environ.get("TENANT_B_NAMESPACE", ""),
+        "base_url": urls["TENANT_B"],
+    }
+    missing = [item["slot"] for item in (tenant_a, tenant_b) if not item["namespace"]]
+    if missing:
+        pytest.fail(f"tenant namespaces not configured; set {', '.join(f'{slot}_NAMESPACE' for slot in missing)}")
+    return tenant_a, tenant_b
+
+
+@pytest.fixture
+def tenant_subscriptions(tenant_env):
+    suffix = uuid.uuid4().hex[:6]
+    shared_name = f"e2e-shared-sub-{suffix}"
+    tenant_a_only = f"e2e-a-only-{suffix}"
+    tenant_b_only = f"e2e-b-only-{suffix}"
+    tenant_a, tenant_b = tenant_env
+    try:
+        apply_maas_subscription(shared_name, tenant_a["namespace"], token_limit=50, priority=10)
+        apply_maas_subscription(shared_name, tenant_b["namespace"], token_limit=500, priority=20)
+        apply_maas_subscription(tenant_a_only, tenant_a["namespace"], token_limit=75, priority=30)
+        apply_maas_subscription(tenant_b_only, tenant_b["namespace"], token_limit=750, priority=30)
+        for tenant, names in ((tenant_a, [shared_name, tenant_a_only]), (tenant_b, [shared_name, tenant_b_only])):
+            for name in names:
+                wait_for_status_phase("maassubscription", name, tenant["namespace"], expected_phase=("Active", "Degraded"))
+        yield {
+            "shared": shared_name,
+            "tenant_a_only": tenant_a_only,
+            "tenant_b_only": tenant_b_only,
+            "tenant_a": tenant_a,
+            "tenant_b": tenant_b,
+        }
+    finally:
+        for namespace in (tenant_a["namespace"], tenant_b["namespace"]):
+            for name in (shared_name, tenant_a_only, tenant_b_only):
+                delete_maas_subscription(name, namespace)
+
+
+def _create_key_for_subscription(tenant: dict[str, str], subscription: str) -> str:
+    response = create_api_key_at(
+        tenant["base_url"],
+        _get_cluster_token(),
+        f"e2e-sub-iso-{uuid.uuid4().hex[:6]}",
+        subscription=subscription,
+    )
+    assert response.status_code in (200, 201), (
+        f"create API key for {tenant['name']} failed: {response.status_code} {response.text}"
+    )
+    return response.json()["key"]
+
+
+class TestTenantSubscriptionIsolation:
+    """S27 section 4 — subscription isolation."""
+
+    def test_subscription_list_scoped_to_tenant(self, tenant_subscriptions):
+        """4.1: Subscription list contains current tenant subscriptions and excludes the other tenant."""
+        tenant_a = tenant_subscriptions["tenant_a"]
+        tenant_b = tenant_subscriptions["tenant_b"]
+        key_a = _create_key_for_subscription(tenant_a, tenant_subscriptions["tenant_a_only"])
+        key_b = _create_key_for_subscription(tenant_b, tenant_subscriptions["tenant_b_only"])
+
+        response_a = list_subscriptions_at(tenant_a["base_url"], key_a)
+        assert response_a.status_code == 200, f"Tenant A list failed: {response_a.status_code} {response_a.text}"
+        ids_a = {item["subscription_id_header"] for item in response_a.json()}
+        assert tenant_subscriptions["tenant_a_only"] in ids_a
+        assert tenant_subscriptions["tenant_b_only"] not in ids_a
+
+        response_b = list_subscriptions_at(tenant_b["base_url"], key_b)
+        assert response_b.status_code == 200, f"Tenant B list failed: {response_b.status_code} {response_b.text}"
+        ids_b = {item["subscription_id_header"] for item in response_b.json()}
+        assert tenant_subscriptions["tenant_b_only"] in ids_b
+        assert tenant_subscriptions["tenant_a_only"] not in ids_b
+
+    def test_subscription_selection_per_tenant(self, tenant_subscriptions):
+        """4.2: Same-named subscriptions resolve to the namespace behind each tenant endpoint."""
+        shared = tenant_subscriptions["shared"]
+        tenant_a = tenant_subscriptions["tenant_a"]
+        tenant_b = tenant_subscriptions["tenant_b"]
+        key_a = _create_key_for_subscription(tenant_a, shared)
+        key_b = _create_key_for_subscription(tenant_b, shared)
+
+        requested_model = f"{MODEL_NAMESPACE}/{MODEL_REF}"
+        response_a = select_subscription_at(
+            tenant_a["base_url"],
+            key_a,
+            "e2e-sub-user",
+            ["system:authenticated"],
+            requested_subscription=shared,
+            requested_model=requested_model,
+        )
+        assert response_a.status_code == 200
+        data_a = response_a.json()
+        assert data_a.get("error") is None, data_a
+        assert data_a.get("name") == shared
+        assert data_a.get("namespace") == tenant_a["namespace"]
+
+        response_b = select_subscription_at(
+            tenant_b["base_url"],
+            key_b,
+            "e2e-sub-user",
+            ["system:authenticated"],
+            requested_subscription=shared,
+            requested_model=requested_model,
+        )
+        assert response_b.status_code == 200
+        data_b = response_b.json()
+        assert data_b.get("error") is None, data_b
+        assert data_b.get("name") == shared
+        assert data_b.get("namespace") == tenant_b["namespace"]

--- a/test/e2e/tests/test_tenant_subscription_isolation.py
+++ b/test/e2e/tests/test_tenant_subscription_isolation.py
@@ -18,7 +18,9 @@ from multitenancy_helpers import (
     delete_maas_subscription,
     env_bool,
     list_subscriptions_at,
+    redact_sensitive,
     require_tenant_api_base_urls,
+    response_summary,
     select_subscription_at,
     wait_for_status_phase,
 )
@@ -88,7 +90,7 @@ def _create_key_for_subscription(tenant: dict[str, str], subscription: str) -> s
         subscription=subscription,
     )
     assert response.status_code in (200, 201), (
-        f"create API key for {tenant['name']} failed: {response.status_code} {response.text}"
+        f"create API key for {tenant['name']} failed: {response_summary(response)}"
     )
     return response.json()["key"]
 
@@ -104,13 +106,13 @@ class TestTenantSubscriptionIsolation:
         key_b = _create_key_for_subscription(tenant_b, tenant_subscriptions["tenant_b_only"])
 
         response_a = list_subscriptions_at(tenant_a["base_url"], key_a)
-        assert response_a.status_code == 200, f"Tenant A list failed: {response_a.status_code} {response_a.text}"
+        assert response_a.status_code == 200, f"Tenant A list failed: {response_summary(response_a)}"
         ids_a = {item["subscription_id_header"] for item in response_a.json()}
         assert tenant_subscriptions["tenant_a_only"] in ids_a
         assert tenant_subscriptions["tenant_b_only"] not in ids_a
 
         response_b = list_subscriptions_at(tenant_b["base_url"], key_b)
-        assert response_b.status_code == 200, f"Tenant B list failed: {response_b.status_code} {response_b.text}"
+        assert response_b.status_code == 200, f"Tenant B list failed: {response_summary(response_b)}"
         ids_b = {item["subscription_id_header"] for item in response_b.json()}
         assert tenant_subscriptions["tenant_b_only"] in ids_b
         assert tenant_subscriptions["tenant_a_only"] not in ids_b
@@ -134,7 +136,7 @@ class TestTenantSubscriptionIsolation:
         )
         assert response_a.status_code == 200
         data_a = response_a.json()
-        assert data_a.get("error") is None, data_a
+        assert data_a.get("error") is None, redact_sensitive(data_a)
         assert data_a.get("name") == shared
         assert data_a.get("namespace") == tenant_a["namespace"]
 
@@ -148,6 +150,6 @@ class TestTenantSubscriptionIsolation:
         )
         assert response_b.status_code == 200
         data_b = response_b.json()
-        assert data_b.get("error") is None, data_b
+        assert data_b.get("error") is None, redact_sensitive(data_b)
         assert data_b.get("name") == shared
         assert data_b.get("namespace") == tenant_b["namespace"]


### PR DESCRIPTION
## Description

Implements [RHOAIENG-67709](https://redhat.atlassian.net/browse/RHOAIENG-67709) (MT S27): automated E2E tests for Multi-tenancy Phase 1 operator-managed tenant slices.

Adds pytest coverage for tenant namespace discovery, gateway-scoped AuthPolicy, multi-tenant integration, and env-gated suites for stories still landing in follow-up PRs (#968 S24, #981 S4).

### New test modules

| File | Story / PR | CI behavior |
|------|------------|-------------|
| `test_tenant_namespace_discovery.py` | S1 / #975, S6 / #942 | Runs when discovery is enabled |
| `test_gateway_scoped_authpolicy.py` | S10 / #912 | Default Konflux smoke |
| `test_multi_tenant_integration.py` | S27 integration | Runs when discovery is enabled |
| `test_multi_tenant_maas_api.py` | S24 / #968 | Skips unless `ENABLE_S24_E2E=true` |
| `test_tenant_auth_isolation.py` | S4 / #981 | Skips unless `ENABLE_S4_E2E=true` |
| `test_tenant_subscription_isolation.py` | S4 / #981 | Skips unless `ENABLE_S4_E2E=true` |
| `test_tenant_rate_limit_isolation.py` | S4 / #981 | Skips unless `ENABLE_S4_E2E=true` |

Shared helpers live in `multitenancy_helpers.py` (AITenant/Gateway fixtures, discovery labels, controller flag patch/assert, Kuadrant policy checks).

### Extensions to existing tests

- `test_aitenant_lifecycle.py` — regression for [RHOAIENG-66836](https://redhat.atlassian.net/browse/RHOAIENG-66836) (non-default `AITenant` must not use `models-as-a-service` tenant namespace).
- `test_namespace_scoping.py` — skips when `ENABLE_TENANT_NAMESPACE_DISCOVERY=true` (dormant-mode assumptions no longer apply).

### CI / smoke script (`prow_run_smoke_test.sh`)

Konflux integration tests (including `/group-test`) already invoke this script — no separate Prow job config in-repo.

- Registers all S27 modules in the explicit pytest file list.
- Defaults `ENABLE_TENANT_NAMESPACE_DISCOVERY=true` and patches `maas-controller` with `--enable-tenant-namespace-discovery=true` before pytest so S1/S27 discovery and integration tests execute in CI.
- Exports `AITENANT_NAMESPACE`, `GATEWAY_NAME`, and related multi-tenant env vars for tests.

S24/S4 modules are listed in pytest but remain skipped until their backing implementation is deployed and opt-in env vars are set (`ENABLE_S24_E2E`, `ENABLE_S4_E2E`, tenant API URLs/namespaces).

### Test plan coverage (JIRA sections)

1. **Tenant namespace discovery (S1)** — labeled/unlabeled namespaces, label removal, dynamic discovery, per-tenant OIDC, namespace-qualified contributors, namespace-scoped RBAC, S6 webhook rejection.
2. **Per-tenant maas-api (S24)** — env-gated infrastructure, `TENANT_NAME`, routing, HTTPRoute attachment, multi-tenant coexistence.
3. **Authentication isolation (S4)** — env-gated API-key mint/validate/list and cross-tenant rejection, per-tenant OIDC.
4. **Subscription isolation (S4)** — env-gated list/selection per tenant.
5. **Rate limit isolation (S4)** — env-gated per-tenant enforcement.
6. **Gateway-scoped AuthPolicy (S10)** — Gateway `targetRef`, singleton `maas-gateway-auth`, rego updates on policy change.
7. **Integration** — full AITenant lifecycle, default tenant unaffected, same-named CRs across tenants, label-change reconciliation.

### Docs

- `test/e2e/README.md` — module table, CI env gating, discovery vs dormant mode.

## Risk analysis

- **Risk rating**: 1
- **Why**: Test-only change (pytest + smoke script wiring). Runtime impact is limited to CI/local E2E: the smoke script now enables tenant namespace discovery by default and patches the controller Deployment before pytest. That is intentional for MT validation and matches Phase 1 test goals. Blast radius is low because production/default installs still ship discovery off; S24/S4 suites skip without explicit env. Main residual risk is longer or flakier Konflux runs if discovery tests are sensitive to cluster timing — mitigated by existing wait helpers and skips.

## How Has This Been Tested?

**Konflux (primary)**

Comment `/group-test` on the PR (or rely on automatic group testing after `maas-api` + `maas-controller` PR builds). The group pipeline in [odh-konflux-central](https://github.com/opendatahub-io/odh-konflux-central) provisions a cluster and runs:

```bash
./test/e2e/scripts/prow_run_smoke_test.sh
```

Expect discovery, gateway AuthPolicy, AITenant lifecycle, and integration modules to **run** (not skip). S24/S4 modules should **skip** until `ENABLE_S24_E2E` / `ENABLE_S4_E2E` are set.

**Local / existing cluster (optional)**

```bash
# Full deploy + tests (discovery on by default in smoke script)
./test/e2e/scripts/prow_run_smoke_test.sh

# Against an already-deployed cluster
SKIP_DEPLOYMENT=true ./test/e2e/scripts/prow_run_smoke_test.sh

# Opt into blocked-story suites when backends are present
ENABLE_S24_E2E=true ENABLE_S4_E2E=true \
  MAAS_API_BASE_URL_TENANT_A=... MAAS_API_BASE_URL_TENANT_B=... \
  TENANT_A_NAMESPACE=... TENANT_B_NAMESPACE=... \
  SKIP_DEPLOYMENT=true ./test/e2e/scripts/prow_run_smoke_test.sh
```

**Static**

- Pytest modules import and use shared helpers; no Go/controller changes in this PR.

## Merge criteria:

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded E2E README to describe broader Deep MaaS multi-tenancy coverage, the CI smoke subset, artifacts reporting, and conditional test skip/gating behavior.
* **New Features**
  * Added Phase 1 multi-tenancy E2E helper utilities for tenant discovery, lifecycle orchestration, and per-tenant API-key workflows.
* **Tests**
  * Added/expanded E2E suites for tenant lifecycle, tenant-namespace discovery (including webhook validation and dormant mode), gateway-scoped auth policy, per-tenant MaaS API (S24), and tenant auth/subscription/rate-limit isolation (S4), plus an AITenant invalid placement check.
* **Bug Fixes**
  * Improved E2E gateway routing/header handling and gateway DNS resolution for host:port inputs; updated discovery-related skipping.
* **Chores**
  * Updated smoke runner to optionally enable tenant-namespace discovery and export related gating variables by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->