### PR TITLE
docs: update for multi-tenant Phase 1 implementation

### DIFF
--- a/docs/content/architecture-internals/authentication-internals.md
+++ b/docs/content/architecture-internals/authentication-internals.md
@@ -8,8 +8,10 @@ This page describes how **identity and subscription context** are established at
 
 Today’s pipeline does **not** drive TokenRateLimitPolicy by splitting group membership in CEL the way older drafts did. The flow is:
 
-1. **AuthPolicy** (controller-generated per model) authenticates the caller and calls **maas-api** at  
-   `POST https://maas-api.<namespace>.svc.cluster.local:8443/internal/v1/subscriptions/select`  
+1. **AuthPolicy** (controller-generated per model) authenticates the caller and calls **maas-api** at:
+   - Default tenant: `POST https://maas-api.opendatahub.svc.cluster.local:8443/internal/v1/subscriptions/select`
+   - Additional tenants: `POST https://maas-api-{tenantID}.opendatahub.svc.cluster.local:8443/internal/v1/subscriptions/select`
+   
    with the caller’s groups, username, requested subscription header (when applicable), and model scope.
 
 2. **maas-api** resolves which **MaaSSubscription** applies (including validation, auto-selection when only one subscription applies, and error paths). Results are exposed to Authorino as **`subscription-info`** metadata.

--- a/docs/content/install/maas-setup.md
+++ b/docs/content/install/maas-setup.md
@@ -280,6 +280,59 @@ kubectl patch odhdashboardconfig odh-dashboard-config \
     API version `opendatahub.io/v1alpha`. The operator re-creates this resource with factory
     defaults if it is deleted, but does not overwrite user changes to existing fields.
 
+## Creating Additional Tenants (Optional)
+
+The default installation creates a single tenant in the `models-as-a-service` namespace. To create additional isolated tenants:
+
+### 1. Create a Gateway
+
+Each tenant requires its own Gateway. Follow the [Gateway Patterns](../configuration-and-management/gateway-patterns.md) guide to create a gateway using the same pattern as `maas-default-gateway`.
+
+!!! warning "Avoid hostname filters"
+    Do not add `hostname` fields to Gateway listeners. Hostname-based routing can cause TLS/SNI issues. Use the default pattern with no hostname filter.
+
+### 2. Create AITenant CR
+
+Create an `AITenant` resource in the `ai-tenants` namespace:
+
+```yaml
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: AITenant
+metadata:
+  name: team-red
+  namespace: ai-tenants
+spec:
+  gateway:
+    name: team-red-gateway  # Must already exist in openshift-ingress
+```
+
+Apply the manifest:
+
+```bash
+kubectl apply -f aitenant.yaml
+```
+
+The controller will automatically create:
+- Tenant namespace: `ai-tenant-team-red`
+- Tenant CR: `default-tenant` in the tenant namespace
+- maas-api deployment: `maas-api-team-red`
+- HTTPRoute and AuthPolicy for the tenant
+
+### 3. Verify
+
+```bash
+# Check AITenant status
+kubectl get aitenant team-red -n ai-tenants -o yaml
+
+# Check tenant namespace was created
+kubectl get namespace ai-tenant-team-red
+
+# Check Tenant CR
+kubectl get tenant default-tenant -n ai-tenant-team-red
+```
+
+For complete AITenant configuration options (OIDC, RBAC), see the [AITenant CRD reference](../reference/crds/ai-tenant.md).
+
 ## Next steps
 
 * **Deploy models.** See [Model Setup](model-setup.md) for sample model deployments.

--- a/docs/content/reference/crds/maas-auth-policy.md
+++ b/docs/content/reference/crds/maas-auth-policy.md
@@ -1,6 +1,10 @@
 # MaaSAuthPolicy
 
-Defines who (groups/users) can access which models. Creates Kuadrant AuthPolicies that validate API keys via MaaS API callback and perform subscription selection. Must be created in the `models-as-a-service` namespace.
+Defines who (groups/users) can access which models. Creates Kuadrant AuthPolicies that validate API keys via MaaS API callback and perform subscription selection.
+
+**Namespace requirement:** Must be created in the tenant namespace:
+- Default tenant: `models-as-a-service`
+- Additional tenants: `ai-tenant-{tenantID}`
 
 ## MaaSAuthPolicySpec
 

--- a/docs/content/reference/crds/tenant.md
+++ b/docs/content/reference/crds/tenant.md
@@ -2,6 +2,28 @@
 
 Configures the MaaS platform tenant. The Tenant CRD is a namespace-scoped singleton — the resource name must be `default-tenant` (enforced by CEL validation). It specifies the gateway used to expose model endpoints, API key policies, external OIDC authentication, and telemetry settings.
 
+## Multi-Tenant Deployment
+
+In multi-tenant deployments, each tenant has its own Tenant CR in a dedicated namespace:
+
+| Tenant Type | Tenant CR Namespace | Tenant CR Name | maas-api Service (in operator namespace) | Created By |
+|-------------|---------------------|----------------|------------------------------------------|------------|
+| **Default** | `models-as-a-service` | `default-tenant` | `maas-api` | maas-controller on startup |
+| **Additional** | `ai-tenant-{tenantID}` | `default-tenant` | `maas-api-{tenantID}` | AITenant reconciler |
+
+**Key points:**
+- All Tenant CRs are named `default-tenant` within their respective namespace
+- Additional tenants are created by the AITenant reconciler, which provisions the tenant namespace and Tenant CR
+- All maas-api Services deploy to the operator namespace (opendatahub for ODH, redhat-ods-applications for RHOAI), not to tenant namespaces
+- Each tenant has an isolated maas-api instance for API key and subscription management
+- Tenant CRs for additional tenants have the finalizer `maas.opendatahub.io/tenant-cleanup`
+
+**Naming conventions:**
+- `TenantIdentifier`: Used for Kubernetes resource naming (empty string for default, `{tenantID}` for additional tenants)
+- `TenantName`: Used for database queries and HTTP headers (always `models-as-a-service` for default, `{tenantID}` for additional tenants)
+
+See [AITenant CRD](ai-tenant.md) for creating additional tenants.
+
 ---
 
 ## Spec


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- authentication-internals.md: Document per-tenant maas-api service endpoints
- maas-setup.md: Add "Creating Additional Tenants" section with AITenant workflow
- maas-auth-policy.md: Clarify namespace requirements for default vs additional tenants
- tenant.md: Add Multi-Tenant Deployment section explaining namespace patterns, service locations, naming conventions, and clarify that maas-api Services deploy to operator namespace (opendatahub for ODH, redhat-ods-applications for RHOAI)


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API endpoint specifications for subscription selection and rate limit configuration
  * Added comprehensive setup guide for creating and managing additional isolated tenant resources with verification steps
  * Expanded namespace requirements documentation for authentication policies to support multi-tenant deployment scenarios
  * Introduced multi-tenant deployment guide including operational best practices, resource naming conventions, and configuration references

<!-- end of auto-generated comment: release notes by coderabbit.ai -->