### PR TITLE
feat: add Loki-based user-scoped usage dashboard with Perses datasource

### DIFF
--- a/deployment/components/observability/observability/dashboards/kustomization.yaml
+++ b/deployment/components/observability/observability/dashboards/kustomization.yaml
@@ -8,6 +8,8 @@ metadata:
 
 resources:
   - usage-dashboard.yaml
+  - usage-user-loki-dashboard.yaml
+  - loki-datasource-scoped.yaml
 
 labels:
   - pairs:

--- a/deployment/components/observability/observability/dashboards/loki-datasource-scoped.yaml
+++ b/deployment/components/observability/observability/dashboards/loki-datasource-scoped.yaml
@@ -1,0 +1,29 @@
+# User-scoped Loki datasource — routes through loki-query-proxy which injects
+# user_id filtering. Named "scoped-loki" to avoid prefix collision with "loki".
+---
+apiVersion: perses.dev/v1alpha1
+kind: PersesDatasource
+metadata:
+  name: scoped-loki
+  namespace: opendatahub
+  labels:
+    app.kubernetes.io/managed-by: maas-observability
+    app.kubernetes.io/component: perses
+spec:
+  config:
+    display:
+      name: "Loki (User Scoped)"
+    default: false
+    plugin:
+      kind: "LokiDatasource"
+      spec:
+        proxy:
+          kind: HTTPProxy
+          spec:
+            url: http://loki-query-proxy-user.kuadrant-system.svc:8080
+            allowedEndpoints:
+              - endpointPattern: "/loki/api/v1/.*"
+                method: GET
+  client:
+    kubernetesAuth:
+      enable: true

