### PR TITLE
feat: eliminate X-MaaS-Tenant header (RHOAIENG-70517)

### DIFF
--- a/maas-api/cmd/main.go
+++ b/maas-api/cmd/main.go
@@ -207,7 +207,7 @@ func registerHandlers(ctx context.Context, log *logger.Logger, router *gin.Engin
 		log.Fatal("Failed to create model manager", "error", err)
 	}
 
-	tokenHandler := token.NewHandler(log, cfg.Name)
+	tokenHandler := token.NewHandler(log, cfg.TenantName)
 	modelsHandler := handlers.NewModelsHandler(log, modelManager, subscriptionSelector, cluster.MaaSModelRefLister)
 	subscriptionHandler := subscription.NewHandler(log, subscriptionSelector)
 

--- a/maas-api/internal/config/config.go
+++ b/maas-api/internal/config/config.go
@@ -165,6 +165,11 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("MAAS_SUBSCRIPTION_NAMESPACE %q is invalid: %v", c.MaaSSubscriptionNamespace, errs)
 	}
 
+	// Validate TenantName is non-empty and non-whitespace to ensure tenant isolation
+	if strings.TrimSpace(c.TenantName) == "" {
+		return errors.New("TENANT_NAME must be non-empty and non-whitespace to ensure tenant isolation")
+	}
+
 	// Validate API key max expiration days
 	if c.APIKeyMaxExpirationDays < 1 {
 		return errors.New("API_KEY_MAX_EXPIRATION_DAYS must be at least 1")

--- a/maas-api/internal/config/config_test.go
+++ b/maas-api/internal/config/config_test.go
@@ -123,6 +123,7 @@ func TestValidate(t *testing.T) {
 				AccessCheckTimeoutSeconds: 15,
 				MetricsPort:               9090,
 				MaaSSubscriptionNamespace: "models-as-a-service",
+				TenantName:                "test-tenant",
 			},
 		},
 		{
@@ -134,6 +135,7 @@ func TestValidate(t *testing.T) {
 				AccessCheckTimeoutSeconds: 15,
 				MetricsPort:               9090,
 				MaaSSubscriptionNamespace: "models-as-a-service",
+				TenantName:                "test-tenant",
 			},
 		},
 		{
@@ -145,6 +147,7 @@ func TestValidate(t *testing.T) {
 				AccessCheckTimeoutSeconds: 15,
 				MetricsPort:               9090,
 				MaaSSubscriptionNamespace: "models-as-a-service",
+				TenantName:                "test-tenant",
 			},
 		},
 		{
@@ -155,6 +158,7 @@ func TestValidate(t *testing.T) {
 				AccessCheckTimeoutSeconds: 15,
 				MetricsPort:               9090,
 				MaaSSubscriptionNamespace: "models-as-a-service",
+				TenantName:                "test-tenant",
 			},
 		},
 		{
@@ -165,6 +169,7 @@ func TestValidate(t *testing.T) {
 				AccessCheckTimeoutSeconds: 15,
 				MetricsPort:               9090,
 				MaaSSubscriptionNamespace: "models-as-a-service",
+				TenantName:                "test-tenant",
 			},
 		},
 		{
@@ -175,6 +180,7 @@ func TestValidate(t *testing.T) {
 				AccessCheckTimeoutSeconds: 15,
 				MetricsPort:               9090,
 				MaaSSubscriptionNamespace: "models-as-a-service",
+				TenantName:                "test-tenant",
 			},
 		},
 		{
@@ -183,6 +189,7 @@ func TestValidate(t *testing.T) {
 				DBConnectionURL:           "postgresql://localhost/test",
 				APIKeyMaxExpirationDays:   0,
 				MaaSSubscriptionNamespace: "models-as-a-service",
+				TenantName:                "test-tenant",
 			},
 			expectError: "must be at least 1",
 		},
@@ -192,6 +199,7 @@ func TestValidate(t *testing.T) {
 				DBConnectionURL:           "postgresql://localhost/test",
 				APIKeyMaxExpirationDays:   -1,
 				MaaSSubscriptionNamespace: "models-as-a-service",
+				TenantName:                "test-tenant",
 			},
 			expectError: "must be at least 1",
 		},
@@ -204,6 +212,7 @@ func TestValidate(t *testing.T) {
 				SARCacheMaxSize:           8192,
 				MetricsPort:               0,
 				MaaSSubscriptionNamespace: "models-as-a-service",
+				TenantName:                "test-tenant",
 			},
 			expectError: "METRICS_PORT must be between 1 and 65535",
 		},
