### PR TITLE
chore: improve pipeline execution speed by removing redundant waits

### DIFF
--- a/test/e2e/scripts/prow_run_smoke_test.sh
+++ b/test/e2e/scripts/prow_run_smoke_test.sh
@@ -793,6 +793,7 @@ run_e2e_tests() {
     fi
 
     # Run the default smoke e2e tests
+    export E2E_RECONCILE_WAIT="${E2E_RECONCILE_WAIT:-4}"
     if ! PYTHONPATH="$test_dir:${PYTHONPATH:-}" pytest \
         -v --maxfail=5 --disable-warnings \
         --junitxml="$xml" \

--- a/test/e2e/tests/test_models_endpoint.py
+++ b/test/e2e/tests/test_models_endpoint.py
@@ -2152,7 +2152,6 @@ class TestModelsEndpoint:
                 model_refs=[model_ref],
                 groups=["system:authenticated"]
             )
-            _wait_reconcile()
             _wait_for_maas_auth_policy_phase(auth_policy_name, timeout=90)
 
             # 2. Create subscription with low token limit
@@ -2164,7 +2163,6 @@ class TestModelsEndpoint:
                 token_limit=token_limit,
                 window=window
             )
-            _wait_reconcile()
             _wait_for_maas_subscription_phase(subscription_name, timeout=90)
 
             # Wait for TRLP to be created and enforced

--- a/test/e2e/tests/test_namespace_scoping.py
+++ b/test/e2e/tests/test_namespace_scoping.py
@@ -302,7 +302,6 @@ class TestMaaSControllerWatchNamespace:
                     "modelRefs": [{"name": MODEL_REF, "namespace": MODEL_NAMESPACE, "tokenRateLimits": [{"limit": 1, "window": "1m"}]}],
                 },
             })
-            _wait_reconcile(15)
             _wait_for_maas_auth_policy_phase("e2e-watched-auth", timeout=90)
             _wait_for_maas_subscription_phase("e2e-watched-sub", namespace=ns, timeout=90)
 

--- a/test/e2e/tests/test_subscription.py
+++ b/test/e2e/tests/test_subscription.py
@@ -564,7 +564,6 @@ class TestSubscriptionEnforcement:
                 model_refs=[model_ref],
                 groups=["system:authenticated"]
             )
-            _wait_reconcile()
             _wait_for_maas_auth_policy_phase(auth_policy_name, timeout=90, require_auth_policies=False)
 
             # 2. Create subscription with low token limit
@@ -575,7 +574,6 @@ class TestSubscriptionEnforcement:
                 token_limit=token_limit,
                 window=window
             )
-            _wait_reconcile()
             _wait_for_maas_subscription_phase(subscription_name, timeout=90)
 
             # Wait for TRLP to be created AND enforced by Kuadrant/Limitador
@@ -986,7 +984,6 @@ class TestOrderingEdgeCases:
                 groups=["system:authenticated"],
                 namespace=ns,
             )
-            _wait_reconcile()
             _wait_for_maas_subscription_phase("e2e-ordering-sub", namespace=ns, timeout=180)
 
             # Use SA token instead of user token to avoid environment-specific 401s on /v1/api-keys.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Currently, the e2e test pipeline executes for over an hour. That slows down the efficiency for getting changes delivered. This PR is taking a first step towards improving pipeline execution speed by reducing/removing redundant waits for resource reconciliations.

(~10 min savings expected)

  ## Summary of changes                                                                                                                             
                                                                                                                                          
  - Set `E2E_RECONCILE_WAIT=4` (down from default 8s) in the prow smoke test                                                                
    script. The env var is already supported by `test_helper.py` — this halves
    the sleep time across ~140 `_wait_reconcile()` calls (~9 min saved).                                                                    
  - Remove 6 redundant `_wait_reconcile()` calls that immediately preceded                                                                  
    `_wait_for_maas_auth_policy_phase()` or `_wait_for_maas_subscription_phase()`.                                                          
    The phase waiters already poll until the CR reaches the target status, making                                                           
    the preceding fixed sleep unnecessary (~30-48s saved).                                                                                  
                                                                                                                                            
  ## Risk analysis                                                                                                                          
                                                                                                                                            
  - **Risk rating:** 1                                                                                                                      
  - **Why:** Only wait-time reductions in E2E tests — no behavioral changes.                                                              
    `E2E_RECONCILE_WAIT` defaults to 4 but remains overridable. The removed                                                                 
    `_wait_reconcile()` calls are fully covered by the phase-polling functions                                                              
    that follow them. Cleanup `_wait_reconcile()` calls in `finally` blocks are                                                             
    intentionally preserved.    

https://redhat.atlassian.net/browse/RHOAIENG-69577

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end reliability by replacing fixed reconciliation delays with phase-specific synchronization for MaaSAuthPolicy and MaaSSubscription readiness before assertions.
  * Tightened test execution order to ensure endpoints and token/quota behaviors are validated only after the expected controller phases complete.
* **Chores**
  * Added environment-variable configurability for the default E2E reconciliation wait time used during test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->