--- a/deployment/components/observability/observability/dashboards/usage-user-loki-dashboard.yaml
+++ b/deployment/components/observability/observability/dashboards/usage-user-loki-dashboard.yaml
@@ -1,0 +1,386 @@
+# User-scoped usage dashboard — queries go through loki-query-proxy which
+# injects user_id filtering based on the logged-in user's Kubernetes token.
+# CEL filter restricts logs to inference-only paths; no probe traffic to filter.
+# customAllValue: ".*" on ListVariables ensures "All" matches entries with
+# absent labels (e.g. user_id when capturing is disabled). Do not remove.
+apiVersion: perses.dev/v1alpha1
+kind: PersesDashboard
+metadata:
+  name: usage-user-loki-dashboard
+  namespace: opendatahub
+  labels:
+    app.kubernetes.io/managed-by: maas-observability
+    app.kubernetes.io/component: perses
+spec:
+  display:
+    name: "Usage User Dashboard"
+    description: >-
+      Personal view of model usage. Shows your token consumption, request
+      counts, and rate limiting. Queries are automatically filtered to your
+      user identity via the Loki query proxy.
+  duration: 1h
+
+  variables:
+    - kind: ListVariable
+      spec:
+        name: subscription
+        display:
+          name: "Subscription"
+        allowMultiple: true
+        allowAllValue: true
+        customAllValue: ".*"
+        defaultValue: "$__all"
+        plugin:
+          kind: LokiLabelValuesVariable
+          spec:
+            datasource:
+              kind: LokiDatasource
+              name: scoped-loki
+            labelName: subscription
+            matchers:
+              - '{service_name="maas-gateway", subscription!="-"}'
+    - kind: ListVariable
+      spec:
+        name: model
+        display:
+          name: "Model"
+        allowMultiple: true
+        allowAllValue: true
+        customAllValue: ".*"
+        defaultValue: "$__all"
+        plugin:
+          kind: LokiLabelValuesVariable
+          spec:
+            datasource:
+              kind: LokiDatasource
+              name: scoped-loki
+            labelName: model
+            matchers:
+              - '{service_name="maas-gateway", model!="-"}'
+    - kind: ListVariable
+      spec:
+        name: view_by
+        display:
+          name: "View by"
+        allowMultiple: false
+        allowAllValue: false
+        defaultValue: "model"
+        plugin:
+          kind: StaticListVariable
+          spec:
+            values:
+              - value: "model"
+                label: By model
+              - value: "subscription"
+                label: By subscription
+
+  panels:
+    totalTokens:
+      kind: Panel
+      spec:
+        display:
+          name: "Total tokens"
+          description: "Total tokens consumed over the selected time window."
+        plugin:
+          kind: StatChart
+          spec:
+            calculation: last
+            format:
+              unit: decimal
+              shortValues: true
+              decimalPlaces: 0
+        queries:
+          - kind: TimeSeriesQuery
+            spec:
+              plugin:
+                kind: LokiTimeSeriesQuery
+                spec:
+                  datasource:
+                    kind: LokiDatasource
+                    name: scoped-loki
+                  query: >-
+                    sum(sum_over_time({service_name="maas-gateway",
+                    subscription=~"$subscription", model=~"$model", response_type="hit"}
+                    | unwrap tokens_total [$__range]))
+                    or vector(0)
+
+    totalRequests:
+      kind: Panel
+      spec:
+        display:
+          name: "Total requests"
+          description: "Total API requests over the selected time window."
+        plugin:
+          kind: StatChart
+          spec:
+            calculation: last
+            format:
+              unit: decimal
+              shortValues: true
+              decimalPlaces: 0
+        queries:
+          - kind: TimeSeriesQuery
+            spec:
+              plugin:
+                kind: LokiTimeSeriesQuery
+                spec:
+                  datasource:
+                    kind: LokiDatasource
+                    name: scoped-loki
+                  query: >-
+                    sum(count_over_time({service_name="maas-gateway",
+                    subscription=~"$subscription", model=~"$model"}
+                    [$__range]))
+                    or vector(0)
+
+    totalRateLimited:
+      kind: Panel
+      spec:
+        display:
+          name: "Total rate limited"
+          description: "Total rate-limited requests over the selected time window."
+        plugin:
+          kind: StatChart
+          spec:
+            calculation: last
+            format:
+              unit: decimal
+              shortValues: true
+              decimalPlaces: 0
+        queries:
+          - kind: TimeSeriesQuery
+            spec:
+              plugin:
+                kind: LokiTimeSeriesQuery
+                spec:
+                  datasource:
+                    kind: LokiDatasource
+                    name: scoped-loki
+                  query: >-
+                    sum(count_over_time({service_name="maas-gateway",
+                    subscription=~"$subscription", model=~"$model", response_type="rate_limit"}
+                    [$__range]))
+                    or vector(0)
+
+    successRate:
+      kind: Panel
+      spec:
+        display:
+          description: "Percentage of authorized vs total requests over the selected time window."
+          name: Success rate
+        plugin:
+          kind: StatChart
+          spec:
+            calculation: last
+            format:
+              decimalPlaces: 1
+              unit: percent-decimal
+        queries:
+          - kind: TimeSeriesQuery
+            spec:
+              plugin:
+                kind: LokiTimeSeriesQuery
+                spec:
+                  datasource:
+                    kind: LokiDatasource
+                    name: scoped-loki
+                  query: >-
+                    (sum(count_over_time({service_name="maas-gateway",
+                    subscription=~"$subscription", model=~"$model", response_type="hit"}
+                    [$__range]))
+                    /
+                    sum(count_over_time({service_name="maas-gateway",
+                    subscription=~"$subscription", model=~"$model"}
+                    [$__range])))
+                    or vector(1)
+
+    tokenConsumptionOverTime:
+      kind: Panel
+      spec:
+        display:
+          name: "Token consumption chart"
+          description: >-
+            Tokens from successful requests (2xx) over time by model or subscription.
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              position: bottom
+              mode: table
+              values: []
+            visual:
+              display: line
+              lineWidth: 3
+              areaOpacity: 1
+              connectNulls: true
+              stack: all
+              showPoints: always
+              pointRadius: 6
+            yAxis:
+              min: 0
+              format:
+                unit: decimal
+        queries:
+          - kind: TimeSeriesQuery
+            spec:
+              plugin:
+                kind: LokiTimeSeriesQuery
+                spec:
+                  datasource:
+                    kind: LokiDatasource
+                    name: scoped-loki
+                  query: >-
+                    sum by (${view_by:raw}) (sum_over_time({service_name="maas-gateway",
+                    subscription=~"$subscription", model=~"$model", response_type="hit"}
+                    | unwrap tokens_total [30m]))
+
+    tokenConsumptionTable:
+      kind: Panel
+      spec:
+        display:
+          name: "Usage breakdown"
+          description: >-
+            All model/subscription pairs. **View by** changes the chart; table always shows full detail.
+        plugin:
+          kind: Table
+          spec:
+            density: "compact"
+            pagination: true
+            transforms:
+              - kind: "MergeSeries"
+                spec: {}
+            columnSettings:
+              - name: "timestamp"
+                hide: true
+              - name: "model"
+                header: "Model"
+                align: "left"
+                enableSorting: true
+              - name: "subscription"
+                header: "Subscription"
+                align: "left"
+                enableSorting: true
+              - name: "key_name"
+                header: "Key Name"
+                align: "left"
+                enableSorting: true
+              - name: "value #1"
+                header: "Tokens used"
+                align: "right"
+                enableSorting: true
+                sort: "desc"
+                format:
+                  unit: decimal
+                  shortValues: true
+              - name: "value #2"
+                header: "Successful Requests"
+                align: "right"
+                enableSorting: true
+                format:
+                  unit: decimal
+                  decimalPlaces: 0
+              - name: "value #3"
+                header: "Rate Limited Requests"
+                align: "right"
+                enableSorting: true
+                format:
+                  unit: decimal
+                  decimalPlaces: 0
+        queries:
+          - kind: TimeSeriesQuery
+            spec:
+              plugin:
+                kind: LokiTimeSeriesQuery
+                spec:
+                  datasource:
+                    kind: LokiDatasource
+                    name: scoped-loki
+                  query: >-
+                    sum by (model, subscription, key_name) (sum_over_time(
+                    {service_name="maas-gateway",
+                    subscription=~"$subscription", model=~"$model", response_type="hit"}
+                    | unwrap tokens_total [$__range]))
+          - kind: TimeSeriesQuery
+            spec:
+              plugin:
+                kind: LokiTimeSeriesQuery
+                spec:
+                  datasource:
+                    kind: LokiDatasource
+                    name: scoped-loki
+                  query: >-
+                    sum by (model, subscription, key_name) (count_over_time(
+                    {service_name="maas-gateway",
+                    subscription=~"$subscription", model=~"$model", response_type="hit"}
+                    [$__range]))
+          - kind: TimeSeriesQuery
+            spec:
+              plugin:
+                kind: LokiTimeSeriesQuery
+                spec:
+                  datasource:
+                    kind: LokiDatasource
+                    name: scoped-loki
+                  query: >-
+                    sum by (model, subscription, key_name) (count_over_time(
+                    {service_name="maas-gateway",
+                    subscription=~"$subscription", model=~"$model", response_type="rate_limit"}
+                    [$__range]))
+                    or
+                    (sum by (model, subscription, key_name) (count_over_time(
+                    {service_name="maas-gateway",
+                    subscription=~"$subscription", model=~"$model", response_type="hit"}
+                    [$__range])) * 0)
+
+  layouts:
+    - kind: Grid
+      spec:
+        display:
+          title: "Overview"
+          collapse:
+            open: true
+        items:
+          - x: 0
+            "y": 0
+            width: 6
+            height: 5
+            content:
+              "$ref": "#/spec/panels/totalTokens"
+          - x: 6
+            "y": 0
+            width: 6
+            height: 5
+            content:
+              "$ref": "#/spec/panels/totalRequests"
+          - x: 12
+            "y": 0
+            width: 6
+            height: 5
+            content:
+              "$ref": "#/spec/panels/totalRateLimited"
+          - x: 18
+            "y": 0
+            width: 6
+            height: 5
+            content:
+              "$ref": "#/spec/panels/successRate"
+
+    - kind: Grid
+      spec:
+        display:
+          title: "Token consumption"
+          collapse:
+            open: true
+        items:
+          - x: 0
+            "y": 0
+            width: 24
+            height: 10
+            content:
+              "$ref": "#/spec/panels/tokenConsumptionOverTime"
+          - x: 0
+            "y": 10
+            width: 24
+            height: 8
+            content:
+              "$ref": "#/spec/panels/tokenConsumptionTable"


