### PR TITLE
fix: skip tenant-cleanup finalizer on default-tenant

### DIFF
--- a/maas-controller/pkg/controller/maas/tenant_reconcile.go
+++ b/maas-controller/pkg/controller/maas/tenant_reconcile.go
@@ -52,6 +52,17 @@ const (
 	tenantFinalizer = "maas.opendatahub.io/tenant-cleanup"
 )
 
+// tenantUsesCleanupFinalizer reports whether this Tenant should carry tenant-cleanup.
+// The default platform tenant (no AITenant labels) relies on Config/default GC for teardown;
+// only AITenant-managed tenants need explicit per-tenant resource cleanup on delete.
+func tenantUsesCleanupFinalizer(tenant *maasv1alpha1.Tenant) (bool, error) {
+	tenantID, err := tenantreconcile.TenantIdentifierFor(tenant)
+	if err != nil {
+		return false, err
+	}
+	return tenantID != "", nil
+}
+
 func managementState(ann map[string]string) string {
 	if ann == nil {
 		return ""
@@ -101,14 +112,26 @@ func (r *TenantReconciler) reconcile(ctx context.Context, req ctrl.Request) (ctr
 		}
 	}
 
+	usesCleanupFinalizer, err := tenantUsesCleanupFinalizer(&tenant)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
 	// Handle deletion
 	if !tenant.DeletionTimestamp.IsZero() {
 		return r.handleDeletion(ctx, log, &tenant)
 	}
 
-	// Add finalizer if not present
-	if !controllerutil.ContainsFinalizer(&tenant, tenantFinalizer) {
-		controllerutil.AddFinalizer(&tenant, tenantFinalizer)
+	if usesCleanupFinalizer {
+		if !controllerutil.ContainsFinalizer(&tenant, tenantFinalizer) {
+			controllerutil.AddFinalizer(&tenant, tenantFinalizer)
+			if err := r.Update(ctx, &tenant); err != nil {
+				return ctrl.Result{}, err
+			}
+		}
+	} else if controllerutil.ContainsFinalizer(&tenant, tenantFinalizer) {
+		// Converge upgraded clusters: default-tenant teardown is owned by Config GC.
+		controllerutil.RemoveFinalizer(&tenant, tenantFinalizer)
 		if err := r.Update(ctx, &tenant); err != nil {
 			return ctrl.Result{}, err
 		}
@@ -523,27 +546,14 @@ func (r *TenantReconciler) cleanupTenantResources(ctx context.Context, log logr.
 	appNs := r.appNamespaceForTenant()
 	log.Info("Cleaning up per-tenant maas-api resources", "tenant", tenantID, "namespace", appNs)
 
-	// List of resources to delete (name functions from tenantreconcile package)
 	resourcesToDelete := []struct {
 		gvk  schema.GroupVersionKind
 		name string
 	}{
-		{
-			gvk:  tenantreconcile.GVKDeployment,
-			name: tenantreconcile.MaaSAPIDeploymentName(tenantID),
-		},
-		{
-			gvk:  tenantreconcile.GVKService,
-			name: tenantreconcile.MaaSAPIServiceName(tenantID),
-		},
-		{
-			gvk:  tenantreconcile.GVKHTTPRoute,
-			name: fmt.Sprintf("maas-api-%s-route", tenantID),
-		},
-		{
-			gvk:  tenantreconcile.GVKCronJob,
-			name: tenantreconcile.MaaSAPIKeyCleanupCronJobName(tenantID),
-		},
+		{gvk: tenantreconcile.GVKDeployment, name: tenantreconcile.MaaSAPIDeploymentName(tenantID)},
+		{gvk: tenantreconcile.GVKService, name: tenantreconcile.MaaSAPIServiceName(tenantID)},
+		{gvk: tenantreconcile.GVKHTTPRoute, name: fmt.Sprintf("maas-api-%s-route", tenantID)},
+		{gvk: tenantreconcile.GVKCronJob, name: tenantreconcile.MaaSAPIKeyCleanupCronJobName(tenantID)},
 	}
 
 	for _, res := range resourcesToDelete {
@@ -554,9 +564,7 @@ func (r *TenantReconciler) cleanupTenantResources(ctx context.Context, log logr.
 
 		if err := r.Delete(ctx, obj); err != nil && !apierrors.IsNotFound(err) {
 			log.Error(err, "failed to delete tenant resource",
-				"gvk", res.gvk.String(),
-				"name", res.name,
-				"namespace", appNs)
+				"gvk", res.gvk.String(), "name", res.name, "namespace", appNs)
 			return err
 		}
 		log.Info("Deleted tenant resource", "gvk", res.gvk.Kind, "name", res.name)
@@ -566,28 +574,23 @@ func (r *TenantReconciler) cleanupTenantResources(ctx context.Context, log logr.
 }
 
 // cleanupMaaSAuthPolicies deletes all MaaSAuthPolicy CRs in the tenant namespace.
-// MaaSAuthPolicyReconciler's handleDeletion will clean up the gateway AuthPolicy
-// when the last MaaSAuthPolicy is deleted.
 func (r *TenantReconciler) cleanupMaaSAuthPolicies(ctx context.Context, log logr.Logger, tenant *maasv1alpha1.Tenant) error {
 	tenantID, err := tenantreconcile.TenantIdentifierFor(tenant)
 	if err != nil {
 		return err
 	}
 
-	// Skip cleanup for default tenant - Config lifecycle handles it
 	if tenantID == "" {
 		return nil
 	}
 
 	log.Info("Cleaning up MaaSAuthPolicy CRs", "namespace", tenant.Namespace)
 
-	// List all MaaSAuthPolicy CRs in this namespace
 	policyList := &maasv1alpha1.MaaSAuthPolicyList{}
 	if err := r.List(ctx, policyList, client.InNamespace(tenant.Namespace)); err != nil {
 		return fmt.Errorf("failed to list MaaSAuthPolicies: %w", err)
 	}
 
-	// Delete each MaaSAuthPolicy
 	for i := range policyList.Items {
 		policy := &policyList.Items[i]
 		log.Info("Deleting MaaSAuthPolicy", "name", policy.Name, "namespace", policy.Namespace)

--- a/maas-controller/pkg/controller/maas/tenant_reconcile.go
+++ b/maas-controller/pkg/controller/maas/tenant_reconcile.go
@@ -53,7 +53,7 @@ const (
 )
 
 // tenantUsesCleanupFinalizer reports whether this Tenant should carry tenant-cleanup.
-// The default platform tenant (no AITenant labels) relies on Config/default GC for teardown;
+// The default platform tenant (no AITenant labels) relies on Config/default GC for teardown (TODO: fix in GA release);
 // only AITenant-managed tenants need explicit per-tenant resource cleanup on delete.
 func tenantUsesCleanupFinalizer(tenant *maasv1alpha1.Tenant) (bool, error) {
 	tenantID, err := tenantreconcile.TenantIdentifierFor(tenant)
@@ -546,14 +546,27 @@ func (r *TenantReconciler) cleanupTenantResources(ctx context.Context, log logr.
 	appNs := r.appNamespaceForTenant()
 	log.Info("Cleaning up per-tenant maas-api resources", "tenant", tenantID, "namespace", appNs)
 
+	// List of resources to delete (name functions from tenantreconcile package)
 	resourcesToDelete := []struct {
 		gvk  schema.GroupVersionKind
 		name string
 	}{
-		{gvk: tenantreconcile.GVKDeployment, name: tenantreconcile.MaaSAPIDeploymentName(tenantID)},
-		{gvk: tenantreconcile.GVKService, name: tenantreconcile.MaaSAPIServiceName(tenantID)},
-		{gvk: tenantreconcile.GVKHTTPRoute, name: fmt.Sprintf("maas-api-%s-route", tenantID)},
-		{gvk: tenantreconcile.GVKCronJob, name: tenantreconcile.MaaSAPIKeyCleanupCronJobName(tenantID)},
+		{
+			gvk:  tenantreconcile.GVKDeployment,
+			name: tenantreconcile.MaaSAPIDeploymentName(tenantID),
+		},
+		{
+			gvk:  tenantreconcile.GVKService,
+			name: tenantreconcile.MaaSAPIServiceName(tenantID),
+		},
+		{
+			gvk:  tenantreconcile.GVKHTTPRoute,
+			name: fmt.Sprintf("maas-api-%s-route", tenantID),
+		},
+		{
+			gvk:  tenantreconcile.GVKCronJob,
+			name: tenantreconcile.MaaSAPIKeyCleanupCronJobName(tenantID),
+		},
 	}
 
 	for _, res := range resourcesToDelete {
@@ -564,7 +577,9 @@ func (r *TenantReconciler) cleanupTenantResources(ctx context.Context, log logr.
 
 		if err := r.Delete(ctx, obj); err != nil && !apierrors.IsNotFound(err) {
 			log.Error(err, "failed to delete tenant resource",
-				"gvk", res.gvk.String(), "name", res.name, "namespace", appNs)
+				"gvk", res.gvk.String(),
+				"name", res.name,
+				"namespace", appNs)
 			return err
 		}
 		log.Info("Deleted tenant resource", "gvk", res.gvk.Kind, "name", res.name)
@@ -574,23 +589,28 @@ func (r *TenantReconciler) cleanupTenantResources(ctx context.Context, log logr.
 }
 
 // cleanupMaaSAuthPolicies deletes all MaaSAuthPolicy CRs in the tenant namespace.
+// MaaSAuthPolicyReconciler's handleDeletion will clean up the gateway AuthPolicy
+// when the last MaaSAuthPolicy is deleted.
 func (r *TenantReconciler) cleanupMaaSAuthPolicies(ctx context.Context, log logr.Logger, tenant *maasv1alpha1.Tenant) error {
 	tenantID, err := tenantreconcile.TenantIdentifierFor(tenant)
 	if err != nil {
 		return err
 	}
 
+	// Skip cleanup for default tenant - Config lifecycle handles it
 	if tenantID == "" {
 		return nil
 	}
 
 	log.Info("Cleaning up MaaSAuthPolicy CRs", "namespace", tenant.Namespace)
 
+	// List all MaaSAuthPolicy CRs in this namespace
 	policyList := &maasv1alpha1.MaaSAuthPolicyList{}
 	if err := r.List(ctx, policyList, client.InNamespace(tenant.Namespace)); err != nil {
 		return fmt.Errorf("failed to list MaaSAuthPolicies: %w", err)
 	}
 
+	// Delete each MaaSAuthPolicy
 	for i := range policyList.Items {
 		policy := &policyList.Items[i]
 		log.Info("Deleting MaaSAuthPolicy", "name", policy.Name, "namespace", policy.Namespace)

--- a/maas-controller/pkg/controller/maas/tenant_reconcile_test.go
+++ b/maas-controller/pkg/controller/maas/tenant_reconcile_test.go
@@ -121,7 +121,7 @@ func TestTenantReconcile_NonSingletonNameIsNoOp(t *testing.T) {
 	g.Expect(updated.Finalizers).To(BeEmpty(), "non-singleton should not get a finalizer")
 }
 
-func TestTenantReconcile_ManagedReconcileDoesNotAddFinalizer(t *testing.T) {
+func TestTenantReconcile_DefaultTenantDoesNotAddCleanupFinalizer(t *testing.T) {
 	g := NewWithT(t)
 	s := tenantTestScheme(t)
 
@@ -152,6 +152,85 @@ func TestTenantReconcile_ManagedReconcileDoesNotAddFinalizer(t *testing.T) {
 	})
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(res.RequeueAfter).To(Equal(10 * time.Second))
+
+	var updated maasv1alpha1.Tenant
+	g.Expect(cl.Get(context.Background(), client.ObjectKey{Name: maasv1alpha1.TenantInstanceName, Namespace: testNS}, &updated)).To(Succeed())
+	g.Expect(updated.Finalizers).To(BeEmpty(), "default-tenant teardown is Config-driven; no tenant-cleanup finalizer")
+}
+
+func TestTenantReconcile_DefaultTenantStripsLegacyCleanupFinalizer(t *testing.T) {
+	g := NewWithT(t)
+	s := tenantTestScheme(t)
+
+	const testNS = "models-as-a-service"
+	tenant := &maasv1alpha1.Tenant{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       maasv1alpha1.TenantInstanceName,
+			Namespace:  testNS,
+			Finalizers: []string{"maas.opendatahub.io/tenant-cleanup"},
+		},
+	}
+
+	cl := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(&maasv1alpha1.Tenant{}).
+		WithObjects(tenant, tenantTestNamespace(testNS)).
+		Build()
+
+	r := &TenantReconciler{
+		Client:           cl,
+		Scheme:           s,
+		AppNamespace:     testNS,
+		GatewayName:      testTenantGatewayName,
+		GatewayNamespace: testTenantGatewayNamespace,
+	}
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: maasv1alpha1.TenantInstanceName, Namespace: testNS},
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+
+	var updated maasv1alpha1.Tenant
+	g.Expect(cl.Get(context.Background(), client.ObjectKey{Name: maasv1alpha1.TenantInstanceName, Namespace: testNS}, &updated)).To(Succeed())
+	g.Expect(updated.Finalizers).To(BeEmpty())
+}
+
+func TestTenantReconcile_AITenantManagedAddsCleanupFinalizer(t *testing.T) {
+	g := NewWithT(t)
+	s := tenantTestScheme(t)
+
+	const testNS = "ai-tenant-redteam"
+	tenant := &maasv1alpha1.Tenant{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      maasv1alpha1.TenantInstanceName,
+			Namespace: testNS,
+			Labels: map[string]string{
+				tenantreconcile.LabelManagedByAITenant: "true",
+				tenantreconcile.LabelTenantName:       "redteam",
+			},
+		},
+	}
+
+	cl := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(&maasv1alpha1.Tenant{}).
+		WithObjects(tenant, tenantTestNamespace(testNS)).
+		Build()
+
+	r := &TenantReconciler{
+		Client:                          cl,
+		Scheme:                          s,
+		AppNamespace:                    "opendatahub",
+		TenantNamespace:                 "models-as-a-service",
+		TenantNamespaceDiscoveryEnabled: true,
+		GatewayName:                     testTenantGatewayName,
+		GatewayNamespace:                testTenantGatewayNamespace,
+	}
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: maasv1alpha1.TenantInstanceName, Namespace: testNS},
+	})
+	g.Expect(err).NotTo(HaveOccurred())
 
 	var updated maasv1alpha1.Tenant
 	g.Expect(cl.Get(context.Background(), client.ObjectKey{Name: maasv1alpha1.TenantInstanceName, Namespace: testNS}, &updated)).To(Succeed())

--- a/maas-controller/pkg/controller/maas/tenant_reconcile_test.go
+++ b/maas-controller/pkg/controller/maas/tenant_reconcile_test.go
@@ -206,7 +206,7 @@ func TestTenantReconcile_AITenantManagedAddsCleanupFinalizer(t *testing.T) {
 			Namespace: testNS,
 			Labels: map[string]string{
 				tenantreconcile.LabelManagedByAITenant: "true",
-				tenantreconcile.LabelTenantName:       "redteam",
+				tenantreconcile.LabelTenantName:        "redteam",
 			},
 		},
 	}


### PR DESCRIPTION
## Summary

- Stop adding `maas.opendatahub.io/tenant-cleanup` on `default-tenant`; its operands are torn down via `Config/default` owner references (#894).
- Strip a legacy `tenant-cleanup` finalizer on reconcile so upgraded clusters converge without manual patches.
- Keep `tenant-cleanup` on AITenant-managed tenants (`TenantIdentifierFor` ≠ `""`); per-tenant `maas-api-*` and `MaaSAuthPolicy` cleanup on individual delete is unchanged.

Fixes the platform-disable hang where `default-tenant` stayed `Terminating` with a no-op finalizer after `maas-controller` was removed (#993 regression on top of #894).

Follow-up (not in this PR): cluster-wide tenant finalization during `Config/default` teardown for AITenant-managed tenants — see `docs/jira/tenant-cleanup-on-platform-teardown.jira`.

## Test plan

- [x] `make -C maas-controller test`
- [x] `TestTenantReconcile_DefaultTenantDoesNotAddCleanupFinalizer`
- [x] `TestTenantReconcile_DefaultTenantStripsLegacyCleanupFinalizer`
- [x] `TestTenantReconcile_AITenantManagedAddsCleanupFinalizer`
- [x] Manual: on a cluster with legacy finalizer on `default-tenant`, reconcile removes it and Config delete proceeds
- [x] Manual: AITenant-managed tenant delete still cleans up `maas-api-*` and strips finalizer

## Risk analysis

**Risk rating: 2**

**Why:** Controller-only change with focused unit tests. Blast radius is limited to `default-tenant` finalizer behavior; AITenant delete path is untouched. Improves platform disable for the common case but does not address AITenant tenants stuck during full teardown (tracked in follow-up JIRA). Full operator disable flow is not covered by default Prow smoke.


Follow up Jira:
https://redhat.atlassian.net/browse/RHOAIENG-69775

@coderabbitai review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **Bug Fixes**
  * Improved tenant reconciliation so the tenant-cleanup finalizer is added or removed based on tenant type, ensuring the correct cleanup behavior during both normal reconciliation and deletion handling.
  * Default tenants now end up without the legacy cleanup finalizer, while AI-managed tenants retain it.

* **Tests**
  * Updated and expanded tenant reconciliation test coverage to validate finalizer presence/absence for default vs AI-managed tenants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
