### PR TITLE
fix: skip storage-initializer for simulator LLMInferenceServices

### DIFF
--- a/docs/samples/models/e2e-distinct-2-simulated/model.yaml
+++ b/docs/samples/models/e2e-distinct-2-simulated/model.yaml
@@ -4,8 +4,12 @@ metadata:
   name: e2e-distinct-2-simulated
 spec:
   model:
-    uri: hf://sshleifer/tiny-gpt2 # ~2MB test model, simulator ignores it anyway
+    # uri is required by the LLMIS schema but not used by llm-d-inference-sim.
+    uri: hf://placeholder/no-model
     name: test/e2e-distinct-model-2
+  # Skip storage-initializer; simulator generates responses without model weights.
+  storageInitializer:
+    enabled: false
   replicas: 1
   router:
     route: {}

--- a/docs/samples/models/e2e-distinct-simulated/model.yaml
+++ b/docs/samples/models/e2e-distinct-simulated/model.yaml
@@ -4,8 +4,12 @@ metadata:
   name: e2e-distinct-simulated
 spec:
   model:
-    uri: hf://sshleifer/tiny-gpt2 # ~2MB test model, simulator ignores it anyway
+    # uri is required by the LLMIS schema but not used by llm-d-inference-sim.
+    uri: hf://placeholder/no-model
     name: test/e2e-distinct-model
+  # Skip storage-initializer; simulator generates responses without model weights.
+  storageInitializer:
+    enabled: false
   replicas: 1
   router:
     route: {}

--- a/docs/samples/models/simulator-premium/model.yaml
+++ b/docs/samples/models/simulator-premium/model.yaml
@@ -4,8 +4,12 @@ metadata:
   name: simulated-premium
 spec:
   model:
-    uri: hf://sshleifer/tiny-gpt2 # ~2MB test model, simulator ignores it anyway
+    # uri is required by the LLMIS schema but not used by llm-d-inference-sim.
+    uri: hf://placeholder/no-model
     name: facebook/opt-125m
+  # Skip storage-initializer; simulator generates responses without model weights.
+  storageInitializer:
+    enabled: false
   replicas: 1
   router: 
     route: {}

--- a/docs/samples/models/simulator/model.yaml
+++ b/docs/samples/models/simulator/model.yaml
@@ -4,8 +4,12 @@ metadata:
   name: simulated
 spec:
   model:
-    uri: hf://sshleifer/tiny-gpt2 # ~2MB test model, simulator ignores it anyway
+    # uri is required by the LLMIS schema but not used by llm-d-inference-sim.
+    uri: hf://placeholder/no-model
     name: facebook/opt-125m
+  # Skip storage-initializer; simulator generates responses without model weights.
+  storageInitializer:
+    enabled: false
   replicas: 1
   router: 
     route: {}
@@ -18,6 +22,7 @@ spec:
     containers:
       # llm-d-inference-sim: OpenAI-compatible HTTP on --port; /health + /ready for probes.
       # Image ENTRYPOINT is /app/llm-d-inference-sim (v0.8.x); args are appended to it.
+      # storageInitializer.enabled=false skips HF model download; simulator needs no weights.
       # See: https://github.com/llm-d/llm-d-inference-sim
       - name: main
         image: "ghcr.io/llm-d/llm-d-inference-sim:v0.8.2"

--- a/test/e2e/fixtures/trlp-test/llm/llmis.yaml
+++ b/test/e2e/fixtures/trlp-test/llm/llmis.yaml
@@ -4,8 +4,12 @@ metadata:
   name: e2e-trlp-test-simulated
 spec:
   model:
-    uri: hf://sshleifer/tiny-gpt2 # ~2MB test model, simulator ignores it anyway
+    # uri is required by the LLMIS schema but not used by llm-d-inference-sim.
+    uri: hf://placeholder/no-model
     name: test/e2e-trlp-test-model
+  # Skip storage-initializer; simulator generates responses without model weights.
+  storageInitializer:
+    enabled: false
   replicas: 1
   router:
     route: {}

--- a/test/e2e/scripts/local-deploy.sh
+++ b/test/e2e/scripts/local-deploy.sh
@@ -1270,8 +1270,10 @@ metadata:
   namespace: ${INTERNAL_MODEL_NAMESPACE}
 spec:
   model:
-    uri: hf://sshleifer/tiny-gpt2
+    uri: hf://placeholder/no-model
     name: facebook/opt-125m
+  storageInitializer:
+    enabled: false
   replicas: 1
   router:
     route: {}


### PR DESCRIPTION
Simulator LLMInferenceService manifests used in e2e and sample deployments were still triggering KServe’s storage-initializer init container to download hf://sshleifer/tiny-gpt2, even though llm-d-inference-sim never reads model weights. That download can time out in CI and block pods from becoming Ready.

This change sets storageInitializer.enabled: false on all simulator LLMIS resources and replaces the HuggingFace URI with a placeholder (hf://placeholder/no-model) that satisfies the schema but is never fetched.