### PR TITLE
feat: add Loki-based usage dashboards with Perses datasources

### DIFF
--- a/deployment/base/maas-controller/base/params.env
+++ b/deployment/base/maas-controller/base/params.env
@@ -2,5 +2,6 @@ maas-api-image=quay.io/opendatahub/maas-api:odh-stable
 maas-controller-image=quay.io/opendatahub/maas-controller:odh-stable
 payload-processing-image=quay.io/opendatahub/odh-ai-gateway-payload-processing:odh-stable
 maas-api-key-cleanup-image=registry.redhat.io/ubi9/ubi-minimal:9.7
+usage-logs-tenancy-proxy-image=registry.redhat.io/ubi9/python-312
 monitoring-namespace=opendatahub
 infrastructure-namespace=AUTO

--- a/deployment/base/maas-controller/default/params.env
+++ b/deployment/base/maas-controller/default/params.env
@@ -2,4 +2,5 @@ maas-api-image=quay.io/opendatahub/maas-api:latest
 maas-controller-image=quay.io/opendatahub/maas-controller:latest
 payload-processing-image=quay.io/opendatahub/odh-ai-gateway-payload-processing:odh-stable
 maas-api-key-cleanup-image=registry.redhat.io/ubi9/ubi-minimal:9.7
+usage-logs-tenancy-proxy-image=registry.redhat.io/ubi9/python-312
 monitoring-namespace=opendatahub

--- a/deployment/base/maas-controller/manager/manager.yaml
+++ b/deployment/base/maas-controller/manager/manager.yaml
@@ -74,6 +74,12 @@ spec:
                 key: maas-api-key-cleanup-image
                 name: maas-parameters
                 optional: true
+          - name: RELATED_IMAGE_ODH_PYTHON_312_IMAGE
+            valueFrom:
+              configMapKeyRef:
+                key: usage-logs-tenancy-proxy-image
+                name: maas-parameters
+                optional: true
           - name: MONITORING_NAMESPACE
             valueFrom:
               configMapKeyRef:

--- a/deployment/components/observability/usage-logs/kustomization.yaml
+++ b/deployment/components/observability/usage-logs/kustomization.yaml
@@ -7,3 +7,5 @@ resources:
   - tenancy-proxy-code.yaml
   - tenancy-proxy-rbac.yaml
   - tenancy-proxy.yaml
+  - usage-logs-admin-dashboard.yaml
+  - usage-logs-dashboard.yaml

--- a/deployment/components/observability/usage-logs/kustomization.yaml
+++ b/deployment/components/observability/usage-logs/kustomization.yaml
@@ -4,3 +4,6 @@ kind: Kustomization
 resources:
   - otel-collector.yaml
   - otel-collector-rbac.yaml
+  - tenancy-proxy-code.yaml
+  - tenancy-proxy-rbac.yaml
+  - tenancy-proxy.yaml

