### PR TITLE
feat: add Loki query proxy for user-scoped log isolation

### DIFF
--- a/deployment/base/maas-controller/base/params.env
+++ b/deployment/base/maas-controller/base/params.env
@@ -2,5 +2,6 @@ maas-api-image=quay.io/opendatahub/maas-api:odh-stable
 maas-controller-image=quay.io/opendatahub/maas-controller:odh-stable
 payload-processing-image=quay.io/opendatahub/odh-ai-gateway-payload-processing:odh-stable
 maas-api-key-cleanup-image=registry.redhat.io/ubi9/ubi-minimal:9.7
+usage-logs-tenancy-proxy-image=registry.redhat.io/ubi9/python-312
 monitoring-namespace=opendatahub
 infrastructure-namespace=AUTO

--- a/deployment/base/maas-controller/default/params.env
+++ b/deployment/base/maas-controller/default/params.env
@@ -2,4 +2,5 @@ maas-api-image=quay.io/opendatahub/maas-api:latest
 maas-controller-image=quay.io/opendatahub/maas-controller:latest
 payload-processing-image=quay.io/opendatahub/odh-ai-gateway-payload-processing:odh-stable
 maas-api-key-cleanup-image=registry.redhat.io/ubi9/ubi-minimal:9.7
+usage-logs-tenancy-proxy-image=registry.redhat.io/ubi9/python-312
 monitoring-namespace=opendatahub

--- a/deployment/base/maas-controller/manager/manager.yaml
+++ b/deployment/base/maas-controller/manager/manager.yaml
@@ -74,6 +74,12 @@ spec:
                 key: maas-api-key-cleanup-image
                 name: maas-parameters
                 optional: true
+          - name: RELATED_IMAGE_ODH_PYTHON_312_IMAGE
+            valueFrom:
+              configMapKeyRef:
+                key: usage-logs-tenancy-proxy-image
+                name: maas-parameters
+                optional: true
           - name: MONITORING_NAMESPACE
             valueFrom:
               configMapKeyRef:

--- a/deployment/components/observability/usage-logs/kustomization.yaml
+++ b/deployment/components/observability/usage-logs/kustomization.yaml
@@ -4,3 +4,6 @@ kind: Kustomization
 resources:
   - otel-collector.yaml
   - otel-collector-rbac.yaml
+  - tenancy-proxy-code.yaml
+  - tenancy-proxy-rbac.yaml
+  - tenancy-proxy.yaml

