### PR TITLE
feat: add webhook to validate AITenant CR namespace on creation

### DIFF
--- a/deployment/base/maas-controller/webhook/validating_webhook_configuration.yaml
+++ b/deployment/base/maas-controller/webhook/validating_webhook_configuration.yaml
@@ -9,6 +9,25 @@ webhooks:
       service:
         name: maas-controller-webhook-service
         namespace: system
+        path: /validate-maas-opendatahub-io-v1alpha1-aitenant
+    failurePolicy: Fail
+    name: vaitenant.kb.io
+    rules:
+      - apiGroups:
+          - maas.opendatahub.io
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+        resources:
+          - aitenants
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: maas-controller-webhook-service
+        namespace: system
         path: /validate-maas-opendatahub-io-v1alpha1-maassubscription
     failurePolicy: Fail
     name: vmaassubscription.kb.io

--- a/docs/content/install/troubleshooting.md
+++ b/docs/content/install/troubleshooting.md
@@ -120,6 +120,22 @@ This guide helps you diagnose and resolve common issues with MaaS Platform deplo
 
       Creates succeed once controller pods are healthy. Model inference requests are unaffected during controller downtime (data plane continues operating normally).
 
+13. **Cannot create `AITenant` (`must be created in the configured AITenant infrastructure namespace`)**: The object is being created outside the namespace configured by `--aitenant-namespace` (default `redhat-ai-gateway-infra`).
+
+      - [ ] Check which namespace the controller is configured to accept:
+
+      ```bash
+      kubectl get deployment maas-controller -n opendatahub -o jsonpath='{.spec.template.spec.containers[0].args}'
+      ```
+
+      - [ ] Create the `AITenant` in that namespace instead of the target tenant namespace:
+
+      ```bash
+      kubectl get namespace redhat-ai-gateway-infra
+      ```
+
+      - [ ] If the error is `no endpoints available for service "maas-controller-webhook-service"`, follow the same webhook health checks as issue 12 above.
+
 ## Conflicting AuthPolicy Detection
 
 MaaS automatically detects non-MaaS AuthPolicies (e.g., from KServe or other controllers) that target the same HTTPRoutes used by MaaS-governed models. When a conflict is detected, MaaS sets a `ConflictingAuthPolicy` condition on the affected MaaSAuthPolicy resource and emits a Kubernetes warning event.

--- a/docs/content/install/troubleshooting.md
+++ b/docs/content/install/troubleshooting.md
@@ -120,7 +120,7 @@ This guide helps you diagnose and resolve common issues with MaaS Platform deplo
 
       Creates succeed once controller pods are healthy. Model inference requests are unaffected during controller downtime (data plane continues operating normally).
 
-13. **Cannot create `AITenant` (`must be created in the configured AITenant infrastructure namespace`)**: The object is being created outside the namespace configured by `--aitenant-namespace` (default `redhat-ai-gateway-infra`).
+13. **Cannot create `AITenant` (`must be created in the configured AITenant infrastructure namespace`)**: The object is being created outside the namespace configured by `--aitenant-namespace` (default `ai-tenants`).
 
       - [ ] Check which namespace the controller is configured to accept:
 
@@ -131,7 +131,7 @@ This guide helps you diagnose and resolve common issues with MaaS Platform deplo
       - [ ] Create the `AITenant` in that namespace instead of the target tenant namespace:
 
       ```bash
-      kubectl get namespace redhat-ai-gateway-infra
+      kubectl get namespace ai-tenants
       ```
 
       - [ ] If the error is `no endpoints available for service "maas-controller-webhook-service"`, follow the same webhook health checks as issue 12 above.

--- a/docs/content/reference/crds/ai-tenant.md
+++ b/docs/content/reference/crds/ai-tenant.md
@@ -4,6 +4,8 @@ Bootstraps a MaaS tenant from an infrastructure namespace. `AITenant` creates or
 
 `AITenant` resources must be created in the controller-configured infrastructure namespace, which defaults to `ai-tenants`. The controller creates this namespace if it does not already exist. Set the controller `--aitenant-namespace` flag to use a different infrastructure namespace.
 