--- a/deployment/components/observability/usage-logs/tenancy-proxy-code.yaml
+++ b/deployment/components/observability/usage-logs/tenancy-proxy-code.yaml
@@ -1,0 +1,538 @@
+# Loki Query Proxy -- Python stdlib-only implementation
+# Runs on ubi9/python-312 base image with zero external dependencies.
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: loki-query-proxy-source
+  namespace: opendatahub
+  labels:
+    app: loki-query-proxy
+    app.kubernetes.io/managed-by: maas-controller
+    app.kubernetes.io/component: loki-proxy
+data:
+  main.py: |
+    #!/usr/bin/env python3
+    """Loki Query Proxy - stdlib-only implementation."""
+    import contextvars
+    import hashlib
+    import json
+    import logging
+    import os
+    import ssl
+    import sys
+    import time
+    import uuid
+    from http.server import ThreadingHTTPServer, BaseHTTPRequestHandler
+    from threading import Lock
+    from urllib.parse import urlparse, parse_qs, urlencode, urljoin
+
+    from auth import extract_from_bearer_token, create_ssl_context
+    from rewriter import inject_user_filter
+
+    # Context variable for request ID
+    request_id_var = contextvars.ContextVar('request_id', default='')
+
+    # Simple in-memory cache for query results
+    query_cache = {}
+    cache_lock = Lock()
+    CACHE_TTL_SECONDS = 30  # Cache responses for 30 seconds
+
+    class RequestIDFilter(logging.Filter):
+        """Inject request ID into log records."""
+        def filter(self, record):
+            record.request_id = request_id_var.get() or '-'
+            return True
+
+    # Configure logging with request ID support
+    log_level = os.getenv('LOG_LEVEL', 'INFO').upper()
+    logging.basicConfig(
+        level=getattr(logging, log_level, logging.INFO),
+        format="%(asctime)s [%(levelname)s] [%(request_id)s] %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+    # Add filter to all handlers so request_id is available in all log records
+    for handler in logging.getLogger().handlers:
+        handler.addFilter(RequestIDFilter())
+    logger = logging.getLogger(__name__)
+
+    # Global configuration
+    ssl_context = None
+    token_review_url = None
+
+    ALLOWED_PATHS = {
+        "/loki/api/v1/query",
+        "/loki/api/v1/query_range",
+        "/loki/api/v1/index/stats",
+        "/loki/api/v1/index/volume",
+        "/loki/api/v1/index/volume_range",
+        "/loki/api/v1/labels",
+        "/loki/api/v1/series",
+        "/health",
+        "/ready",
+    }
+
+    HOP_BY_HOP_HEADERS = {
+        "connection",
+        "keep-alive",
+        "proxy-authenticate",
+        "proxy-authorization",
+        "te",
+        "trailers",
+        "transfer-encoding",
+        "upgrade",
+        "authorization",
+        "content-length",
+    }
+
+
+    def is_allowed_path(path):
+        """Check if path is allowed."""
+        if path in ALLOWED_PATHS:
+            return True
+        if path.startswith("/loki/api/v1/label/") and path.endswith("/values"):
+            return True
+        return False
+
+
+    class ProxyHandler(BaseHTTPRequestHandler):
+        """HTTP request handler for the Loki proxy."""
+
+        protocol_version = "HTTP/1.1"
+
+        def log_message(self, format, *args):
+            """Suppress default logging - we handle it ourselves."""
+            pass
+
+        def send_json_error(self, msg, code):
+            """Send JSON error response."""
+            self.send_response(code)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            response = {
+                "status": "error",
+                "error": msg,
+                "errorType": "proxy",
+                "data": None,
+            }
+            self.wfile.write(json.dumps(response).encode())
+
+        def do_GET(self):
+            """Handle GET requests."""
+            # Generate unique request ID for log correlation
+            req_id = str(uuid.uuid4())[:8]
+            request_id_var.set(req_id)
+
+            logger.info(f"REQ GET {self.path}")
+
+            # Health check endpoints
+            if self.path in ("/health", "/ready"):
+                try:
+                    self.send_response(200)
+                    self.send_header("Content-Type", "text/plain")
+                    self.end_headers()
+                    self.wfile.write(b"OK\n")
+                except (BrokenPipeError, ConnectionResetError):
+                    # Kubernetes probes may close connection early - this is normal
+                    pass
+                return
+
+            # Authenticate and extract username
+            auth_header = self.headers.get("Authorization", "")
+            if not auth_header:
+                logger.error("Missing Authorization header")
+                self.send_json_error("Unauthorized", 401)
+                return
+
+            try:
+                user_info = extract_from_bearer_token(
+                    auth_header, token_review_url, ssl_context
+                )
+            except Exception as e:
+                logger.error(f"Auth extraction failed: {e}")
+                self.send_json_error("Unauthorized", 401)
+                return
+
+            username = user_info.username
+
+            # Parse path and check if allowed
+            parsed = urlparse(self.path)
+            if not is_allowed_path(parsed.path):
+                logger.warning(f"Blocked access to {parsed.path} for user={username}")
+                self.send_json_error("Forbidden: endpoint not available", 403)
+                return
+
+            # Parse and rewrite query parameters
+            query_params = parse_qs(parsed.query, keep_blank_values=True)
+
+            if "query" in query_params:
+                original_query = query_params["query"][0]
+                # Label values endpoints only support label matchers, not pipeline filters
+                is_label_values = parsed.path.startswith("/loki/api/v1/label/") and parsed.path.endswith("/values")
+                rewritten_query = inject_user_filter(original_query, username, labels_only=is_label_values)
+                query_params["query"] = [rewritten_query]
+                logger.debug(
+                    f"Query rewritten for user={username} (labels_only={is_label_values}): "
+                    f"original={original_query} -> rewritten={rewritten_query}"
+                )
+
+            # Build upstream URL
+            upstream_parsed = urlparse(loki_upstream)
+            upstream_path = upstream_parsed.path + parsed.path
+            if query_params:
+                query_string = urlencode(query_params, doseq=True)
+                upstream_url = f"{upstream_parsed.scheme}://{upstream_parsed.netloc}{upstream_path}?{query_string}"
+            else:
+                upstream_url = f"{upstream_parsed.scheme}://{upstream_parsed.netloc}{upstream_path}"
+
+            # Prepare upstream request
+            from urllib.request import Request, urlopen
+
+            # Copy headers, excluding hop-by-hop
+            headers = {}
+            for key, value in self.headers.items():
+                if key.lower() not in HOP_BY_HOP_HEADERS:
+                    headers[key] = value
+
+            headers["Host"] = upstream_parsed.netloc
+            headers["X-Scope-OrgID"] = "application"
+
+            # Add service account token for upstream authentication
+            try:
+                with open("/var/run/secrets/kubernetes.io/serviceaccount/token", "r") as f:
+                    sa_token = f.read().strip()
+                    headers["Authorization"] = f"Bearer {sa_token}"
+            except OSError:
+                pass
+
+            # Check cache (cache key = rewritten query + user)
+            cache_key = hashlib.sha256(f"{username}:{upstream_url}".encode()).hexdigest()
+            with cache_lock:
+                if cache_key in query_cache:
+                    cached_entry = query_cache[cache_key]
+                    if time.time() - cached_entry["timestamp"] < CACHE_TTL_SECONDS:
+                        logger.info(f"CACHE HIT {parsed.path}")
+                        self.send_response(cached_entry["code"])
+                        for key, value in cached_entry["headers"].items():
+                            self.send_header(key, value)
+                        self.end_headers()
+                        self.wfile.write(cached_entry["body"])
+                        return
+                    else:
+                        # Expired entry
+                        del query_cache[cache_key]
+
+            # Make upstream request
+            try:
+                from urllib.error import HTTPError
+                req = Request(upstream_url, headers=headers, method="GET")
+                start_time = time.time()
+                with urlopen(req, timeout=60, context=ssl_context) as resp:
+                    resp_body = resp.read()
+                    resp_code = resp.status
+                    resp_headers = resp.headers
+
+                elapsed_ms = int((time.time() - start_time) * 1000)
+                if elapsed_ms > 3000:
+                    logger.warning(f"SLOW QUERY {elapsed_ms}ms {parsed.path}")
+                logger.info(f"RESP {parsed.path} {resp_code} ({len(resp_body)} bytes) {elapsed_ms}ms")
+
+                # Handle non-JSON error responses
+                is_json = len(resp_body) > 0 and resp_body[0:1] in (b"{", b"[")
+                if resp_code >= 400 and not is_json:
+                    err_msg = resp_body.decode("utf-8", errors="replace").strip()
+                    if not err_msg:
+                        err_msg = f"Loki returned HTTP {resp_code}"
+                    logger.error(f"Upstream non-JSON error {resp_code}: {err_msg[:200]}")
+                    self.send_json_error(err_msg, resp_code)
+                    return
+
+                # Filter hop-by-hop headers for forwarding
+                filtered_headers = {
+                    k: v for k, v in resp_headers.items()
+                    if k.lower() not in HOP_BY_HOP_HEADERS
+                }
+                filtered_headers["Content-Length"] = str(len(resp_body))
+
+                # Store successful responses in cache (with filtered headers)
+                if resp_code == 200:
+                    with cache_lock:
+                        query_cache[cache_key] = {
+                            "timestamp": time.time(),
+                            "code": resp_code,
+                            "headers": filtered_headers,
+                            "body": resp_body,
+                        }
+                        # Simple cache size limit (keep last 100 entries)
+                        if len(query_cache) > 100:
+                            oldest_key = min(query_cache.keys(), key=lambda k: query_cache[k]["timestamp"])
+                            del query_cache[oldest_key]
+
+                # Forward response
+                self.send_response(resp_code)
+                for key, value in filtered_headers.items():
+                    self.send_header(key, value)
+                self.end_headers()
+                self.wfile.write(resp_body)
+
+            except HTTPError as e:
+                # Log the error response body
+                try:
+                    error_body = e.read().decode('utf-8', errors='replace')
+                    logger.error(f"Upstream HTTP {e.code} error body: {error_body[:500]}")
+                except:
+                    logger.error(f"Upstream HTTP {e.code}: {e.reason}")
+                self.send_json_error(f"Bad gateway: HTTP {e.code} {e.reason}", 502)
+            except Exception as e:
+                logger.error(f"Upstream request failed: {type(e).__name__}: {e}")
+                self.send_json_error("Bad gateway: upstream request failed", 502)
+
+
+    def initialize():
+        """Initialize global configuration."""
+        global loki_upstream, ssl_context, token_review_url
+
+        loki_upstream = os.getenv("LOKI_UPSTREAM_URL")
+        if not loki_upstream:
+            logger.fatal(f"Failed to load loki_upstream: {e}")
+            sys.exit(1)
+
+        # Create SSL context with CA certificates
+        ssl_context = create_ssl_context()
+
+        # Build TokenReview URL
+        api_host = os.getenv("KUBERNETES_SERVICE_HOST")
+        api_port = os.getenv("KUBERNETES_SERVICE_PORT", "443")
+        token_review_url = (
+            f"https://{api_host}:{api_port}/apis/authentication.k8s.io/v1/tokenreviews"
+        )
+        logger.info(f"TokenReview endpoint: {token_review_url}")
+
+
+    def main():
+        """Main entry point."""
+        initialize()
+
+        port = os.getenv("PORT", "8080")
+        server = ThreadingHTTPServer(("0.0.0.0", int(port)), ProxyHandler)
+        logger.info(f"Proxy listening on ::{port}")
+        try:
+            server.serve_forever()
+        except KeyboardInterrupt:
+            logger.info("Shutting down")
+            server.shutdown()
+
+
+    if __name__ == "__main__":
+        main()
+
+  auth.py: |
+    """Authentication via Kubernetes TokenReview API."""
+    import json
+    import logging
+    import os
+    import ssl
+    from urllib.request import Request, urlopen
+
+    SA_TOKEN_PATH = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    logger = logging.getLogger(__name__)
+
+
+    class UserInfo:
+        """User information extracted from token."""
+
+        def __init__(self, username):
+            self.username = username
+
+
+    def create_ssl_context():
+        """Create SSL context with Kubernetes CA certificates."""
+        ca_paths = [
+            "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt",
+            "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
+        ]
+
+        context = ssl.create_default_context()
+
+        for ca_path in ca_paths:
+            try:
+                context.load_verify_locations(ca_path)
+                logger.info(f"Loaded CA certificate from {ca_path}")
+            except OSError:
+                pass
+
+        return context
+
+
+    def extract_from_bearer_token(auth_header, token_review_url, ssl_context):
+        """
+        Extract user info from Authorization: Bearer <token>.
+
+        All tokens are validated server-side via the Kubernetes TokenReview API.
+        """
+        if not auth_header:
+            raise ValueError("missing Authorization header")
+
+        parts = auth_header.split(" ", 1)
+        if len(parts) != 2 or parts[0].lower() != "bearer":
+            raise ValueError("invalid Authorization header format")
+
+        return resolve_token(parts[1], token_review_url, ssl_context)
+
+
+    def resolve_token(token, token_review_url, ssl_context):
+        """
+        Call the Kubernetes TokenReview API to validate bearer token.
+
+        This is the sole authentication path -- tokens are never parsed or
+        trusted locally.
+        """
+        try:
+            with open(SA_TOKEN_PATH, "r") as f:
+                sa_token = f.read().strip()
+        except OSError as e:
+            raise ValueError(f"cannot read SA token for TokenReview: {e}") from e
+
+        body = {
+            "apiVersion": "authentication.k8s.io/v1",
+            "kind": "TokenReview",
+            "spec": {"token": token},
+        }
+
+        body_bytes = json.dumps(body).encode("utf-8")
+
+        req = Request(
+            token_review_url,
+            data=body_bytes,
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {sa_token}",
+            },
+            method="POST",
+        )
+
+        try:
+            with urlopen(req, timeout=10, context=ssl_context) as resp:
+                resp_body = resp.read()
+                resp_code = resp.status
+        except Exception as e:
+            raise ValueError(f"TokenReview request failed: {e}") from e
+
+        if resp_code not in (200, 201):
+            raise ValueError(f"TokenReview returned HTTP {resp_code}")
+
+        try:
+            result = json.loads(resp_body)
+        except json.JSONDecodeError as e:
+            raise ValueError(f"failed to parse TokenReview response: {e}") from e
+
+        status = result.get("status", {})
+        if not status.get("authenticated", False):
+            error_msg = status.get("error", "token not authenticated")
+            raise ValueError(f"TokenReview: {error_msg}")
+
+        user = status.get("user", {})
+        username = user.get("username", "")
+        if not username:
+            raise ValueError("TokenReview returned empty username")
+
+        return UserInfo(username=username)
+
+  rewriter.py: |
+    """LogQL query rewriting to inject user filters."""
+
+
+    def escape_logql_value(value):
+        """Escape special characters in LogQL values."""
+        value = value.replace("\\", "\\\\")
+        value = value.replace('"', '\\"')
+        return value
+
+
+    def inject_user_filter(query, username, labels_only=False):
+        """
+        Inject user filter into LogQL query.
+
+        Modifies stream selectors to add kubernetes_namespace_name="opendatahub" label.
+        If labels_only=False, also adds pipeline filter `| user_id="<user>"` after the selector.
+
+        Args:
+            query: LogQL query string
+            username: User identifier to filter by
+            labels_only: If True, skip pipeline filter (for label values endpoints)
+
+        Examples:
+            Normal query (labels_only=False):
+                {app="x"} | line_format "{{.msg}}"
+             -> {app="x", kubernetes_namespace_name="opendatahub"} | user_id="alice" | line_format "{{.msg}}"
+
+            Empty selector (labels_only=False):
+                {}
+             -> {kubernetes_namespace_name="opendatahub"} | user_id="alice"
+
+            Label values query (labels_only=True):
+                {app="x"}
+             -> {app="x", kubernetes_namespace_name="opendatahub"}
+        """
+        if not query or not username:
+            return query
+
+        namespace_label = 'kubernetes_namespace_name="opendatahub"'
+        user_filter = '' if labels_only else f' | user_id="{escape_logql_value(username)}"'
+        result = []
+        in_selector = False
+        selector_start_pos = -1
+        in_double_quote = False
+        in_backtick = False
+        i = 0
+
+        while i < len(query):
+            ch = query[i]
+
+            # Handle escape sequences in double quotes
+            if ch == "\\" and in_double_quote and i + 1 < len(query):
+                result.append(ch)
+                i += 1
+                result.append(query[i])
+                i += 1
+                continue
+
+            # Toggle quote states
+            if ch == '"' and not in_backtick:
+                in_double_quote = not in_double_quote
+            if ch == "`" and not in_double_quote:
+                in_backtick = not in_backtick
+
+            in_quote = in_double_quote or in_backtick
+
+            # Track selector braces
+            if ch == "{" and not in_quote:
+                in_selector = True
+                selector_start_pos = len(result)
+                result.append(ch)
+                i += 1
+                continue
+
+            # Inject namespace label and optionally user filter before closing selector brace
+            if ch == "}" and in_selector and not in_quote:
+                # Check if selector is empty by looking at content since '{'
+                selector_content = "".join(result[selector_start_pos + 1:]).strip()
+                is_empty = len(selector_content) == 0
+
+                # Add comma only if selector has existing matchers
+                if is_empty:
+                    result.append(namespace_label)
+                else:
+                    result.append(", ")
+                    result.append(namespace_label)
+
+                result.append(ch)
+                result.append(user_filter)
+                in_selector = False
+            else:
+                result.append(ch)
+
+            i += 1
+
+        return "".join(result)