### PR DESCRIPTION
## Summary

User-scoped Loki usage dashboard + scoped datasource for per-user MaaS model usage observability. All queries routed through `loki-query-proxy` which injects `user_id` filtering via Kubernetes TokenReview — users see only their own data.

## Files

| File | Purpose |
|---|---|
| `usage-user-loki-dashboard.yaml` | PersesDashboard — user-scoped usage panels and table |
| `loki-datasource-scoped.yaml` | PersesDatasource `scoped-loki` — routes through loki-query-proxy |

## Dashboard

**Panels**:
- Total Tokens (stat)
- Total Successful Requests (stat)
- Total Rate Limited Requests (stat)
- Success Rate (stat, `or vector(1)` — no traffic = 100%)
- Token consumption over time (time-series, grouped by `$view_by`)
- Usage breakdown (table — 3 queries merged via `MergeSeries`)

**Variables**:
- `subscription` — `LokiLabelValuesVariable` via `scoped-loki` (multi-select, `customAllValue: ".*"`)
- `model` — `LokiLabelValuesVariable` via `scoped-loki` (multi-select, `customAllValue: ".*"`)
- `view_by` — `StaticListVariable`: model | subscription
- No `user` variable — filtering enforced server-side by proxy

**Table panel** — "Usage breakdown":
- Q1: `sum by (model, subscription, key_name) (sum_over_time(... response_type="hit" | unwrap tokens_total [$__range]))`
- Q2: `sum by (model, subscription, key_name) (count_over_time(... response_type="hit" [$__range]))`
- Q3: `sum by (model, subscription, key_name) (count_over_time(... response_type="rate_limit" [$__range])) or (... hit ... * 0)`
- `key_name` shown in table via structured metadata grouping (high cardinality — no dropdown)
- `key_id` UUID NOT displayed (remains in Loki for programmatic access)
- Zero-padding `or (hit * 0)` ensures `MergeSeries` joins correctly

