### PR TITLE
fix: pick default appNamespace to be same as maas-controller instead of hardcoded value

### DIFF
--- a/maas-controller/pkg/controller/maas/tenant_controller.go
+++ b/maas-controller/pkg/controller/maas/tenant_controller.go
@@ -48,10 +48,9 @@ type TenantReconciler struct {
 	OperatorNamespace string
 	// ManifestPath is the directory containing kustomization.yaml for the ODH maas-api overlay (e.g. maas-api/deploy/overlays/odh).
 	ManifestPath string
-	// AppNamespace is the protected application namespace (--maas-api-namespace, default opendatahub).
-	// NOTE: This field is ONLY used for namespace protection checks (isProtectedNamespace).
-	// The actual maas-api deployment namespace is determined by appNamespaceForTenant(), which
-	// hardcodes redhat-ai-gateway-infra regardless of this field's value.
+	// AppNamespace is the namespace where maas-api workloads are deployed (--maas-api-namespace,
+	// default opendatahub for ODH, redhat-ods-applications for RHOAI).
+	// Used by appNamespaceForTenant() and isProtectedNamespace().
 	AppNamespace string
 	// TenantNamespace is the namespace where the Tenant CR lives (--maas-subscription-namespace, default models-as-a-service).
 	TenantNamespace string

--- a/maas-controller/pkg/controller/maas/tenant_reconcile.go
+++ b/maas-controller/pkg/controller/maas/tenant_reconcile.go
@@ -407,9 +407,7 @@ func (r *TenantReconciler) operatorNamespace() string {
 }
 
 func (r *TenantReconciler) appNamespaceForTenant() string {
-	// All maas-api instances deploy to the operator namespace (opendatahub for ODH,
-	// redhat-ods-applications for RHOAI). The shared database secret also lives in this namespace.
-	return tenantreconcile.DefaultMaaSAPINamespace
+	return r.AppNamespace
 }
 
 func (r *TenantReconciler) applyGatewayDefaults(tenant *maasv1alpha1.Tenant) error {

--- a/maas-controller/pkg/controller/maas/tenant_reconcile_test.go
+++ b/maas-controller/pkg/controller/maas/tenant_reconcile_test.go
@@ -479,20 +479,16 @@ func TestTenantReconcile_ConfigTerminatingSkipsPlatform(t *testing.T) {
 	g.Expect(ready.Reason).To(Equal("ConfigTerminating"))
 }
 
-func TestTenantReconcile_AppNamespaceUsesConfiguredAppNamespaceForAITenantManagedTenant(t *testing.T) {
+func TestTenantReconcile_AppNamespaceUsesConfiguredAppNamespace(t *testing.T) {
 	g := NewWithT(t)
 	r := &TenantReconciler{AppNamespace: "opendatahub"}
-
-	// All tenants deploy maas-api to operator namespace
-	g.Expect(r.appNamespaceForTenant()).To(Equal(tenantreconcile.DefaultMaaSAPINamespace))
+	g.Expect(r.appNamespaceForTenant()).To(Equal("opendatahub"))
 }
 
-func TestTenantReconcile_AppNamespaceForLegacyTenant(t *testing.T) {
+func TestTenantReconcile_AppNamespaceReturnsRHOAINamespace(t *testing.T) {
 	g := NewWithT(t)
-	r := &TenantReconciler{AppNamespace: "opendatahub"}
-
-	// All tenants deploy maas-api to operator namespace
-	g.Expect(r.appNamespaceForTenant()).To(Equal(tenantreconcile.DefaultMaaSAPINamespace))
+	r := &TenantReconciler{AppNamespace: "redhat-ods-applications"}
+	g.Expect(r.appNamespaceForTenant()).To(Equal("redhat-ods-applications"))
 }
 
 func TestTenantReconcile_NotFoundIsNoOp(t *testing.T) {


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
pick default appNamespace to be same as maas-controller instead of hardcoded value

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