--- a/deployment/components/observability/usage-logs/tenancy-proxy-rbac.yaml
+++ b/deployment/components/observability/usage-logs/tenancy-proxy-rbac.yaml
@@ -1,0 +1,92 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: loki-query-proxy
+  namespace: opendatahub
+  labels:
+    app: loki-query-proxy
+    app.kubernetes.io/managed-by: maas-controller
+    app.kubernetes.io/component: loki-proxy
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: loki-query-proxy-logs
+  labels:
+    app: loki-query-proxy
+    app.kubernetes.io/managed-by: maas-controller
+    app.kubernetes.io/component: loki-proxy
+rules:
+- apiGroups:
+  - ''
+  resources:
+  - pods/log
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: loki-query-proxy-logging-view
+  namespace: opendatahub
+  labels:
+    app: loki-query-proxy
+    app.kubernetes.io/managed-by: maas-controller
+    app.kubernetes.io/component: loki-proxy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: loki-query-proxy-logs
+subjects:
+- kind: ServiceAccount
+  name: loki-query-proxy
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: loki-query-proxy-logging-view-custom
+  namespace: opendatahub
+  labels:
+    app: loki-query-proxy
+    app.kubernetes.io/component: loki-proxy
+    app.kubernetes.io/managed-by: maas-controller
+subjects:
+  - kind: ServiceAccount
+    name: loki-query-proxy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-logging-application-view
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: loki-query-proxy-tokenreview
+  labels:
+    app: loki-query-proxy
+    app.kubernetes.io/managed-by: maas-controller
+    app.kubernetes.io/component: loki-proxy
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: loki-query-proxy-tokenreview
+  labels:
+    app: loki-query-proxy
+    app.kubernetes.io/managed-by: maas-controller
+    app.kubernetes.io/component: loki-proxy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: loki-query-proxy-tokenreview
+subjects:
+- kind: ServiceAccount
+  name: loki-query-proxy
+  namespace: opendatahub