--- a/deployment/components/observability/usage-logs/tenancy-proxy-code.yaml
+++ b/deployment/components/observability/usage-logs/tenancy-proxy-code.yaml
@@ -1,0 +1,538 @@
+# Loki Query Proxy -- Python stdlib-only implementation
+# Runs on ubi9/python-312 base image with zero external dependencies.
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: loki-query-proxy-source
+  namespace: opendatahub
+  labels:
+    app: loki-query-proxy
+    app.kubernetes.io/managed-by: maas-controller
+    app.kubernetes.io/component: loki-proxy
+data:
+  main.py: |
+    #!/usr/bin/env python3
+    """Loki Query Proxy - stdlib-only implementation."""
+    import contextvars
+    import hashlib
+    import json
+    import logging
+    import os
+    import ssl
+    import sys
+    import time
+    import uuid
+    from http.server import ThreadingHTTPServer, BaseHTTPRequestHandler
+    from threading import Lock
+    from urllib.parse import urlparse, parse_qs, urlencode, urljoin
+
+    from auth import extract_from_bearer_token, create_ssl_context
+    from rewriter import inject_user_filter
+
+    # Context variable for request ID
+    request_id_var = contextvars.ContextVar('request_id', default='')
+
+    # Simple in-memory cache for query results
+    query_cache = {}
+    cache_lock = Lock()
+    CACHE_TTL_SECONDS = 30  # Cache responses for 30 seconds
+
+    class RequestIDFilter(logging.Filter):
+        """Inject request ID into log records."""
+        def filter(self, record):
+            record.request_id = request_id_var.get() or '-'
+            return True
+
+    # Configure logging with request ID support
+    log_level = os.getenv('LOG_LEVEL', 'INFO').upper()
+    logging.basicConfig(
+        level=getattr(logging, log_level, logging.INFO),
+        format="%(asctime)s [%(levelname)s] [%(request_id)s] %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+    # Add filter to all handlers so request_id is available in all log records
+    for handler in logging.getLogger().handlers:
+        handler.addFilter(RequestIDFilter())
+    logger = logging.getLogger(__name__)
+
+    # Global configuration
+    ssl_context = None
+    token_review_url = None
+
+    ALLOWED_PATHS = {
+        "/loki/api/v1/query",
+        "/loki/api/v1/query_range",
+        "/loki/api/v1/index/stats",
+        "/loki/api/v1/index/volume",
+        "/loki/api/v1/index/volume_range",
+        "/loki/api/v1/labels",
+        "/loki/api/v1/series",
+        "/health",
+        "/ready",
+    }
+
+    HOP_BY_HOP_HEADERS = {
+        "connection",
+        "keep-alive",
+        "proxy-authenticate",
+        "proxy-authorization",
+        "te",
+        "trailers",
+        "transfer-encoding",
+        "upgrade",
+        "authorization",
+        "content-length",
+    }
+
+
+    def is_allowed_path(path):
+        """Check if path is allowed."""
+        if path in ALLOWED_PATHS:
+            return True
+        if path.startswith("/loki/api/v1/label/") and path.endswith("/values"):
+            return True
+        return False
+
+
+    class ProxyHandler(BaseHTTPRequestHandler):
+        """HTTP request handler for the Loki proxy."""
+
+        protocol_version = "HTTP/1.1"
+
+        def log_message(self, format, *args):
+            """Suppress default logging - we handle it ourselves."""
+            pass
+
+        def send_json_error(self, msg, code):
+            """Send JSON error response."""
+            self.send_response(code)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            response = {
+                "status": "error",
+                "error": msg,
+                "errorType": "proxy",
+                "data": None,
+            }
+            self.wfile.write(json.dumps(response).encode())
+
+        def do_GET(self):
+            """Handle GET requests."""
+            # Generate unique request ID for log correlation
+            req_id = str(uuid.uuid4())[:8]
+            request_id_var.set(req_id)
+
+            logger.info(f"REQ GET {self.path}")
+
+            # Health check endpoints
+            if self.path in ("/health", "/ready"):
+                try:
+                    self.send_response(200)
+                    self.send_header("Content-Type", "text/plain")
+                    self.end_headers()
+                    self.wfile.write(b"OK\n")
+                except (BrokenPipeError, ConnectionResetError):
+                    # Kubernetes probes may close connection early - this is normal
+                    pass
+                return
+
+            # Authenticate and extract username
+            auth_header = self.headers.get("Authorization", "")
+            if not auth_header:
+                logger.error("Missing Authorization header")
+                self.send_json_error("Unauthorized", 401)
+                return
+
+            try:
+                user_info = extract_from_bearer_token(
+                    auth_header, token_review_url, ssl_context
+                )
+            except Exception as e:
+                logger.error(f"Auth extraction failed: {e}")
+                self.send_json_error("Unauthorized", 401)
+                return
+
+            username = user_info.username
+
+            # Parse path and check if allowed
+            parsed = urlparse(self.path)
+            if not is_allowed_path(parsed.path):
+                logger.warning(f"Blocked access to {parsed.path} for user={username}")
+                self.send_json_error("Forbidden: endpoint not available", 403)
+                return
+
+            # Parse and rewrite query parameters
+            query_params = parse_qs(parsed.query, keep_blank_values=True)
+
+            if "query" in query_params:
+                original_query = query_params["query"][0]
+                # Label values endpoints only support label matchers, not pipeline filters
+                is_label_values = parsed.path.startswith("/loki/api/v1/label/") and parsed.path.endswith("/values")
+                rewritten_query = inject_user_filter(original_query, username, labels_only=is_label_values)
+                query_params["query"] = [rewritten_query]
+                logger.debug(
+                    f"Query rewritten for user={username} (labels_only={is_label_values}): "
+                    f"original={original_query} -> rewritten={rewritten_query}"
+                )
+
+            # Build upstream URL
+            upstream_parsed = urlparse(loki_upstream)
+            upstream_path = upstream_parsed.path + parsed.path
+            if query_params:
+                query_string = urlencode(query_params, doseq=True)
+                upstream_url = f"{upstream_parsed.scheme}://{upstream_parsed.netloc}{upstream_path}?{query_string}"
+            else:
+                upstream_url = f"{upstream_parsed.scheme}://{upstream_parsed.netloc}{upstream_path}"
+
+            # Prepare upstream request
+            from urllib.request import Request, urlopen
+
+            # Copy headers, excluding hop-by-hop
+            headers = {}
+            for key, value in self.headers.items():
+                if key.lower() not in HOP_BY_HOP_HEADERS:
+                    headers[key] = value
+
+            headers["Host"] = upstream_parsed.netloc
+            headers["X-Scope-OrgID"] = "application"
+
+            # Add service account token for upstream authentication
+            try:
+                with open("/var/run/secrets/kubernetes.io/serviceaccount/token", "r") as f:
+                    sa_token = f.read().strip()
+                    headers["Authorization"] = f"Bearer {sa_token}"
+            except OSError:
+                pass
+
+            # Check cache (cache key = rewritten query + user)
+            cache_key = hashlib.sha256(f"{username}:{upstream_url}".encode()).hexdigest()
+            with cache_lock:
+                if cache_key in query_cache:
+                    cached_entry = query_cache[cache_key]
+                    if time.time() - cached_entry["timestamp"] < CACHE_TTL_SECONDS:
+                        logger.info(f"CACHE HIT {parsed.path}")
+                        self.send_response(cached_entry["code"])
+                        for key, value in cached_entry["headers"].items():
+                            self.send_header(key, value)
+                        self.end_headers()
+                        self.wfile.write(cached_entry["body"])
+                        return
+                    else:
+                        # Expired entry
+                        del query_cache[cache_key]
+
+            # Make upstream request
+            try:
+                from urllib.error import HTTPError
+                req = Request(upstream_url, headers=headers, method="GET")
+                start_time = time.time()
+                with urlopen(req, timeout=60, context=ssl_context) as resp:
+                    resp_body = resp.read()
+                    resp_code = resp.status
+                    resp_headers = resp.headers
+
+                elapsed_ms = int((time.time() - start_time) * 1000)
+                if elapsed_ms > 3000:
+                    logger.warning(f"SLOW QUERY {elapsed_ms}ms {parsed.path}")
+                logger.info(f"RESP {parsed.path} {resp_code} ({len(resp_body)} bytes) {elapsed_ms}ms")
+
+                # Handle non-JSON error responses
+                is_json = len(resp_body) > 0 and resp_body[0:1] in (b"{", b"[")
+                if resp_code >= 400 and not is_json:
+                    err_msg = resp_body.decode("utf-8", errors="replace").strip()
+                    if not err_msg:
+                        err_msg = f"Loki returned HTTP {resp_code}"
+                    logger.error(f"Upstream non-JSON error {resp_code}: {err_msg[:200]}")
+                    self.send_json_error(err_msg, resp_code)
+                    return
+
+                # Filter hop-by-hop headers for forwarding
+                filtered_headers = {
+                    k: v for k, v in resp_headers.items()
+                    if k.lower() not in HOP_BY_HOP_HEADERS
+                }
+                filtered_headers["Content-Length"] = str(len(resp_body))
+
+                # Store successful responses in cache (with filtered headers)
+                if resp_code == 200:
+                    with cache_lock:
+                        query_cache[cache_key] = {
+                            "timestamp": time.time(),
+                            "code": resp_code,
+                            "headers": filtered_headers,
+                            "body": resp_body,
+                        }
+                        # Simple cache size limit (keep last 100 entries)
+                        if len(query_cache) > 100:
+                            oldest_key = min(query_cache.keys(), key=lambda k: query_cache[k]["timestamp"])
+                            del query_cache[oldest_key]
+
+                # Forward response
+                self.send_response(resp_code)
+                for key, value in filtered_headers.items():
+                    self.send_header(key, value)
+                self.end_headers()
+                self.wfile.write(resp_body)
+
+            except HTTPError as e:
+                # Log the error response body
+                try:
+                    error_body = e.read().decode('utf-8', errors='replace')
+                    logger.error(f"Upstream HTTP {e.code} error body: {error_body[:500]}")
+                except:
+                    logger.error(f"Upstream HTTP {e.code}: {e.reason}")
+                self.send_json_error(f"Bad gateway: HTTP {e.code} {e.reason}", 502)
+            except Exception as e:
+                logger.error(f"Upstream request failed: {type(e).__name__}: {e}")
+                self.send_json_error("Bad gateway: upstream request failed", 502)
+
+
+    def initialize():
+        """Initialize global configuration."""
+        global loki_upstream, ssl_context, token_review_url
+
+        loki_upstream = os.getenv("LOKI_UPSTREAM_URL")
+        if not loki_upstream:
+            logger.fatal(f"Failed to load loki_upstream: {e}")
+            sys.exit(1)
+
+        # Create SSL context with CA certificates
+        ssl_context = create_ssl_context()
+
+        # Build TokenReview URL
+        api_host = os.getenv("KUBERNETES_SERVICE_HOST")
+        api_port = os.getenv("KUBERNETES_SERVICE_PORT", "443")
+        token_review_url = (
+            f"https://{api_host}:{api_port}/apis/authentication.k8s.io/v1/tokenreviews"
+        )
+        logger.info(f"TokenReview endpoint: {token_review_url}")
+
+
+    def main():
+        """Main entry point."""
+        initialize()
+
+        port = os.getenv("PORT", "8080")
+        server = ThreadingHTTPServer(("0.0.0.0", int(port)), ProxyHandler)
+        logger.info(f"Proxy listening on ::{port}")
+        try:
+            server.serve_forever()
+        except KeyboardInterrupt:
+            logger.info("Shutting down")
+            server.shutdown()
+
+
+    if __name__ == "__main__":
+        main()
+
+  auth.py: |
+    """Authentication via Kubernetes TokenReview API."""
+    import json
+    import logging
+    import os
+    import ssl
+    from urllib.request import Request, urlopen
+
+    SA_TOKEN_PATH = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    logger = logging.getLogger(__name__)
+
+
+    class UserInfo:
+        """User information extracted from token."""
+
+        def __init__(self, username):
+            self.username = username
+
+
+    def create_ssl_context():
+        """Create SSL context with Kubernetes CA certificates."""
+        ca_paths = [
+            "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt",
+            "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
+        ]
+
+        context = ssl.create_default_context()
+
+        for ca_path in ca_paths:
+            try:
+                context.load_verify_locations(ca_path)
+                logger.info(f"Loaded CA certificate from {ca_path}")
+            except OSError:
+                pass
+
+        return context
+
+
+    def extract_from_bearer_token(auth_header, token_review_url, ssl_context):
+        """
+        Extract user info from Authorization: Bearer <token>.
+
+        All tokens are validated server-side via the Kubernetes TokenReview API.
+        """
+        if not auth_header:
+            raise ValueError("missing Authorization header")
+
+        parts = auth_header.split(" ", 1)
+        if len(parts) != 2 or parts[0].lower() != "bearer":
+            raise ValueError("invalid Authorization header format")
+
+        return resolve_token(parts[1], token_review_url, ssl_context)
+
+
+    def resolve_token(token, token_review_url, ssl_context):
+        """
+        Call the Kubernetes TokenReview API to validate bearer token.
+
+        This is the sole authentication path -- tokens are never parsed or
+        trusted locally.
+        """
+        try:
+            with open(SA_TOKEN_PATH, "r") as f:
+                sa_token = f.read().strip()
+        except OSError as e:
+            raise ValueError(f"cannot read SA token for TokenReview: {e}") from e
+
+        body = {
+            "apiVersion": "authentication.k8s.io/v1",
+            "kind": "TokenReview",
+            "spec": {"token": token},
+        }
+
+        body_bytes = json.dumps(body).encode("utf-8")
+
+        req = Request(
+            token_review_url,
+            data=body_bytes,
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {sa_token}",
+            },
+            method="POST",
+        )
+
+        try:
+            with urlopen(req, timeout=10, context=ssl_context) as resp:
+                resp_body = resp.read()
+                resp_code = resp.status
+        except Exception as e:
+            raise ValueError(f"TokenReview request failed: {e}") from e
+
+        if resp_code not in (200, 201):
+            raise ValueError(f"TokenReview returned HTTP {resp_code}")
+
+        try:
+            result = json.loads(resp_body)
+        except json.JSONDecodeError as e:
+            raise ValueError(f"failed to parse TokenReview response: {e}") from e
+
+        status = result.get("status", {})
+        if not status.get("authenticated", False):
+            error_msg = status.get("error", "token not authenticated")
+            raise ValueError(f"TokenReview: {error_msg}")
+
+        user = status.get("user", {})
+        username = user.get("username", "")
+        if not username:
+            raise ValueError("TokenReview returned empty username")
+
+        return UserInfo(username=username)
+
+  rewriter.py: |
+    """LogQL query rewriting to inject user filters."""
+
+
+    def escape_logql_value(value):
+        """Escape special characters in LogQL values."""
+        value = value.replace("\\", "\\\\")
+        value = value.replace('"', '\\"')
+        return value
+
+
+    def inject_user_filter(query, username, labels_only=False):
+        """
+        Inject user filter into LogQL query.
+
+        Modifies stream selectors to add kubernetes_namespace_name="opendatahub" label.
+        If labels_only=False, also adds pipeline filter `| user_id="<user>"` after the selector.
+
+        Args:
+            query: LogQL query string
+            username: User identifier to filter by
+            labels_only: If True, skip pipeline filter (for label values endpoints)
+
+        Examples:
+            Normal query (labels_only=False):
+                {app="x"} | line_format "{{.msg}}"
+             -> {app="x", kubernetes_namespace_name="opendatahub"} | user_id="alice" | line_format "{{.msg}}"
+
+            Empty selector (labels_only=False):
+                {}
+             -> {kubernetes_namespace_name="opendatahub"} | user_id="alice"
+
+            Label values query (labels_only=True):
+                {app="x"}
+             -> {app="x", kubernetes_namespace_name="opendatahub"}
+        """
+        if not query or not username:
+            return query
+
+        namespace_label = 'kubernetes_namespace_name="opendatahub"'
+        user_filter = '' if labels_only else f' | user_id="{escape_logql_value(username)}"'
+        result = []
+        in_selector = False
+        selector_start_pos = -1
+        in_double_quote = False
+        in_backtick = False
+        i = 0
+
+        while i < len(query):
+            ch = query[i]
+
+            # Handle escape sequences in double quotes
+            if ch == "\\" and in_double_quote and i + 1 < len(query):
+                result.append(ch)
+                i += 1
+                result.append(query[i])
+                i += 1
+                continue
+
+            # Toggle quote states
+            if ch == '"' and not in_backtick:
+                in_double_quote = not in_double_quote
+            if ch == "`" and not in_double_quote:
+                in_backtick = not in_backtick
+
+            in_quote = in_double_quote or in_backtick
+
+            # Track selector braces
+            if ch == "{" and not in_quote:
+                in_selector = True
+                selector_start_pos = len(result)
+                result.append(ch)
+                i += 1
+                continue
+
+            # Inject namespace label and optionally user filter before closing selector brace
+            if ch == "}" and in_selector and not in_quote:
+                # Check if selector is empty by looking at content since '{'
+                selector_content = "".join(result[selector_start_pos + 1:]).strip()
+                is_empty = len(selector_content) == 0
+
+                # Add comma only if selector has existing matchers
+                if is_empty:
+                    result.append(namespace_label)
+                else:
+                    result.append(", ")
+                    result.append(namespace_label)
+
+                result.append(ch)
+                result.append(user_filter)
+                in_selector = False
+            else:
+                result.append(ch)
+
+            i += 1
+
+        return "".join(result)

