### PR TITLE
feat: add OTel Collector for usage logs

### DIFF
--- a/deployment/base/maas-controller/rbac/clusterrole.yaml
+++ b/deployment/base/maas-controller/rbac/clusterrole.yaml
@@ -336,6 +336,17 @@ rules:
   - patch
   - watch
 - apiGroups:
+  - opentelemetry.io
+  resources:
+  - opentelemetrycollectors
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
   - operator.authorino.kuadrant.io
   resources:
   - authorinos

--- a/deployment/components/observability/usage-logs/kustomization.yaml
+++ b/deployment/components/observability/usage-logs/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - otel-collector.yaml
+  - otel-collector-rbac.yaml

--- a/deployment/components/observability/usage-logs/otel-collector-rbac.yaml
+++ b/deployment/components/observability/usage-logs/otel-collector-rbac.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: usage-logs-writer
+  labels:
+    app.kubernetes.io/part-of: maas-observability
+    app.kubernetes.io/managed-by: maas-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-logging-application-write
+subjects:
+- kind: ServiceAccount
+  name: usage-logs-collector
+  namespace: opendatahub

--- a/deployment/components/observability/usage-logs/otel-collector.yaml
+++ b/deployment/components/observability/usage-logs/otel-collector.yaml
@@ -1,0 +1,146 @@
+# NetworkPolicy to restrict access to OTel Collector gRPC receiver
+#
+# Security constraints:
+# - podSelector: Restricted to usage-logs-collector pods only
+# - from: Only Gateway pods in openshift-ingress namespace
+#
+# Background:
+# The OTel Collector receives usage logs from Envoy Gateway via gRPC (port 4317).
+# Without this policy, any reachable workload could submit forged usage logs and
+# poison billing/audit data. This policy ensures only the authorized gateway can
+# send logs to the collector.
+#
+# Note: This is defense-in-depth alongside the bearertokenauth extension, which
+# protects the Loki exporter but not the OTLP receiver.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: usage-logs-collector-allow-gateway
+  namespace: opendatahub
+  labels:
+    app.kubernetes.io/part-of: maas-observability
+    app.kubernetes.io/managed-by: maas-controller
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: usage-logs-collector
+      app.kubernetes.io/component: opentelemetry-collector
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              gateway.istio.io/managed: istio.io-gateway-controller
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-ingress
+      ports:
+        - protocol: TCP
+          port: 4317
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: usage-logs-service-ca
+  namespace: opendatahub
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"
+  labels:
+    app.kubernetes.io/part-of: maas-observability
+    app.kubernetes.io/managed-by: maas-controller
+---
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: usage-logs
+  namespace: opendatahub
+  labels:
+    app.kubernetes.io/part-of: maas-observability
+    app.kubernetes.io/managed-by: maas-controller
+spec:
+  replicas: 2
+  resources:
+    limits:
+      cpu: '1'
+      memory: 256Mi
+    requests:
+      cpu: 100m
+      memory: 256Mi
+  env:
+  - name: NAMESPACE
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.namespace
+  volumeMounts:
+  - name: service-ca
+    mountPath: /etc/pki/ca-trust/extracted/pem
+    readOnly: true
+  volumes:
+  - name: service-ca
+    configMap:
+      name: usage-logs-service-ca
+  config:
+    extensions:
+      bearertokenauth:
+        filename: /var/run/secrets/kubernetes.io/serviceaccount/token
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:4317
+    processors:
+      memory_limiter:
+        check_interval: 1s
+        limit_mib: 200
+        spike_limit_mib: 50
+      batch: {}
+      resource:
+        attributes:
+        - key: log_type
+          value: application
+          action: upsert
+        - key: service.name
+          value: maas-gateway
+          action: upsert
+        - key: kubernetes_namespace_name
+          value: "${env:NAMESPACE}"
+          action: upsert
+      transform:
+        error_mode: ignore
+        log_statements:
+          - context: log
+            statements:
+              - replace_pattern(attributes["user_id"], "\"", "")
+              - replace_pattern(attributes["subscription"], "\"", "")
+              - replace_pattern(attributes["key_id"], "\"", "")
+              - replace_pattern(attributes["key_name"], "\"", "")
+              - replace_pattern(attributes["groups"], "\"", "")
+              - replace_pattern(attributes["organization_id"], "\"", "")
+      groupbyattrs:
+        keys:
+        - subscription
+        - model
+        - response_type
+    exporters:
+      otlp_http/loki:
+        endpoint: "https://maas-loki-gateway-http.opendatahub.svc.cluster.local:8080/api/logs/v1/application/otlp"
+        auth:
+          authenticator: bearertokenauth
+        tls:
+          ca_file: /etc/pki/ca-trust/extracted/pem/service-ca.crt
+    service:
+      extensions:
+        - bearertokenauth
+      pipelines:
+        logs:
+          receivers:
+          - otlp
+          processors:
+          - memory_limiter
+          - resource
+          - batch
+          - transform
+          - groupbyattrs
+          exporters:
+          - otlp_http/loki