--- a/deployment/components/observability/usage-logs/tenancy-proxy.yaml
+++ b/deployment/components/observability/usage-logs/tenancy-proxy.yaml
@@ -1,0 +1,96 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: usage-logs-tenancy-proxy
+  namespace: opendatahub
+  labels:
+    app: loki-query-proxy
+    app.kubernetes.io/managed-by: maas-controller
+    app.kubernetes.io/component: loki-proxy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: loki-query-proxy
+  template:
+    metadata:
+      labels:
+        app: loki-query-proxy
+    spec:
+      serviceAccountName: loki-query-proxy
+      containers:
+      - name: proxy
+        # Image is set by controller (DefaultUsageLogsTenancyProxyImage or RELATED_IMAGE override)
+        command:
+        - python3
+        - /opt/app-root/src/proxy/main.py
+        securityContext:
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        env:
+        - name: PORT
+          value: "8080"
+        # Override via kustomize patch for your LokiStack service name/namespace.
+        - name: LOKI_UPSTREAM_URL
+          value: "https://maas-loki-gateway-http.opendatahub.svc.cluster.local:8080/api/logs/v1/application"
+        - name: PYTHONPATH
+          value: "/opt/app-root/src/proxy"
+        - name: PYTHONUNBUFFERED
+          value: "1"
+        - name: LOG_LEVEL
+          value: "INFO"
+        volumeMounts:
+        - name: proxy-source
+          mountPath: /opt/app-root/src/proxy
+          readOnly: true
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 30
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          requests:
+            cpu: 50m
+            memory: 128Mi
+          limits:
+            cpu: 200m
+            memory: 256Mi
+      volumes:
+      - name: proxy-source
+        configMap:
+          name: loki-query-proxy-source
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: usage-logs-tenancy-proxy
+  namespace: opendatahub
+  labels:
+    app: loki-query-proxy
+    app.kubernetes.io/managed-by: maas-controller
+    app.kubernetes.io/component: loki-proxy
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8080
+    targetPort: 8080
+    protocol: TCP
+    name: http
+  selector:
+    app: loki-query-proxy

