### PR TITLE
feat: integrate operator-chaos shift-left upgrade validation

### DIFF
--- a/.github/workflows/operator-chaos.yml
+++ b/.github/workflows/operator-chaos.yml
@@ -1,0 +1,145 @@
+name: Operator Chaos
+
+on:
+  pull_request:
+    paths:
+      - "maas-controller/api/**"
+      - "maas-controller/pkg/controller/**"
+      - "maas-controller/pkg/reconciler/**"
+      - "deployment/base/maas-controller/**"
+      - "maas-api/deploy/**"
+      - "deployment/base/maas-api/**"
+      - "deployment/components/**"
+      - "chaos/knowledge/**"
+      - "maas-controller/go.mod"
+      - "maas-controller/go.sum"
+      - ".github/workflows/operator-chaos.yml"
+
+permissions:
+  contents: read
+
+env:
+  OPERATOR_CHAOS_VERSION: "ec5cd239b770735cab3028d3594385950b51e327"
+
+jobs:
+  operator-chaos:
+    name: Operator Chaos
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version-file: maas-controller/go.mod
+
+      - name: Install operator-chaos
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "${RUNNER_TEMP}/bin"
+          GOBIN="${RUNNER_TEMP}/bin" go install "github.com/opendatahub-io/operator-chaos/cmd/operator-chaos@${OPERATOR_CHAOS_VERSION}"
+          echo "${RUNNER_TEMP}/bin" >> "${GITHUB_PATH}"
+
+      - name: Checkout base branch assets
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: base-branch
+          persist-credentials: false
+          sparse-checkout: |
+            chaos/knowledge
+            deployment/base/maas-controller/crd/bases
+          sparse-checkout-cone-mode: false
+
+      - name: Validate knowledge model
+        shell: bash
+        run: |
+          set -euo pipefail
+          operator-chaos validate --knowledge "chaos/knowledge/maas.yaml"
+
+      - name: Run local preflight
+        shell: bash
+        run: |
+          set -euo pipefail
+          operator-chaos preflight --knowledge "chaos/knowledge/maas.yaml" --local
+
+      - name: Diff knowledge model
+        shell: bash
+        run: |
+          set -euo pipefail
+          base_knowledge_file="base-branch/chaos/knowledge/maas.yaml"
+          if [[ ! -f "${base_knowledge_file}" ]]; then
+            echo "No base knowledge model found; skipping knowledge diff for bootstrap PR."
+            exit 0
+          fi
+
+          output_dir="${RUNNER_TEMP}/operator-chaos"
+          mkdir -p "${output_dir}"
+          knowledge_diff_json="${output_dir}/knowledge-diff.json"
+
+          operator-chaos diff \
+            --source "base-branch/chaos/knowledge" \
+            --target "chaos/knowledge" \
+            --breaking \
+            --format json > "${knowledge_diff_json}"
+          operator-chaos diff \
+            --source "base-branch/chaos/knowledge" \
+            --target "chaos/knowledge" \
+            --breaking
+
+          knowledge_breaking=$(jq -r '.summary.breakingChanges // 0' "${knowledge_diff_json}")
+          if (( knowledge_breaking > 0 )); then
+            echo "operator-chaos detected ${knowledge_breaking} breaking knowledge change(s)."
+            exit 1
+          fi
+
+      - name: Diff CRD schemas
+        shell: bash
+        run: |
+          set -euo pipefail
+          source_crd_dir="base-branch/deployment/base/maas-controller/crd/bases"
+          target_crd_dir="deployment/base/maas-controller/crd/bases"
+          if [[ ! -d "${source_crd_dir}" || ! -d "${target_crd_dir}" ]]; then
+            echo "Base or current CRD directory not found; skipping CRD diff for bootstrap PR."
+            exit 0
+          fi
+
+          output_dir="${RUNNER_TEMP}/operator-chaos"
+          mkdir -p "${output_dir}"
+          crd_diff_json="${output_dir}/crd-diff.json"
+
+          operator-chaos diff-crds \
+            --source-crds "${source_crd_dir}" \
+            --target-crds "${target_crd_dir}" \
+            --format json > "${crd_diff_json}"
+          operator-chaos diff-crds \
+            --source-crds "${source_crd_dir}" \
+            --target-crds "${target_crd_dir}"
+
+          crd_breaking=$(jq -r '
+            reduce ((.crds // [])[]?.apiVersions[]?.schemaChanges[]?) as $change
+              (0; if ($change.severity | ascii_downcase) == "breaking" then . + 1 else . end)
+          ' "${crd_diff_json}")
+          if (( crd_breaking > 0 )); then
+            echo "operator-chaos detected ${crd_breaking} breaking CRD schema change(s)."
+            exit 1
+          fi
+
+      - name: Preview upgrade simulation
+        shell: bash
+        run: |
+          set -euo pipefail
+          base_knowledge_file="base-branch/chaos/knowledge/maas.yaml"
+          if [[ ! -f "${base_knowledge_file}" ]]; then
+            echo "No base knowledge model found; skipping simulate-upgrade for bootstrap PR."
+            exit 0
+          fi
+
+          operator-chaos simulate-upgrade \
+            --source "base-branch/chaos/knowledge" \
+            --target "chaos/knowledge" \
+            --dry-run

--- a/chaos/knowledge/README.md
+++ b/chaos/knowledge/README.md
@@ -1,0 +1,149 @@
+# Operator Chaos — Shift-Left Upgrade Validation
+
+This directory contains the [operator-chaos](https://github.com/opendatahub-io/operator-chaos) knowledge model for the MaaS controller. It enables automated detection of upgrade-breaking changes at PR time, before code is merged.
+
+## What is operator-chaos?
+
+operator-chaos is a Go-based chaos engineering and upgrade validation tool maintained by the OpenDataHub community. It provides:
+
+- **Knowledge models** — declarative YAML describing an operator's topology (managed resources, webhooks, finalizers, steady-state checks)
+- **Breaking change detection** — diffs knowledge models and CRD schemas between PR and base branch to flag regressions
+- **Upgrade simulation** — previews what upgrade experiments would run (dry-run, no cluster required)
+
+## Maturity levels adopted
+
+This integration targets **L1–L2**:
+
+| Level | What it covers | Status |
+|-------|---------------|--------|
+| L1 | GitHub Actions workflow validates knowledge model and CRDs on every PR | Active |
+| L2 | Knowledge model contributed to upstream operator-chaos profiles | Active |
+| L3 | ChaosClient SDK integrated into controller tests | Future |
+| L4 | Upgrade playbook YAML contributed | Future |
+
+## How the CI workflow works
+
+```mermaid
+flowchart TD
+    A[PR opened / updated] --> B{Paths changed?}
+    B -->|maas-controller/api/**\nmaas-controller/pkg/**\ndeployment/**\nmaas-api/deploy/**\nchaos/knowledge/**| C[Trigger operator-chaos workflow]
+    B -->|Other paths only| Z[Skip — no chaos check needed]
+
+    C --> D[Install operator-chaos CLI]
+    D --> E[Sparse checkout base branch\nchaos/knowledge + CRD bases]
+
+    E --> F[Validate knowledge model]
+    F --> G[Run local preflight]
+    G --> H[Diff knowledge model\nbase vs PR branch]
+    H --> I[Diff all 7 CRD schemas\nbase vs PR branch]
+    I --> J[Preview upgrade simulation\ndry-run]
+
+    H -->|Breaking changes detected| FAIL[Fail PR check]
+    I -->|Breaking CRD changes detected| FAIL
+    J --> PASS[Pass]
+
+    style FAIL fill:#f44,stroke:#d32,color:#fff
+    style PASS fill:#4c4,stroke:#2a2,color:#fff
+```
+
+## What the knowledge model describes
+
+The knowledge model (`maas.yaml`) declares the MaaS operator's expected topology:
+
+```mermaid
+graph LR
+    subgraph "maas-controller component"
+        D[Deployment\nmaas-controller]
+        SA[ServiceAccount]
+        CR1[ClusterRole\nmaas-controller-role]
+        CRB1[ClusterRoleBinding]
+        CR2[ClusterRole\ncluster-config-role]
+        CRB2[ClusterRoleBinding]
+        R[Role\nleader-election]
+        RB[RoleBinding]
+        SVC[Service\nwebhook-service]
+        PM[PodMonitor]
+        CFG[Config/default]
+    end
+
+    subgraph "Webhooks"
+        W1[vmaassubscription.kb.io\nvalidating]
+        W2[vmaasauthpolicy.kb.io\nvalidating]
+    end
+
+    subgraph "Finalizers"
+        F1[aitenant-cleanup]
+        F2[model-cleanup]
+        F3[authpolicy-cleanup]
+        F4[subscription-cleanup]
+    end
+
+    D --> SA
+    D --> CR1 --> CRB1
+    D --> CR2 --> CRB2
+    D --> R --> RB
+    D --> SVC
+    D --> PM
+    D --> CFG
+```
+
+## Relationship to upstream profiles
+
+This repo maintains a local knowledge model for CI validation. The upstream
+`operator-chaos` repo maintains platform-specific copies under its profile
+directories:
+
+```
+operator-chaos/profiles/
+├── odh/
+│   ├── profile.yaml                  # namespace: opendatahub
+│   └── knowledge/
+│       └── maas.yaml                 # ODH variant
+├── rhoai/
+│   ├── profile.yaml                  # namespace: redhat-ods-applications
+│   └── knowledge/
+│       └── maas.yaml                 # RHOAI variant
+```
+
+The local file (`chaos/knowledge/maas.yaml`) uses the base namespace
+(`opendatahub`) and is used exclusively for offline CI checks where the
+namespace value does not affect validation outcomes.
+
+## CRDs validated
+
+The workflow diffs all MaaS CRDs between the base and PR branches:
+
+| CRD | File |
+|-----|------|
+| AITenant | `deployment/base/maas-controller/crd/bases/maas.opendatahub.io_aitenants.yaml` |
+| Config | `deployment/base/maas-controller/crd/bases/maas.opendatahub.io_configs.yaml` |
+| ExternalModel | `deployment/base/maas-controller/crd/bases/maas.opendatahub.io_externalmodels.yaml` |
+| MaaSAuthPolicy | `deployment/base/maas-controller/crd/bases/maas.opendatahub.io_maasauthpolicies.yaml` |
+| MaaSModelRef | `deployment/base/maas-controller/crd/bases/maas.opendatahub.io_maasmodelrefs.yaml` |
+| MaaSSubscription | `deployment/base/maas-controller/crd/bases/maas.opendatahub.io_maassubscriptions.yaml` |
+| Tenant | `deployment/base/maas-controller/crd/bases/maas.opendatahub.io_tenants.yaml` |
+
+## Running locally
+
+```bash
+# from the repo root — install operator-chaos and validate
+make -C maas-controller chaos-validate
+
+# or manually:
+operator-chaos validate --knowledge chaos/knowledge/maas.yaml
+operator-chaos preflight --knowledge chaos/knowledge/maas.yaml --local
+```
+
+## Maintaining the knowledge model
+
+Update `chaos/knowledge/maas.yaml` whenever:
+
+- A new managed resource is added or removed from a controller
+- CRD types are added, renamed, or removed
+- Webhooks are added or changed
+- Finalizers are added or removed
+- The operator Deployment spec changes (name, labels, replicas)
+- RBAC resources are added or restructured
+
+Also update the upstream profiles in the `operator-chaos` repo when making
+these changes.

--- a/chaos/knowledge/maas.yaml
+++ b/chaos/knowledge/maas.yaml
@@ -1,0 +1,78 @@
+operator:
+  name: maas-controller
+  namespace: opendatahub
+  repository: https://github.com/opendatahub-io/models-as-a-service
+
+components:
+  - name: maas-controller
+    controller: TenantReconciler
+    managedResources:
+      - apiVersion: apps/v1
+        kind: Deployment
+        name: maas-controller
+        namespace: opendatahub
+        labels:
+          control-plane: maas-controller
+          app: maas-controller
+        expectedSpec:
+          replicas: 1
+      - apiVersion: v1
+        kind: ServiceAccount
+        name: maas-controller
+        namespace: opendatahub
+      - apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRole
+        name: maas-controller-role
+      - apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRoleBinding
+        name: maas-controller-rolebinding
+      - apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRole
+        name: maas-controller-cluster-config-role
+      - apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRoleBinding
+        name: maas-controller-cluster-config-rolebinding
+      - apiVersion: rbac.authorization.k8s.io/v1
+        kind: Role
+        name: maas-controller-leader-election-role
+        namespace: opendatahub
+      - apiVersion: rbac.authorization.k8s.io/v1
+        kind: RoleBinding
+        name: maas-controller-leader-election-rolebinding
+        namespace: opendatahub
+      - apiVersion: v1
+        kind: Service
+        name: maas-controller-webhook-service
+        namespace: opendatahub
+      - apiVersion: monitoring.coreos.com/v1
+        kind: PodMonitor
+        name: maas-controller-metrics
+        namespace: opendatahub
+      - apiVersion: maas.opendatahub.io/v1alpha1
+        kind: Config
+        name: default
+    webhooks:
+      - name: vmaassubscription.kb.io
+        type: validating
+        path: /validate-maas-opendatahub-io-v1alpha1-maassubscription
+      - name: vmaasauthpolicy.kb.io
+        type: validating
+        path: /validate-maas-opendatahub-io-v1alpha1-maasauthpolicy
+    finalizers:
+      - maas.opendatahub.io/aitenant-cleanup
+      - maas.opendatahub.io/model-cleanup
+      - maas.opendatahub.io/authpolicy-cleanup
+      - maas.opendatahub.io/subscription-cleanup
+    steadyState:
+      checks:
+        - type: conditionTrue
+          apiVersion: apps/v1
+          kind: Deployment
+          name: maas-controller
+          namespace: opendatahub
+          conditionType: Available
+      timeout: "60s"
+
+recovery:
+  reconcileTimeout: "300s"
+  maxReconcileCycles: 10

--- a/maas-controller/Makefile
+++ b/maas-controller/Makefile
@@ -118,6 +118,15 @@ verify-codegen: generate manifests ##	run generate + manifests and fail if files
 	fi
 	@echo "Generated files are up to date."
 
+##@ Chaos validation
+
+KNOWLEDGE_MODEL ?= ../chaos/knowledge/maas.yaml
+
+.PHONY: chaos-validate
+chaos-validate: $(OPERATOR_CHAOS) ##	validate knowledge model and run local preflight
+	"$(OPERATOR_CHAOS)" validate --knowledge "$(KNOWLEDGE_MODEL)"
+	"$(OPERATOR_CHAOS)" preflight --knowledge "$(KNOWLEDGE_MODEL)" --local
+
 ##@ Deployment
 
 # Install CRDs, RBAC, and manager deployment (default: opendatahub namespace).

--- a/maas-controller/tools.mk
+++ b/maas-controller/tools.mk
@@ -6,12 +6,18 @@ $(LOCALBIN):
 
 ## Tools
 GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint
+OPERATOR_CHAOS ?= $(LOCALBIN)/operator-chaos
 
 GOLANGCI_LINT_VERSION ?= v2.6.2
+OPERATOR_CHAOS_VERSION ?= ec5cd239b770735cab3028d3594385950b51e327
 # Target the versioned binary so version bumps trigger reinstall
 $(GOLANGCI_LINT)-$(GOLANGCI_LINT_VERSION): $(LOCALBIN)
 	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
 $(GOLANGCI_LINT): $(GOLANGCI_LINT)-$(GOLANGCI_LINT_VERSION)
+
+$(OPERATOR_CHAOS)-$(OPERATOR_CHAOS_VERSION): $(LOCALBIN)
+	$(call go-install-tool,$(OPERATOR_CHAOS),github.com/opendatahub-io/operator-chaos/cmd/operator-chaos,$(OPERATOR_CHAOS_VERSION))
+$(OPERATOR_CHAOS): $(OPERATOR_CHAOS)-$(OPERATOR_CHAOS_VERSION)
 
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
 # $1 - target path with name of binary (ideally with version)


### PR DESCRIPTION
## Summary

Integrate operator-chaos shift-left upgrade validation for the MaaS controller to detect breaking changes at PR time.

**JIRA:** [RHOAIENG-63092](https://redhat.atlassian.net/browse/RHOAIENG-63092)

## Description

Adds operator-chaos L1–L2 integration to catch upgrade-breaking changes before they are merged. This is an offline, asset-focused validation — no cluster is required.

- Add GitHub Actions workflow (`operator-chaos.yml`) that runs on PRs touching controller code, API types, CRDs, deployment manifests, or maas-api deploy overlays
- Add knowledge model YAML (`chaos/knowledge/maas.yaml`) describing the MaaS operator topology: 1 component, 11 managed resources, 2 validating webhooks, 4 finalizers
- Add `chaos-validate` Makefile target and `operator-chaos` tool download to `maas-controller/tools.mk` using the same versioned-binary pattern as golangci-lint
- Add `chaos/knowledge/README.md` with Mermaid diagrams explaining the CI flow, knowledge model structure, and relationship to upstream operator-chaos profiles

The workflow validates the knowledge model, runs local preflight checks, diffs the knowledge model and all 7 MaaS CRD schemas between base and PR branches for breaking changes, and previews upgrade simulation (dry-run). First-time bootstrap is handled gracefully (skips diff steps when no base knowledge exists).

Companion PR for upstream operator-chaos profiles: https://github.com/opendatahub-io/operator-chaos/pull/5

## How it was tested

- Ran `make -C maas-controller chaos-validate` locally — knowledge model validated, preflight passed
- Ran `operator-chaos diff --breaking` with identical base/target — 0 breaking changes detected
- Ran `operator-chaos diff-crds` against all 7 CRD bases — 0 breaking, 0 warning, 0 info
- Ran `operator-chaos simulate-upgrade --dry-run` — no experiments generated (expected for identical source/target)
- Validated the RHOAI upstream knowledge model separately — passed validate and preflight

## Risk analysis

- **Risk rating:** 1
- **Why:** Pure additive change — new GHA workflow, new YAML files, and Makefile convenience targets. No changes to controller logic, CRDs, or existing CI. The workflow only runs on PRs matching specific path filters and has no write permissions. Covered by the Prow smoke path since it does not affect runtime behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated “Operator Chaos” pull request workflow that validates updated knowledge models and CRD schemas, blocks breaking changes, and runs a dry-run upgrade simulation.
  * Added a `chaos-validate` make target and default knowledge model to perform local validation.
  * Installed and versioned the `operator-chaos` CLI tool for build/validation runs.
* **Documentation**
  * Added/expanded documentation describing the MaaS chaos knowledge model, CI validation flow, and guidance for maintaining it.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->