+Creates outside the configured infrastructure namespace are rejected by the validating admission webhook before the object is persisted.
+
 ---
 
 ## Spec

--- a/docs/content/release-notes/index.md
+++ b/docs/content/release-notes/index.md
@@ -15,6 +15,7 @@ Release notes summarize user-visible changes, breaking changes, and migration re
 - Per-model `AuthPolicy` objects managed by the controller are deleted on the first reconcile after upgrade.
 - `status.authPolicies` now references `maas-gateway-auth / openshift-ingress` instead of per-model policy names.
 - New admission webhooks (`failurePolicy=Ignore`) validate that `MaaSAuthPolicy` and `MaaSSubscription` are created in namespaces that contain a `Tenant` CR.
+- `AITenant` creates outside the configured `--aitenant-namespace` are now rejected at admission instead of being accepted and later marked `Failed/InvalidPlacement` by the controller.
 - **Minimum Kuadrant version:** v1.4.2 or later required for `spec.defaults.rules` support.
 - **End-user auth behavior is unchanged** — valid API key + active subscription + allowed group still returns `200`.
 

--- a/docs/content/release-notes/index.md
+++ b/docs/content/release-notes/index.md
@@ -15,7 +15,7 @@ Release notes summarize user-visible changes, breaking changes, and migration re
 - Per-model `AuthPolicy` objects managed by the controller are deleted on the first reconcile after upgrade.
 - `status.authPolicies` now references `maas-gateway-auth / openshift-ingress` instead of per-model policy names.
 - New admission webhooks (`failurePolicy=Ignore`) validate that `MaaSAuthPolicy` and `MaaSSubscription` are created in namespaces that contain a `Tenant` CR.
-- `AITenant` creates outside the configured `--aitenant-namespace` are now rejected at admission instead of being accepted and later marked `Failed/InvalidPlacement` by the controller.
+- `AITenant` created outside the configured `--aitenant-namespace` are now rejected at admission instead of being accepted and later marked `Failed/InvalidPlacement` by the controller.
 - **Minimum Kuadrant version:** v1.4.2 or later required for `spec.defaults.rules` support.
 - **End-user auth behavior is unchanged** — valid API key + active subscription + allowed group still returns `200`.
 

--- a/maas-controller/cmd/manager/main.go
+++ b/maas-controller/cmd/manager/main.go
@@ -674,9 +674,17 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Setup validating webhooks for MaaSSubscription and MaaSAuthPolicy to ensure they are only
-	// created in tenant-enabled namespaces. This prevents users from creating resources in
-	// random namespaces where they will be silently ignored.
+	// Setup validating webhooks for placement-sensitive MaaS resources.
+	if err := (&webhook.AITenantValidator{
+		AITenantNamespace: aitenantNamespace,
+	}).SetupWebhookWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create webhook", "webhook", "AITenant")
+		os.Exit(1)
+	}
+
+	// MaaSSubscription and MaaSAuthPolicy must be created in tenant-enabled namespaces.
+	// This prevents users from creating resources in random namespaces where they
+	// would be silently ignored.
 	tenantValidator := &webhook.TenantNamespaceValidator{
 		Client: mgr.GetAPIReader(), // Use APIReader for uncached reads
 	}

