### PR TITLE
feat: enable x-api-key inbound authentication when IPP ExternalModel uses messages API format

### DIFF
--- a/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
@@ -359,6 +359,7 @@ func subscriptionGatewayCacheKeySelector() string {
 //+kubebuilder:rbac:groups=config.openshift.io,resources=authentications,verbs=get
 //+kubebuilder:rbac:groups=maas.opendatahub.io,resources=tenants,verbs=get;list;watch
 //+kubebuilder:rbac:groups="",resources=events,verbs=create;patch
+//+kubebuilder:rbac:groups=inference.opendatahub.io,resources=externalmodels,verbs=list
 
 // Reconcile is part of the main kubernetes reconciliation loop
 const maasAuthPolicyFinalizer = "maas.opendatahub.io/authpolicy-cleanup"
@@ -431,6 +432,7 @@ func (r *MaaSAuthPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		r.updateStatus(ctx, policy, maasv1alpha1.PhaseFailed, fmt.Sprintf("Failed to resolve tenant identifier: %v", err), statusSnapshot)
 		return ctrl.Result{}, err
 	}
+	xAPIKeyEnabled := r.discoverXAPIKeyNeeded(ctx, log)
 
 	gatewayNs, gatewayName, err := r.fetchGatewayInfo(ctx, log, req.Namespace)
 	if err != nil {
@@ -460,7 +462,7 @@ func (r *MaaSAuthPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		return ctrl.Result{}, nil
 	}
 
-	if err := r.reconcileGatewayAuthPolicy(ctx, log, string(modelAllowlistsJSON), oidc, tenantID, gatewayNs, gatewayName); err != nil {
+	if err := r.reconcileGatewayAuthPolicy(ctx, log, string(modelAllowlistsJSON), oidc, xAPIKeyEnabled, tenantID, gatewayNs, gatewayName); err != nil {
 		log.Error(err, "failed to reconcile gateway AuthPolicy")
 		r.updateStatus(ctx, policy, maasv1alpha1.PhaseFailed, fmt.Sprintf("Failed to reconcile gateway AuthPolicy: %v", err), statusSnapshot)
 		return ctrl.Result{}, err
@@ -591,7 +593,7 @@ type modelSubjectAllowlist struct {
 // buildGatewayAuthPolicySpec returns the Authorino AuthPolicy spec for the singleton
 // Gateway-level policy. Model identity is resolved dynamically via CEL on every request
 // rather than being baked in per-model, so this spec is the same for all MaaSAuthPolicy CRs.
-func (r *MaaSAuthPolicyReconciler) buildGatewayAuthPolicySpec(modelAccessJSON string, oidc *oidcConfig, tenantID, tenantName, gatewayNamespace, gatewayName string) map[string]any {
+func (r *MaaSAuthPolicyReconciler) buildGatewayAuthPolicySpec(modelAccessJSON string, oidc *oidcConfig, xAPIKeyEnabled bool, tenantID, tenantName, gatewayNamespace, gatewayName string) map[string]any {
 	// Construct tenant-specific maas-api service name using TenantIdentifier
 	// Default tenant (tenantID="") uses "maas-api", others use "maas-api-{tenantID}"
 	maasAPIServiceName := "maas-api"
@@ -609,6 +611,8 @@ func (r *MaaSAuthPolicyReconciler) buildGatewayAuthPolicySpec(modelAccessJSON st
   "requestedSubscription": `+celSubscription+`,
   "requestedModel": %s
 }`, celGroups, celUsername, celModelIdentity)
+
+	celIsAPIKey, celIsNotAPIKey, celExtractKey := apiKeyCELPredicates(xAPIKeyEnabled)
 
 	authenticationRules := map[string]any{
 		"api-keys": map[string]any{
@@ -631,12 +635,27 @@ func (r *MaaSAuthPolicyReconciler) buildGatewayAuthPolicySpec(modelAccessJSON st
 			},
 			"when": []any{
 				map[string]any{
-					"predicate": `!request.headers.authorization.startsWith("Bearer sk-oai-")`,
+					"predicate": celIsNotAPIKey,
 				},
 			},
 			"metrics":  false,
 			"priority": int64(2),
 		},
+	}
+
+	if xAPIKeyEnabled {
+		authenticationRules["api-keys-x-api-key"] = map[string]any{
+			"plain": map[string]any{
+				"expression": `"Bearer " + request.headers["x-api-key"]`,
+			},
+			"when": []any{
+				map[string]any{
+					"predicate": `"x-api-key" in request.headers && request.headers["x-api-key"].matches("^sk-oai-.*")`,
+				},
+			},
+			"metrics":  false,
+			"priority": int64(0),
+		}
 	}
 
 	if oidc != nil {
@@ -647,7 +666,7 @@ func (r *MaaSAuthPolicyReconciler) buildGatewayAuthPolicySpec(modelAccessJSON st
 			},
 			"when": []any{
 				map[string]any{
-					"predicate": `!request.headers.authorization.startsWith("Bearer sk-oai-") && request.headers.authorization.matches("^Bearer [^.]+\\.[^.]+\\.[^.]+$")`,
+					"predicate": celIsNotAPIKey + ` && request.headers.authorization.matches("^Bearer [^.]+\\.[^.]+\\.[^.]+$")`,
 				},
 			},
 			"metrics":  false,
@@ -655,7 +674,7 @@ func (r *MaaSAuthPolicyReconciler) buildGatewayAuthPolicySpec(modelAccessJSON st
 		}
 	}
 
-	authValidCacheKey := `"api-key|" + request.headers.authorization.replace("Bearer ", "") + "|" + ` + celModelIdentity
+	authValidCacheKey := `"api-key|" + (` + celExtractKey + `) + "|" + ` + celModelIdentity
 
 	// tenantGatewayIsolationRule is a stub that always allows. It will be replaced with a real
 	// maas-api call to verify the API key's tenant matches the gateway hostname when multi-tenant
@@ -742,9 +761,7 @@ allow {
 			"apiKeyValidation": map[string]any{
 				"when": []any{
 					map[string]any{
-						"selector": "request.headers.authorization",
-						"operator": "matches",
-						"value":    "^Bearer sk-oai-.*",
+						"predicate": celIsAPIKey,
 					},
 				},
 				"http": map[string]any{
@@ -752,12 +769,12 @@ allow {
 					"contentType": "application/json",
 					"method":      "POST",
 					"body": map[string]any{
-						"expression": `{"key": request.headers.authorization.replace("Bearer ", "")}`,
+						"expression": `{"key": ` + celExtractKey + `}`,
 					},
 				},
 				"cache": map[string]any{
 					"key": map[string]any{
-						"selector": `request.headers.authorization.replace("Bearer ", "")`,
+						"selector": celExtractKey,
 					},
 					"ttl": r.MetadataCacheTTL,
 				},
@@ -854,9 +871,7 @@ allow {
 					"X-MaaS-Username": map[string]any{
 						"when": []any{
 							map[string]any{
-								"selector": "request.headers.authorization",
-								"operator": "matches",
-								"value":    "^Bearer sk-oai-.*",
+								"predicate": celIsAPIKey,
 							},
 						},
 						"plain": map[string]any{
@@ -868,7 +883,7 @@ allow {
 					"X-MaaS-Username-Token": map[string]any{
 						"when": []any{
 							map[string]any{
-								"predicate": `!request.headers.authorization.startsWith("Bearer sk-oai-")`,
+								"predicate": celIsNotAPIKey,
 							},
 						},
 						"plain": map[string]any{
@@ -881,9 +896,7 @@ allow {
 					"X-MaaS-Group": map[string]any{
 						"when": []any{
 							map[string]any{
-								"selector": "request.headers.authorization",
-								"operator": "matches",
-								"value":    "^Bearer sk-oai-.*",
+								"predicate": celIsAPIKey,
 							},
 						},
 						"plain": map[string]any{
@@ -898,7 +911,7 @@ allow {
 					"X-MaaS-Group-Token": map[string]any{
 						"when": []any{
 							map[string]any{
-								"predicate": `!request.headers.authorization.startsWith("Bearer sk-oai-")`,
+								"predicate": celIsNotAPIKey,
 							},
 						},
 						"plain": map[string]any{
@@ -1020,8 +1033,8 @@ allow {
 
 // reconcileGatewayAuthPolicy creates or updates the singleton Gateway-level AuthPolicy in
 // the gateway namespace. All MaaSAuthPolicy reconciliations converge on this one resource.
-func (r *MaaSAuthPolicyReconciler) reconcileGatewayAuthPolicy(ctx context.Context, log logr.Logger, modelAccessJSON string, oidc *oidcConfig, tenantID, gatewayNamespace, gatewayName string) error {
-	log.Info("reconcileGatewayAuthPolicy entered", "gatewayNamespace", gatewayNamespace, "gatewayName", gatewayName, "tenantID", tenantID)
+func (r *MaaSAuthPolicyReconciler) reconcileGatewayAuthPolicy(ctx context.Context, log logr.Logger, modelAccessJSON string, oidc *oidcConfig, xAPIKeyEnabled bool, tenantID, gatewayNamespace, gatewayName string) error {
+	log.Info("reconcileGatewayAuthPolicy entered", "gatewayNamespace", gatewayNamespace, "gatewayName", gatewayName, "tenantID", tenantID, "xAPIKeyEnabled", xAPIKeyEnabled)
 
 	// Calculate tenantName from tenantID
 	// Default tenant (tenantID="") uses "models-as-a-service", others use tenantID
@@ -1030,7 +1043,7 @@ func (r *MaaSAuthPolicyReconciler) reconcileGatewayAuthPolicy(ctx context.Contex
 		tenantName = tenantID
 	}
 
-	spec := r.buildGatewayAuthPolicySpec(modelAccessJSON, oidc, tenantID, tenantName, gatewayNamespace, gatewayName)
+	spec := r.buildGatewayAuthPolicySpec(modelAccessJSON, oidc, xAPIKeyEnabled, tenantID, tenantName, gatewayNamespace, gatewayName)
 
 	// Use legacy name for default gateway (backward compatibility), dynamic name for tenant gateways
 	authPolicyName := maasGatewayAuthPolicyName
@@ -1432,6 +1445,64 @@ func (r *MaaSAuthPolicyReconciler) ensureGatewayDefaultAuthPolicy(ctx context.Co
 	}
 	log.Info("restored gateway-default-auth (no remaining MaaSAuthPolicies)", "name", gatewayDefaultAuthPolicyName, "namespace", r.GatewayNamespace)
 	return nil
+}
+
+// discoverXAPIKeyNeeded lists ExternalModel CRs from inference.opendatahub.io/v1alpha1
+// and returns true if any externalProviderRef uses apiFormat "messages" (Anthropic SDK),
+// which requires accepting API keys from the x-api-key header. Returns false if the
+// CRD is not installed or no "messages" format is found.
+func (r *MaaSAuthPolicyReconciler) discoverXAPIKeyNeeded(ctx context.Context, log logr.Logger) bool {
+	list := &unstructured.UnstructuredList{}
+	list.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "inference.opendatahub.io",
+		Version: "v1alpha1",
+		Kind:    "ExternalModelList",
+	})
+	if err := r.List(ctx, list); err != nil {
+		if apimeta.IsNoMatchError(err) || apierrors.IsNotFound(err) {
+			log.V(1).Info("inference.opendatahub.io ExternalModel CRD not found, skipping x-api-key discovery")
+			return false
+		}
+		log.Error(err, "failed to list inference ExternalModels for x-api-key discovery (non-fatal)")
+		return false
+	}
+
+	for i := range list.Items {
+		refs, found, err := unstructured.NestedSlice(list.Items[i].Object, "spec", "externalProviderRefs")
+		if err != nil || !found {
+			continue
+		}
+		for _, ref := range refs {
+			refMap, ok := ref.(map[string]any)
+			if !ok {
+				continue
+			}
+			if fmt.Sprintf("%v", refMap["apiFormat"]) == "messages" {
+				log.V(1).Info("found ExternalModel with apiFormat=messages, enabling x-api-key identity source",
+					"externalModel", list.Items[i].GetName(), "namespace", list.Items[i].GetNamespace())
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// apiKeyCELPredicates returns CEL expressions for API key detection, negation, and
+// raw key extraction. When xAPIKeyEnabled is true, the expressions also accept
+// keys from the x-api-key header (Anthropic SDK format).
+func apiKeyCELPredicates(xAPIKeyEnabled bool) (isAPIKey, isNotAPIKey, extractRawKey string) {
+	if !xAPIKeyEnabled {
+		return `request.headers.authorization.matches("^Bearer sk-oai-.*")`,
+			`!request.headers.authorization.startsWith("Bearer sk-oai-")`,
+			`request.headers.authorization.replace("Bearer ", "")`
+	}
+	isAPIKey = `request.headers.authorization.matches("^Bearer sk-oai-.*") || ` +
+		`("x-api-key" in request.headers && request.headers["x-api-key"].matches("^sk-oai-.*"))`
+	isNotAPIKey = `!(` + isAPIKey + `)`
+	extractRawKey = `("x-api-key" in request.headers && request.headers["x-api-key"].startsWith("sk-oai-")) ` +
+		`? request.headers["x-api-key"] ` +
+		`: request.headers.authorization.replace("Bearer ", "")`
+	return isAPIKey, isNotAPIKey, extractRawKey
 }
 
 func (r *MaaSAuthPolicyReconciler) updateAuthPolicyRefStatus(ctx context.Context, log logr.Logger, policy *maasv1alpha1.MaaSAuthPolicy, refs []authPolicyRef) {

--- a/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
@@ -650,11 +650,11 @@ func (r *MaaSAuthPolicyReconciler) buildGatewayAuthPolicySpec(modelAccessJSON st
 			},
 			"when": []any{
 				map[string]any{
-					"predicate": `"x-api-key" in request.headers && request.headers["x-api-key"].matches("^sk-oai-.*")`,
+					"predicate": `"x-api-key" in request.headers && request.headers["x-api-key"].matches("^sk-oai-.*") && !request.headers.authorization.matches("^Bearer sk-oai-.*")`,
 				},
 			},
 			"metrics":  false,
-			"priority": int64(0),
+			"priority": int64(1),
 		}
 	}
 
@@ -1499,9 +1499,9 @@ func apiKeyCELPredicates(xAPIKeyEnabled bool) (isAPIKey, isNotAPIKey, extractRaw
 	isAPIKey = `request.headers.authorization.matches("^Bearer sk-oai-.*") || ` +
 		`("x-api-key" in request.headers && request.headers["x-api-key"].matches("^sk-oai-.*"))`
 	isNotAPIKey = `!(` + isAPIKey + `)`
-	extractRawKey = `("x-api-key" in request.headers && request.headers["x-api-key"].startsWith("sk-oai-")) ` +
-		`? request.headers["x-api-key"] ` +
-		`: request.headers.authorization.replace("Bearer ", "")`
+	extractRawKey = `request.headers.authorization.matches("^Bearer sk-oai-.*") ` +
+		`? request.headers.authorization.replace("Bearer ", "") ` +
+		`: request.headers["x-api-key"]`
 	return isAPIKey, isNotAPIKey, extractRawKey
 }
 

--- a/maas-controller/pkg/controller/maas/maasauthpolicy_controller_test.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_controller_test.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/go-logr/logr"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -916,7 +917,7 @@ func TestMaaSAuthPolicyReconciler_CacheKeyIsolation(t *testing.T) {
 	// Test 1: apiKeyValidation cache key must include API key material (gateway policy)
 	t.Run("apiKeyValidation includes API key", func(t *testing.T) {
 		assertCacheKeyContains(t, gwPolicy,
-			[]string{"request.headers.authorization", `replace("Bearer ", "")`},
+			[]string{`replace("Bearer ", "")`},
 			"spec", "defaults", "rules", "metadata", "apiKeyValidation", "cache", "key", "selector",
 		)
 	})
@@ -945,8 +946,8 @@ func TestMaaSAuthPolicyReconciler_CacheKeyIsolation(t *testing.T) {
 		if !contains(key, "x-gateway-model-name") && !contains(key, "request.path") {
 			t.Errorf("auth-valid cache key must include dynamic model identity (header or path), got: %s", key)
 		}
-		if !contains(key, "authorization") {
-			t.Errorf("auth-valid cache key must include authorization header for key identity, got: %s", key)
+		if !contains(key, `replace("Bearer ", "")`) {
+			t.Errorf("auth-valid cache key must include API key extraction expression, got: %s", key)
 		}
 	})
 
@@ -1230,7 +1231,7 @@ func TestBuildGatewayAuthPolicySpec_K8sAndOIDCAuth(t *testing.T) {
 	}
 
 	t.Run("without OIDC", func(t *testing.T) {
-		spec := r.buildGatewayAuthPolicySpec("{}", nil, "", "models-as-a-service", "test-gateway-ns", "test-gateway")
+		spec := r.buildGatewayAuthPolicySpec("{}", nil, false, "", "models-as-a-service", "test-gateway-ns", "test-gateway")
 		obj := gwSpecToUnstructured(t, spec)
 
 		auth, found, err := unstructured.NestedMap(obj.Object, "spec", "defaults", "rules", "authentication")
@@ -1246,6 +1247,9 @@ func TestBuildGatewayAuthPolicySpec_K8sAndOIDCAuth(t *testing.T) {
 		if _, exists := auth["oidc-identities"]; exists {
 			t.Error("oidc-identities should NOT be present when OIDC config is nil")
 		}
+		if _, exists := auth["api-keys-x-api-key"]; exists {
+			t.Error("api-keys-x-api-key should NOT be present when xAPIKeyEnabled is false")
+		}
 	})
 
 	t.Run("with OIDC", func(t *testing.T) {
@@ -1253,7 +1257,7 @@ func TestBuildGatewayAuthPolicySpec_K8sAndOIDCAuth(t *testing.T) {
 			IssuerURL: "https://keycloak.example.com/realms/test",
 			ClientID:  "maas-client",
 		}
-		spec := r.buildGatewayAuthPolicySpec("{}", oidc, "", "models-as-a-service", "test-gateway-ns", "test-gateway")
+		spec := r.buildGatewayAuthPolicySpec("{}", oidc, false, "", "models-as-a-service", "test-gateway-ns", "test-gateway")
 		obj := gwSpecToUnstructured(t, spec)
 
 		auth, found, err := unstructured.NestedMap(obj.Object, "spec", "defaults", "rules", "authentication")
@@ -1273,7 +1277,7 @@ func TestBuildGatewayAuthPolicySpec_K8sAndOIDCAuth(t *testing.T) {
 	})
 
 	t.Run("subscription-info has model-route scoped when condition", func(t *testing.T) {
-		spec := r.buildGatewayAuthPolicySpec("{}", nil, "", "models-as-a-service", "test-gateway-ns", "test-gateway")
+		spec := r.buildGatewayAuthPolicySpec("{}", nil, false, "", "models-as-a-service", "test-gateway-ns", "test-gateway")
 		obj := gwSpecToUnstructured(t, spec)
 
 		when, found, err := unstructured.NestedSlice(obj.Object, "spec", "defaults", "rules", "metadata", "subscription-info", "when")
@@ -1297,7 +1301,7 @@ func TestBuildGatewayAuthPolicySpec_K8sAndOIDCAuth(t *testing.T) {
 	})
 
 	t.Run("subscription-valid has model-route scoped when condition", func(t *testing.T) {
-		spec := r.buildGatewayAuthPolicySpec("{}", nil, "", "models-as-a-service", "test-gateway-ns", "test-gateway")
+		spec := r.buildGatewayAuthPolicySpec("{}", nil, false, "", "models-as-a-service", "test-gateway-ns", "test-gateway")
 		obj := gwSpecToUnstructured(t, spec)
 
 		when, found, err := unstructured.NestedSlice(obj.Object, "spec", "defaults", "rules", "authorization", "subscription-valid", "when")
@@ -1321,7 +1325,7 @@ func TestBuildGatewayAuthPolicySpec_K8sAndOIDCAuth(t *testing.T) {
 	})
 
 	t.Run("require-group-membership recognizes tenant model paths", func(t *testing.T) {
-		spec := r.buildGatewayAuthPolicySpec("{}", nil, "", "models-as-a-service", "test-gateway-ns", "test-gateway")
+		spec := r.buildGatewayAuthPolicySpec("{}", nil, false, "", "models-as-a-service", "test-gateway-ns", "test-gateway")
 		obj := gwSpecToUnstructured(t, spec)
 
 		rego, found, err := unstructured.NestedString(obj.Object, "spec", "defaults", "rules", "authorization", "require-group-membership", "opa", "rego")
@@ -1337,7 +1341,7 @@ func TestBuildGatewayAuthPolicySpec_K8sAndOIDCAuth(t *testing.T) {
 	})
 
 	t.Run("auth-valid supports non-API-key tokens", func(t *testing.T) {
-		spec := r.buildGatewayAuthPolicySpec("{}", nil, "", "models-as-a-service", "test-gateway-ns", "test-gateway")
+		spec := r.buildGatewayAuthPolicySpec("{}", nil, false, "", "models-as-a-service", "test-gateway-ns", "test-gateway")
 		obj := gwSpecToUnstructured(t, spec)
 
 		rego, found, err := unstructured.NestedString(obj.Object, "spec", "defaults", "rules", "authorization", "auth-valid", "opa", "rego")
@@ -1348,6 +1352,62 @@ func TestBuildGatewayAuthPolicySpec_K8sAndOIDCAuth(t *testing.T) {
 			t.Errorf("auth-valid rego should allow non-API-key tokens, got: %s", rego)
 		}
 	})
+}
+
+func TestBuildGatewayAuthPolicySpec_XAPIKeyEnabled(t *testing.T) {
+	r := &MaaSAuthPolicyReconciler{
+		MaaSAPINamespace: "maas-system",
+		GatewayName:      "maas-default-gateway",
+		GatewayNamespace: "gateway-ns",
+		ClusterAudience:  "https://kubernetes.default.svc",
+		MetadataCacheTTL: 60,
+		AuthzCacheTTL:    60,
+	}
+
+	spec := r.buildGatewayAuthPolicySpec("{}", nil, true, "", "models-as-a-service", "gateway-ns", "maas-default-gateway")
+	obj := &unstructured.Unstructured{Object: map[string]any{"spec": spec}}
+
+	auth, found, err := unstructured.NestedMap(obj.Object, "spec", "defaults", "rules", "authentication")
+	if err != nil || !found {
+		t.Fatalf("authentication block missing: found=%v err=%v", found, err)
+	}
+	xAPIKey, exists := auth["api-keys-x-api-key"]
+	if !exists {
+		t.Fatal("api-keys-x-api-key should be present when xAPIKeyEnabled is true")
+	}
+	xAPIKeyMap, ok := xAPIKey.(map[string]any)
+	if !ok {
+		t.Fatalf("api-keys-x-api-key is not a map: %T", xAPIKey)
+	}
+	expr, _, _ := unstructured.NestedString(xAPIKeyMap, "plain", "expression")
+	if !contains(expr, "x-api-key") {
+		t.Errorf("api-keys-x-api-key plain.expression should reference x-api-key header, got: %s", expr)
+	}
+
+	apiKeyWhen, found, err := unstructured.NestedSlice(obj.Object, "spec", "defaults", "rules", "metadata", "apiKeyValidation", "when")
+	if err != nil || !found || len(apiKeyWhen) == 0 {
+		t.Fatalf("apiKeyValidation when missing: found=%v err=%v", found, err)
+	}
+	whenMap, ok := apiKeyWhen[0].(map[string]any)
+	if !ok {
+		t.Fatalf("apiKeyValidation when[0] is not a map")
+	}
+	pred, ok := whenMap["predicate"].(string)
+	if !ok {
+		t.Fatal("apiKeyValidation when should use predicate (not selector) when x-api-key enabled")
+	}
+	if !contains(pred, "x-api-key") {
+		t.Errorf("apiKeyValidation when predicate should include x-api-key check, got: %s", pred)
+	}
+
+	osWhen, found, err := unstructured.NestedSlice(obj.Object, "spec", "defaults", "rules", "authentication", "openshift-identities", "when")
+	if err != nil || !found || len(osWhen) == 0 {
+		t.Fatalf("openshift-identities when missing")
+	}
+	osPred, _ := osWhen[0].(map[string]any)["predicate"].(string)
+	if !contains(osPred, "x-api-key") {
+		t.Errorf("openshift-identities when should exclude x-api-key requests, got: %s", osPred)
+	}
 }
 
 // contains is a helper to check if a string contains a substring (case-sensitive).
@@ -1740,4 +1800,114 @@ func TestMaaSAuthPolicyReconciler_StaleEvent_NoOp(t *testing.T) {
 	if res != (ctrl.Result{}) {
 		t.Errorf("expected empty Result, got %+v", res)
 	}
+}
+
+func TestDiscoverXAPIKeyNeeded(t *testing.T) {
+	t.Run("returns true when ExternalModel has messages apiFormat", func(t *testing.T) {
+		extModel := &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "inference.opendatahub.io/v1alpha1",
+			"kind":       "ExternalModel",
+			"metadata":   map[string]any{"name": "claude-model", "namespace": "default"},
+			"spec": map[string]any{
+				"externalProviderRefs": []any{
+					map[string]any{
+						"ref":         map[string]any{"name": "anthropic-provider"},
+						"targetModel": "claude-sonnet-4-5-20241022",
+						"apiFormat":   "messages",
+					},
+				},
+			},
+		}}
+		extModel.SetGroupVersionKind(schema.GroupVersionKind{
+			Group: "inference.opendatahub.io", Version: "v1alpha1", Kind: "ExternalModel",
+		})
+
+		c := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithRESTMapper(testRESTMapper()).
+			WithObjects(extModel).
+			Build()
+
+		r := &MaaSAuthPolicyReconciler{Client: c, Scheme: scheme}
+		got := r.discoverXAPIKeyNeeded(context.Background(), logr.Discard())
+		if !got {
+			t.Error("expected true when ExternalModel has apiFormat=messages")
+		}
+	})
+
+	t.Run("returns false when only openai-chat apiFormat", func(t *testing.T) {
+		extModel := &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "inference.opendatahub.io/v1alpha1",
+			"kind":       "ExternalModel",
+			"metadata":   map[string]any{"name": "gpt-model", "namespace": "default"},
+			"spec": map[string]any{
+				"externalProviderRefs": []any{
+					map[string]any{
+						"ref":         map[string]any{"name": "openai-provider"},
+						"targetModel": "gpt-4o",
+						"apiFormat":   "openai-chat",
+					},
+				},
+			},
+		}}
+		extModel.SetGroupVersionKind(schema.GroupVersionKind{
+			Group: "inference.opendatahub.io", Version: "v1alpha1", Kind: "ExternalModel",
+		})
+
+		c := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithRESTMapper(testRESTMapper()).
+			WithObjects(extModel).
+			Build()
+
+		r := &MaaSAuthPolicyReconciler{Client: c, Scheme: scheme}
+		got := r.discoverXAPIKeyNeeded(context.Background(), logr.Discard())
+		if got {
+			t.Error("expected false when only openai-chat apiFormat is present")
+		}
+	})
+
+	t.Run("returns false when CRD not found", func(t *testing.T) {
+		c := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithRESTMapper(testRESTMapper()).
+			Build()
+
+		r := &MaaSAuthPolicyReconciler{Client: c, Scheme: scheme}
+		got := r.discoverXAPIKeyNeeded(context.Background(), logr.Discard())
+		if got {
+			t.Error("expected false when inference CRD is not installed")
+		}
+	})
+}
+
+func TestAPIKeyCELPredicates(t *testing.T) {
+	t.Run("disabled returns original expressions", func(t *testing.T) {
+		isAPIKey, isNotAPIKey, extractKey := apiKeyCELPredicates(false)
+		if contains(isAPIKey, "x-api-key") {
+			t.Errorf("isAPIKey should not reference x-api-key when disabled, got: %s", isAPIKey)
+		}
+		if contains(isNotAPIKey, "x-api-key") {
+			t.Errorf("isNotAPIKey should not reference x-api-key when disabled, got: %s", isNotAPIKey)
+		}
+		if contains(extractKey, "x-api-key") {
+			t.Errorf("extractKey should not reference x-api-key when disabled, got: %s", extractKey)
+		}
+	})
+
+	t.Run("enabled includes x-api-key in all expressions", func(t *testing.T) {
+		isAPIKey, isNotAPIKey, extractKey := apiKeyCELPredicates(true)
+		if !contains(isAPIKey, "x-api-key") {
+			t.Errorf("isAPIKey should reference x-api-key when enabled, got: %s", isAPIKey)
+		}
+		if !contains(isNotAPIKey, "x-api-key") {
+			t.Errorf("isNotAPIKey should reference x-api-key when enabled, got: %s", isNotAPIKey)
+		}
+		if !contains(extractKey, "x-api-key") {
+			t.Errorf("extractKey should reference x-api-key when enabled, got: %s", extractKey)
+		}
+		if !contains(isAPIKey, "authorization") {
+			t.Errorf("isAPIKey should still reference authorization header, got: %s", isAPIKey)
+		}
+	})
 }

--- a/maas-controller/pkg/controller/maas/maasauthpolicy_controller_test.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_controller_test.go
@@ -1384,6 +1384,20 @@ func TestBuildGatewayAuthPolicySpec_XAPIKeyEnabled(t *testing.T) {
 		t.Errorf("api-keys-x-api-key plain.expression should reference x-api-key header, got: %s", expr)
 	}
 
+	priority, ok := xAPIKeyMap["priority"].(int64)
+	if !ok || priority != 1 {
+		t.Errorf("api-keys-x-api-key priority should be 1 (fallback after api-keys), got: %v", xAPIKeyMap["priority"])
+	}
+
+	xAPIKeyWhen, found2, err2 := unstructured.NestedSlice(xAPIKeyMap, "when")
+	if err2 != nil || !found2 || len(xAPIKeyWhen) == 0 {
+		t.Fatalf("api-keys-x-api-key when missing: found=%v err=%v", found2, err2)
+	}
+	xWhenPred, _ := xAPIKeyWhen[0].(map[string]any)["predicate"].(string)
+	if !contains(xWhenPred, `!request.headers.authorization.matches`) {
+		t.Errorf("api-keys-x-api-key when should exclude requests with Authorization Bearer sk-oai-, got: %s", xWhenPred)
+	}
+
 	apiKeyWhen, found, err := unstructured.NestedSlice(obj.Object, "spec", "defaults", "rules", "metadata", "apiKeyValidation", "when")
 	if err != nil || !found || len(apiKeyWhen) == 0 {
 		t.Fatalf("apiKeyValidation when missing: found=%v err=%v", found, err)
@@ -1908,6 +1922,13 @@ func TestAPIKeyCELPredicates(t *testing.T) {
 		}
 		if !contains(isAPIKey, "authorization") {
 			t.Errorf("isAPIKey should still reference authorization header, got: %s", isAPIKey)
+		}
+	})
+
+	t.Run("enabled extractKey prefers Authorization over x-api-key", func(t *testing.T) {
+		_, _, extractKey := apiKeyCELPredicates(true)
+		if !strings.HasPrefix(extractKey, `request.headers.authorization.matches`) {
+			t.Errorf("extractKey should check Authorization first (prefer Bearer over x-api-key), got: %s", extractKey)
 		}
 	})
 }

--- a/maas-controller/pkg/controller/maas/maasauthpolicy_gateway_aggregate_test.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_gateway_aggregate_test.go
@@ -83,7 +83,7 @@ func TestAggregateModelSubjectAllowlistsAndGatewaySpec(t *testing.T) {
 		t.Fatalf("json.Marshal(allowlists) returned error: %v", err)
 	}
 
-	spec := r.buildGatewayAuthPolicySpec(string(allowlistsJSON), nil, "", "models-as-a-service", "test-gateway-ns", "test-gateway")
+	spec := r.buildGatewayAuthPolicySpec(string(allowlistsJSON), nil, false, "", "models-as-a-service", "test-gateway-ns", "test-gateway")
 	defaults, ok := spec["defaults"].(map[string]any)
 	if !ok {
 		t.Fatalf("gateway spec missing defaults block")

--- a/test/e2e/tests/test_x_api_key_auth.py
+++ b/test/e2e/tests/test_x_api_key_auth.py
@@ -1,0 +1,231 @@
+"""
+E2E tests for x-api-key inbound authentication.
+
+Validates that the gateway AuthPolicy dynamically adds an x-api-key identity
+source when an IPP ExternalModel CR with apiFormat=messages exists, allowing
+Anthropic SDK clients to authenticate via x-api-key header instead of
+Authorization: Bearer.
+
+Prerequisites:
+- MaaS deployed with x-api-key support in the controller
+- IPP ExternalModel CRD (externalmodels.inference.opendatahub.io) installed
+
+Environment variables:
+  See test_helper.py module docstring for shared environment variables.
+  Additional:
+  - GATEWAY_NAMESPACE: Gateway namespace (default: openshift-ingress)
+"""
+
+import json
+import logging
+import os
+import subprocess
+import time
+
+import pytest
+import requests
+
+from test_helper import (
+    MODEL_NAME,
+    MODEL_NAMESPACE,
+    MODEL_PATH,
+    TIMEOUT,
+    TLS_VERIFY,
+    _apply_cr,
+    _delete_cr,
+    _gateway_url,
+    _inference,
+    _poll_status,
+    _wait_reconcile,
+)
+
+log = logging.getLogger(__name__)
+
+GATEWAY_NAMESPACE = os.environ.get("GATEWAY_NAMESPACE", "openshift-ingress")
+GATEWAY_AUTH_POLICY_NAME = "maas-gateway-auth"
+IDENTITY_SOURCE_NAME = "api-keys-x-api-key"
+
+IPP_EXTERNAL_MODEL_CRD = "externalmodels.inference.opendatahub.io"
+IPP_EXTERNAL_MODEL_NAME = "e2e-x-api-key-trigger"
+
+IPP_EXTERNAL_MODEL_CR = {
+    "apiVersion": "inference.opendatahub.io/v1alpha1",
+    "kind": "ExternalModel",
+    "metadata": {"name": IPP_EXTERNAL_MODEL_NAME, "namespace": MODEL_NAMESPACE},
+    "spec": {
+        "modelName": "claude-test",
+        "externalProviderRefs": [{
+            "ref": {"name": "dummy-anthropic"},
+            "targetModel": "claude-sonnet-4-20250514",
+            "apiFormat": "messages",
+        }],
+    },
+}
+
+
+def _crd_installed(crd_name):
+    """Check if a CRD is installed on the cluster."""
+    result = subprocess.run(
+        ["oc", "get", "crd", crd_name],
+        capture_output=True, text=True, timeout=30,
+    )
+    return result.returncode == 0
+
+
+def _get_authpolicy_identities():
+    """Get the list of identity source names from the gateway AuthPolicy."""
+    result = subprocess.run(
+        ["oc", "get", "authpolicy", GATEWAY_AUTH_POLICY_NAME,
+         "-n", GATEWAY_NAMESPACE, "-o", "json"],
+        capture_output=True, text=True, timeout=30,
+    )
+    if result.returncode != 0:
+        return []
+
+    ap = json.loads(result.stdout)
+    defaults = (ap.get("spec") or {}).get("defaults") or {}
+    rules = defaults.get("rules") or {}
+    authentication = rules.get("authentication") or {}
+    return list(authentication.keys())
+
+
+def _wait_for_identity_source(identity_name, present=True, timeout=120):
+    """Poll AuthPolicy until an identity source appears or disappears."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        identities = _get_authpolicy_identities()
+        found = identity_name in identities
+        if found == present:
+            log.info(
+                "Identity source %r %s (identities: %s)",
+                identity_name, "appeared" if present else "removed", identities,
+            )
+            return True
+        time.sleep(5)
+    raise TimeoutError(
+        f"Identity source {identity_name!r} did not {'appear' if present else 'disappear'} "
+        f"within {timeout}s. Current identities: {_get_authpolicy_identities()}"
+    )
+
+
+def _trigger_reconcile():
+    """Annotate all MaaSAuthPolicies to trigger controller reconciliation."""
+    ns = os.environ.get("MAAS_SUBSCRIPTION_NAMESPACE", "models-as-a-service")
+    result = subprocess.run(
+        ["oc", "get", "maasauthpolicy", "-n", ns, "-o", "name"],
+        capture_output=True, text=True, timeout=30,
+    )
+    if result.returncode != 0:
+        log.warning("Failed to list MaaSAuthPolicies: %s", result.stderr.strip())
+        return
+
+    for resource in result.stdout.strip().splitlines():
+        if not resource:
+            continue
+        subprocess.run(
+            ["oc", "annotate", resource, "-n", ns,
+             f"e2e.maas/reconcile-trigger={int(time.time())}", "--overwrite"],
+            capture_output=True, text=True, timeout=30,
+        )
+
+
+def _inference_x_api_key(api_key, path=None, model_name=None):
+    """Send inference with x-api-key header instead of Authorization."""
+    path = path or MODEL_PATH
+    url = f"{_gateway_url()}{path}/v1/completions"
+    headers = {"x-api-key": api_key, "Content-Type": "application/json"}
+    return requests.post(
+        url, headers=headers,
+        json={"model": model_name or MODEL_NAME, "prompt": "Hello", "max_tokens": 3},
+        timeout=TIMEOUT, verify=TLS_VERIFY,
+    )
+
+
+pytestmark = pytest.mark.skipif(
+    not _crd_installed(IPP_EXTERNAL_MODEL_CRD),
+    reason=f"IPP ExternalModel CRD ({IPP_EXTERNAL_MODEL_CRD}) not installed",
+)
+
+
+@pytest.fixture(scope="module")
+def x_api_key_setup(api_key):
+    """Create IPP ExternalModel with apiFormat=messages to enable x-api-key identity source.
+
+    Setup:
+      1. Apply IPP ExternalModel CR
+      2. Trigger reconciliation
+      3. Wait for api-keys-x-api-key identity to appear in gateway AuthPolicy
+
+    Teardown:
+      1. Delete IPP ExternalModel CR
+      2. Trigger reconciliation
+      3. Wait for api-keys-x-api-key identity to be removed
+    """
+    log.info("Setting up x-api-key auth test fixture...")
+
+    _apply_cr(IPP_EXTERNAL_MODEL_CR)
+    _wait_reconcile()
+    _trigger_reconcile()
+
+    try:
+        _wait_for_identity_source(IDENTITY_SOURCE_NAME, present=True, timeout=120)
+    except TimeoutError:
+        _delete_cr("externalmodel.inference.opendatahub.io", IPP_EXTERNAL_MODEL_NAME, MODEL_NAMESPACE)
+        raise
+
+    _poll_status(api_key, 200, timeout=60)
+
+    log.info("x-api-key identity source is active, running tests...")
+    yield api_key
+
+    log.info("Cleaning up x-api-key auth test fixture...")
+    _delete_cr("externalmodel.inference.opendatahub.io", IPP_EXTERNAL_MODEL_NAME, MODEL_NAMESPACE)
+    _wait_reconcile()
+    _trigger_reconcile()
+
+    try:
+        _wait_for_identity_source(IDENTITY_SOURCE_NAME, present=False, timeout=120)
+    except TimeoutError:
+        log.warning("Identity source %s did not disappear during cleanup", IDENTITY_SOURCE_NAME)
+
+
+class TestXAPIKeyAuthentication:
+    """Validate x-api-key header authentication when IPP ExternalModel with apiFormat=messages exists."""
+
+    def test_x_api_key_authenticates(self, x_api_key_setup):
+        """x-api-key header with valid API key returns 200."""
+        api_key = x_api_key_setup
+        r = _inference_x_api_key(api_key)
+        assert r.status_code == 200, (
+            f"Expected 200 with x-api-key header, got {r.status_code}: {r.text[:500]}"
+        )
+
+    def test_authorization_bearer_still_works(self, x_api_key_setup):
+        """Authorization: Bearer still works when x-api-key identity source is active."""
+        api_key = x_api_key_setup
+        r = _inference(api_key)
+        assert r.status_code == 200, (
+            f"Expected 200 with Authorization: Bearer, got {r.status_code}: {r.text[:500]}"
+        )
+
+    def test_invalid_x_api_key_rejected(self, x_api_key_setup):
+        """Invalid API key in x-api-key header is rejected."""
+        r = _inference_x_api_key("sk-oai-invalid-not-a-real-key-12345")
+        assert r.status_code in (401, 403), (
+            f"Expected 401/403 for invalid x-api-key, got {r.status_code}: {r.text[:500]}"
+        )
+
+    def test_x_api_key_without_prefix_rejected(self, x_api_key_setup):
+        """Random value without sk-oai- prefix in x-api-key header is rejected."""
+        r = _inference_x_api_key("random-value-no-prefix")
+        assert r.status_code in (401, 403), (
+            f"Expected 401/403 for x-api-key without valid prefix, got {r.status_code}: {r.text[:500]}"
+        )
+
+    def test_both_headers_no_conflict(self, x_api_key_setup):
+        """Sending both Authorization: Bearer and x-api-key does not cause conflicts."""
+        api_key = x_api_key_setup
+        r = _inference(api_key, extra_headers={"x-api-key": api_key})
+        assert r.status_code == 200, (
+            f"Expected 200 with both auth headers, got {r.status_code}: {r.text[:500]}"
+        )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
 Clients using SDKs that send credentials via `x-api-key `instead of `Authorization: Bearer` are currently rejected at the gateway. This PR detects when an IPP ExternalModel with `apiFormat: "messages"` exists and automatically adds an api-keys-x-api-key identity source to the gateway AuthPolicy, removing it when no longer needed.
## Summary                                                                                                                                                                                
                                                                                                                                                                                            
  - Dynamically add an `api-keys-x-api-key` identity source to the gateway AuthPolicy when an IPP ExternalModel CR with `apiFormat: "messages"` exists on the cluster                       
  - The controller discovers IPP ExternalModel CRs (unstructured client, no Go module dependency) and checks if any `externalProviderRefs[].apiFormat` is `"messages"` (Anthropic SDK)      
  - Identity normalization: the `api-keys-x-api-key` source uses `"Bearer " + request.headers["x-api-key"]` so downstream Authorino logic (validation, OPA) sees the same format regardless 
  of inbound header                                                                                                                                                                         
  - When no `apiFormat: "messages"` ExternalModel exists, the identity source is removed — zero impact on clusters without IPP  

## How Has This Been Tested?
* Manually tested cases
   * E2E TEST RESULTS
      STEP 1: Baseline (no ExternalModel with apiFormat=messages)
      1a: Authorization: Bearer works           HTTP 200  PASS
      1b: x-api-key rejected                           HTTP 401  PASS

      STEP 2-3: Create ExternalModel, trigger reconcile
      Controller: xAPIKeyEnabled=true                           PASS
      AuthPolicy: api-keys-x-api-key present                PASS
 
      STEP 4: x-api-key authentication
      4a: x-api-key: sk-oai-* works             HTTP 200       PASS
      4b: Authorization: Bearer still works     HTTP 200    PASS
      4c: Invalid x-api-key rejected            HTTP 401        PASS
      4d: Non-sk-oai prefix rejected            HTTP 401      PASS
      4e: Both headers (no conflict)            HTTP 200      PASS
  
     STEP 5: Full inference response with x-api-key        PASS

     STEP 6: Cleanup and fallback
     api-keys-x-api-key removed from AuthPolicy          PASS
     Controller: xAPIKeyEnabled=false                             PASS
     6a: x-api-key stops working               HTTP 401       PASS
     6b: Authorization: Bearer still works     HTTP 200   PASS
  

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for API-key authentication when compatible model configurations are detected.
  * Requests can now authenticate with an `x-api-key` header alongside existing bearer-token access.

* **Bug Fixes**
  * Improved authentication handling so API-key and non-API-key requests are routed correctly.
  * Made missing model-discovery data non-fatal, with graceful fallback behavior.

* **Tests**
  * Expanded automated coverage for API-key detection, policy generation, and end-to-end authentication flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->