--- a/deployment/components/observability/usage-logs/tenancy-proxy-rbac.yaml
+++ b/deployment/components/observability/usage-logs/tenancy-proxy-rbac.yaml
@@ -1,0 +1,92 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: loki-query-proxy
+  namespace: opendatahub
+  labels:
+    app: loki-query-proxy
+    app.kubernetes.io/managed-by: maas-controller
+    app.kubernetes.io/component: loki-proxy
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: loki-query-proxy-logs
+  labels:
+    app: loki-query-proxy
+    app.kubernetes.io/managed-by: maas-controller
+    app.kubernetes.io/component: loki-proxy
+rules:
+- apiGroups:
+  - ''
+  resources:
+  - pods/log
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: loki-query-proxy-logging-view
+  namespace: opendatahub
+  labels:
+    app: loki-query-proxy
+    app.kubernetes.io/managed-by: maas-controller
+    app.kubernetes.io/component: loki-proxy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: loki-query-proxy-logs
+subjects:
+- kind: ServiceAccount
+  name: loki-query-proxy
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: loki-query-proxy-logging-view-custom
+  namespace: opendatahub
+  labels:
+    app: loki-query-proxy
+    app.kubernetes.io/component: loki-proxy
+    app.kubernetes.io/managed-by: maas-controller
+subjects:
+  - kind: ServiceAccount
+    name: loki-query-proxy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-logging-application-view
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: loki-query-proxy-tokenreview
+  labels:
+    app: loki-query-proxy
+    app.kubernetes.io/managed-by: maas-controller
+    app.kubernetes.io/component: loki-proxy
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: loki-query-proxy-tokenreview
+  labels:
+    app: loki-query-proxy
+    app.kubernetes.io/managed-by: maas-controller
+    app.kubernetes.io/component: loki-proxy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: loki-query-proxy-tokenreview
+subjects:
+- kind: ServiceAccount
+  name: loki-query-proxy
+  namespace: opendatahub

