### PR TITLE
fix: validate user-specified API key name

### DIFF
--- a/maas-api/internal/api_keys/handler.go
+++ b/maas-api/internal/api_keys/handler.go
@@ -5,8 +5,10 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"regexp"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/gin-gonic/gin"
 
@@ -22,6 +24,8 @@ const (
 	apiKeySubscriptionResolutionErrCode = "invalid_subscription"
 	apiKeySubscriptionResolutionErrMsg  = "Unable to resolve a subscription for this API key" //nolint:gosec // G101: public JSON error text, not a credential
 )
+
+var invalidKeyNameCharsPattern = regexp.MustCompile(`[\x00-\x1F\x7F]`)
 
 // AdminChecker is an interface for checking if a user is an admin.
 // The SARAdminChecker implementation uses Kubernetes SubjectAccessReview
@@ -185,6 +189,20 @@ func (h *Handler) CreateAPIKey(c *gin.Context) {
 	name := req.Name
 	if req.Ephemeral && name == "" {
 		name = fmt.Sprintf("ephemeral-%d", time.Now().UnixNano())
+	} else {
+		name = strings.TrimSpace(name)
+		if len(name) == 0 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "key name cannot be whitespace only"})
+			return
+		}
+		if utf8.RuneCountInString(name) > 128 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "key name cannot exceed 128 characters"})
+			return
+		}
+		if invalidKeyNameCharsPattern.MatchString(name) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "key name contains invalid control characters"})
+			return
+		}
 	}
 
 	// Parse expiration duration if provided

--- a/maas-api/internal/api_keys/handler_test.go
+++ b/maas-api/internal/api_keys/handler_test.go
@@ -2103,3 +2103,93 @@ func TestSearchAPIKeys_EmptyTenantNoResults(t *testing.T) {
 	assert.Empty(t, response.Data, "tenant-c user should see no keys")
 	assert.False(t, response.HasMore)
 }
+
+func TestCreateAPIKey_NameValidation(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	store := NewMockStore()
+	cfg := &config.Config{}
+	service := NewServiceWithLogger(store, cfg, fixedSubSelector{}, logger.Development())
+	handler := NewHandler(logger.Development(), service, newMockAdminChecker())
+
+	user := &token.UserContext{
+		Username: "user",
+		Groups:   []string{"test-group"},
+		Tenant:   "tenant",
+	}
+
+	validNames := []struct {
+		name        string
+		description string
+	}{
+		{"simple-key", "ASCII alphanumeric with dash"},
+		{"test_key_123", "ASCII with underscores and numbers"},
+		{"My API Key", "ASCII with spaces"},
+		{"café", "Latin-1 accented characters"},
+		{"🔑 api-key", "Emoji with ASCII"},
+		{"ключ", "Cyrillic characters"},
+		{"مفتاح", "Arabic characters"},
+		{"κλειδί", "Greek characters"},
+		{"a", "Single character"},
+		{strings.Repeat("a", 128), "Exactly 128 characters"},
+		{"key.with.dots", "Dots"},
+		{"key:with:colons", "Colons"},
+		{"key-with_mixed.chars:123", "Mixed valid punctuation"},
+	}
+
+	for _, tc := range validNames {
+		t.Run("valid_"+tc.description, func(t *testing.T) {
+			requestBody := fmt.Sprintf(`{"name": %q}`, tc.name)
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			c.Request = httptest.NewRequest(http.MethodPost, "/v1/api-keys", nil)
+			c.Request.Header.Set("Content-Type", "application/json")
+			c.Request.Body = io.NopCloser(strings.NewReader(requestBody))
+			c.Set("user", user)
+
+			handler.CreateAPIKey(c)
+
+			assert.Equal(t, http.StatusCreated, w.Code, "key name %q should be valid: %s", tc.name, tc.description)
+			var response CreateAPIKeyResponse
+			err := json.Unmarshal(w.Body.Bytes(), &response)
+			require.NoError(t, err)
+			// Verify the name is stored (trimmed if had whitespace)
+			assert.Equal(t, strings.TrimSpace(tc.name), response.Name)
+		})
+	}
+
+	invalidNames := []struct {
+		name      string
+		reason    string
+		errMsg    string
+	}{
+		{"   ", "whitespace only", "whitespace only"},
+		{"\t\t", "tabs only", "whitespace only"},
+		{"\n\n", "newlines only", "whitespace only"},
+		{"key\nwith\nnewline", "newline character", "control characters"},
+		{"key\twith\ttab", "tab character", "control characters"},
+		{"key\rwith\rcarriage", "carriage return", "control characters"},
+		{strings.Repeat("a", 129), "129 characters (over limit)", "exceed 128"},
+		{strings.Repeat("x", 200), "200 characters (way over limit)", "exceed 128"},
+		{"line1\nline2\nline3", "multiple newlines", "control characters"},
+	}
+
+	for _, tc := range invalidNames {
+		t.Run("invalid_"+tc.reason, func(t *testing.T) {
+			requestBody := fmt.Sprintf(`{"name": %q}`, tc.name)
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			c.Request = httptest.NewRequest(http.MethodPost, "/v1/api-keys", nil)
+			c.Request.Header.Set("Content-Type", "application/json")
+			c.Request.Body = io.NopCloser(strings.NewReader(requestBody))
+			c.Set("user", user)
+
+			handler.CreateAPIKey(c)
+
+			assert.Equal(t, http.StatusBadRequest, w.Code, "key name should be rejected: %s", tc.reason)
+			var response map[string]any
+			err := json.Unmarshal(w.Body.Bytes(), &response)
+			require.NoError(t, err)
+			assert.Contains(t, response["error"], tc.errMsg, "error message should mention %s for %s", tc.errMsg, tc.reason)
+		})
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The API key names can be specified by users and thus, we need to make sure they're valid. It's even more important now that they are returned by Authorino.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested manually

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * API key names are now cleaned up automatically by trimming surrounding whitespace.
  * Invalid API key names are rejected more consistently, including empty names, overly long names, and names with unsupported control characters.
  * Ephemeral API keys continue to support automatic name generation when no name is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->