### PR TITLE
fix: fall back to inference.opendatahub.io ExternalModel in MaasModel…

### DIFF
--- a/maas-controller/pkg/controller/maas/providers_external.go
+++ b/maas-controller/pkg/controller/maas/providers_external.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/go-logr/logr"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -92,7 +93,7 @@ func (h *externalModelHandler) ReconcileRoute(ctx context.Context, log logr.Logg
 			model.Status.HTTPRouteHostnames = nil
 			return nil
 		}
-	} else if apierrors.IsNotFound(err) {
+	} else if apierrors.IsNotFound(err) || apimeta.IsNoMatchError(err) {
 		externalModel := &maasv1alpha1.ExternalModel{}
 		if err := h.r.Get(ctx, externalModelKey, externalModel); err != nil {
 			if apierrors.IsNotFound(err) {
@@ -287,6 +288,9 @@ func (externalModelRouteResolver) HTTPRouteForModel(ctx context.Context, c clien
 			if name, found, _ := unstructured.NestedString(inferenceEM.Object, "status", "httpRouteName"); found && name != "" {
 				return name, routeNamespace, nil
 			}
+		} else if !apierrors.IsNotFound(err) && !apimeta.IsNoMatchError(err) {
+			return "", routeNamespace, fmt.Errorf("failed to get inference ExternalModel %s/%s: %w",
+				model.Namespace, model.Spec.ModelRef.Name, err)
 		}
 	}
 

--- a/maas-controller/pkg/controller/maas/providers_external.go
+++ b/maas-controller/pkg/controller/maas/providers_external.go
@@ -22,6 +22,8 @@ import (
 
 	"github.com/go-logr/logr"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -36,6 +38,14 @@ import (
 // but gateway controllers commonly set it on route parent status as well.
 const routeConditionProgrammed = "Programmed"
 
+var inferenceExternalModelGVK = schema.GroupVersionKind{
+	Group:   "inference.opendatahub.io",
+	Version: "v1alpha1",
+	Kind:    "ExternalModel",
+}
+
+//+kubebuilder:rbac:groups=inference.opendatahub.io,resources=externalmodels,verbs=get;list;watch
+
 // externalModelHandler implements BackendHandler for kind "ExternalModel".
 type externalModelHandler struct {
 	r *MaaSModelRefReconciler
@@ -45,16 +55,42 @@ type externalModelHandler struct {
 // The ExternalModel reconciler creates a MaaS-prefixed HTTPRoute in the
 // model's namespace. This method validates that it exists and is accepted by the gateway.
 func (h *externalModelHandler) ReconcileRoute(ctx context.Context, log logr.Logger, model *maasv1alpha1.MaaSModelRef) error {
-	// Fetch the referenced ExternalModel CR to get provider configuration
-	externalModel := &maasv1alpha1.ExternalModel{}
 	externalModelKey := types.NamespacedName{
 		Name:      model.Spec.ModelRef.Name,
 		Namespace: model.Namespace,
 	}
-	if err := h.r.Get(ctx, externalModelKey, externalModel); err != nil {
-		if apierrors.IsNotFound(err) {
-			return fmt.Errorf("ExternalModel %s not found in namespace %s", model.Spec.ModelRef.Name, model.Namespace)
+
+	var externalModelName string
+	var providerInfo string
+
+	// Try inference.opendatahub.io/ExternalModel first (canonical), fall back to maas.opendatahub.io (legacy)
+	inferenceEM := &unstructured.Unstructured{}
+	inferenceEM.SetGroupVersionKind(inferenceExternalModelGVK)
+	err := h.r.Get(ctx, externalModelKey, inferenceEM)
+	if err == nil {
+		externalModelName = inferenceEM.GetName()
+		if refs, found, _ := unstructured.NestedSlice(inferenceEM.Object, "spec", "externalProviderRefs"); found && len(refs) > 0 {
+			if ref, ok := refs[0].(map[string]any); ok {
+				if refObj, ok := ref["ref"].(map[string]any); ok {
+					if name, ok := refObj["name"].(string); ok {
+						providerInfo = name
+					}
+				}
+			}
 		}
+	} else if apierrors.IsNotFound(err) {
+		externalModel := &maasv1alpha1.ExternalModel{}
+		if err := h.r.Get(ctx, externalModelKey, externalModel); err != nil {
+			if apierrors.IsNotFound(err) {
+				return fmt.Errorf("ExternalModel %s not found in namespace %s (checked inference.opendatahub.io and maas.opendatahub.io)",
+					model.Spec.ModelRef.Name, model.Namespace)
+			}
+			return fmt.Errorf("failed to get maas ExternalModel %s: %w", model.Spec.ModelRef.Name, err)
+		}
+		externalModelName = externalModel.Name
+		providerInfo = externalModel.Spec.Provider
+		log.Info("resolved ExternalModel from legacy maas.opendatahub.io", "name", externalModelName, "namespace", model.Namespace)
+	} else {
 		return fmt.Errorf("failed to get ExternalModel %s: %w", model.Spec.ModelRef.Name, err)
 	}
 
@@ -156,7 +192,7 @@ func (h *externalModelHandler) ReconcileRoute(ctx context.Context, log logr.Logg
 
 	log.Info("HTTPRoute validated for ExternalModel",
 		"routeName", routeName, "namespace", routeNS, "model", model.Name,
-		"externalModel", externalModel.Name, "provider", externalModel.Spec.Provider,
+		"externalModel", externalModelName, "provider", providerInfo,
 		"gateway", fmt.Sprintf("%s/%s", gatewayNamespace, gatewayName), "hostnames", hostnames)
 
 	return nil

--- a/maas-controller/pkg/controller/maas/providers_external.go
+++ b/maas-controller/pkg/controller/maas/providers_external.go
@@ -81,6 +81,16 @@ func (h *externalModelHandler) ReconcileRoute(ctx context.Context, log logr.Logg
 		}
 		if name, found, _ := unstructured.NestedString(inferenceEM.Object, "status", "httpRouteName"); found && name != "" {
 			routeName = name
+		} else {
+			log.Info("inference ExternalModel found but status.httpRouteName not set yet, waiting for reconciler",
+				"name", externalModelName, "namespace", model.Namespace)
+			model.Status.Endpoint = ""
+			model.Status.HTTPRouteName = ""
+			model.Status.HTTPRouteNamespace = ""
+			model.Status.HTTPRouteGatewayName = ""
+			model.Status.HTTPRouteGatewayNamespace = ""
+			model.Status.HTTPRouteHostnames = nil
+			return nil
 		}
 	} else if apierrors.IsNotFound(err) {
 		externalModel := &maasv1alpha1.ExternalModel{}
@@ -93,13 +103,10 @@ func (h *externalModelHandler) ReconcileRoute(ctx context.Context, log logr.Logg
 		}
 		externalModelName = externalModel.Name
 		providerInfo = externalModel.Spec.Provider
+		routeName = modelnaming.ExternalModelResourceName(model.Spec.ModelRef.Name)
 		log.Info("resolved ExternalModel from legacy maas.opendatahub.io", "name", externalModelName, "namespace", model.Namespace)
 	} else {
 		return fmt.Errorf("failed to get ExternalModel %s: %w", model.Spec.ModelRef.Name, err)
-	}
-
-	if routeName == "" {
-		routeName = modelnaming.ExternalModelResourceName(model.Spec.ModelRef.Name)
 	}
 	routeNS := model.Namespace
 

--- a/maas-controller/pkg/controller/maas/providers_external.go
+++ b/maas-controller/pkg/controller/maas/providers_external.go
@@ -22,9 +22,9 @@ import (
 
 	"github.com/go-logr/logr"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"

--- a/maas-controller/pkg/controller/maas/providers_external.go
+++ b/maas-controller/pkg/controller/maas/providers_external.go
@@ -62,6 +62,7 @@ func (h *externalModelHandler) ReconcileRoute(ctx context.Context, log logr.Logg
 
 	var externalModelName string
 	var providerInfo string
+	var routeName string
 
 	// Try inference.opendatahub.io/ExternalModel first (canonical), fall back to maas.opendatahub.io (legacy)
 	inferenceEM := &unstructured.Unstructured{}
@@ -77,6 +78,9 @@ func (h *externalModelHandler) ReconcileRoute(ctx context.Context, log logr.Logg
 					}
 				}
 			}
+		}
+		if name, found, _ := unstructured.NestedString(inferenceEM.Object, "status", "httpRouteName"); found && name != "" {
+			routeName = name
 		}
 	} else if apierrors.IsNotFound(err) {
 		externalModel := &maasv1alpha1.ExternalModel{}
@@ -94,7 +98,9 @@ func (h *externalModelHandler) ReconcileRoute(ctx context.Context, log logr.Logg
 		return fmt.Errorf("failed to get ExternalModel %s: %w", model.Spec.ModelRef.Name, err)
 	}
 
-	routeName := modelnaming.ExternalModelResourceName(model.Spec.ModelRef.Name)
+	if routeName == "" {
+		routeName = modelnaming.ExternalModelResourceName(model.Spec.ModelRef.Name)
+	}
 	routeNS := model.Namespace
 
 	route := &gatewayapiv1.HTTPRoute{}
@@ -263,7 +269,20 @@ func (h *externalModelHandler) CleanupOnDelete(ctx context.Context, log logr.Log
 type externalModelRouteResolver struct{}
 
 func (externalModelRouteResolver) HTTPRouteForModel(ctx context.Context, c client.Reader, model *maasv1alpha1.MaaSModelRef) (routeName, routeNamespace string, err error) {
-	routeName = modelnaming.ExternalModelResourceName(model.Spec.ModelRef.Name)
 	routeNamespace = model.Namespace
+
+	// Read route name from inference ExternalModel status if available
+	if c != nil {
+		key := types.NamespacedName{Name: model.Spec.ModelRef.Name, Namespace: model.Namespace}
+		inferenceEM := &unstructured.Unstructured{}
+		inferenceEM.SetGroupVersionKind(inferenceExternalModelGVK)
+		if err := c.Get(ctx, key, inferenceEM); err == nil {
+			if name, found, _ := unstructured.NestedString(inferenceEM.Object, "status", "httpRouteName"); found && name != "" {
+				return name, routeNamespace, nil
+			}
+		}
+	}
+
+	routeName = modelnaming.ExternalModelResourceName(model.Spec.ModelRef.Name)
 	return routeName, routeNamespace, nil
 }

--- a/maas-controller/pkg/controller/maas/providers_external_test.go
+++ b/maas-controller/pkg/controller/maas/providers_external_test.go
@@ -22,6 +22,9 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
@@ -295,6 +298,96 @@ func TestExternalModel_CredentialRef(t *testing.T) {
 
 	if externalModel.Spec.CredentialRef.Name != "openai-api-key" {
 		t.Errorf("CredentialRef.Name = %q, want %q", externalModel.Spec.CredentialRef.Name, "openai-api-key")
+	}
+}
+
+func newInferenceExternalModelCR(name, ns, providerRef string) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(inferenceExternalModelGVK)
+	obj.SetName(name)
+	obj.SetNamespace(ns)
+	obj.Object["spec"] = map[string]any{
+		"externalProviderRefs": []any{
+			map[string]any{
+				"ref":         map[string]any{"name": providerRef},
+				"targetModel": "gpt-4o",
+				"apiFormat":   "openai-chat",
+			},
+		},
+	}
+	return obj
+}
+
+func newTestReconcilerWithMapper(objects ...client.Object) (*MaaSModelRefReconciler, client.Client) {
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithRESTMapper(testRESTMapper()).
+		WithObjects(objects...).
+		WithStatusSubresource(&maasv1alpha1.MaaSModelRef{}).
+		Build()
+	return &MaaSModelRefReconciler{
+		Client:           c,
+		Scheme:           scheme,
+		GatewayName:      "maas-default-gateway",
+		GatewayNamespace: "openshift-ingress",
+	}, c
+}
+
+func TestExternalModel_ReconcileRoute_InferenceExternalModel(t *testing.T) {
+	model := newExternalModel("gpt-4o", "default", "", "")
+	inferenceEM := newInferenceExternalModelCR("gpt-4o", "default", "openai-provider")
+	route := newHTTPRouteWithGateway("gpt-4o", "default", "maas-default-gateway", "openshift-ingress")
+
+	r, _ := newTestReconcilerWithMapper(model, inferenceEM, route)
+	handler := &externalModelHandler{r: r}
+	log := zap.New(zap.UseDevMode(true))
+
+	err := handler.ReconcileRoute(context.Background(), log, model)
+	if err != nil {
+		t.Fatalf("ReconcileRoute: unexpected error: %v", err)
+	}
+
+	if model.Status.HTTPRouteName != "gpt-4o" {
+		t.Errorf("HTTPRouteName = %q, want %q", model.Status.HTTPRouteName, "gpt-4o")
+	}
+	if model.Status.HTTPRouteGatewayName != "maas-default-gateway" {
+		t.Errorf("HTTPRouteGatewayName = %q, want %q", model.Status.HTTPRouteGatewayName, "maas-default-gateway")
+	}
+}
+
+func TestExternalModel_ReconcileRoute_BothMissing(t *testing.T) {
+	model := newExternalModel("gpt-4o", "default", "", "")
+
+	r, _ := newTestReconcilerWithMapper(model)
+	handler := &externalModelHandler{r: r}
+	log := zap.New(zap.UseDevMode(true))
+
+	err := handler.ReconcileRoute(context.Background(), log, model)
+	if err == nil {
+		t.Fatal("ReconcileRoute: expected error when both ExternalModel types are missing")
+	}
+	if !strings.Contains(err.Error(), "maas.opendatahub.io") || !strings.Contains(err.Error(), "inference.opendatahub.io") {
+		t.Errorf("error should mention both API groups, got: %v", err)
+	}
+}
+
+func TestExternalModel_ReconcileRoute_MaasPreferred(t *testing.T) {
+	model := newExternalModel("gpt-4o", "default", "", "")
+	maasEM := newExternalModelCR("gpt-4o", "default", "openai", "api.openai.com")
+	inferenceEM := newInferenceExternalModelCR("gpt-4o", "default", "different-provider")
+	route := newHTTPRouteWithGateway("gpt-4o", "default", "maas-default-gateway", "openshift-ingress")
+
+	r, _ := newTestReconcilerWithMapper(model, maasEM, inferenceEM, route)
+	handler := &externalModelHandler{r: r}
+	log := zap.New(zap.UseDevMode(true))
+
+	err := handler.ReconcileRoute(context.Background(), log, model)
+	if err != nil {
+		t.Fatalf("ReconcileRoute: unexpected error: %v", err)
+	}
+
+	if model.Status.HTTPRouteGatewayName != "maas-default-gateway" {
+		t.Errorf("HTTPRouteGatewayName = %q, want %q", model.Status.HTTPRouteGatewayName, "maas-default-gateway")
 	}
 }
 

--- a/maas-controller/pkg/controller/maas/providers_external_test.go
+++ b/maas-controller/pkg/controller/maas/providers_external_test.go
@@ -336,7 +336,7 @@ func newTestReconcilerWithMapper(objects ...client.Object) (*MaaSModelRefReconci
 func TestExternalModel_ReconcileRoute_InferenceExternalModel(t *testing.T) {
 	model := newExternalModel("gpt-4o", "default", "", "")
 	inferenceEM := newInferenceExternalModelCR("gpt-4o", "default", "openai-provider")
-	route := newHTTPRouteWithGateway("gpt-4o", "default", "maas-default-gateway", "openshift-ingress")
+	route := newHTTPRouteWithGateway(modelnaming.ExternalModelResourceName("gpt-4o"), "default", "maas-default-gateway", "openshift-ingress")
 
 	r, _ := newTestReconcilerWithMapper(model, inferenceEM, route)
 	handler := &externalModelHandler{r: r}
@@ -347,8 +347,8 @@ func TestExternalModel_ReconcileRoute_InferenceExternalModel(t *testing.T) {
 		t.Fatalf("ReconcileRoute: unexpected error: %v", err)
 	}
 
-	if model.Status.HTTPRouteName != "gpt-4o" {
-		t.Errorf("HTTPRouteName = %q, want %q", model.Status.HTTPRouteName, "gpt-4o")
+	if model.Status.HTTPRouteName != "maas-gpt-4o" {
+		t.Errorf("HTTPRouteName = %q, want %q", model.Status.HTTPRouteName, "maas-gpt-4o")
 	}
 	if model.Status.HTTPRouteGatewayName != "maas-default-gateway" {
 		t.Errorf("HTTPRouteGatewayName = %q, want %q", model.Status.HTTPRouteGatewayName, "maas-default-gateway")
@@ -371,11 +371,11 @@ func TestExternalModel_ReconcileRoute_BothMissing(t *testing.T) {
 	}
 }
 
-func TestExternalModel_ReconcileRoute_MaasPreferred(t *testing.T) {
+func TestExternalModel_ReconcileRoute_InferencePreferredOverLegacy(t *testing.T) {
 	model := newExternalModel("gpt-4o", "default", "", "")
 	maasEM := newExternalModelCR("gpt-4o", "default", "openai", "api.openai.com")
 	inferenceEM := newInferenceExternalModelCR("gpt-4o", "default", "different-provider")
-	route := newHTTPRouteWithGateway("gpt-4o", "default", "maas-default-gateway", "openshift-ingress")
+	route := newHTTPRouteWithGateway(modelnaming.ExternalModelResourceName("gpt-4o"), "default", "maas-default-gateway", "openshift-ingress")
 
 	r, _ := newTestReconcilerWithMapper(model, maasEM, inferenceEM, route)
 	handler := &externalModelHandler{r: r}

--- a/maas-controller/pkg/controller/maas/providers_external_test.go
+++ b/maas-controller/pkg/controller/maas/providers_external_test.go
@@ -315,6 +315,9 @@ func newInferenceExternalModelCR(name, ns, providerRef string) *unstructured.Uns
 			},
 		},
 	}
+	obj.Object["status"] = map[string]any{
+		"httpRouteName": name,
+	}
 	return obj
 }
 
@@ -336,7 +339,8 @@ func newTestReconcilerWithMapper(objects ...client.Object) (*MaaSModelRefReconci
 func TestExternalModel_ReconcileRoute_InferenceExternalModel(t *testing.T) {
 	model := newExternalModel("gpt-4o", "default", "", "")
 	inferenceEM := newInferenceExternalModelCR("gpt-4o", "default", "openai-provider")
-	route := newHTTPRouteWithGateway(modelnaming.ExternalModelResourceName("gpt-4o"), "default", "maas-default-gateway", "openshift-ingress")
+	// HTTPRoute name comes from inference ExternalModel status.httpRouteName ("gpt-4o")
+	route := newHTTPRouteWithGateway("gpt-4o", "default", "maas-default-gateway", "openshift-ingress")
 
 	r, _ := newTestReconcilerWithMapper(model, inferenceEM, route)
 	handler := &externalModelHandler{r: r}
@@ -347,8 +351,8 @@ func TestExternalModel_ReconcileRoute_InferenceExternalModel(t *testing.T) {
 		t.Fatalf("ReconcileRoute: unexpected error: %v", err)
 	}
 
-	if model.Status.HTTPRouteName != "maas-gpt-4o" {
-		t.Errorf("HTTPRouteName = %q, want %q", model.Status.HTTPRouteName, "maas-gpt-4o")
+	if model.Status.HTTPRouteName != "gpt-4o" {
+		t.Errorf("HTTPRouteName = %q, want %q", model.Status.HTTPRouteName, "gpt-4o")
 	}
 	if model.Status.HTTPRouteGatewayName != "maas-default-gateway" {
 		t.Errorf("HTTPRouteGatewayName = %q, want %q", model.Status.HTTPRouteGatewayName, "maas-default-gateway")
@@ -375,7 +379,8 @@ func TestExternalModel_ReconcileRoute_InferencePreferredOverLegacy(t *testing.T)
 	model := newExternalModel("gpt-4o", "default", "", "")
 	maasEM := newExternalModelCR("gpt-4o", "default", "openai", "api.openai.com")
 	inferenceEM := newInferenceExternalModelCR("gpt-4o", "default", "different-provider")
-	route := newHTTPRouteWithGateway(modelnaming.ExternalModelResourceName("gpt-4o"), "default", "maas-default-gateway", "openshift-ingress")
+	// Route name from inference ExternalModel status.httpRouteName
+	route := newHTTPRouteWithGateway("gpt-4o", "default", "maas-default-gateway", "openshift-ingress")
 
 	r, _ := newTestReconcilerWithMapper(model, maasEM, inferenceEM, route)
 	handler := &externalModelHandler{r: r}
@@ -401,6 +406,25 @@ func TestExternalModelRouteResolver(t *testing.T) {
 	}
 	if routeName != "maas-gpt-4o" {
 		t.Errorf("routeName = %q, want %q", routeName, "maas-gpt-4o")
+	}
+	if routeNS != "default" {
+		t.Errorf("routeNS = %q, want %q", routeNS, "default")
+	}
+}
+
+func TestExternalModelRouteResolver_FromInferenceStatus(t *testing.T) {
+	model := newExternalModel("gpt-4o", "default", "", "")
+	inferenceEM := newInferenceExternalModelCR("gpt-4o", "default", "openai-provider")
+
+	_, c := newTestReconcilerWithMapper(model, inferenceEM)
+	resolver := externalModelRouteResolver{}
+
+	routeName, routeNS, err := resolver.HTTPRouteForModel(context.Background(), c, model)
+	if err != nil {
+		t.Fatalf("HTTPRouteForModel: unexpected error: %v", err)
+	}
+	if routeName != "gpt-4o" {
+		t.Errorf("routeName = %q, want %q (from inference status)", routeName, "gpt-4o")
 	}
 	if routeNS != "default" {
 		t.Errorf("routeNS = %q, want %q", routeNS, "default")

--- a/maas-controller/pkg/controller/maas/providers_test.go
+++ b/maas-controller/pkg/controller/maas/providers_test.go
@@ -63,6 +63,7 @@ func testRESTMapper() apimeta.RESTMapper {
 	m.Add(schema.GroupVersionKind{Group: "kuadrant.io", Version: "v1", Kind: "AuthPolicyList"}, ns)
 	m.Add(schema.GroupVersionKind{Group: "kuadrant.io", Version: "v1alpha1", Kind: "TokenRateLimitPolicy"}, ns)
 	m.Add(schema.GroupVersionKind{Group: "kuadrant.io", Version: "v1alpha1", Kind: "TokenRateLimitPolicyList"}, ns)
+	m.Add(inferenceExternalModelGVK, ns)
 	return m
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- externalModelHandler.ReconcileRoute now tries `maas.opendatahub.io/ExternalModel` first, then falls back to `inference.opendatahub.io/ExternalModel` via unstructured client              
- Uses unstructured lookup to avoid adding a Go module dependency on `ai-gateway-payload-processing`
- Adds RBAC marker for inference.opendatahub.io externalmodels (codegen pending)                                                                    
                                                            
## Problem                                                                     
When a MaaSModelRef with `kind: ExternalModel` points to an `inference.opendatahub.io/ExternalModel`, the handler only looked up `maas.opendatahub.io/ExternalModel` — which doesn't exist — and failed with ExternalModel not found. This blocks the transition from legacy `maas.opendatahub.io` CRDs to the new inference.opendatahub.io CRDs.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Route reconciliation now prefers the currently supported ExternalModel API when present, with automatic fallback to the legacy API.
  * HTTPRoute resolution now derives the route name/namespace and gateway status from the supported ExternalModel status data for more consistent routing.
  * When both ExternalModel resources are unavailable, errors clearly reference both supported API groups.
* **Tests**
  * Expanded controller tests to cover inference-only, missing-both, and inference-precedence scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->