### PR TITLE
feat: inject X-MaaS-Username header in AuthConfig response

### DIFF
--- a/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
@@ -783,7 +783,7 @@ allow {
 		// User identity, groups, and key IDs are not forwarded to upstream model workloads
 		// to prevent accidental disclosure in logs or dumps. All identity information remains
 		// available to TRLP and telemetry via auth.identity and filters.identity below.
-		// Exception: X-MaaS-Subscription is injected for Istio Telemetry (per-subscription latency tracking).
+		// Exceptions: X-MaaS-Subscription (Istio Telemetry) and X-MaaS-Username (per-user metering) are injected.
 		rule["response"] = map[string]any{
 			"success": map[string]any{
 				"headers": map[string]any{
@@ -803,6 +803,14 @@ allow {
 					"X-MaaS-Subscription": map[string]any{
 						"plain": map[string]any{
 							"expression": `(has(auth.metadata) && has(auth.metadata.apiKeyValidation)) ? auth.metadata.apiKeyValidation.subscription : ""`,
+						},
+						"metrics":  false,
+						"priority": int64(0),
+					},
+					// Username for per-user metering (API keys: from validation, K8s tokens: from identity)
+					"X-MaaS-Username": map[string]any{
+						"plain": map[string]any{
+							"expression": `(has(auth.metadata) && has(auth.metadata.apiKeyValidation)) ? auth.metadata.apiKeyValidation.username : (has(auth.identity) && has(auth.identity.user) ? auth.identity.user.username : "")`,
 						},
 						"metrics":  false,
 						"priority": int64(0),

--- a/maas-controller/pkg/controller/maas/maasauthpolicy_controller_test.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_controller_test.go
@@ -1076,7 +1076,7 @@ func TestMaaSAuthPolicyReconciler_CacheKeyModelIsolation(t *testing.T) {
 }
 
 // TestMaaSAuthPolicyReconciler_NoIdentityHeadersUpstream verifies that identity headers
-// (X-MaaS-Username, X-MaaS-Group, X-MaaS-Key-Id) are NOT injected into requests forwarded
+// (X-MaaS-Group, X-MaaS-Key-Id) are NOT injected into requests forwarded
 // to upstream model workloads (defense-in-depth). Exception: X-MaaS-Subscription IS injected
 // for Istio Telemetry (per-subscription latency tracking).
 // All identity information remains available to TRLP and telemetry via filters.identity.
@@ -1119,7 +1119,7 @@ func TestMaaSAuthPolicyReconciler_NoIdentityHeadersUpstream(t *testing.T) {
 		t.Fatalf("Get AuthPolicy %q: %v", authPolicyName, err)
 	}
 
-	// Test 1: Verify identity headers (except X-MaaS-Subscription) are not forwarded upstream
+	// Test 1: Verify identity headers (except X-MaaS-Subscription and X-MaaS-Username) are not forwarded upstream
 	t.Run("identity headers not forwarded to upstream", func(t *testing.T) {
 		headers, found, err := unstructured.NestedMap(got.Object, "spec", "rules", "response", "success", "headers")
 		if err != nil {
@@ -1135,8 +1135,13 @@ func TestMaaSAuthPolicyReconciler_NoIdentityHeadersUpstream(t *testing.T) {
 			t.Errorf("X-MaaS-Subscription header should be present for Istio Telemetry")
 		}
 
-		// Verify identity headers are NOT present (defense-in-depth)
-		forbiddenHeaders := []string{"X-MaaS-Username", "X-MaaS-Group", "X-MaaS-Key-Id"}
+		// Verify X-MaaS-Username IS present (required for per-user metering)
+		if _, exists := headers["X-MaaS-Username"]; !exists {
+			t.Errorf("X-MaaS-Username header should be present for per-user metering")
+		}
+
+		// Verify sensitive identity headers are NOT present (defense-in-depth)
+		forbiddenHeaders := []string{"X-MaaS-Group", "X-MaaS-Key-Id"}
 		for _, header := range forbiddenHeaders {
 			if _, exists := headers[header]; exists {
 				t.Errorf("Identity header %q should NOT be forwarded to upstream workloads (defense-in-depth)", header)


### PR DESCRIPTION
## Summary
- Adds `X-MaaS-Username` header to the AuthConfig response template generated by the MaaSAuthPolicy controller
- For API keys: username from `apiKeyValidation.username`
- For K8s tokens: username from `auth.identity.user.username`
- Enables per-user metering in the IPP external-metering plugin

## Why
Previously only `X-MaaS-Subscription` was injected as a response header. The IPP metering plugin reads `x-maas-username` to attribute token usage to individual users. Without this header, all usage was attributed to the subscription name (e.g. "engineering") instead of the actual user (e.g. "noy").

## Test plan
- [x] Unit tests updated and passing (`make -C maas-controller test`)
- [x] Deployed to sandbox659 cluster and verified metering dashboard shows per-user attribution

## Risk analysis
- **Risk rating**: 1
- **Why**: Adds a single response header to the AuthConfig template. No change to authentication or authorization logic. The header is read-only metadata for downstream consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)