@@ -216,6 +225,7 @@ func TestValidate(t *testing.T) {
 				SARCacheMaxSize:           8192,
 				MetricsPort:               -1,
 				MaaSSubscriptionNamespace: "models-as-a-service",
+				TenantName:                "test-tenant",
 			},
 			expectError: "METRICS_PORT must be between 1 and 65535",
 		},
@@ -228,6 +238,7 @@ func TestValidate(t *testing.T) {
 				SARCacheMaxSize:           8192,
 				MetricsPort:               65536,
 				MaaSSubscriptionNamespace: "models-as-a-service",
+				TenantName:                "test-tenant",
 			},
 			expectError: "METRICS_PORT must be between 1 and 65535",
 		},

--- a/maas-api/internal/constant/const.go
+++ b/maas-api/internal/constant/const.go
@@ -15,7 +15,6 @@ const (
 	// Header configuration constants.
 	HeaderUsername = "X-MaaS-Username"
 	HeaderGroup    = "X-MaaS-Group"
-	HeaderTenant   = "X-MaaS-Tenant"
 
 	// API Key configuration defaults.
 	// DefaultAPIKeyMaxExpirationDays is the default maximum allowed expiration for API keys.

--- a/maas-api/internal/handlers/models_test.go
+++ b/maas-api/internal/handlers/models_test.go
@@ -375,7 +375,6 @@ func TestListingModels(t *testing.T) { //nolint:maintidx // table-driven test wi
 	req.Header.Set("Authorization", "Bearer valid-token")
 	req.Header.Set(constant.HeaderUsername, "test-user@example.com")
 	req.Header.Set(constant.HeaderGroup, `["free-users"]`)
-	req.Header.Set(constant.HeaderTenant, "test-tenant")
 	router.ServeHTTP(w, req)
 
 	require.Equal(t, http.StatusOK, w.Code, "Expected status OK")
@@ -519,8 +518,7 @@ func TestListingModelsWithSubscriptionHeader(t *testing.T) {
 			req.Header.Set("X-Maas-Subscription", tt.subscription)
 			req.Header.Set(constant.HeaderUsername, "test-user@example.com")
 			req.Header.Set(constant.HeaderGroup, tt.userGroups)
-			req.Header.Set(constant.HeaderTenant, "test-tenant")
-			router.ServeHTTP(w, req)
+					router.ServeHTTP(w, req)
 
 			require.Equal(t, http.StatusOK, w.Code, "Expected status OK")
 
@@ -541,8 +539,7 @@ func TestListingModelsWithSubscriptionHeader(t *testing.T) {
 		req.Header.Set("Authorization", "Bearer valid-token")
 		req.Header.Set(constant.HeaderUsername, "test-user@example.com")
 		req.Header.Set(constant.HeaderGroup, `["free-users"]`)
-		req.Header.Set(constant.HeaderTenant, "test-tenant")
-		router.ServeHTTP(w, req)
+			router.ServeHTTP(w, req)
 
 		require.Equal(t, http.StatusOK, w.Code, "Expected status OK")
 
@@ -564,8 +561,7 @@ func TestListingModelsWithSubscriptionHeader(t *testing.T) {
 		req.Header.Set("Authorization", "Bearer valid-token")
 		req.Header.Set(constant.HeaderUsername, "test-user@example.com")
 		req.Header.Set(constant.HeaderGroup, `["free-users", "premium-users"]`)
-		req.Header.Set(constant.HeaderTenant, "test-tenant")
-		router.ServeHTTP(w, req)
+			router.ServeHTTP(w, req)
 
 		// User token (no X-MaaS-Subscription header) returns all accessible models
 		require.Equal(t, http.StatusOK, w.Code, "Expected status OK")
@@ -613,8 +609,7 @@ func TestListingModelsWithSubscriptionHeader(t *testing.T) {
 			req.Header.Set("X-Maas-Subscription", tt.subscription)
 			req.Header.Set(constant.HeaderUsername, "test-user@example.com")
 			req.Header.Set(constant.HeaderGroup, tt.userGroups)
-			req.Header.Set(constant.HeaderTenant, "test-tenant")
-			router.ServeHTTP(w, req)
+					router.ServeHTTP(w, req)
 
 			require.Equal(t, http.StatusForbidden, w.Code, "Expected 403 Forbidden")
 
@@ -722,8 +717,7 @@ func TestListModels_ReturnAllModels(t *testing.T) {
 		// No X-MaaS-Subscription header = user token authentication
 		req.Header.Set(constant.HeaderUsername, "test-user@example.com")
 		req.Header.Set(constant.HeaderGroup, `["group-a", "group-b"]`)
-		req.Header.Set(constant.HeaderTenant, "test-tenant")
-		router.ServeHTTP(w, req)
+			router.ServeHTTP(w, req)
 
 		require.Equal(t, http.StatusOK, w.Code)
 
@@ -775,8 +769,7 @@ func TestListModels_ReturnAllModels(t *testing.T) {
 		// No X-MaaS-Subscription header = user token authentication
 		req.Header.Set(constant.HeaderUsername, "test-user@example.com")
 		req.Header.Set(constant.HeaderGroup, `["user-group"]`)
-		req.Header.Set(constant.HeaderTenant, "test-tenant")
-		router2.ServeHTTP(w, req)
+			router2.ServeHTTP(w, req)
 
 		require.Equal(t, http.StatusOK, w.Code)
 
@@ -797,8 +790,7 @@ func TestListModels_ReturnAllModels(t *testing.T) {
 		// No X-MaaS-Subscription header = user token authentication
 		req.Header.Set(constant.HeaderUsername, "test-user@example.com")
 		req.Header.Set(constant.HeaderGroup, `["group-a"]`)
-		req.Header.Set(constant.HeaderTenant, "test-tenant")
-		router.ServeHTTP(w, req)
+			router.ServeHTTP(w, req)
 
 		require.Equal(t, http.StatusOK, w.Code)
 
@@ -914,8 +906,7 @@ func TestListModels_DeduplicationBySubscription(t *testing.T) {
 		req.Header.Set("X-Maas-Return-All-Models", "true")
 		req.Header.Set(constant.HeaderUsername, "test-user@example.com")
 		req.Header.Set(constant.HeaderGroup, `["user-group"]`)
-		req.Header.Set(constant.HeaderTenant, "test-tenant")
-		router.ServeHTTP(w, req)
+			router.ServeHTTP(w, req)
 
 		require.Equal(t, http.StatusOK, w.Code)
 
@@ -1033,8 +1024,7 @@ func TestListModels_DifferentModelRefsWithSameModelID(t *testing.T) {
 		req.Header.Set("X-Maas-Return-All-Models", "true")
 		req.Header.Set(constant.HeaderUsername, "test-user@example.com")
 		req.Header.Set(constant.HeaderGroup, `["user-group"]`)
-		req.Header.Set(constant.HeaderTenant, "test-tenant")
-		router.ServeHTTP(w, req)
+			router.ServeHTTP(w, req)
 
 		require.Equal(t, http.StatusOK, w.Code)
 
@@ -1141,8 +1131,7 @@ func TestListModels_DifferentModelRefsWithSameURLAndModelID(t *testing.T) {
 		req.Header.Set("X-Maas-Return-All-Models", "true")
 		req.Header.Set(constant.HeaderUsername, "test-user@example.com")
 		req.Header.Set(constant.HeaderGroup, `["user-group"]`)
-		req.Header.Set(constant.HeaderTenant, "test-tenant")
-		router.ServeHTTP(w, req)
+			router.ServeHTTP(w, req)
 
 		require.Equal(t, http.StatusOK, w.Code)
 
@@ -1248,8 +1237,7 @@ func TestListModels_DifferentModelRefsWithSameModelIDAndDifferentSubscriptions(t
 		req.Header.Set("X-Maas-Return-All-Models", "true")
 		req.Header.Set(constant.HeaderUsername, "test-user@example.com")
 		req.Header.Set(constant.HeaderGroup, `["user-group"]`)
-		req.Header.Set(constant.HeaderTenant, "test-tenant")
-		router.ServeHTTP(w, req)
+			router.ServeHTTP(w, req)
 
 		require.Equal(t, http.StatusOK, w.Code)
 
@@ -1340,7 +1328,6 @@ func TestListModels_ExternalModelUsesModelRefName(t *testing.T) {
 	req.Header.Set("Authorization", "Bearer valid-token")
 	req.Header.Set(constant.HeaderUsername, "test-user@example.com")
 	req.Header.Set(constant.HeaderGroup, `["free-users"]`)
-	req.Header.Set(constant.HeaderTenant, "test-tenant")
 	router.ServeHTTP(w, req)
 
 	require.Equal(t, http.StatusOK, w.Code)

--- a/maas-api/internal/handlers/models_test.go
+++ b/maas-api/internal/handlers/models_test.go
@@ -518,7 +518,7 @@ func TestListingModelsWithSubscriptionHeader(t *testing.T) {
 			req.Header.Set("X-Maas-Subscription", tt.subscription)
 			req.Header.Set(constant.HeaderUsername, "test-user@example.com")
 			req.Header.Set(constant.HeaderGroup, tt.userGroups)
-					router.ServeHTTP(w, req)
+			router.ServeHTTP(w, req)
 
 			require.Equal(t, http.StatusOK, w.Code, "Expected status OK")
 
@@ -539,7 +539,7 @@ func TestListingModelsWithSubscriptionHeader(t *testing.T) {
 		req.Header.Set("Authorization", "Bearer valid-token")
 		req.Header.Set(constant.HeaderUsername, "test-user@example.com")
 		req.Header.Set(constant.HeaderGroup, `["free-users"]`)
-			router.ServeHTTP(w, req)
+		router.ServeHTTP(w, req)
 
 		require.Equal(t, http.StatusOK, w.Code, "Expected status OK")
 
@@ -561,7 +561,7 @@ func TestListingModelsWithSubscriptionHeader(t *testing.T) {
 		req.Header.Set("Authorization", "Bearer valid-token")
 		req.Header.Set(constant.HeaderUsername, "test-user@example.com")
 		req.Header.Set(constant.HeaderGroup, `["free-users", "premium-users"]`)
-			router.ServeHTTP(w, req)
+		router.ServeHTTP(w, req)
 
 		// User token (no X-MaaS-Subscription header) returns all accessible models
 		require.Equal(t, http.StatusOK, w.Code, "Expected status OK")
@@ -609,7 +609,7 @@ func TestListingModelsWithSubscriptionHeader(t *testing.T) {
 			req.Header.Set("X-Maas-Subscription", tt.subscription)
 			req.Header.Set(constant.HeaderUsername, "test-user@example.com")
 			req.Header.Set(constant.HeaderGroup, tt.userGroups)
-					router.ServeHTTP(w, req)
+			router.ServeHTTP(w, req)
 
 			require.Equal(t, http.StatusForbidden, w.Code, "Expected 403 Forbidden")
 
@@ -717,7 +717,7 @@ func TestListModels_ReturnAllModels(t *testing.T) {
 		// No X-MaaS-Subscription header = user token authentication
 		req.Header.Set(constant.HeaderUsername, "test-user@example.com")
 		req.Header.Set(constant.HeaderGroup, `["group-a", "group-b"]`)
-			router.ServeHTTP(w, req)
+		router.ServeHTTP(w, req)
 
 		require.Equal(t, http.StatusOK, w.Code)
 
@@ -769,7 +769,7 @@ func TestListModels_ReturnAllModels(t *testing.T) {
 		// No X-MaaS-Subscription header = user token authentication
 		req.Header.Set(constant.HeaderUsername, "test-user@example.com")
 		req.Header.Set(constant.HeaderGroup, `["user-group"]`)
-			router2.ServeHTTP(w, req)
+		router2.ServeHTTP(w, req)
 
 		require.Equal(t, http.StatusOK, w.Code)
 
@@ -790,7 +790,7 @@ func TestListModels_ReturnAllModels(t *testing.T) {
 		// No X-MaaS-Subscription header = user token authentication
 		req.Header.Set(constant.HeaderUsername, "test-user@example.com")
 		req.Header.Set(constant.HeaderGroup, `["group-a"]`)
-			router.ServeHTTP(w, req)
+		router.ServeHTTP(w, req)
 
 		require.Equal(t, http.StatusOK, w.Code)
 
@@ -906,7 +906,7 @@ func TestListModels_DeduplicationBySubscription(t *testing.T) {
 		req.Header.Set("X-Maas-Return-All-Models", "true")
 		req.Header.Set(constant.HeaderUsername, "test-user@example.com")
 		req.Header.Set(constant.HeaderGroup, `["user-group"]`)
-			router.ServeHTTP(w, req)
+		router.ServeHTTP(w, req)
 
 		require.Equal(t, http.StatusOK, w.Code)
 
@@ -1024,7 +1024,7 @@ func TestListModels_DifferentModelRefsWithSameModelID(t *testing.T) {
 		req.Header.Set("X-Maas-Return-All-Models", "true")
 		req.Header.Set(constant.HeaderUsername, "test-user@example.com")
 		req.Header.Set(constant.HeaderGroup, `["user-group"]`)
-			router.ServeHTTP(w, req)
+		router.ServeHTTP(w, req)
 
 		require.Equal(t, http.StatusOK, w.Code)
 
@@ -1131,7 +1131,7 @@ func TestListModels_DifferentModelRefsWithSameURLAndModelID(t *testing.T) {
 		req.Header.Set("X-Maas-Return-All-Models", "true")
 		req.Header.Set(constant.HeaderUsername, "test-user@example.com")
 		req.Header.Set(constant.HeaderGroup, `["user-group"]`)
-			router.ServeHTTP(w, req)
+		router.ServeHTTP(w, req)
 
 		require.Equal(t, http.StatusOK, w.Code)
 
@@ -1237,7 +1237,7 @@ func TestListModels_DifferentModelRefsWithSameModelIDAndDifferentSubscriptions(t
 		req.Header.Set("X-Maas-Return-All-Models", "true")
 		req.Header.Set(constant.HeaderUsername, "test-user@example.com")
 		req.Header.Set(constant.HeaderGroup, `["user-group"]`)
-			router.ServeHTTP(w, req)
+		router.ServeHTTP(w, req)
 
 		require.Equal(t, http.StatusOK, w.Code)
 

--- a/maas-api/internal/token/handler.go
+++ b/maas-api/internal/token/handler.go
@@ -14,17 +14,17 @@ import (
 )
 
 type Handler struct {
-	name   string
-	logger *logger.Logger
+	tenantName string
+	logger     *logger.Logger
 }
 
-func NewHandler(log *logger.Logger, name string) *Handler {
+func NewHandler(log *logger.Logger, tenantName string) *Handler {
 	if log == nil {
 		log = logger.Production()
 	}
 	return &Handler{
-		name:   name,
-		logger: log,
+		tenantName: tenantName,
+		logger:     log,
 	}
 }
 
@@ -106,25 +106,12 @@ func (h *Handler) ExtractUserInfo() gin.HandlerFunc {
 			return
 		}
 
-		tenant := strings.TrimSpace(c.GetHeader(constant.HeaderTenant))
-		if tenant == "" {
-			h.logger.Error("Missing or empty tenant header",
-				"header", constant.HeaderTenant,
-			)
-			c.JSON(http.StatusInternalServerError, gin.H{
-				"error":         "Exception thrown while generating token",
-				"exceptionCode": "AUTH_FAILURE",
-				"refId":         "004",
-			})
-			c.Abort()
-			return
-		}
-
-		// Create UserContext from headers
+		// Create UserContext from headers and handler config.
+		// Tenant comes from TENANT_NAME env var set during maas-api deployment.
 		userContext := &UserContext{
 			Username: username,
 			Groups:   groups,
-			Tenant:   tenant,
+			Tenant:   h.tenantName,
 		}
 
 		h.logger.Debug("Extracted user info from headers",

--- a/maas-api/internal/token/handler_test.go
+++ b/maas-api/internal/token/handler_test.go
@@ -34,17 +34,15 @@ func setupRouter(t *testing.T) *gin.Engine {
 	return router
 }
 
-// TestExtractUserInfo_TenantHeader verifies that the ExtractUserInfo middleware
-// correctly extracts the X-MaaS-Tenant header and rejects requests where it is
-// missing or whitespace-only.
-func TestExtractUserInfo_TenantHeader(t *testing.T) {
+// TestExtractUserInfo_TenantFromConfig verifies that the ExtractUserInfo middleware
+// correctly sets the tenant from the handler's configured tenantName (from TENANT_NAME env var).
+func TestExtractUserInfo_TenantFromConfig(t *testing.T) {
 	router := setupRouter(t)
 
-	t.Run("ValidTenantHeader", func(t *testing.T) {
+	t.Run("TenantFromHandler", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "/test", nil)
 		req.Header.Set(constant.HeaderUsername, "testuser")
 		req.Header.Set(constant.HeaderGroup, `["group1"]`)
-		req.Header.Set(constant.HeaderTenant, "my-tenant")
 
 		w := httptest.NewRecorder()
 		router.ServeHTTP(w, req)
@@ -55,38 +53,6 @@ func TestExtractUserInfo_TenantHeader(t *testing.T) {
 		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
 		assert.Equal(t, "testuser", body.Username)
 		assert.Equal(t, []string{"group1"}, body.Groups)
-		assert.Equal(t, "my-tenant", body.Tenant)
-	})
-
-	t.Run("MissingTenantHeader", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodGet, "/test", nil)
-		req.Header.Set(constant.HeaderUsername, "testuser")
-		req.Header.Set(constant.HeaderGroup, `["group1"]`)
-		// No tenant header set
-
-		w := httptest.NewRecorder()
-		router.ServeHTTP(w, req)
-
-		assert.Equal(t, http.StatusInternalServerError, w.Code)
-
-		var body map[string]any
-		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
-		assert.Equal(t, "004", body["refId"])
-	})
-
-	t.Run("WhitespaceOnlyTenantHeader", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodGet, "/test", nil)
-		req.Header.Set(constant.HeaderUsername, "testuser")
-		req.Header.Set(constant.HeaderGroup, `["group1"]`)
-		req.Header.Set(constant.HeaderTenant, "   ")
-
-		w := httptest.NewRecorder()
-		router.ServeHTTP(w, req)
-
-		assert.Equal(t, http.StatusInternalServerError, w.Code)
-
-		var body map[string]any
-		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
-		assert.Equal(t, "004", body["refId"])
+		assert.Equal(t, "test", body.Tenant, "tenant should come from handler config")
 	})
 }

--- a/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
-	"strconv"
 	"strings"
 
 	"github.com/go-logr/logr"
@@ -897,34 +896,6 @@ allow {
 								` : '["' + auth.identity.user.groups.join('","') + '"]'`,
 						},
 						"key":      "X-MaaS-Group",
-						"metrics":  false,
-						"priority": int64(1),
-					},
-					"X-MaaS-Tenant": map[string]any{
-						"when": []any{
-							map[string]any{
-								"selector": "request.headers.authorization",
-								"operator": "matches",
-								"value":    "^Bearer sk-oai-.*",
-							},
-						},
-						"plain": map[string]any{
-							"selector": "auth.metadata.apiKeyValidation.tenant",
-						},
-						"metrics":  false,
-						"priority": int64(0),
-					},
-					"X-MaaS-Tenant-Token": map[string]any{
-						"when": []any{
-							map[string]any{
-								"predicate": `!request.headers.authorization.startsWith("Bearer sk-oai-")`,
-							},
-						},
-						"plain": map[string]any{
-							// Use tenantName (DB/header value) not tenantID (resource identifier)
-							"expression": strconv.Quote(tenantName),
-						},
-						"key":      "X-MaaS-Tenant",
 						"metrics":  false,
 						"priority": int64(1),
 					},

--- a/maas-controller/pkg/controller/maas/maasauthpolicy_controller_test.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_controller_test.go
@@ -1140,7 +1140,6 @@ func TestMaaSAuthPolicyReconciler_IdentityHeadersUpstream(t *testing.T) {
 		requiredHeaders := []string{
 			"X-MaaS-Username", "X-MaaS-Username-Token",
 			"X-MaaS-Group", "X-MaaS-Group-Token",
-			"X-MaaS-Tenant", "X-MaaS-Tenant-Token",
 			"X-MaaS-Subscription",
 		}
 		for _, header := range requiredHeaders {


### PR DESCRIPTION
The X-MaaS-Tenant header was redundant - maas-api already has tenant identity from the TENANT_NAME environment variable set during deployment. Removing it simplifies the auth flow and reduces attack surface.

Addresses https://redhat.atlassian.net/browse/RHOAIENG-70517

Changes:
- Remove X-MaaS-Tenant header extraction from token handler
- Use TENANT_NAME env var (via handler.tenantName) instead
- Remove X-MaaS-Tenant and X-MaaS-Tenant-Token injection from AuthPolicy
- Remove HeaderTenant constant
- Update tests to verify tenant comes from handler config
- Remove strconv import (no longer needed)

All tests pass - maas-api and maas-controller both at 0 lint issues.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Tenant information is now configured at API initialization rather than passed per-request via headers.
  * The `X-MaaS-Tenant` header is no longer required for API requests; tenant context is derived from configuration.
  * Updated authentication policy to remove tenant-related header injection logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->