--- a/deployment/components/observability/usage-logs/tenancy-proxy.yaml
+++ b/deployment/components/observability/usage-logs/tenancy-proxy.yaml
@@ -1,0 +1,96 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: usage-logs-tenancy-proxy
+  namespace: opendatahub
+  labels:
+    app: loki-query-proxy
+    app.kubernetes.io/managed-by: maas-controller
+    app.kubernetes.io/component: loki-proxy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: loki-query-proxy
+  template:
+    metadata:
+      labels:
+        app: loki-query-proxy
+    spec:
+      serviceAccountName: loki-query-proxy
+      containers:
+      - name: proxy
+        # Image is set by controller (DefaultUsageLogsTenancyProxyImage or RELATED_IMAGE override)
+        command:
+        - python3
+        - /opt/app-root/src/proxy/main.py
+        securityContext:
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        env:
+        - name: PORT
+          value: "8080"
+        # Override via kustomize patch for your LokiStack service name/namespace.
+        - name: LOKI_UPSTREAM_URL
+          value: "https://maas-loki-gateway-http.opendatahub.svc.cluster.local:8080/api/logs/v1/application"
+        - name: PYTHONPATH
+          value: "/opt/app-root/src/proxy"
+        - name: PYTHONUNBUFFERED
+          value: "1"
+        - name: LOG_LEVEL
+          value: "INFO"
+        volumeMounts:
+        - name: proxy-source
+          mountPath: /opt/app-root/src/proxy
+          readOnly: true
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 30
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          requests:
+            cpu: 50m
+            memory: 128Mi
+          limits:
+            cpu: 200m
+            memory: 256Mi
+      volumes:
+      - name: proxy-source
+        configMap:
+          name: loki-query-proxy-source
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: usage-logs-tenancy-proxy
+  namespace: opendatahub
+  labels:
+    app: loki-query-proxy
+    app.kubernetes.io/managed-by: maas-controller
+    app.kubernetes.io/component: loki-proxy
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8080
+    targetPort: 8080
+    protocol: TCP
+    name: http
+  selector:
+    app: loki-query-proxy