**Query patterns**:
- `response_type` stream label for filtering (`hit`/`rate_limit`/`error`)
- `[$__range]` time window (no offset)
- Fallbacks: `or vector(0)` on counts, `or vector(1)` on Success Rate

## Datasource (`scoped-loki`)

- Routes through `loki-query-proxy-user.kuadrant-system.svc:8080`
- `kubernetesAuth: true` — forwards Console user's OAuth token to proxy
- Proxy performs TokenReview, injects `| user_id="<caller>"` into every LogQL query
- Admins (`system:cluster-admins`/`system:masters`) bypass the filter
- Named `scoped-loki` (not `loki-scoped`) to avoid prefix collision with `loki` admin datasource
- `allowedEndpoints: /loki/api/v1/.*` (GET only)

## No `kustomization.yaml`

PR #995 (admin dashboard, merges first) provides the `kustomization.yaml` that already lists `usage-user-loki-dashboard.yaml` in its resources. This PR only adds its own files.

## Dependencies

- **PR #999** — loki-query-proxy (datasource URL points to proxy service)
- **PR #995** — admin dashboard (provides kustomization.yaml and loki datasource)
- **PR #1032** — OTel Collector (pipeline must be active for Loki data)
- **PR #1035** — EnvoyFilter (emits structured usage logs)
- LokiStack deployed with OTLP ingestion
- COO 1.5+ (required for `LokiLabelValuesVariable` plugin)

## Merge order

`#1035 (EnvoyFilter) → #1032 (OTel Collector) → #999 (Proxy) → #995 (Admin Dashboard) → #988 (this PR)`

## Risk analysis

- **Risk rating**: 2
- **Why**: Dashboard-only (2 YAML files, no Go code). User isolation enforced by proxy, not dashboard. Same query patterns as admin dashboard. All queries verified against live Loki data on amit cluster with 200/429/streaming traffic.

## Test plan

- [x] Deploy dashboard to cluster
- [x] Verify user-scoped queries work through proxy (only own data visible)
- [x] Verify `key_name` appears in table rows
- [x] Verify streaming requests counted correctly with token totals
- [x] Verify 200 and 429 traffic appears correctly
- [x] Verify "All" selection on variables returns complete data
- [x] Confirm `key_id` UUID not shown in UI
- [x] Verify Success Rate shows 100% with no traffic (not 0%)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a user-scoped Loki data source (“Loki (User Scoped)”) backed by a query proxy with endpoint restrictions.
  * Added a new user-usage dashboard with template filters for subscription and model, plus grouping controls.
  * Added usage panels for total tokens consumed, successful requests, rate-limited requests, and calculated success rate.
  * Added token consumption trends and a usage breakdown table by model, subscription, and access key.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->