--- a/maas-controller/pkg/webhook/aitenant_webhook.go
+++ b/maas-controller/pkg/webhook/aitenant_webhook.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	maasv1alpha1 "github.com/opendatahub-io/models-as-a-service/maas-controller/api/maas/v1alpha1"
+)
+
+// AITenantValidator validates AITenant resources.
+// +kubebuilder:webhook:path=/validate-maas-opendatahub-io-v1alpha1-aitenant,mutating=false,failurePolicy=fail,sideEffects=None,groups=maas.opendatahub.io,resources=aitenants,verbs=create,versions=v1alpha1,name=vaitenant.kb.io,admissionReviewVersions=v1
+type AITenantValidator struct {
+	AITenantNamespace string
+}
+
+// SetupWebhookWithManager registers the webhook with the manager.
+func (v *AITenantValidator) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(&maasv1alpha1.AITenant{}).
+		WithValidator(v).
+		Complete()
+}
+
+// ValidateCreate validates AITenant on creation.
+func (v *AITenantValidator) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	aitenant, ok := obj.(*maasv1alpha1.AITenant)
+	if !ok {
+		return nil, fmt.Errorf("expected AITenant object, got %T", obj)
+	}
+	if v == nil {
+		return nil, errors.New("webhook validator not configured")
+	}
+	if v.AITenantNamespace == "" {
+		return nil, errors.New("AITenant infrastructure namespace is not configured")
+	}
+	if aitenant.Namespace != v.AITenantNamespace {
+		return nil, fmt.Errorf(
+			"AITenant %s/%s must be created in the configured AITenant infrastructure namespace %q",
+			aitenant.Namespace, aitenant.Name, v.AITenantNamespace,
+		)
+	}
+	_ = ctx
+	return nil, nil
+}
+
+// ValidateUpdate validates AITenant on update.
+// Namespace is immutable and placement is enforced on create, so no update validation is needed here.
+func (v *AITenantValidator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
+	_ = ctx
+	_ = oldObj
+	_ = newObj
+	return nil, nil
+}
+
+// ValidateDelete validates AITenant on deletion.
+// No validation needed for deletion.
+func (v *AITenantValidator) ValidateDelete(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	_ = ctx
+	_ = obj
+	return nil, nil
+}