--- a/deployment/overlays/odh/params.env
+++ b/deployment/overlays/odh/params.env
@@ -2,6 +2,7 @@ maas-api-image=quay.io/opendatahub/maas-api:odh-stable
 maas-controller-image=quay.io/opendatahub/maas-controller:odh-stable
 payload-processing-image=quay.io/opendatahub/odh-ai-gateway-payload-processing:odh-stable
 maas-api-key-cleanup-image=registry.redhat.io/ubi9/ubi-minimal:9.7
+usage-logs-tenancy-proxy-image=registry.redhat.io/ubi9/python-312
 payload-processing-replicas=1
 gateway-namespace=openshift-ingress
 gateway-name=maas-default-gateway

--- a/maas-controller/pkg/controller/maas/constants.go
+++ b/maas-controller/pkg/controller/maas/constants.go
@@ -1,5 +1,11 @@
 package maas
 
+const (
+	// DefaultUsageLogsTenancyProxyImage is the default image for the usage-logs tenancy proxy container.
+	// Can be overridden via RELATED_IMAGE_ODH_PYTHON_312_IMAGE for disconnected environments.
+	DefaultUsageLogsTenancyProxyImage = "registry.redhat.io/ubi9/python-312"
+)
+
 // OptionalAPIGroups lists API groups whose CRDs are installed by optional platform
 // components (e.g. COO for Perses). Resources in these groups are skipped gracefully
 // when their CRDs are not yet registered, instead of failing the Tenant reconcile.

