### PR TITLE
fix: clean up validatingwebhookconfiguration in script

### DIFF
--- a/.github/hack/cleanup-odh.sh
+++ b/.github/hack/cleanup-odh.sh
@@ -12,6 +12,7 @@
 # - Cluster-scoped MaaS anchor CR (Config/default; legacy ClusterTenant/default if present)
 # - MaaS subscription namespace (models-as-a-service)
 # - Policy engine artifacts (Kuadrant/RHCL OLM resources, AuthConfig CRs)
+# - MaaS validating webhook configuration
 # - Keycloak identity provider (if deployed)
 # - ODH CRDs (optional)
 #
@@ -273,8 +274,9 @@ kubectl delete ratelimitpolicy -n openshift-ingress --all --ignore-not-found 2>/
 kubectl delete tokenratelimitpolicy -n openshift-ingress --all --ignore-not-found 2>/dev/null || true
 kubectl delete gatewayclass openshift-default --ignore-not-found 2>/dev/null || true
 
-# 16. Delete MaaS RBAC (ClusterRoles, ClusterRoleBindings - can conflict with other managers)
-echo "16. Deleting MaaS RBAC..."
+# 16. Delete MaaS cluster-scoped resources (webhook configuration, ClusterRoles, ClusterRoleBindings)
+echo "16. Deleting MaaS cluster-scoped resources..."
+kubectl delete validatingwebhookconfiguration maas-validating-webhook-configuration --ignore-not-found 2>/dev/null || true
 kubectl delete clusterrolebinding maas-api maas-controller-rolebinding --ignore-not-found 2>/dev/null || true
 kubectl delete clusterrole maas-api maas-controller-role --ignore-not-found 2>/dev/null || true
 # Extra operator-safe binding for Config API (and legacy ClusterTenant binding/role if present)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Cleaning up ValidatingWebhookConfiguration in `cleanup-odh.sh`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved cleanup handling to remove an additional validating webhook configuration as part of environment teardown.
  * Made the cleanup process more resilient by continuing even if that removal step fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->