--- a/maas-controller/pkg/webhook/aitenant_webhook_test.go
+++ b/maas-controller/pkg/webhook/aitenant_webhook_test.go
@@ -36,12 +36,12 @@ func TestAITenantValidator_ValidateCreate(t *testing.T) {
 		{
 			name: "allow aitenant in configured namespace",
 			validator: &AITenantValidator{
-				AITenantNamespace: "redhat-ai-gateway-infra",
+				AITenantNamespace: "ai-tenants",
 			},
 			aitenant: &maasv1alpha1.AITenant{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "team-a",
-					Namespace: "redhat-ai-gateway-infra",
+					Namespace: "ai-tenants",
 				},
 			},
 			wantErr: false,
@@ -49,7 +49,7 @@ func TestAITenantValidator_ValidateCreate(t *testing.T) {
 		{
 			name: "reject aitenant outside configured namespace",
 			validator: &AITenantValidator{
-				AITenantNamespace: "redhat-ai-gateway-infra",
+				AITenantNamespace: "ai-tenants",
 			},
 			aitenant: &maasv1alpha1.AITenant{
 				ObjectMeta: metav1.ObjectMeta{
@@ -58,7 +58,7 @@ func TestAITenantValidator_ValidateCreate(t *testing.T) {
 				},
 			},
 			wantErr:     true,
-			errContains: `configured AITenant infrastructure namespace "redhat-ai-gateway-infra"`,
+			errContains: `configured AITenant infrastructure namespace "ai-tenants"`,
 		},
 		{
 			name: "allow aitenant in custom configured namespace",
@@ -79,7 +79,7 @@ func TestAITenantValidator_ValidateCreate(t *testing.T) {
 			aitenant: &maasv1alpha1.AITenant{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "team-a",
-					Namespace: "redhat-ai-gateway-infra",
+					Namespace: "ai-tenants",
 				},
 			},
 			wantErr:     true,
@@ -91,7 +91,7 @@ func TestAITenantValidator_ValidateCreate(t *testing.T) {
 			aitenant: &maasv1alpha1.AITenant{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "team-a",
-					Namespace: "redhat-ai-gateway-infra",
+					Namespace: "ai-tenants",
 				},
 			},
 			wantErr:     true,
@@ -116,19 +116,19 @@ func TestAITenantValidator_ValidateCreate(t *testing.T) {
 
 func TestAITenantValidator_ValidateUpdate(t *testing.T) {
 	validator := &AITenantValidator{
-		AITenantNamespace: "redhat-ai-gateway-infra",
+		AITenantNamespace: "ai-tenants",
 	}
 
 	oldAITenant := &maasv1alpha1.AITenant{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "team-a",
-			Namespace: "redhat-ai-gateway-infra",
+			Namespace: "ai-tenants",
 		},
 	}
 	newAITenant := &maasv1alpha1.AITenant{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "team-a",
-			Namespace: "redhat-ai-gateway-infra",
+			Namespace: "ai-tenants",
 		},
 	}
 
@@ -140,13 +140,13 @@ func TestAITenantValidator_ValidateUpdate(t *testing.T) {
 
 func TestAITenantValidator_ValidateDelete(t *testing.T) {
 	validator := &AITenantValidator{
-		AITenantNamespace: "redhat-ai-gateway-infra",
+		AITenantNamespace: "ai-tenants",
 	}
 
 	aitenant := &maasv1alpha1.AITenant{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "team-a",
-			Namespace: "redhat-ai-gateway-infra",
+			Namespace: "ai-tenants",
 		},
 	}
 

--- a/maas-controller/pkg/webhook/aitenant_webhook_test.go
+++ b/maas-controller/pkg/webhook/aitenant_webhook_test.go
@@ -1,0 +1,157 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	maasv1alpha1 "github.com/opendatahub-io/models-as-a-service/maas-controller/api/maas/v1alpha1"
+)
+
+func TestAITenantValidator_ValidateCreate(t *testing.T) {
+	tests := []struct {
+		name               string
+		validator          *AITenantValidator
+		aitenant           *maasv1alpha1.AITenant
+		wantErr            bool
+		errContains        string
+	}{
+		{
+			name: "allow aitenant in configured namespace",
+			validator: &AITenantValidator{
+				AITenantNamespace: "redhat-ai-gateway-infra",
+			},
+			aitenant: &maasv1alpha1.AITenant{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "team-a",
+					Namespace: "redhat-ai-gateway-infra",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "reject aitenant outside configured namespace",
+			validator: &AITenantValidator{
+				AITenantNamespace: "redhat-ai-gateway-infra",
+			},
+			aitenant: &maasv1alpha1.AITenant{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "team-a",
+					Namespace: "llm",
+				},
+			},
+			wantErr:     true,
+			errContains: `configured AITenant infrastructure namespace "redhat-ai-gateway-infra"`,
+		},
+		{
+			name: "allow aitenant in custom configured namespace",
+			validator: &AITenantValidator{
+				AITenantNamespace: "custom-infra",
+			},
+			aitenant: &maasv1alpha1.AITenant{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "team-a",
+					Namespace: "custom-infra",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:      "reject when validator is nil",
+			validator: nil,
+			aitenant: &maasv1alpha1.AITenant{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "team-a",
+					Namespace: "redhat-ai-gateway-infra",
+				},
+			},
+			wantErr:     true,
+			errContains: "webhook validator not configured",
+		},
+		{
+			name: "reject when configured namespace is empty",
+			validator: &AITenantValidator{},
+			aitenant: &maasv1alpha1.AITenant{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "team-a",
+					Namespace: "redhat-ai-gateway-infra",
+				},
+			},
+			wantErr:     true,
+			errContains: "AITenant infrastructure namespace is not configured",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := tt.validator.ValidateCreate(context.Background(), tt.aitenant)
+
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ValidateCreate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if tt.errContains != "" && (err == nil || !contains(err.Error(), tt.errContains)) {
+				t.Fatalf("ValidateCreate() error = %v, want error containing %q", err, tt.errContains)
+			}
+		})
+	}
+}
+
+func TestAITenantValidator_ValidateUpdate(t *testing.T) {
+	validator := &AITenantValidator{
+		AITenantNamespace: "redhat-ai-gateway-infra",
+	}
+
+	oldAITenant := &maasv1alpha1.AITenant{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "team-a",
+			Namespace: "redhat-ai-gateway-infra",
+		},
+	}
+	newAITenant := &maasv1alpha1.AITenant{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "team-a",
+			Namespace: "redhat-ai-gateway-infra",
+		},
+	}
+
+	_, err := validator.ValidateUpdate(context.Background(), oldAITenant, newAITenant)
+	if err != nil {
+		t.Fatalf("ValidateUpdate() unexpected error: %v", err)
+	}
+}
+
+func TestAITenantValidator_ValidateDelete(t *testing.T) {
+	validator := &AITenantValidator{
+		AITenantNamespace: "redhat-ai-gateway-infra",
+	}
+
+	aitenant := &maasv1alpha1.AITenant{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "team-a",
+			Namespace: "redhat-ai-gateway-infra",
+		},
+	}
+
+	_, err := validator.ValidateDelete(context.Background(), aitenant)
+	if err != nil {
+		t.Fatalf("ValidateDelete() unexpected error: %v", err)
+	}
+}

