### PR TITLE
feat: expose api key display name in auth identity

### DIFF
--- a/maas-api/internal/api_keys/service.go
+++ b/maas-api/internal/api_keys/service.go
@@ -282,6 +282,7 @@ func (s *Service) ValidateAPIKey(ctx context.Context, key string) (*ValidationRe
 		UserID:       metadata.ID, // Database-assigned UUID (immutable, collision-resistant)
 		Username:     metadata.Username,
 		KeyID:        metadata.ID,
+		KeyName:      metadata.Name,
 		Groups:       groups, // Original user groups for subscription-based authorization
 		Subscription: metadata.Subscription,
 		Tenant:       metadata.Tenant,

--- a/maas-api/internal/api_keys/types.go
+++ b/maas-api/internal/api_keys/types.go
@@ -40,6 +40,7 @@ type ValidationResult struct {
 	UserID       string   `json:"userId,omitempty"`
 	Username     string   `json:"username,omitempty"`
 	KeyID        string   `json:"keyId,omitempty"`
+	KeyName      string   `json:"keyName,omitempty"`      // User-provided name for the key
 	Groups       []string `json:"groups,omitempty"`       // User groups for subscription-based authorization
 	Subscription string   `json:"subscription,omitempty"` // MaaSSubscription name from DB (Authorino → subscription-info)
 	Tenant       string   `json:"tenant"`                 // Tenant bound at key creation (always present, empty string for legacy keys)

--- a/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
@@ -949,6 +949,9 @@ allow {
 								"keyId": map[string]any{
 									"expression": `(has(auth.metadata) && has(auth.metadata.apiKeyValidation)) ? auth.metadata.apiKeyValidation.keyId : ""`,
 								},
+								"keyName": map[string]any{
+									"expression": `(has(auth.metadata) && has(auth.metadata.apiKeyValidation)) ? auth.metadata.apiKeyValidation.keyName : ""`,
+								},
 								"selected_subscription": map[string]any{
 									"expression": `has(auth.metadata["subscription-info"].name) ? auth.metadata["subscription-info"].name : ""`,
 								},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Return keyName from maas-api validation and expose it in Authorino filters.identity so access logs can include the key display name for the usage dashboard.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested manually

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * API key validation now includes the API key name in validation results, improving identification and traceability of authenticated requests.
  * The API key name is now exposed through generated authentication policy identities, enabling enhanced auditing, logging, and request tracking for better visibility into API key usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->