--- a/deployment/components/observability/usage-logs/usage-logs-admin-dashboard.yaml
+++ b/deployment/components/observability/usage-logs/usage-logs-admin-dashboard.yaml
@@ -1,0 +1,478 @@
+# Admin usage dashboard — queries Loki structured logs via LogQL.
+# Uses $__range to bind LogQL windows to the native time picker.
+# LokiLabelValuesVariable for model/subscription dropdowns (COO 1.5+).
+# CEL filter restricts logs to inference-only paths; no probe traffic to filter.
+# customAllValue: ".*" on ListVariables ensures "All" matches entries with
+# absent labels (e.g. user_id when capturing is disabled). Do not remove.
+apiVersion: perses.dev/v1alpha1
+kind: PersesDashboard
+metadata:
+  name: dashboard-4-maas-usage-logs-admin
+  namespace: opendatahub
+  labels:
+    app.kubernetes.io/managed-by: maas-controller
+    app.kubernetes.io/component: perses
+spec:
+  display:
+    name: "All usage (logs)"
+    description: >-
+      Admin view of model usage. Shows token consumption, request counts,
+      rate limiting, and per-user breakdown across all users and subscriptions.
+  duration: 1h
+  variables:
+    - kind: ListVariable
+      spec:
+        name: user
+        display:
+          name: "User"
+        allowMultiple: true
+        allowAllValue: true
+        customAllValue: ".*"
+        defaultValue: "$__all"
+        plugin:
+          kind: LokiLabelValuesVariable
+          spec:
+            datasource:
+              kind: LokiDatasource
+              name: usage-logs
+            labelName: user_id
+            matchers:
+              - '{service_name="maas-gateway"}'
+    - kind: ListVariable
+      spec:
+        name: subscription
+        display:
+          name: "Subscription"
+        allowMultiple: true
+        allowAllValue: true
+        customAllValue: ".*"
+        defaultValue: "$__all"
+        plugin:
+          kind: LokiLabelValuesVariable
+          spec:
+            datasource:
+              kind: LokiDatasource
+              name: usage-logs
+            labelName: subscription
+            matchers:
+              - '{service_name="maas-gateway", subscription!="-"}'
+    - kind: ListVariable
+      spec:
+        name: model
+        display:
+          name: "Model"
+        allowMultiple: true
+        allowAllValue: true
+        customAllValue: ".*"
+        defaultValue: "$__all"
+        plugin:
+          kind: LokiLabelValuesVariable
+          spec:
+            datasource:
+              kind: LokiDatasource
+              name: usage-logs
+            labelName: model
+            matchers:
+              - '{service_name="maas-gateway", model!="-"}'
+    - kind: ListVariable
+      spec:
+        name: view_by
+        display:
+          name: "View by"
+        allowMultiple: false
+        allowAllValue: false
+        defaultValue: "model"
+        plugin:
+          kind: StaticListVariable
+          spec:
+            values:
+              - value: "model"
+                label: By model
+              - value: "subscription"
+                label: By subscription
+
+  panels:
+    totalTokens:
+      kind: Panel
+      spec:
+        display:
+          name: "Total tokens"
+          description: "Total tokens consumed over the selected time window."
+        plugin:
+          kind: StatChart
+          spec:
+            calculation: last
+            format:
+              unit: decimal
+              shortValues: true
+              decimalPlaces: 0
+        queries:
+          - kind: TimeSeriesQuery
+            spec:
+              plugin:
+                kind: LokiTimeSeriesQuery
+                spec:
+                  datasource:
+                    kind: LokiDatasource
+                    name: usage-logs
+                  query: >-
+                    sum(sum_over_time({service_name="maas-gateway",
+                    subscription=~"$subscription", model=~"$model", response_type="hit"}
+                    | user_id=~"$user"
+                    | unwrap tokens_total [$__range]))
+                    or vector(0)
+
+    totalRequests:
+      kind: Panel
+      spec:
+        display:
+          name: "Total requests"
+          description: "Total API requests over the selected time window."
+        plugin:
+          kind: StatChart
+          spec:
+            calculation: last
+            format:
+              unit: decimal
+              shortValues: true
+              decimalPlaces: 0
+        queries:
+          - kind: TimeSeriesQuery
+            spec:
+              plugin:
+                kind: LokiTimeSeriesQuery
+                spec:
+                  datasource:
+                    kind: LokiDatasource
+                    name: usage-logs
+                  query: >-
+                    sum(count_over_time({service_name="maas-gateway",
+                    subscription=~"$subscription", model=~"$model"}
+                    | user_id=~"$user" [$__range]))
+                    or vector(0)
+
+    totalRateLimited:
+      kind: Panel
+      spec:
+        display:
+          name: "Total rate limited"
+          description: "Total rate-limited requests over the selected time window."
+        plugin:
+          kind: StatChart
+          spec:
+            calculation: last
+            format:
+              unit: decimal
+              shortValues: true
+              decimalPlaces: 0
+        queries:
+          - kind: TimeSeriesQuery
+            spec:
+              plugin:
+                kind: LokiTimeSeriesQuery
+                spec:
+                  datasource:
+                    kind: LokiDatasource
+                    name: usage-logs
+                  query: >-
+                    sum(count_over_time({service_name="maas-gateway",
+                    subscription=~"$subscription", model=~"$model", response_type="rate_limit"}
+                    | user_id=~"$user" [$__range]))
+                    or vector(0)
+
+    successRate:
+      kind: Panel
+      spec:
+        display:
+          description: "Percentage of authorized vs total requests over the selected time window."
+          name: Success rate
+        plugin:
+          kind: StatChart
+          spec:
+            calculation: last
+            format:
+              decimalPlaces: 1
+              unit: percent-decimal
+        queries:
+          - kind: TimeSeriesQuery
+            spec:
+              plugin:
+                kind: LokiTimeSeriesQuery
+                spec:
+                  datasource:
+                    kind: LokiDatasource
+                    name: usage-logs
+                  query: >-
+                    (sum(count_over_time({service_name="maas-gateway",
+                    subscription=~"$subscription", model=~"$model", response_type="hit"}
+                    | user_id=~"$user" [$__range]))
+                    /
+                    sum(count_over_time({service_name="maas-gateway",
+                    subscription=~"$subscription", model=~"$model"}
+                    | user_id=~"$user" [$__range])))
+                    or vector(1)
+
+    activeUsers:
+      kind: Panel
+      spec:
+        display:
+          name: "Active users"
+          description: "Distinct users with API activity over the selected time window."
+        plugin:
+          kind: StatChart
+          spec:
+            calculation: last
+            format:
+              unit: decimal
+              decimalPlaces: 0
+        queries:
+          - kind: TimeSeriesQuery
+            spec:
+              plugin:
+                kind: LokiTimeSeriesQuery
+                spec:
+                  datasource:
+                    kind: LokiDatasource
+                    name: usage-logs
+                  query: >-
+                    count(sum by (user_id) (count_over_time({service_name="maas-gateway",
+                    subscription=~"$subscription", model=~"$model"}
+                    | user_id=~"$user" | user_id!="" | user_id!="-" [$__range])))
+                    or vector(0)
+
+    tokenConsumptionOverTime:
+      kind: Panel
+      spec:
+        display:
+          name: "Token consumption chart"
+          description: >-
+            Tokens from successful requests (2xx) over time by model or subscription.
+            **View by** drives chart ``sum by (${view_by:raw})``. Table uses hardcoded ``sum by (model, subscription)``.
+            LogQL ``[30m]`` is the range window for ``sum_over_time`` (Perses time-series step).
+            Visual: OpenShift Perses pattern — ``line`` + ``areaOpacity: 1`` + ``stack: all``.
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              position: bottom
+              mode: table
+              values: []
+            visual:
+              display: line
+              lineWidth: 3
+              areaOpacity: 1
+              connectNulls: true
+              stack: all
+              showPoints: always
+              pointRadius: 6
+            yAxis:
+              min: 0
+              format:
+                unit: decimal
+        queries:
+          - kind: TimeSeriesQuery
+            spec:
+              plugin:
+                kind: LokiTimeSeriesQuery
+                spec:
+                  datasource:
+                    kind: LokiDatasource
+                    name: usage-logs
+                  query: >-
+                    sum by (${view_by:raw}) (sum_over_time({service_name="maas-gateway",
+                    subscription=~"$subscription", model=~"$model", response_type="hit"}
+                    | user_id=~"$user"
+                    | unwrap tokens_total [30m]))
+
+    tokenConsumptionTable:
+      kind: Panel
+      spec:
+        display:
+          name: "Usage breakdown"
+          description: >-
+            All model/subscription pairs. **View by** changes the chart; table always shows full detail.
+        plugin:
+          kind: Table
+          spec:
+            density: "compact"
+            pagination: true
+            transforms:
+              - kind: "MergeSeries"
+                spec: {}
+            columnSettings:
+              - name: "timestamp"
+                hide: true
+              - name: "user_id"
+                header: "User"
+                align: "left"
+                enableSorting: true
+              - name: "model"
+                header: "Model"
+                align: "left"
+                enableSorting: true
+              - name: "subscription"
+                header: "Subscription"
+                align: "left"
+                enableSorting: true
+              - name: "value #1"
+                header: "Tokens used"
+                align: "right"
+                enableSorting: true
+                sort: "desc"
+                format:
+                  unit: decimal
+                  shortValues: true
+              - name: "value #2"
+                header: "Successful requests"
+                align: "right"
+                enableSorting: true
+                format:
+                  unit: decimal
+                  decimalPlaces: 0
+              - name: "value #3"
+                header: "Rate limited requests"
+                align: "right"
+                enableSorting: true
+                format:
+                  unit: decimal
+                  decimalPlaces: 0
+        queries:
+          - kind: TimeSeriesQuery
+            spec:
+              plugin:
+                kind: LokiTimeSeriesQuery
+                spec:
+                  datasource:
+                    kind: LokiDatasource
+                    name: usage-logs
+                  query: >-
+                    sum by (user_id, model, subscription) (sum_over_time(
+                    {service_name="maas-gateway",
+                    subscription=~"$subscription", model=~"$model", response_type="hit"}
+                    | user_id=~"$user"
+                    | unwrap tokens_total [$__range]))
+          - kind: TimeSeriesQuery
+            spec:
+              plugin:
+                kind: LokiTimeSeriesQuery
+                spec:
+                  datasource:
+                    kind: LokiDatasource
+                    name: usage-logs
+                  query: >-
+                    sum by (user_id, model, subscription) (count_over_time(
+                    {service_name="maas-gateway",
+                    subscription=~"$subscription", model=~"$model", response_type="hit"}
+                    | user_id=~"$user" [$__range]))
+          - kind: TimeSeriesQuery
+            spec:
+              plugin:
+                kind: LokiTimeSeriesQuery
+                spec:
+                  datasource:
+                    kind: LokiDatasource
+                    name: usage-logs
+                  query: >-
+                    sum by (user_id, model, subscription) (count_over_time(
+                    {service_name="maas-gateway",
+                    subscription=~"$subscription", model=~"$model", response_type="rate_limit"}
+                    | user_id=~"$user" [$__range]))
+                    or
+                    (sum by (user_id, model, subscription) (count_over_time(
+                    {service_name="maas-gateway",
+                    subscription=~"$subscription", model=~"$model", response_type="hit"}
+                    | user_id=~"$user" [$__range])) * 0)
+
+  layouts:
+    - kind: Grid
+      spec:
+        display:
+          title: "Overview"
+          collapse:
+            open: true
+        items:
+          - x: 0
+            "y": 0
+            width: 5
+            height: 5
+            content:
+              "$ref": "#/spec/panels/totalTokens"
+          - x: 5
+            "y": 0
+            width: 5
+            height: 5
+            content:
+              "$ref": "#/spec/panels/totalRequests"
+          - x: 10
+            "y": 0
+            width: 5
+            height: 5
+            content:
+              "$ref": "#/spec/panels/totalRateLimited"
+          - x: 15
+            "y": 0
+            width: 5
+            height: 5
+            content:
+              "$ref": "#/spec/panels/successRate"
+          - x: 20
+            "y": 0
+            width: 4
+            height: 5
+            content:
+              "$ref": "#/spec/panels/activeUsers"
+
+    - kind: Grid
+      spec:
+        display:
+          title: "Token consumption"
+          collapse:
+            open: true
+        items:
+          - x: 0
+            "y": 0
+            width: 24
+            height: 10
+            content:
+              "$ref": "#/spec/panels/tokenConsumptionOverTime"
+          - x: 0
+            "y": 10
+            width: 24
+            height: 8
+            content:
+              "$ref": "#/spec/panels/tokenConsumptionTable"
+---
+apiVersion: perses.dev/v1alpha1
+kind: PersesDatasource
+metadata:
+  name: usage-logs
+  namespace: opendatahub
+  labels:
+    app.kubernetes.io/managed-by: maas-controller
+    app.kubernetes.io/component: perses
+spec:
+  config:
+    display:
+      name: "All usage (logs)"
+    default: false
+    plugin:
+      kind: "LokiDatasource"
+      spec:
+        proxy:
+          kind: HTTPProxy
+          spec:
+            url: 'https://maas-loki-gateway-http.opendatahub.svc.cluster.local:8080/api/logs/v1/application'
+            allowedEndpoints:
+              - endpointPattern: "/loki/api/v1/.*"
+                method: GET
+            secret: usage-logs-secret
+  client:
+    kubernetesAuth:
+      enable: true
+    tls:
+      enable: true
+      insecureSkipVerify: false
+      caCert:
+        type: configmap
+        name: maas-loki-gateway-ca-bundle
+        certPath: service-ca.crt

