### PR TITLE
fix: improve test coverage and e2e reliability

### DIFF
--- a/maas-api/internal/api_keys/service.go
+++ b/maas-api/internal/api_keys/service.go
@@ -59,15 +59,6 @@ func NewServiceWithLogger(store MetadataStore, cfg *config.Config, sub Subscript
 	}
 }
 
-// GetMaxExpirationDays returns the maximum expiration days for API keys.
-// Returns the configured value if set, otherwise returns the default.
-// Safely handles nil config to prevent service crashes.
-func (s *Service) GetMaxExpirationDays() int {
-	if s.config != nil && s.config.APIKeyMaxExpirationDays > 0 {
-		return s.config.APIKeyMaxExpirationDays
-	}
-	return constant.DefaultAPIKeyMaxExpirationDays
-}
 
 // CreateAPIKeyResponse is returned when creating an API key.
 // Per Feature Refinement "Keys Shown Only Once": plaintext key is ONLY returned at creation time.

--- a/maas-api/internal/api_keys/service.go
+++ b/maas-api/internal/api_keys/service.go
@@ -59,6 +59,16 @@ func NewServiceWithLogger(store MetadataStore, cfg *config.Config, sub Subscript
 	}
 }
 
+// GetMaxExpirationDays returns the maximum expiration days for API keys.
+// Returns the configured value if set, otherwise returns the default.
+// Safely handles nil config to prevent service crashes.
+func (s *Service) GetMaxExpirationDays() int {
+	if s.config != nil && s.config.APIKeyMaxExpirationDays > 0 {
+		return s.config.APIKeyMaxExpirationDays
+	}
+	return constant.DefaultAPIKeyMaxExpirationDays
+}
+
 // CreateAPIKeyResponse is returned when creating an API key.
 // Per Feature Refinement "Keys Shown Only Once": plaintext key is ONLY returned at creation time.
 type CreateAPIKeyResponse struct {

--- a/maas-api/internal/api_keys/service.go
+++ b/maas-api/internal/api_keys/service.go
@@ -59,7 +59,6 @@ func NewServiceWithLogger(store MetadataStore, cfg *config.Config, sub Subscript
 	}
 }
 
-
 // CreateAPIKeyResponse is returned when creating an API key.
 // Per Feature Refinement "Keys Shown Only Once": plaintext key is ONLY returned at creation time.
 type CreateAPIKeyResponse struct {

--- a/maas-api/internal/api_keys/service_test.go
+++ b/maas-api/internal/api_keys/service_test.go
@@ -987,6 +987,77 @@ func TestCreateAPIKey_ValidatesSubscriptionPhase(t *testing.T) {
 	}
 }
 