--- a/maas-controller/pkg/controller/maas/self_deployment_controller.go
+++ b/maas-controller/pkg/controller/maas/self_deployment_controller.go
@@ -582,6 +582,9 @@ func (r *LifecycleReconciler) ensureUsageLogs(ctx context.Context, log logr.Logg
 			if err := patchUsageLogsOpenTelemetryCollector(&res, r.MonitoringNamespace); err != nil {
 				return fmt.Errorf("patch %s %s: %w", res.GetKind(), res.GetName(), err)
 			}
+			if err := patchTenancyProxyImage(&res); err != nil {
+				return fmt.Errorf("patch %s %s: %w", res.GetKind(), res.GetName(), err)
+			}
 			if err := controllerutil.SetControllerReference(&cfg, &res, r.Scheme); err != nil {
 				return fmt.Errorf("set controller reference on %s %s: %w", res.GetKind(), res.GetName(), err)
 			}
@@ -665,6 +668,37 @@ func patchUsageLogsOpenTelemetryCollector(res *unstructured.Unstructured, monito
 		return fmt.Errorf("set loki exporter endpoint: %w", err)
 	}
 	return nil
+}
+
+// patchTenancyProxyImage sets the tenancy-proxy container image to RELATED_IMAGE_ODH_PYTHON_312_IMAGE
+// if configured, otherwise uses DefaultUsageLogsTenancyProxyImage. This enables disconnected deployments
+// to mirror the image while maintaining a code-defined default.
+func patchTenancyProxyImage(res *unstructured.Unstructured) error {
+	if res.GetKind() != "Deployment" || res.GetName() != "usage-logs-tenancy-proxy" {
+		return nil
+	}
+
+	image := os.Getenv("RELATED_IMAGE_ODH_PYTHON_312_IMAGE")
+	if image == "" {
+		image = DefaultUsageLogsTenancyProxyImage
+	}
+
+	containers, found, err := unstructured.NestedSlice(res.Object, "spec", "template", "spec", "containers")
+	if err != nil || !found {
+		return fmt.Errorf("containers not found in deployment: %w", err)
+	}
+
+	for i, c := range containers {
+		cm, ok := c.(map[string]any)
+		if !ok || cm["name"] != "proxy" {
+			continue
+		}
+		cm["image"] = image
+		containers[i] = cm
+		return unstructured.SetNestedSlice(res.Object, containers, "spec", "template", "spec", "containers")
+	}
+
+	return errors.New("proxy container not found in usage-logs-tenancy-proxy deployment")
 }
 
 // ensureUsageLogsEnvoyFilter deploys or removes the OTel usage logs EnvoyFilter based on