--- a/deployment/components/observability/usage-logs/usage-logs-dashboard.yaml
+++ b/deployment/components/observability/usage-logs/usage-logs-dashboard.yaml
@@ -1,0 +1,416 @@
+# User-scoped usage dashboard — queries go through loki-query-proxy which
+# injects user_id filtering based on the logged-in user's Kubernetes token.
+# CEL filter restricts logs to inference-only paths; no probe traffic to filter.
+# customAllValue: ".*" on ListVariables ensures "All" matches entries with
+# absent labels (e.g. user_id when capturing is disabled). Do not remove.
+apiVersion: perses.dev/v1alpha1
+kind: PersesDashboard
+metadata:
+  name: dashboard-5-maas-usage-logs
+  namespace: opendatahub
+  labels:
+    app.kubernetes.io/managed-by: maas-controller
+    app.kubernetes.io/component: perses
+spec:
+  display:
+    name: "Usage (logs)"
+    description: >-
+      Personal view of model usage. Shows your token consumption, request
+      counts, and rate limiting. Queries are automatically filtered to your
+      user identity via the Loki query proxy.
+  duration: 1h
+
+  variables:
+    - kind: ListVariable
+      spec:
+        name: subscription
+        display:
+          name: "Subscription"
+        allowMultiple: true
+        allowAllValue: true
+        customAllValue: ".*"
+        defaultValue: "$__all"
+        plugin:
+          kind: LokiLabelValuesVariable
+          spec:
+            datasource:
+              kind: LokiDatasource
+              name: usage-logs-multi-tenancy
+            labelName: subscription
+            matchers:
+              - '{service_name="maas-gateway", subscription!="-"}'
+    - kind: ListVariable
+      spec:
+        name: model
+        display:
+          name: "Model"
+        allowMultiple: true
+        allowAllValue: true
+        customAllValue: ".*"
+        defaultValue: "$__all"
+        plugin:
+          kind: LokiLabelValuesVariable
+          spec:
+            datasource:
+              kind: LokiDatasource
+              name: usage-logs-multi-tenancy
+            labelName: model
+            matchers:
+              - '{service_name="maas-gateway", model!="-"}'
+    - kind: ListVariable
+      spec:
+        name: view_by
+        display:
+          name: "View by"
+        allowMultiple: false
+        allowAllValue: false
+        defaultValue: "model"
+        plugin:
+          kind: StaticListVariable
+          spec:
+            values:
+              - value: "model"
+                label: By model
+              - value: "subscription"
+                label: By subscription
+
+  panels:
+    totalTokens:
+      kind: Panel
+      spec:
+        display:
+          name: "Total tokens"
+          description: "Total tokens consumed over the selected time window."
+        plugin:
+          kind: StatChart
+          spec:
+            calculation: last
+            format:
+              unit: decimal
+              shortValues: true
+              decimalPlaces: 0
+        queries:
+          - kind: TimeSeriesQuery
+            spec:
+              plugin:
+                kind: LokiTimeSeriesQuery
+                spec:
+                  datasource:
+                    kind: LokiDatasource
+                    name: usage-logs-multi-tenancy
+                  query: >-
+                    sum(sum_over_time({service_name="maas-gateway",
+                    subscription=~"$subscription", model=~"$model", response_type="hit"}
+                    | unwrap tokens_total [$__range]))
+                    or vector(0)
+
+    totalRequests:
+      kind: Panel
+      spec:
+        display:
+          name: "Total requests"
+          description: "Total API requests over the selected time window."
+        plugin:
+          kind: StatChart
+          spec:
+            calculation: last
+            format:
+              unit: decimal
+              shortValues: true
+              decimalPlaces: 0
+        queries:
+          - kind: TimeSeriesQuery
+            spec:
+              plugin:
+                kind: LokiTimeSeriesQuery
+                spec:
+                  datasource:
+                    kind: LokiDatasource
+                    name: usage-logs-multi-tenancy
+                  query: >-
+                    sum(count_over_time({service_name="maas-gateway",
+                    subscription=~"$subscription", model=~"$model"}
+                    [$__range]))
+                    or vector(0)
+
+    totalRateLimited:
+      kind: Panel
+      spec:
+        display:
+          name: "Total rate limited"
+          description: "Total rate-limited requests over the selected time window."
+        plugin:
+          kind: StatChart
+          spec:
+            calculation: last
+            format:
+              unit: decimal
+              shortValues: true
+              decimalPlaces: 0
+        queries:
+          - kind: TimeSeriesQuery
+            spec:
+              plugin:
+                kind: LokiTimeSeriesQuery
+                spec:
+                  datasource:
+                    kind: LokiDatasource
+                    name: usage-logs-multi-tenancy
+                  query: >-
+                    sum(count_over_time({service_name="maas-gateway",
+                    subscription=~"$subscription", model=~"$model", response_type="rate_limit"}
+                    [$__range]))
+                    or vector(0)
+
+    successRate:
+      kind: Panel
+      spec:
+        display:
+          description: "Percentage of authorized vs total requests over the selected time window."
+          name: Success rate
+        plugin:
+          kind: StatChart
+          spec:
+            calculation: last
+            format:
+              decimalPlaces: 1
+              unit: percent-decimal
+        queries:
+          - kind: TimeSeriesQuery
+            spec:
+              plugin:
+                kind: LokiTimeSeriesQuery
+                spec:
+                  datasource:
+                    kind: LokiDatasource
+                    name: usage-logs-multi-tenancy
+                  query: >-
+                    (sum(count_over_time({service_name="maas-gateway",
+                    subscription=~"$subscription", model=~"$model", response_type="hit"}
+                    [$__range]))
+                    /
+                    sum(count_over_time({service_name="maas-gateway",
+                    subscription=~"$subscription", model=~"$model"}
+                    [$__range])))
+                    or vector(1)
+
+    tokenConsumptionOverTime:
+      kind: Panel
+      spec:
+        display:
+          name: "Token consumption chart"
+          description: >-
+            Tokens from successful requests (2xx) over time by model or subscription.
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              position: bottom
+              mode: table
+              values: []
+            visual:
+              display: line
+              lineWidth: 3
+              areaOpacity: 1
+              connectNulls: true
+              stack: all
+              showPoints: always
+              pointRadius: 6
+            yAxis:
+              min: 0
+              format:
+                unit: decimal
+        queries:
+          - kind: TimeSeriesQuery
+            spec:
+              plugin:
+                kind: LokiTimeSeriesQuery
+                spec:
+                  datasource:
+                    kind: LokiDatasource
+                    name: usage-logs-multi-tenancy
+                  query: >-
+                    sum by (${view_by:raw}) (sum_over_time({service_name="maas-gateway",
+                    subscription=~"$subscription", model=~"$model", response_type="hit"}
+                    | unwrap tokens_total [30m]))
+
+    tokenConsumptionTable:
+      kind: Panel
+      spec:
+        display:
+          name: "Usage breakdown"
+          description: >-
+            All model/subscription pairs. **View by** changes the chart; table always shows full detail.
+        plugin:
+          kind: Table
+          spec:
+            density: "compact"
+            pagination: true
+            transforms:
+              - kind: "MergeSeries"
+                spec: {}
+            columnSettings:
+              - name: "timestamp"
+                hide: true
+              - name: "model"
+                header: "Model"
+                align: "left"
+                enableSorting: true
+              - name: "subscription"
+                header: "Subscription"
+                align: "left"
+                enableSorting: true
+              - name: "key_name"
+                header: "Key Name"
+                align: "left"
+                enableSorting: true
+              - name: "value #1"
+                header: "Tokens used"
+                align: "right"
+                enableSorting: true
+                sort: "desc"
+                format:
+                  unit: decimal
+                  shortValues: true
+              - name: "value #2"
+                header: "Successful requests"
+                align: "right"
+                enableSorting: true
+                format:
+                  unit: decimal
+                  decimalPlaces: 0
+              - name: "value #3"
+                header: "Rate limited requests"
+                align: "right"
+                enableSorting: true
+                format:
+                  unit: decimal
+                  decimalPlaces: 0
+        queries:
+          - kind: TimeSeriesQuery
+            spec:
+              plugin:
+                kind: LokiTimeSeriesQuery
+                spec:
+                  datasource:
+                    kind: LokiDatasource
+                    name: usage-logs-multi-tenancy
+                  query: >-
+                    sum by (model, subscription, key_name) (sum_over_time(
+                    {service_name="maas-gateway",
+                    subscription=~"$subscription", model=~"$model", response_type="hit"}
+                    | unwrap tokens_total [$__range]))
+          - kind: TimeSeriesQuery
+            spec:
+              plugin:
+                kind: LokiTimeSeriesQuery
+                spec:
+                  datasource:
+                    kind: LokiDatasource
+                    name: usage-logs-multi-tenancy
+                  query: >-
+                    sum by (model, subscription, key_name) (count_over_time(
+                    {service_name="maas-gateway",
+                    subscription=~"$subscription", model=~"$model", response_type="hit"}
+                    [$__range]))
+          - kind: TimeSeriesQuery
+            spec:
+              plugin:
+                kind: LokiTimeSeriesQuery
+                spec:
+                  datasource:
+                    kind: LokiDatasource
+                    name: usage-logs-multi-tenancy
+                  query: >-
+                    sum by (model, subscription, key_name) (count_over_time(
+                    {service_name="maas-gateway",
+                    subscription=~"$subscription", model=~"$model", response_type="rate_limit"}
+                    [$__range]))
+                    or
+                    (sum by (model, subscription, key_name) (count_over_time(
+                    {service_name="maas-gateway",
+                    subscription=~"$subscription", model=~"$model", response_type="hit"}
+                    [$__range])) * 0)
+
+  layouts:
+    - kind: Grid
+      spec:
+        display:
+          title: "Overview"
+          collapse:
+            open: true
+        items:
+          - x: 0
+            "y": 0
+            width: 6
+            height: 5
+            content:
+              "$ref": "#/spec/panels/totalTokens"
+          - x: 6
+            "y": 0
+            width: 6
+            height: 5
+            content:
+              "$ref": "#/spec/panels/totalRequests"
+          - x: 12
+            "y": 0
+            width: 6
+            height: 5
+            content:
+              "$ref": "#/spec/panels/totalRateLimited"
+          - x: 18
+            "y": 0
+            width: 6
+            height: 5
+            content:
+              "$ref": "#/spec/panels/successRate"
+
+    - kind: Grid
+      spec:
+        display:
+          title: "Token consumption"
+          collapse:
+            open: true
+        items:
+          - x: 0
+            "y": 0
+            width: 24
+            height: 10
+            content:
+              "$ref": "#/spec/panels/tokenConsumptionOverTime"
+          - x: 0
+            "y": 10
+            width: 24
+            height: 8
+            content:
+              "$ref": "#/spec/panels/tokenConsumptionTable"
+---
+# User-scoped Loki datasource — routes through usage-logs-tenancy-proxy which
+# injects user_id filtering. Named "usage-logs-multi-tenancy" to avoid
+# collision with the admin "usage-logs" datasource.
+apiVersion: perses.dev/v1alpha1
+kind: PersesDatasource
+metadata:
+  name: usage-logs-multi-tenancy
+  namespace: opendatahub
+  labels:
+    app.kubernetes.io/managed-by: maas-controller
+    app.kubernetes.io/component: perses
+spec:
+  config:
+    display:
+      name: "Usage (logs)"
+    default: false
+    plugin:
+      kind: "LokiDatasource"
+      spec:
+        proxy:
+          kind: HTTPProxy
+          spec:
+            url: http://usage-logs-tenancy-proxy.opendatahub.svc.cluster.local:8080
+            allowedEndpoints:
+              - endpointPattern: "/loki/api/v1/.*"
+                method: GET
+  client:
+    kubernetesAuth:
+      enable: true