--- a/maas-controller/pkg/webhook/aitenant_webhook_test.go
+++ b/maas-controller/pkg/webhook/aitenant_webhook_test.go
@@ -27,11 +27,11 @@ import (
 
 func TestAITenantValidator_ValidateCreate(t *testing.T) {
 	tests := []struct {
-		name               string
-		validator          *AITenantValidator
-		aitenant           *maasv1alpha1.AITenant
-		wantErr            bool
-		errContains        string
+		name        string
+		validator   *AITenantValidator
+		aitenant    *maasv1alpha1.AITenant
+		wantErr     bool
+		errContains string
 	}{
 		{
 			name: "allow aitenant in configured namespace",
@@ -86,7 +86,7 @@ func TestAITenantValidator_ValidateCreate(t *testing.T) {
 			errContains: "webhook validator not configured",
 		},
 		{
-			name: "reject when configured namespace is empty",
+			name:      "reject when configured namespace is empty",
 			validator: &AITenantValidator{},
 			aitenant: &maasv1alpha1.AITenant{
 				ObjectMeta: metav1.ObjectMeta{

--- a/test/e2e/tests/test_aitenant_lifecycle.py
+++ b/test/e2e/tests/test_aitenant_lifecycle.py
@@ -264,12 +264,13 @@ class TestAITenantLifecycle:
             )
 
             assert result.returncode != 0, "Expected webhook to reject AITenant outside the configured infra namespace"
-            assert "admission webhook" in result.stderr.lower(), \
-                f"Expected webhook rejection, got: {result.stderr}"
-            assert "configured AITenant infrastructure namespace" in result.stderr, \
-                f"Expected namespace placement error, got: {result.stderr}"
-            assert AITENANT_NAMESPACE in result.stderr, \
-                f"Expected configured infra namespace in error, got: {result.stderr}"
+            combined = f"{result.stderr or ''}\n{result.stdout or ''}"
+            assert "admission webhook" in combined.lower(), \
+                f"Expected webhook rejection, got: {combined}"
+            assert "configured AITenant infrastructure namespace" in combined, \
+                f"Expected namespace placement error, got: {combined}"
+            assert AITENANT_NAMESPACE in combined, \
+                f"Expected configured infra namespace in error, got: {combined}"
 
             assert _get_json_or_none(AITENANT_KIND, aitenant_name, wrong_ns) is None
 

--- a/test/e2e/tests/test_aitenant_lifecycle.py
+++ b/test/e2e/tests/test_aitenant_lifecycle.py
@@ -234,7 +234,7 @@ def _delete_aitenant(case):
 class TestAITenantLifecycle:
     # TODO: Add e2e coverage that Policies, Subscriptions, Models, and inference requests
     # work end-to-end in a newly created AITenant tenant namespace.
-    def test_aitenant_rejected_outside_infra_namespace(self):
+    def test_aitenant_rejected_outside_ai_tenants_namespace(self):
         suffix = uuid.uuid4().hex[:8]
         wrong_ns = f"e2e-ait-wrong-{suffix}"
         tenant_ns = f"e2e-ait-wrong-tenant-{suffix}"

--- a/test/e2e/tests/test_aitenant_lifecycle.py
+++ b/test/e2e/tests/test_aitenant_lifecycle.py
@@ -234,6 +234,49 @@ def _delete_aitenant(case):
 class TestAITenantLifecycle:
     # TODO: Add e2e coverage that Policies, Subscriptions, Models, and inference requests
     # work end-to-end in a newly created AITenant tenant namespace.
+    def test_aitenant_rejected_outside_infra_namespace(self):
+        suffix = uuid.uuid4().hex[:8]
+        wrong_ns = f"e2e-ait-wrong-{suffix}"
+        tenant_ns = f"e2e-ait-wrong-tenant-{suffix}"
+        aitenant_name = f"e2e-ait-wrong-{suffix}"
+
+        try:
+            result = _oc_run(["create", "namespace", wrong_ns])
+            assert result.returncode == 0, f"Failed to create namespace: {result.stderr.strip() or result.stdout.strip()}"
+
+            result = _oc_run(
+                ["apply", "-f", "-"],
+                input_text=json.dumps(
+                    {
+                        "apiVersion": "maas.opendatahub.io/v1alpha1",
+                        "kind": "AITenant",
+                        "metadata": {
+                            "name": aitenant_name,
+                            "namespace": wrong_ns,
+                        },
+                        "spec": {
+                            "tenantNamespace": {
+                                "name": tenant_ns,
+                            },
+                        },
+                    }
+                ),
+            )
+
+            assert result.returncode != 0, "Expected webhook to reject AITenant outside the configured infra namespace"
+            assert "admission webhook" in result.stderr.lower(), \
+                f"Expected webhook rejection, got: {result.stderr}"
+            assert "configured AITenant infrastructure namespace" in result.stderr, \
+                f"Expected namespace placement error, got: {result.stderr}"
+            assert AITENANT_NAMESPACE in result.stderr, \
+                f"Expected configured infra namespace in error, got: {result.stderr}"
+
+            assert _get_json_or_none(AITENANT_KIND, aitenant_name, wrong_ns) is None
+
+        finally:
+            _delete_best_effort(AITENANT_KIND, aitenant_name, wrong_ns)
+            _delete_best_effort("namespace", wrong_ns, timeout="90s")
+
     def test_aitenant_create_bootstrap_resources(self):
         case = _new_aitenant_case()
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
https://redhat.atlassian.net/browse/RHOAIENG-59812

## Description
<!--- Describe your changes in detail -->
Rejecting AITenant outside configured AITenant namespace by adding a webhook.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tried to apply AITenant outside configured AITenant namespace and got `admission webhook "vaitenant.kb.io" denied the request: AITenant llm/test-aitenant must be created in the configured AITenant infrastructure namespace "ai-tenants"`

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Breaking Changes**
  * `AITenant` resources created outside the configured `--aitenant-namespace` are now rejected immediately by a validating admission webhook (instead of being accepted and later marked failed).

* **Documentation**
  * Added troubleshooting steps for `AITenant` creation failures, including how to find the configured infrastructure namespace.
  * Clarified in the `AITenant` reference that out-of-namespace creations are rejected before persistence.

* **Tests**
  * Added unit tests for webhook namespace validation and an E2E test ensuring out-of-namespace `AITenant` creation is denied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->