--- a/maas-controller/cmd/manager/main.go
+++ b/maas-controller/cmd/manager/main.go
@@ -668,6 +668,7 @@ func main() {
 	var enableTenantNamespaceDiscovery bool
 	var observabilityManifestsPath string
 	var monitoringNamespace string
+	var usageLogsManifestPath string
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metrics endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
@@ -680,6 +681,7 @@ func main() {
 		"Infrastructure namespace for maas-api, postgres, and maas-db-config. "+
 			"Defaults to 'AUTO' (namespace separation enabled). Set to empty string to disable for ROSA.")
 	flag.StringVar(&observabilityManifestsPath, "observability-manifests-path", "/deployment/components/observability/observability/dashboards", "Path to observability dashboard kustomize manifests.")
+	flag.StringVar(&usageLogsManifestPath, "usage-logs-manifest-path", "/deployment/components/observability/usage-logs", "Path to usage logs kustomize manifests.")
 	flag.StringVar(&monitoringNamespace, "monitoring-namespace", "opendatahub", "The namespace where the monitoring stack is deployed.")
 	flag.StringVar(&maasSubscriptionNamespace, "maas-subscription-namespace", "models-as-a-service", "The namespace to watch for MaaS CRs.")
 	flag.StringVar(&aitenantNamespace, "aitenant-namespace", tenantreconcile.DefaultAITenantNamespace, "The infrastructure namespace where AITenant CRs are accepted.")
@@ -953,6 +955,7 @@ func main() {
 		TenantSubscriptionNamespace: maasSubscriptionNamespace,
 		AITenantNamespace:           aitenantNamespace,
 		ObservabilityManifestsPath:  observabilityManifestsPath,
+		UsageLogsManifestPath:       usageLogsManifestPath,
 		MonitoringNamespace:         monitoringNamespace,
 		GatewayNamespace:            gatewayNamespace,
 	}).SetupWithManager(mgr); err != nil {

--- a/maas-controller/pkg/controller/maas/constants.go
+++ b/maas-controller/pkg/controller/maas/constants.go
@@ -5,7 +5,8 @@ package maas
 // when their CRDs are not yet registered, instead of failing the Tenant reconcile.
 // The CRD watch in the controller re-triggers reconcile once the CRDs appear.
 var OptionalAPIGroups = map[string]bool{
-	"perses.dev": true, // Cluster Observability Operator (COO) — Perses dashboards and datasources
+	"perses.dev":       true, // Cluster Observability Operator (COO) — Perses dashboards and datasources
+	"opentelemetry.io": true, // OpenTelemetry Collector
 }
 
 // isOptionalAPIGroup returns true when missing CRDs for the given group should not

--- a/maas-controller/pkg/controller/maas/self_deployment_controller.go
+++ b/maas-controller/pkg/controller/maas/self_deployment_controller.go
@@ -26,12 +26,16 @@ import (
 
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	netwv1 "k8s.io/api/networking/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer/yaml"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
@@ -55,6 +59,14 @@ const CleanupFinalizer = "maas.opendatahub.io/cleanup"
 // envoyFilterManifestPath is the absolute path to the EnvoyFilter manifest inside the container.
 const envoyFilterManifestPath = "/deployment/components/observability/usage-logs/envoy-otel-access-log.yaml"
 
+// usageLogsCollectorName is the OpenTelemetryCollector resource for gateway usage logs.
+const usageLogsCollectorName = "usage-logs"
+
+// lokiGatewayHTTPService is the Loki gateway Service fronting the application logs OTLP endpoint.
+const lokiGatewayHTTPService = "maas-loki-gateway-http"
+
+const lokiGatewayOTLPEndpointPath = "/api/logs/v1/application/otlp"
+
 // envoyFilterName is the name of the usage-logs EnvoyFilter resource.
 const envoyFilterName = "maas-model-access-logs"
 
@@ -74,6 +86,7 @@ type LifecycleReconciler struct {
 	ObservabilityManifestsPath  string
 	MonitoringNamespace         string
 	EnvoyFilterManifestPath     string
+	UsageLogsManifestPath       string
 }
 
 //+kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;update;patch
@@ -83,6 +96,8 @@ type LifecycleReconciler struct {
 //+kubebuilder:rbac:groups=maas.opendatahub.io,resources=aitenants,verbs=get;list;watch;update;patch
 //+kubebuilder:rbac:groups=perses.dev,resources=persesdashboards;persesdatasources,verbs=get;list;watch;create;patch;delete
 //+kubebuilder:rbac:groups=networking.istio.io,resources=envoyfilters,verbs=get;list;watch;create;patch;delete
+//+kubebuilder:rbac:groups=opentelemetry.io,resources=opentelemetrycollectors,verbs=get;list;watch;create;patch;delete
+//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings,verbs=get;list;watch;create;patch;delete
 
 func (r *LifecycleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := ctrl.Log.WithName("self-deployment").WithValues("deployment", req.NamespacedName)
@@ -379,6 +394,9 @@ func (r *LifecycleReconciler) ensureObservability(ctx context.Context, log logr.
 	if err := r.ensureUsageLogsEnvoyFilter(ctx, log); err != nil {
 		return err
 	}
+	if err := r.ensureUsageLogs(ctx, log); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -494,6 +512,148 @@ func (r *LifecycleReconciler) ensureUsageDashboard(ctx context.Context, log logr
 		}
 	}
 
+	return nil
+}
+
+// ensureUsageLogs deploys or removes OTel collector and RBAC for usage logging based on
+// the Config's usageLogging feature gate.
+func (r *LifecycleReconciler) ensureUsageLogs(ctx context.Context, log logr.Logger) error {
+	var cfg maasv1alpha1.Config
+	if err := r.Get(ctx, client.ObjectKey{Name: maasv1alpha1.ConfigInstanceName}, &cfg); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
+	resources, err := tenantreconcile.RenderKustomize(r.UsageLogsManifestPath, r.MonitoringNamespace)
+	if err != nil {
+		return fmt.Errorf("render usage logs: %w", err)
+	}
+
+	if !ptr.Deref(cfg.Spec.UsageLogging, false) {
+		for _, resource := range resources {
+			res := resource.DeepCopy()
+			key := client.ObjectKeyFromObject(res)
+			existing := &unstructured.Unstructured{}
+			existing.SetGroupVersionKind(res.GroupVersionKind())
+
+			if err := r.Get(ctx, key, existing); err != nil {
+				if apierrors.IsNotFound(err) || apimeta.IsNoMatchError(err) {
+					continue
+				}
+				return fmt.Errorf("get %s %s/%s before delete: %w", res.GetKind(), res.GetNamespace(), res.GetName(), err)
+			}
+
+			if !isOwnedByConfigOrController(existing, cfg.UID) {
+				log.V(1).Info("skipping deletion of unowned usage-logs resource",
+					"kind", res.GetKind(), "name", res.GetName(), "namespace", res.GetNamespace())
+				continue
+			}
+
+			if err := r.Delete(ctx, existing); err != nil {
+				if apierrors.IsNotFound(err) {
+					continue
+				}
+				return fmt.Errorf("delete %s %s/%s: %w", res.GetKind(), res.GetNamespace(), res.GetName(), err)
+			}
+			log.V(1).Info("deleted usage-logs resource (usageLogging disabled)",
+				"kind", res.GetKind(), "name", res.GetName(), "namespace", res.GetNamespace())
+		}
+	} else {
+		// Track if the collector is skipped due to missing CRD (CWE-863).
+		// If the OpenTelemetryCollector CRD is unavailable, we must skip the entire
+		// bundle to prevent orphaned ClusterRoleBinding from granting cluster-logging-application-write
+		// permissions to a ServiceAccount (usage-logs-collector) that anyone could then create and exploit.
+		collectorSkipped := false
+
+		for _, resource := range resources {
+			res := resource // avoid loop variable aliasing
+			if err := patchUsageLogsOpenTelemetryCollector(&res, r.MonitoringNamespace); err != nil {
+				return fmt.Errorf("patch %s %s: %w", res.GetKind(), res.GetName(), err)
+			}
+			if err := controllerutil.SetControllerReference(&cfg, &res, r.Scheme); err != nil {
+				return fmt.Errorf("set controller reference on %s %s: %w", res.GetKind(), res.GetName(), err)
+			}
+
+			if err := r.Patch(ctx, &res, client.Apply, client.ForceOwnership, client.FieldOwner("maas-controller")); err != nil {
+				if isOptionalAPIGroup(res.GroupVersionKind().Group) && (apimeta.IsNoMatchError(err) || apierrors.IsNotFound(err)) {
+					log.Info("skipping usage-logs resource: optional CRD not yet registered, will apply once installed",
+						"group", res.GroupVersionKind().Group, "kind", res.GetKind(),
+						"name", res.GetName(), "namespace", res.GetNamespace())
+					if res.GetKind() == "OpenTelemetryCollector" {
+						collectorSkipped = true
+					}
+					continue
+				}
+				return fmt.Errorf("apply %s %s/%s: %w", res.GetKind(), res.GetNamespace(), res.GetName(), err)
+			}
+		}
+
+		// If the collector was skipped, delete any orphaned RBAC resources that may have
+		// been created in a prior reconcile when the CRD was available (CWE-863).
+		if collectorSkipped {
+			gvkClusterRoleBinding := schema.GroupVersionKind{
+				Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "ClusterRoleBinding",
+			}
+			crb := &unstructured.Unstructured{}
+			crb.SetGroupVersionKind(gvkClusterRoleBinding)
+			crb.SetName("usage-logs-writer")
+
+			if err := r.Get(ctx, client.ObjectKeyFromObject(crb), crb); err == nil {
+				if isOwnedByConfigOrController(crb, cfg.UID) {
+					if err := r.Delete(ctx, crb); err != nil && !apierrors.IsNotFound(err) {
+						return fmt.Errorf("delete orphaned ClusterRoleBinding after collector skip: %w", err)
+					}
+					log.Info("deleted orphaned usage-logs ClusterRoleBinding (collector CRD unavailable)")
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+// isOwnedByConfigOrController verifies whether a resource is owned by the Config controller
+// or has the trusted managed-by label. This prevents accidental deletion of pre-existing
+// foreign resources with the same name (CWE-284).
+func isOwnedByConfigOrController(obj client.Object, configUID types.UID) bool {
+	// Check if owned by Config via OwnerReferences
+	for _, ref := range obj.GetOwnerReferences() {
+		if ref.UID == configUID && ref.Controller != nil && *ref.Controller {
+			return true
+		}
+	}
+
+	// Check for trusted managed-by label
+	labels := obj.GetLabels()
+	if labels != nil && labels["app.kubernetes.io/managed-by"] == "maas-controller" {
+		return true
+	}
+
+	return false
+}
+
+func lokiGatewayEndpoint(monitoringNamespace string) string {
+	return fmt.Sprintf(
+		"https://%s.%s.svc.cluster.local:8080%s",
+		lokiGatewayHTTPService,
+		monitoringNamespace,
+		lokiGatewayOTLPEndpointPath,
+	)
+}
+
+// patchUsageLogsOpenTelemetryCollector rewrites the Loki OTLP exporter endpoint to target the
+// monitoring namespace. The manifest keeps the overlay default namespace as a build-time placeholder.
+func patchUsageLogsOpenTelemetryCollector(res *unstructured.Unstructured, monitoringNamespace string) error {
+	if res.GetKind() != "OpenTelemetryCollector" || res.GetName() != usageLogsCollectorName {
+		return nil
+	}
+	endpoint := lokiGatewayEndpoint(monitoringNamespace)
+	if err := unstructured.SetNestedField(res.Object, endpoint,
+		"spec", "config", "exporters", "otlp_http/loki", "endpoint"); err != nil {
+		return fmt.Errorf("set loki exporter endpoint: %w", err)
+	}
 	return nil
 }
 
@@ -698,6 +858,45 @@ func (r *LifecycleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 				}}}
 			}),
 			builder.WithPredicates(crdInOptionalAPIGroup()),
+		).
+		// Watch managed usage-log resources so deletions/modifications trigger reconciliation
+		Watches(
+			&corev1.ConfigMap{},
+			handler.EnqueueRequestsFromMapFunc(func(_ context.Context, _ client.Object) []reconcile.Request {
+				return []reconcile.Request{{NamespacedName: types.NamespacedName{
+					Namespace: r.DeploymentNS,
+					Name:      r.DeploymentName,
+				}}}
+			}),
+			builder.WithPredicates(predicate.NewPredicateFuncs(func(o client.Object) bool {
+				return o.GetNamespace() == r.MonitoringNamespace &&
+					o.GetLabels()["app.kubernetes.io/managed-by"] == "maas-controller"
+			})),
+		).
+		Watches(
+			&rbacv1.ClusterRoleBinding{},
+			handler.EnqueueRequestsFromMapFunc(func(_ context.Context, _ client.Object) []reconcile.Request {
+				return []reconcile.Request{{NamespacedName: types.NamespacedName{
+					Namespace: r.DeploymentNS,
+					Name:      r.DeploymentName,
+				}}}
+			}),
+			builder.WithPredicates(predicate.NewPredicateFuncs(func(o client.Object) bool {
+				return o.GetLabels()["app.kubernetes.io/managed-by"] == "maas-controller"
+			})),
+		).
+		Watches(
+			&netwv1.NetworkPolicy{},
+			handler.EnqueueRequestsFromMapFunc(func(_ context.Context, _ client.Object) []reconcile.Request {
+				return []reconcile.Request{{NamespacedName: types.NamespacedName{
+					Namespace: r.DeploymentNS,
+					Name:      r.DeploymentName,
+				}}}
+			}),
+			builder.WithPredicates(predicate.NewPredicateFuncs(func(o client.Object) bool {
+				return o.GetNamespace() == r.MonitoringNamespace &&
+					o.GetLabels()["app.kubernetes.io/managed-by"] == "maas-controller"
+			})),
 		).
 		Complete(r)
 }

--- a/maas-controller/pkg/controller/maas/self_deployment_controller_test.go
+++ b/maas-controller/pkg/controller/maas/self_deployment_controller_test.go
@@ -14,6 +14,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -55,6 +56,11 @@ func TestLifecycleReconciler_CreatesConfigWhenMissing(t *testing.T) {
 		},
 	}
 
+	// Compute absolute path to the usage-logs manifest from this test file's location.
+	_, testFile, _, ok := goruntime.Caller(0)
+	g.Expect(ok).To(BeTrue())
+	usageLogsPath := filepath.Join(filepath.Dir(testFile), "../../../../deployment/components/observability/usage-logs")
+
 	cl := fake.NewClientBuilder().WithScheme(s).WithObjects(dep).Build()
 	r := &LifecycleReconciler{
 		Client:                      cl,
@@ -62,6 +68,7 @@ func TestLifecycleReconciler_CreatesConfigWhenMissing(t *testing.T) {
 		DeploymentName:              "maas-controller",
 		DeploymentNS:                depNS,
 		TenantSubscriptionNamespace: "",
+		UsageLogsManifestPath:       usageLogsPath,
 	}
 
 	_, err := r.Reconcile(context.Background(), ctrl.Request{
@@ -173,6 +180,11 @@ func TestLifecycleReconciler_LinksDefaultTenantToConfig(t *testing.T) {
 		"deployment", "components", "observability", "observability", "dashboards",
 	))
 
+	// Compute absolute path to the usage-logs manifest from this test file's location.
+	_, testFile, _, ok := goruntime.Caller(0)
+	g.Expect(ok).To(BeTrue())
+	usageLogsPath := filepath.Join(filepath.Dir(testFile), "../../../../deployment/components/observability/usage-logs")
+
 	cl := fake.NewClientBuilder().WithScheme(s).WithObjects(dep, cfg, tenant).Build()
 	r := &LifecycleReconciler{
 		Client:                      cl,
@@ -182,6 +194,7 @@ func TestLifecycleReconciler_LinksDefaultTenantToConfig(t *testing.T) {
 		TenantSubscriptionNamespace: tenantNS,
 		ObservabilityManifestsPath:  observabilityPath,
 		MonitoringNamespace:         depNS,
+		UsageLogsManifestPath:       usageLogsPath,
 	}
 
 	_, err := r.Reconcile(context.Background(), ctrl.Request{
@@ -230,13 +243,19 @@ func TestLifecycleReconciler_LinksDefaultAITenantToConfig(t *testing.T) {
 		},
 	}
 
+	// Compute absolute path to the usage-logs manifest from this test file's location.
+	_, testFile, _, ok := goruntime.Caller(0)
+	g.Expect(ok).To(BeTrue())
+	usageLogsPath := filepath.Join(filepath.Dir(testFile), "../../../../deployment/components/observability/usage-logs")
+
 	cl := fake.NewClientBuilder().WithScheme(s).WithObjects(dep, cfg, aitenant).Build()
 	r := &LifecycleReconciler{
-		Client:            cl,
-		Scheme:            s,
-		DeploymentName:    tenantreconcile.MaaSControllerDeploymentName,
-		DeploymentNS:      depNS,
-		AITenantNamespace: tenantreconcile.DefaultAITenantNamespace,
+		Client:                cl,
+		Scheme:                s,
+		DeploymentName:        tenantreconcile.MaaSControllerDeploymentName,
+		DeploymentNS:          depNS,
+		AITenantNamespace:     tenantreconcile.DefaultAITenantNamespace,
+		UsageLogsManifestPath: usageLogsPath,
 	}
 
 	_, err := r.Reconcile(context.Background(), ctrl.Request{
@@ -467,5 +486,165 @@ func TestEnsureUsageLogsEnvoyFilter(t *testing.T) {
 			Name: envoyFilterName, Namespace: gwNS,
 		}, ef)
 		g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "EnvoyFilter should be deleted when usageLogging is disabled")
+	})
+}
+
+func TestEnsureUsageLogs(t *testing.T) {
+	const monitoringNS = "redhat-ods-monitoring"
+
+	gvkOpenTelemetryCollector := schema.GroupVersionKind{
+		Group: "opentelemetry.io", Version: "v1beta1", Kind: "OpenTelemetryCollector",
+	}
+	gvkClusterRoleBinding := schema.GroupVersionKind{
+		Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "ClusterRoleBinding",
+	}
+
+	// Compute absolute path to the usage-logs manifest from this test file's location.
+	_, testFile, _, ok := goruntime.Caller(0)
+	if !ok {
+		t.Fatal("failed to get test file path")
+	}
+	usageLogsPath := filepath.Join(filepath.Dir(testFile), "../../../../deployment/components/observability/usage-logs")
+
+	t.Run("disabled deletes controller-managed resources", func(t *testing.T) {
+		g := NewWithT(t)
+		s := lifecycleTestScheme(t)
+
+		cfg := &maasv1alpha1.Config{
+			ObjectMeta: metav1.ObjectMeta{Name: maasv1alpha1.ConfigInstanceName, UID: types.UID("cfg-uid")},
+			Spec:       maasv1alpha1.ConfigSpec{UsageLogging: ptr.To(false)},
+		}
+
+		otelCR := &unstructured.Unstructured{}
+		otelCR.SetGroupVersionKind(gvkOpenTelemetryCollector)
+		otelCR.SetName("usage-logs")
+		otelCR.SetNamespace(monitoringNS)
+		otelCR.SetLabels(map[string]string{
+			"app.kubernetes.io/managed-by": "maas-controller",
+		})
+
+		crb := &unstructured.Unstructured{}
+		crb.SetGroupVersionKind(gvkClusterRoleBinding)
+		crb.SetName("usage-logs-writer")
+		crb.SetOwnerReferences([]metav1.OwnerReference{{
+			APIVersion: "maas.opendatahub.io/v1alpha1",
+			Kind:       "Config",
+			Name:       maasv1alpha1.ConfigInstanceName,
+			UID:        cfg.UID,
+			Controller: ptr.To(true),
+		}})
+
+		cl := fake.NewClientBuilder().WithScheme(s).WithObjects(cfg, otelCR, crb).Build()
+		r := &LifecycleReconciler{
+			Client:                cl,
+			Scheme:                s,
+			MonitoringNamespace:   monitoringNS,
+			UsageLogsManifestPath: usageLogsPath,
+		}
+
+		err := r.ensureUsageLogs(context.Background(), ctrl.Log)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		got := &unstructured.Unstructured{}
+		got.SetGroupVersionKind(gvkOpenTelemetryCollector)
+		err = cl.Get(context.Background(), client.ObjectKey{Name: "usage-logs", Namespace: monitoringNS}, got)
+		g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "controller-managed OpenTelemetryCollector should be deleted")
+
+		got.SetGroupVersionKind(gvkClusterRoleBinding)
+		err = cl.Get(context.Background(), client.ObjectKey{Name: "usage-logs-writer"}, got)
+		g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "controller-owned ClusterRoleBinding should be deleted")
+	})
+
+	t.Run("disabled preserves unowned resources", func(t *testing.T) {
+		g := NewWithT(t)
+		s := lifecycleTestScheme(t)
+
+		cfg := &maasv1alpha1.Config{
+			ObjectMeta: metav1.ObjectMeta{Name: maasv1alpha1.ConfigInstanceName, UID: types.UID("cfg-uid")},
+			Spec:       maasv1alpha1.ConfigSpec{UsageLogging: ptr.To(false)},
+		}
+
+		// Pre-existing foreign OpenTelemetryCollector with same name but no ownership
+		foreignOtelCR := &unstructured.Unstructured{}
+		foreignOtelCR.SetGroupVersionKind(gvkOpenTelemetryCollector)
+		foreignOtelCR.SetName("usage-logs")
+		foreignOtelCR.SetNamespace(monitoringNS)
+		// No managed-by label, no OwnerReferences
+
+		// Pre-existing foreign ClusterRoleBinding with same name
+		foreignCRB := &unstructured.Unstructured{}
+		foreignCRB.SetGroupVersionKind(gvkClusterRoleBinding)
+		foreignCRB.SetName("usage-logs-writer")
+		// No ownership metadata
+
+		cl := fake.NewClientBuilder().WithScheme(s).WithObjects(cfg, foreignOtelCR, foreignCRB).Build()
+		r := &LifecycleReconciler{
+			Client:                cl,
+			Scheme:                s,
+			MonitoringNamespace:   monitoringNS,
+			UsageLogsManifestPath: usageLogsPath,
+		}
+
+		err := r.ensureUsageLogs(context.Background(), ctrl.Log)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		got := &unstructured.Unstructured{}
+		got.SetGroupVersionKind(gvkOpenTelemetryCollector)
+		err = cl.Get(context.Background(), client.ObjectKey{Name: "usage-logs", Namespace: monitoringNS}, got)
+		g.Expect(err).NotTo(HaveOccurred(), "foreign OpenTelemetryCollector should be preserved (CWE-284)")
+		g.Expect(got.GetLabels()).NotTo(HaveKey("app.kubernetes.io/managed-by"),
+			"foreign resource should not have managed-by label")
+
+		got.SetGroupVersionKind(gvkClusterRoleBinding)
+		err = cl.Get(context.Background(), client.ObjectKey{Name: "usage-logs-writer"}, got)
+		g.Expect(err).NotTo(HaveOccurred(), "foreign ClusterRoleBinding should be preserved (CWE-284)")
+		g.Expect(got.GetOwnerReferences()).To(BeEmpty(),
+			"foreign resource should not have OwnerReferences")
+	})
+
+	t.Run("enabled applies resources with monitoring namespace", func(t *testing.T) {
+		g := NewWithT(t)
+		s := lifecycleTestScheme(t)
+
+		cfg := &maasv1alpha1.Config{
+			ObjectMeta: metav1.ObjectMeta{Name: maasv1alpha1.ConfigInstanceName, UID: types.UID("cfg-uid")},
+			Spec:       maasv1alpha1.ConfigSpec{UsageLogging: ptr.To(true)},
+		}
+
+		cl := fake.NewClientBuilder().WithScheme(s).WithObjects(cfg).Build()
+		r := &LifecycleReconciler{
+			Client:                cl,
+			Scheme:                s,
+			MonitoringNamespace:   monitoringNS,
+			UsageLogsManifestPath: usageLogsPath,
+		}
+
+		err := r.ensureUsageLogs(context.Background(), ctrl.Log)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		got := &unstructured.Unstructured{}
+		got.SetGroupVersionKind(gvkOpenTelemetryCollector)
+		g.Expect(cl.Get(context.Background(), client.ObjectKey{Name: "usage-logs", Namespace: monitoringNS}, got)).
+			To(Succeed(), "OpenTelemetryCollector should exist when usageLogging is enabled")
+
+		endpoint, found, err := unstructured.NestedString(got.Object,
+			"spec", "config", "exporters", "otlp_http/loki", "endpoint")
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(found).To(BeTrue())
+		g.Expect(endpoint).To(Equal(lokiGatewayEndpoint(monitoringNS)),
+			"Loki exporter endpoint should target MonitoringNamespace")
+
+		got = &unstructured.Unstructured{}
+		got.SetGroupVersionKind(gvkClusterRoleBinding)
+		g.Expect(cl.Get(context.Background(), client.ObjectKey{Name: "usage-logs-writer"}, got)).
+			To(Succeed(), "ClusterRoleBinding should exist when usageLogging is enabled")
+
+		subjects, found, err := unstructured.NestedSlice(got.Object, "subjects")
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(found).To(BeTrue())
+		g.Expect(subjects).NotTo(BeEmpty())
+		subj, ok := subjects[0].(map[string]any)
+		g.Expect(ok).To(BeTrue())
+		g.Expect(subj["namespace"]).To(Equal(monitoringNS))
 	})
 }


### PR DESCRIPTION
## Description
Add an OpenTelemetry collector that receives usage logs from the gateway and exports them to Loki.

## How Has This Been Tested?
Tests manually

## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OpenTelemetry-based usage-log collection using a dedicated collector (2 replicas).
  * Introduced managed usage-log Kubernetes manifests via a configurable manifest path.
  * Added RBAC, TLS trust (CA bundle injection), and a NetworkPolicy to restrict OTLP access.
* **Bug Fixes**
  * Improved controller resilience when optional observability CRDs are not yet registered.
* **Tests**
  * Added and updated coverage for usage-log enable/disable behavior, configuration, and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->