--- a/deployment/overlays/odh/params.env
+++ b/deployment/overlays/odh/params.env
@@ -2,6 +2,7 @@ maas-api-image=quay.io/opendatahub/maas-api:odh-stable
 maas-controller-image=quay.io/opendatahub/maas-controller:odh-stable
 payload-processing-image=quay.io/opendatahub/odh-ai-gateway-payload-processing:odh-stable
 maas-api-key-cleanup-image=registry.redhat.io/ubi9/ubi-minimal:9.7
+usage-logs-tenancy-proxy-image=registry.redhat.io/ubi9/python-312
 payload-processing-replicas=1
 gateway-namespace=openshift-ingress
 gateway-name=maas-default-gateway

--- a/maas-controller/pkg/controller/maas/constants.go
+++ b/maas-controller/pkg/controller/maas/constants.go
@@ -1,5 +1,11 @@
 package maas
 
+const (
+	// DefaultUsageLogsTenancyProxyImage is the default image for the usage-logs tenancy proxy container.
+	// Can be overridden via RELATED_IMAGE_ODH_PYTHON_312_IMAGE for disconnected environments.
+	DefaultUsageLogsTenancyProxyImage = "registry.redhat.io/ubi9/python-312"
+)
+
 // OptionalAPIGroups lists API groups whose CRDs are installed by optional platform
 // components (e.g. COO for Perses). Resources in these groups are skipped gracefully
 // when their CRDs are not yet registered, instead of failing the Tenant reconcile.