--- a/maas-controller/pkg/controller/maas/self_deployment_controller_test.go
+++ b/maas-controller/pkg/controller/maas/self_deployment_controller_test.go
@@ -954,3 +954,118 @@ func TestEnsureUsageLogs(t *testing.T) {
 		g.Expect(subj["namespace"]).To(Equal(monitoringNS))
 	})
 }
+
+func TestPatchTenancyProxyImage(t *testing.T) {
+	t.Run("patches proxy container image when RELATED_IMAGE set", func(t *testing.T) {
+		g := NewWithT(t)
+		t.Setenv("RELATED_IMAGE_ODH_PYTHON_312_IMAGE", "quay.io/example/tenancy-proxy:test")
+
+		deployment := &unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": "apps/v1",
+				"kind":       "Deployment",
+				"metadata": map[string]any{
+					"name": "usage-logs-tenancy-proxy",
+				},
+				"spec": map[string]any{
+					"template": map[string]any{
+						"spec": map[string]any{
+							"containers": []any{
+								map[string]any{
+									"name":  "proxy",
+									"image": "registry.redhat.io/ubi9/python-312",
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		err := patchTenancyProxyImage(deployment)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		containers, found, err := unstructured.NestedSlice(deployment.Object, "spec", "template", "spec", "containers")
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(found).To(BeTrue())
+		g.Expect(containers).To(HaveLen(1))
+
+		container, ok := containers[0].(map[string]any)
+		g.Expect(ok).To(BeTrue())
+		g.Expect(container["image"]).To(Equal("quay.io/example/tenancy-proxy:test"))
+	})
+
+	t.Run("uses default image when RELATED_IMAGE not set", func(t *testing.T) {
+		g := NewWithT(t)
+
+		deployment := &unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": "apps/v1",
+				"kind":       "Deployment",
+				"metadata": map[string]any{
+					"name": "usage-logs-tenancy-proxy",
+				},
+				"spec": map[string]any{
+					"template": map[string]any{
+						"spec": map[string]any{
+							"containers": []any{
+								map[string]any{
+									"name": "proxy",
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		err := patchTenancyProxyImage(deployment)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		containers, found, err := unstructured.NestedSlice(deployment.Object, "spec", "template", "spec", "containers")
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(found).To(BeTrue())
+
+		container, ok := containers[0].(map[string]any)
+		g.Expect(ok).To(BeTrue())
+		g.Expect(container["image"]).To(Equal(DefaultUsageLogsTenancyProxyImage))
+	})
+
+	t.Run("ignores non-matching deployment", func(t *testing.T) {
+		g := NewWithT(t)
+		t.Setenv("RELATED_IMAGE_ODH_PYTHON_312_IMAGE", "quay.io/example/tenancy-proxy:test")
+
+		deployment := &unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": "apps/v1",
+				"kind":       "Deployment",
+				"metadata": map[string]any{
+					"name": "some-other-deployment",
+				},
+				"spec": map[string]any{
+					"template": map[string]any{
+						"spec": map[string]any{
+							"containers": []any{
+								map[string]any{
+									"name":  "proxy",
+									"image": "registry.redhat.io/ubi9/python-312",
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		err := patchTenancyProxyImage(deployment)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		containers, found, err := unstructured.NestedSlice(deployment.Object, "spec", "template", "spec", "containers")
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(found).To(BeTrue())
+
+		container, ok := containers[0].(map[string]any)
+		g.Expect(ok).To(BeTrue())
+		g.Expect(container["image"]).To(Equal("registry.redhat.io/ubi9/python-312"))
+	})
+}


### PR DESCRIPTION
## Description
Adding a reverse-proxy that will be used by a usage dashboard for non-admin users based on data in Loki.

## How Has This Been Tested?
Tests manually

## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work