+// ============================================================
+// GET MAX EXPIRATION DAYS TESTS (NIL SAFETY)
+// ============================================================
+
+func TestGetMaxExpirationDays_NilConfig(t *testing.T) {
+	// Service with nil config should not panic and should return default
+	store := api_keys.NewMockStore()
+	svc := api_keys.NewServiceWithLogger(store, nil, serviceTestSubSelector{}, logger.Development())
+
+	result := svc.GetMaxExpirationDays()
+
+	assert.Equal(t, 90, result, "Should return default when config is nil")
+}
+
+func TestGetMaxExpirationDays_ZeroValue(t *testing.T) {
+	// Config with zero APIKeyMaxExpirationDays should return default
+	store := api_keys.NewMockStore()
+	cfg := &config.Config{APIKeyMaxExpirationDays: 0}
+	svc := api_keys.NewServiceWithLogger(store, cfg, serviceTestSubSelector{}, logger.Development())
+
+	result := svc.GetMaxExpirationDays()
+
+	assert.Equal(t, 90, result, "Should return default when config value is 0")
+}
+
+func TestGetMaxExpirationDays_CustomValue(t *testing.T) {
+	// Config with custom value should return that value
+	store := api_keys.NewMockStore()
+	cfg := &config.Config{APIKeyMaxExpirationDays: 30}
+	svc := api_keys.NewServiceWithLogger(store, cfg, serviceTestSubSelector{}, logger.Development())
+
+	result := svc.GetMaxExpirationDays()
+
+	assert.Equal(t, 30, result, "Should return custom config value")
+}
+
+func TestGetMaxExpirationDays_NegativeValue(t *testing.T) {
+	// Config with negative value should return default (treated as invalid)
+	store := api_keys.NewMockStore()
+	cfg := &config.Config{APIKeyMaxExpirationDays: -10}
+	svc := api_keys.NewServiceWithLogger(store, cfg, serviceTestSubSelector{}, logger.Development())
+
+	result := svc.GetMaxExpirationDays()
+
+	assert.Equal(t, 90, result, "Should return default when config value is negative")
+}
+
+func TestGetMaxExpirationDays_UsedByCreateAPIKey(t *testing.T) {
+	// Verify that CreateAPIKey uses GetMaxExpirationDays (integration test)
+	ctx := context.Background()
+	store := api_keys.NewMockStore()
+
+	// Test with custom max expiration days
+	cfg := &config.Config{APIKeyMaxExpirationDays: 15}
+	svc := api_keys.NewServiceWithLogger(store, cfg, serviceTestSubSelector{}, logger.Development())
+
+	// Try to create a key that exceeds the custom limit (should fail)
+	expiresIn := 20 * 24 * time.Hour // 20 days
+	_, err := svc.CreateAPIKey(ctx, "alice", []string{}, "Test Key", "", &expiresIn, false, "")
+
+	require.Error(t, err, "Should reject expiration exceeding custom max")
+	assert.Contains(t, err.Error(), "exceeds maximum allowed (15 days)", "Error should reference custom max from GetMaxExpirationDays")
+
+	// Create a key within the custom limit (should succeed)
+	expiresIn = 10 * 24 * time.Hour // 10 days
+	resp, err := svc.CreateAPIKey(ctx, "alice", []string{}, "Test Key", "", &expiresIn, false, "")
+
+	require.NoError(t, err, "Should accept expiration within custom max")
+	assert.NotNil(t, resp)
+}
+
 // mockHealthSelector implements SubscriptionSelector for health testing.
 type mockHealthSelector struct {
 	phase    string

--- a/maas-api/internal/api_keys/service_test.go
+++ b/maas-api/internal/api_keys/service_test.go
@@ -2,6 +2,7 @@ package api_keys_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -10,6 +11,7 @@ import (
 
 	"github.com/opendatahub-io/models-as-a-service/maas-api/internal/api_keys"
 	"github.com/opendatahub-io/models-as-a-service/maas-api/internal/config"
+	"github.com/opendatahub-io/models-as-a-service/maas-api/internal/constant"
 	"github.com/opendatahub-io/models-as-a-service/maas-api/internal/logger"
 	"github.com/opendatahub-io/models-as-a-service/maas-api/internal/subscription"
 )
@@ -625,7 +627,7 @@ func TestCreateAPIKey_MaxExpirationLimit(t *testing.T) {
 		require.Error(t, err, "should reject expiration exceeding default max (90 days)")
 		assert.Nil(t, result)
 		require.ErrorIs(t, err, api_keys.ErrExpirationExceedsMax)
-		assert.Contains(t, err.Error(), "90 days")
+		assert.Contains(t, err.Error(), fmt.Sprintf("%d days", constant.DefaultAPIKeyMaxExpirationDays))
 	})
 
 	t.Run("ZeroConfigEnforcesDefaultMax", func(t *testing.T) {
@@ -998,7 +1000,7 @@ func TestGetMaxExpirationDays_NilConfig(t *testing.T) {
 
 	result := svc.GetMaxExpirationDays()
 
-	assert.Equal(t, 90, result, "Should return default when config is nil")
+	assert.Equal(t, constant.DefaultAPIKeyMaxExpirationDays, result, "Should return default when config is nil")
 }
 
 func TestGetMaxExpirationDays_ZeroValue(t *testing.T) {
@@ -1009,7 +1011,7 @@ func TestGetMaxExpirationDays_ZeroValue(t *testing.T) {
 
 	result := svc.GetMaxExpirationDays()
 
-	assert.Equal(t, 90, result, "Should return default when config value is 0")
+	assert.Equal(t, constant.DefaultAPIKeyMaxExpirationDays, result, "Should return default when config value is 0")
 }
 
 func TestGetMaxExpirationDays_CustomValue(t *testing.T) {
@@ -1031,7 +1033,7 @@ func TestGetMaxExpirationDays_NegativeValue(t *testing.T) {
 
 	result := svc.GetMaxExpirationDays()
 
-	assert.Equal(t, 90, result, "Should return default when config value is negative")
+	assert.Equal(t, constant.DefaultAPIKeyMaxExpirationDays, result, "Should return default when config value is negative")
 }
 
 func TestGetMaxExpirationDays_UsedByCreateAPIKey(t *testing.T) {
@@ -1045,14 +1047,14 @@ func TestGetMaxExpirationDays_UsedByCreateAPIKey(t *testing.T) {
 
 	// Try to create a key that exceeds the custom limit (should fail)
 	expiresIn := 20 * 24 * time.Hour // 20 days
-	_, err := svc.CreateAPIKey(ctx, "alice", []string{}, "Test Key", "", &expiresIn, false, "")
+	_, err := svc.CreateAPIKey(ctx, "alice", []string{}, "Test Key", "", &expiresIn, false, "", "")
 
 	require.Error(t, err, "Should reject expiration exceeding custom max")
 	assert.Contains(t, err.Error(), "exceeds maximum allowed (15 days)", "Error should reference custom max from GetMaxExpirationDays")
 
 	// Create a key within the custom limit (should succeed)
 	expiresIn = 10 * 24 * time.Hour // 10 days
-	resp, err := svc.CreateAPIKey(ctx, "alice", []string{}, "Test Key", "", &expiresIn, false, "")
+	resp, err := svc.CreateAPIKey(ctx, "alice", []string{}, "Test Key", "", &expiresIn, false, "", "")
 
 	require.NoError(t, err, "Should accept expiration within custom max")
 	assert.NotNil(t, resp)

--- a/test/e2e/tests/test_external_oidc.py
+++ b/test/e2e/tests/test_external_oidc.py
@@ -116,12 +116,12 @@ def _request_oidc_token(
 
 
 def _decode_jwt_payload(token: str) -> dict:
-    """Decode the payload of a JWT (no signature verification)."""
+    """Decode the payload of a JWT (no signature verification — TEST ONLY)."""
     parts = token.split(".")
-    assert len(parts) == 3, f"Token is not a valid JWT (expected 3 parts, got {len(parts)})"
-    # JWT base64url → standard base64
-    payload_b64 = parts[1] + "=" * (4 - len(parts[1]) % 4)
-    return json.loads(base64.urlsafe_b64decode(payload_b64))
+    if len(parts) != 3:
+        raise ValueError(f"Invalid JWT format: expected 3 parts, got {len(parts)}")
+    padding = "=" * (-len(parts[1]) % 4)
+    return json.loads(base64.urlsafe_b64decode(parts[1] + padding))
 
 
 def _oidc_request_with_retry(method, url, oidc_token, label="OIDC request",
@@ -178,6 +178,28 @@ def _create_oidc_api_key(
     data = response.json()
     assert data.get("key", "").startswith("sk-oai-"), f"Unexpected API key payload: {data}"
     return data
+
+
+def _wait_for_api_key_revocation(
+    maas_api_base_url: str,
+    api_key: str,
+    timeout: int = 10,
+    poll_interval: float = 0.5,
+) -> None:
+    """Poll until API key revocation is enforced by the gateway."""
+    start = time.time()
+    while time.time() - start < timeout:
+        response = requests.get(
+            f"{maas_api_base_url}/v1/models",
+            headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
+            timeout=30,
+            verify=TLS_VERIFY,
+        )
+        if response.status_code in (401, 403, 500):
+            log.info("Revocation enforced after %.1fs (status=%d)", time.time() - start, response.status_code)
+            return
+        time.sleep(poll_interval)
+    raise TimeoutError(f"API key revocation not enforced after {timeout}s")
 
 
 def _tenant_b_token_url() -> str:
@@ -469,7 +491,7 @@ class TestOIDCModelAccess:
         )
 
         # Wait for revocation to propagate through gateway
-        time.sleep(3)
+        _wait_for_api_key_revocation(maas_api_base_url, api_key, timeout=10)
 
         # Attempt to use the revoked key
         response = requests.get(

--- a/test/e2e/tests/test_external_oidc.py
+++ b/test/e2e/tests/test_external_oidc.py
@@ -189,13 +189,25 @@ def _wait_for_api_key_revocation(
     """Poll until API key revocation is enforced by the gateway."""
     start = time.time()
     while time.time() - start < timeout:
-        response = requests.get(
-            f"{maas_api_base_url}/v1/models",
-            headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
-            timeout=30,
-            verify=TLS_VERIFY,
-        )
-        if response.status_code in (401, 403, 500):
+        try:
+            response = requests.get(
+                f"{maas_api_base_url}/v1/models",
+                headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
+                timeout=30,
+                verify=TLS_VERIFY,
+            )
+        except requests.RequestException:
+            time.sleep(poll_interval)
+            continue
+
+        if response.status_code in (401, 403):
+            log.info("Revocation enforced after %.1fs (status=%d)", time.time() - start, response.status_code)
+            return
+        if (
+            response.status_code == 500
+            and "AUTH_FAILURE" in response.text
+            and "valid:false" in response.text
+        ):
             log.info("Revocation enforced after %.1fs (status=%d)", time.time() - start, response.status_code)
             return
         time.sleep(poll_interval)


### PR DESCRIPTION
### Code Quality
- Replaces hardcoded `"90 days"` in tests with `constant.DefaultAPIKeyMaxExpirationDays`

### Test Coverage
- Adds 5 new test cases for `GetMaxExpirationDays` covering nil config, zero, custom, and negative values
- Verifies integration with `CreateAPIKey` method

### E2E Improvements
- Fixes base64url padding calculation in `_decode_jwt_payload`
- Replaces `time.sleep(3)` with a polling helper (`_wait_for_api_key_revocation`) for deterministic revocation checks
- Tightens HTTP 500 handling to require `AUTH_FAILURE` confirmation in response body