--- a/maas-controller/pkg/controller/maas/self_deployment_controller.go
+++ b/maas-controller/pkg/controller/maas/self_deployment_controller.go
@@ -582,6 +582,9 @@ func (r *LifecycleReconciler) ensureUsageLogs(ctx context.Context, log logr.Logg
 			if err := patchUsageLogsOpenTelemetryCollector(&res, r.MonitoringNamespace); err != nil {
 				return fmt.Errorf("patch %s %s: %w", res.GetKind(), res.GetName(), err)
 			}
+			if err := patchTenancyProxyImage(&res); err != nil {
+				return fmt.Errorf("patch %s %s: %w", res.GetKind(), res.GetName(), err)
+			}
 			if err := controllerutil.SetControllerReference(&cfg, &res, r.Scheme); err != nil {
 				return fmt.Errorf("set controller reference on %s %s: %w", res.GetKind(), res.GetName(), err)
 			}
@@ -665,6 +668,37 @@ func patchUsageLogsOpenTelemetryCollector(res *unstructured.Unstructured, monito
 		return fmt.Errorf("set loki exporter endpoint: %w", err)
 	}
 	return nil
+}
+
+// patchTenancyProxyImage sets the tenancy-proxy container image to RELATED_IMAGE_ODH_PYTHON_312_IMAGE
+// if configured, otherwise uses DefaultUsageLogsTenancyProxyImage. This enables disconnected deployments
+// to mirror the image while maintaining a code-defined default.
+func patchTenancyProxyImage(res *unstructured.Unstructured) error {
+	if res.GetKind() != "Deployment" || res.GetName() != "usage-logs-tenancy-proxy" {
+		return nil
+	}
+
+	image := os.Getenv("RELATED_IMAGE_ODH_PYTHON_312_IMAGE")
+	if image == "" {
+		image = DefaultUsageLogsTenancyProxyImage
+	}
+
+	containers, found, err := unstructured.NestedSlice(res.Object, "spec", "template", "spec", "containers")
+	if err != nil || !found {
+		return fmt.Errorf("containers not found in deployment: %w", err)
+	}
+
+	for i, c := range containers {
+		cm, ok := c.(map[string]any)
+		if !ok || cm["name"] != "proxy" {
+			continue
+		}
+		cm["image"] = image
+		containers[i] = cm
+		return unstructured.SetNestedSlice(res.Object, containers, "spec", "template", "spec", "containers")
+	}
+
+	return errors.New("proxy container not found in usage-logs-tenancy-proxy deployment")
 }
 
 // ensureUsageLogsEnvoyFilter deploys or removes the OTel usage logs EnvoyFilter based on

--- a/maas-controller/pkg/controller/maas/self_deployment_controller_test.go
+++ b/maas-controller/pkg/controller/maas/self_deployment_controller_test.go
@@ -954,3 +954,118 @@ func TestEnsureUsageLogs(t *testing.T) {
 		g.Expect(subj["namespace"]).To(Equal(monitoringNS))
 	})
 }
+
+func TestPatchTenancyProxyImage(t *testing.T) {
+	t.Run("patches proxy container image when RELATED_IMAGE set", func(t *testing.T) {
+		g := NewWithT(t)
+		t.Setenv("RELATED_IMAGE_ODH_PYTHON_312_IMAGE", "quay.io/example/tenancy-proxy:test")
+
+		deployment := &unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": "apps/v1",
+				"kind":       "Deployment",
+				"metadata": map[string]any{
+					"name": "usage-logs-tenancy-proxy",
+				},
+				"spec": map[string]any{
+					"template": map[string]any{
+						"spec": map[string]any{
+							"containers": []any{
+								map[string]any{
+									"name":  "proxy",
+									"image": "registry.redhat.io/ubi9/python-312",
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		err := patchTenancyProxyImage(deployment)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		containers, found, err := unstructured.NestedSlice(deployment.Object, "spec", "template", "spec", "containers")
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(found).To(BeTrue())
+		g.Expect(containers).To(HaveLen(1))
+
+		container, ok := containers[0].(map[string]any)
+		g.Expect(ok).To(BeTrue())
+		g.Expect(container["image"]).To(Equal("quay.io/example/tenancy-proxy:test"))
+	})
+
+	t.Run("uses default image when RELATED_IMAGE not set", func(t *testing.T) {
+		g := NewWithT(t)
+
+		deployment := &unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": "apps/v1",
+				"kind":       "Deployment",
+				"metadata": map[string]any{
+					"name": "usage-logs-tenancy-proxy",
+				},
+				"spec": map[string]any{
+					"template": map[string]any{
+						"spec": map[string]any{
+							"containers": []any{
+								map[string]any{
+									"name": "proxy",
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		err := patchTenancyProxyImage(deployment)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		containers, found, err := unstructured.NestedSlice(deployment.Object, "spec", "template", "spec", "containers")
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(found).To(BeTrue())
+
+		container, ok := containers[0].(map[string]any)
+		g.Expect(ok).To(BeTrue())
+		g.Expect(container["image"]).To(Equal(DefaultUsageLogsTenancyProxyImage))
+	})
+
+	t.Run("ignores non-matching deployment", func(t *testing.T) {
+		g := NewWithT(t)
+		t.Setenv("RELATED_IMAGE_ODH_PYTHON_312_IMAGE", "quay.io/example/tenancy-proxy:test")
+
+		deployment := &unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": "apps/v1",
+				"kind":       "Deployment",
+				"metadata": map[string]any{
+					"name": "some-other-deployment",
+				},
+				"spec": map[string]any{
+					"template": map[string]any{
+						"spec": map[string]any{
+							"containers": []any{
+								map[string]any{
+									"name":  "proxy",
+									"image": "registry.redhat.io/ubi9/python-312",
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		err := patchTenancyProxyImage(deployment)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		containers, found, err := unstructured.NestedSlice(deployment.Object, "spec", "template", "spec", "containers")
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(found).To(BeTrue())
+
+		container, ok := containers[0].(map[string]any)
+		g.Expect(ok).To(BeTrue())
+		g.Expect(container["image"]).To(Equal("registry.redhat.io/ubi9/python-312"))
+	})
+}


### PR DESCRIPTION
## Summary

Add Perses dashboards and Loki datasources for usage monitoring, providing both admin-wide and user-scoped views of model inference activity.

### Admin dashboard (`usage-admin-loki-dashboard`)
- Direct `loki` datasource (SA token auth + TLS to LokiStack gateway)
- Dropdowns: User, Subscription, Model (`LokiLabelValuesVariable`, COO 1.5+)
- Panels: Total tokens, Total requests, Total rate limited, Success rate, Active users
- Token consumption time-series chart (stacked area, `view_by` toggle: model/subscription)
- Usage breakdown table grouped by model/subscription/key_name (`MergeSeries` transform)
- `customAllValue: ".*"` on ListVariables for absent-label matching

### User dashboard (`usage-user-loki-dashboard`)
- `scoped-loki` datasource routed through `loki-query-proxy` — injects `user_id` filtering based on the caller's Kubernetes token (TokenReview)
- No User dropdown — queries are automatically scoped to the logged-in user
- Same panels as admin minus Active users; wider 4-panel grid layout
- Datasource named `scoped-loki` to avoid Perses prefix collision with `loki`

### Files changed (6)

| File | Change |
|------|--------|
| `dashboards/kustomization.yaml` | Add user dashboard + scoped datasource resources |
| `dashboards/loki-datasource-scoped.yaml` | New: `scoped-loki` datasource → `loki-query-proxy-user` |
| `dashboards/usage-user-loki-dashboard.yaml` | New: user-scoped Perses dashboard |
| `usage-logs/kustomization.yaml` | New: admin dashboard kustomization |
| `usage-logs/loki-datasource.yaml` | New: admin `loki` datasource (direct to LokiStack) |
| `usage-logs/usage-admin-loki-dashboard.yaml` | New: admin Perses dashboard |

### Dependencies

- OTel pipeline deployed (EnvoyFilter → OTel Collector → Loki) for log data
- Loki query proxy (PR #999) for user-scoped dashboard
- LokiStack with `streamLabels.resourceAttributes` configured

## Risk analysis

- **Risk rating**: 1
- **Why**: Dashboard and datasource manifests only — no controller code, no runtime behavior changes. Covered by manual verification on cluster. Risk is limited to dashboard query correctness.