### PR TITLE
fix: fix oidc transient failure tests with retry

### DIFF
--- a/test/e2e/tests/test_external_oidc.py
+++ b/test/e2e/tests/test_external_oidc.py
@@ -339,14 +339,14 @@ class TestOIDCModelAccess:
         """Complete happy path: OIDC token → API key → model list → inference."""
         token = _request_oidc_token()
         api_key = _create_oidc_api_key(maas_api_base_url, token)["key"]
-        headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
 
         # List models
-        models_response = requests.get(
+        models_response = _oidc_request_with_retry(
+            requests.get,
             f"{maas_api_base_url}/v1/models",
-            headers=headers,
+            api_key,
+            label="OIDC list models",
             timeout=45,
-            verify=TLS_VERIFY,
         )
         assert models_response.status_code == 200, (
             f"OIDC-minted API key failed to list models: "
@@ -364,16 +364,17 @@ class TestOIDCModelAccess:
         gateway_host = os.environ.get("GATEWAY_HOST", "")
         scheme = "http" if os.environ.get("INSECURE_HTTP", "").lower() == "true" else "https"
         model_url = f"{scheme}://{gateway_host}{model_path}" if gateway_host else raw_url
-        inference_response = requests.post(
+        inference_response = _oidc_request_with_retry(
+            requests.post,
             f"{model_url}/v1/chat/completions",
-            headers=headers,
+            api_key,
+            label="OIDC inference",
             json={
                 "model": model_id,
                 "messages": [{"role": "user", "content": "Hello from external OIDC e2e"}],
                 "max_tokens": 16,
             },
             timeout=45,
-            verify=TLS_VERIFY,
         )
         assert inference_response.status_code == 200, (
             f"OIDC-minted API key inference failed: "
@@ -446,11 +447,12 @@ class TestOIDCModelAccess:
         token = response.json().get("access_token")
         assert token, "OIDC token response missing access_token"
 
-        models_response = requests.get(
+        models_response = _oidc_request_with_retry(
+            requests.get,
             f"{maas_api_base_url}/v1/models",
-            headers={"Authorization": f"Bearer {token}"},
+            token,
+            label="OIDC list models (no-access user)",
             timeout=45,
-            verify=TLS_VERIFY,
         )
 
         assert models_response.status_code == 200, (
@@ -592,15 +594,12 @@ class TestOIDCHeaderInjection:
         token = _request_oidc_token(username="alice_lead", password="letmein")
         api_key = _create_oidc_api_key(maas_api_base_url, token)["key"]
 
-        response = requests.get(
+        response = _oidc_request_with_retry(
+            requests.get,
             f"{maas_api_base_url}/v1/models",
-            headers={
-                "Authorization": f"Bearer {api_key}",
-                "Content-Type": "application/json",
-                "X-MaaS-Username": "evil_hacker",
-            },
-            timeout=30,
-            verify=TLS_VERIFY,
+            api_key,
+            label="OIDC inject X-MaaS-Username",
+            headers={"X-MaaS-Username": "evil_hacker"},
         )
         # The request should succeed — the spoofed header should be
         # overwritten by Authorino with the real authenticated identity
@@ -621,26 +620,20 @@ class TestOIDCHeaderInjection:
         token = _request_oidc_token(username="alice_lead", password="letmein")
         api_key = _create_oidc_api_key(maas_api_base_url, token)["key"]
 
-        response = requests.get(
+        response = _oidc_request_with_retry(
+            requests.get,
             f"{maas_api_base_url}/v1/models",
-            headers={
-                "Authorization": f"Bearer {api_key}",
-                "Content-Type": "application/json",
-                "X-MaaS-Group": '["system:cluster-admins","cluster-admin"]',
-            },
-            timeout=30,
-            verify=TLS_VERIFY,
+            api_key,
+            label="OIDC inject X-MaaS-Group",
+            headers={"X-MaaS-Group": '["system:cluster-admins","cluster-admin"]'},
         )
 
         # Get baseline (no injection) for comparison
-        baseline = requests.get(
+        baseline = _oidc_request_with_retry(
+            requests.get,
             f"{maas_api_base_url}/v1/models",
-            headers={
-                "Authorization": f"Bearer {api_key}",
-                "Content-Type": "application/json",
-            },
-            timeout=30,
-            verify=TLS_VERIFY,
+            api_key,
+            label="OIDC baseline (group injection test)",
         )
         assert baseline.status_code == 200, (
             f"Baseline request failed: {baseline.status_code} {baseline.text}"
@@ -681,15 +674,12 @@ class TestOIDCHeaderInjection:
         real_subscription = key_data.get("subscription", "")
 
         # Request with spoofed subscription
-        response = requests.get(
+        response = _oidc_request_with_retry(
+            requests.get,
             f"{maas_api_base_url}/v1/models",
-            headers={
-                "Authorization": f"Bearer {api_key}",
-                "Content-Type": "application/json",
-                "X-MaaS-Subscription": "fake-subscription-id-12345",
-            },
-            timeout=30,
-            verify=TLS_VERIFY,
+            api_key,
+            label="OIDC inject X-MaaS-Subscription",
+            headers={"X-MaaS-Subscription": "fake-subscription-id-12345"},
         )
         assert response.status_code == 200, (
             f"Expected 200 (injected subscription header ignored), "
@@ -697,14 +687,11 @@ class TestOIDCHeaderInjection:
         )
 
         # Also request without injection to compare
-        baseline_response = requests.get(
+        baseline_response = _oidc_request_with_retry(
+            requests.get,
             f"{maas_api_base_url}/v1/models",
-            headers={
-                "Authorization": f"Bearer {api_key}",
-                "Content-Type": "application/json",
-            },
-            timeout=30,
-            verify=TLS_VERIFY,
+            api_key,
+            label="OIDC baseline (subscription injection test)",
         )
         assert baseline_response.status_code == 200
 

--- a/test/e2e/tests/test_models_endpoint.py
+++ b/test/e2e/tests/test_models_endpoint.py
@@ -1521,13 +1521,12 @@ class TestModelsEndpoint:
 
             # Query with API key (gateway injects deleted subscription name)
             log.info("Querying /v1/models with API key bound to deleted subscription")
-            r = requests.get(
+            r = _request_with_gateway_retry(
+                requests.get,
                 f"{_maas_api_url()}/v1/models",
                 headers={
                     "Authorization": f"Bearer {api_key}",
                 },
-                timeout=TIMEOUT,
-                verify=TLS_VERIFY,
             )
 
             # Should return 403 because subscription doesn't exist


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
fix oidc transient failure tests with retry

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Enhanced end-to-end OIDC test reliability by routing API calls through shared retry-enabled request helpers, improving stability for model listing, chat inference, and security header validation scenarios.
  * Updated the models endpoint test for deleted subscriptions to use the gateway-retry helper, ensuring consistent behavior when transient gateway propagation issues occur while preserving existing 403/permission assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->