### PR TITLE
docs: document auth service timeout tuning

### DIFF
--- a/docs/content/install/platform-setup.md
+++ b/docs/content/install/platform-setup.md
@@ -294,6 +294,63 @@ Now install the Gateway API controller for your platform:
         ]'
         ```
 
+    #### High-concurrency authentication timeout
+
+    RHCL configures the Kuadrant WASM plugin with an authentication service timeout of `200ms` by default. Under high concurrent request load, this short timeout can appear as intermittent HTTP `500` or `503` responses from gateway policy evaluation even when the model backend is healthy. If you see timeout-related failures during concurrent inference, increase `AUTH_SERVICE_TIMEOUT` to `2s` (`2000ms`) on the RHCL operator Subscription (`spec.config.env`).
+
+    Set the RHCL Subscription name and namespace for your installation before patching. The manual install example above uses `kuadrant-operator` in `kuadrant-system`; RHOAI-managed clusters commonly use `rhcl-operator` in `rh-connectivity-link`.
+
+    ```shell
+    RHCL_NAMESPACE=kuadrant-system
+    RHCL_SUBSCRIPTION=kuadrant-operator
+
+    # For RHOAI-managed RHCL, use:
+    # RHCL_NAMESPACE=rh-connectivity-link
+    # RHCL_SUBSCRIPTION=rhcl-operator
+    ```
+
+    To configure the timeout before installation, add the environment variable to the Subscription. If you already set other `spec.config.env` entries, add it alongside them:
+
+    ```yaml
+    spec:
+      config:
+        env:
+          - name: AUTH_SERVICE_TIMEOUT
+            value: "2s"
+    ```
+
+    To configure the timeout after installation, choose the patch that matches the current Subscription shape:
+
+    If `spec.config.env` already exists, append the timeout value:
+
+    ```shell
+    kubectl patch subscription "${RHCL_SUBSCRIPTION}" -n "${RHCL_NAMESPACE}" --type='json' -p='[
+      {"op":"add","path":"/spec/config/env/-","value":{"name":"AUTH_SERVICE_TIMEOUT","value":"2s"}}
+    ]'
+    ```
+
+    If `spec.config` exists but `spec.config.env` does not, add the `env` array:
+
+    ```shell
+    kubectl patch subscription "${RHCL_SUBSCRIPTION}" -n "${RHCL_NAMESPACE}" --type='json' -p='[
+      {"op":"add","path":"/spec/config/env","value":[
+        {"name":"AUTH_SERVICE_TIMEOUT","value":"2s"}
+      ]}
+    ]'
+    ```
+
+    If the Subscription does not have a `spec.config` section yet, create it with the timeout value:
+
+    ```shell
+    kubectl patch subscription "${RHCL_SUBSCRIPTION}" -n "${RHCL_NAMESPACE}" --type='json' -p='[
+      {"op":"add","path":"/spec/config","value":{"env":[
+        {"name":"AUTH_SERVICE_TIMEOUT","value":"2s"}
+      ]}}
+    ]'
+    ```
+
+    After changing the operator Subscription, wait for RHCL-managed components to roll out and retest the concurrent workload. Keep the value as low as your workload allows: increasing it gives authentication calls more time under load, but failed auth service calls can also take longer before the gateway returns an error.
+
     Wait for the subscription to install successfully:
 
     ```shell

--- a/docs/content/install/troubleshooting.md
+++ b/docs/content/install/troubleshooting.md
@@ -52,7 +52,11 @@ This guide helps you diagnose and resolve common issues with MaaS Platform deplo
       - [ ] Verify Gateway is in `Programmed` state: `kubectl get gateway -n openshift-ingress maas-default-gateway`
       - [ ] Check HTTPRoute configuration and status
 
-7. **Metrics not appearing in dashboards**: Prometheus is not scraping MaaS components.
+7. **High-concurrency inference returns intermittent `500` or `503` errors**: The RHCL/Kuadrant WASM authentication path may be timing out under burst load.
+      - [ ] Confirm the errors occur during concurrent request scenarios and not for low-volume requests
+      - [ ] Increase `AUTH_SERVICE_TIMEOUT` from the default `200ms` to `2s` through the RHCL operator Subscription configuration. See [High-concurrency authentication timeout](platform-setup.md#high-concurrency-authentication-timeout).
+
+8. **Metrics not appearing in dashboards**: Prometheus is not scraping MaaS components.
       - [ ] Verify User Workload Monitoring is enabled — see [Observability Setup](../observability/setup.md#user-workload-monitoring)
       - [ ] Verify Kuadrant observability is enabled — see [Observability Setup](../observability/setup.md#kuadrant-observability)
       - [ ] Check prometheus-user-workload pods are running:
@@ -67,7 +71,7 @@ This guide helps you diagnose and resolve common issues with MaaS Platform deplo
       kubectl get servicemonitor,podmonitor -A | grep -E "(maas|kuadrant|limitador)"
       ```
 
-8. **Rate limiting metrics missing (authorized_calls, limited_calls)**: Kuadrant observability is not enabled.
+9. **Rate limiting metrics missing (authorized_calls, limited_calls)**: Kuadrant observability is not enabled.
       - [ ] Enable observability on Kuadrant CR:
 
       ```bash
@@ -81,7 +85,7 @@ This guide helps you diagnose and resolve common issues with MaaS Platform deplo
       kubectl get podmonitor -n kuadrant-system
       ```
 
-9. **RHOAI Dashboard Observability tab returns `503 Service Unavailable`**: The Dashboard cannot reach the Perses backend.
+10. **RHOAI Dashboard Observability tab returns `503 Service Unavailable`**: The Dashboard cannot reach the Perses backend.
 
       The error typically appears as `{"statusCode": 503, "code": "FST_REPLY_FROM_SERVICE_UNAVAILABLE", ...}`.
       This is a Fastify/Dashboard-level error (not a gateway 503) indicating the monitoring stack
@@ -90,13 +94,13 @@ This guide helps you diagnose and resolve common issues with MaaS Platform deplo
 
       See [RHOAI Dashboard Observability Tab](../observability/setup.md#rhoai-dashboard-observability-tab-optional) for the full prerequisites and verification checklist.
 
-10. **GenAI Studio tab not visible in Dashboard**: Requires `llamastackoperator` set to `Managed` in the DSC and the `genAiStudio` feature flag enabled on `OdhDashboardConfig`.
+11. **GenAI Studio tab not visible in Dashboard**: Requires `llamastackoperator` set to `Managed` in the DSC and the `genAiStudio` feature flag enabled on `OdhDashboardConfig`.
 
       See [OdhDashboardConfig Feature Flags](maas-setup.md#odhdashboardconfig-feature-flags) for setup.
 
-11. **TLS certificate errors (`curl: (60) SSL certificate problem`)**: Your cluster uses self-signed or internal CA certificates that are not in your system trust store. See [TLS Certificate Validation](#tls-certificate-validation) below.
+12. **TLS certificate errors (`curl: (60) SSL certificate problem`)**: Your cluster uses self-signed or internal CA certificates that are not in your system trust store. See [TLS Certificate Validation](#tls-certificate-validation) below.
 
-12. **Cannot create MaaSSubscription or MaaSAuthPolicy (`no endpoints available for service "maas-controller-webhook-service"`)**: The maas-controller pods are not running or not ready.
+13. **Cannot create MaaSSubscription or MaaSAuthPolicy (`no endpoints available for service "maas-controller-webhook-service"`)**: The maas-controller pods are not running or not ready.
 
       MaaS uses admission webhooks to validate resource creation. When the controller is unavailable (pod crash, upgrade, or scaled to 0), the webhook endpoint becomes unreachable and creates are rejected.
 
@@ -120,7 +124,7 @@ This guide helps you diagnose and resolve common issues with MaaS Platform deplo
 
       Creates succeed once controller pods are healthy. Model inference requests are unaffected during controller downtime (data plane continues operating normally).
 
-13. **Cannot create `AITenant` (`must be created in the configured AITenant infrastructure namespace`)**: The object is being created outside the namespace configured by `--aitenant-namespace` (default `ai-tenants`).
+14. **Cannot create `AITenant` (`must be created in the configured AITenant infrastructure namespace`)**: The object is being created outside the namespace configured by `--aitenant-namespace` (default `ai-tenants`).
 
       - [ ] Check which namespace the controller is configured to accept:
 


### PR DESCRIPTION
## Description

Documents how to tune the RHCL/Kuadrant WASM authentication service timeout for high-concurrency MaaS workloads.

This change adds:

- A new **High-concurrency authentication timeout** section in the RHCL install guidance.
- The `AUTH_SERVICE_TIMEOUT` parameter, its default value (`200ms`), and the recommended high-load value (`2s` / `2000ms`).
- Patch examples for the common RHCL Subscription shapes:
  - `spec.config.env` already exists
  - `spec.config` exists but `env` does not
  - `spec.config` does not exist
- A troubleshooting entry for intermittent HTTP `500`/`503` responses under concurrent inference load, linking back to the canonical configuration section.

## Risk analysis

- **Risk rating**: 0
- **Why**: Documentation-only change. No runtime code, manifests, CRDs, generated files, or deployment behavior are modified.

## How Has This Been Tested?

Tested with local documentation validation and non-mutating OpenShift cluster checks.

- Ran `git diff --check` successfully.
- Attempted `python3 -m mkdocs build --strict --site-dir /tmp/maas-docs-site`; this environment does not have `mkdocs` installed, so the full docs build could not be completed locally.
- Verified the target OpenShift cluster has RHCL installed as `subscription/rhcl-operator` in namespace `rh-connectivity-link`.
- Confirmed the original hardcoded `kuadrant-system/kuadrant-operator` command does not apply to that RHOAI-managed cluster shape.
- Ran a server-side dry-run of the documented “no `spec.config` exists” patch against the live RHCL Subscription; it succeeded and did not mutate the cluster.
- Ran `oc patch --local` checks for the other documented JSON Patch shapes:
  - appending `AUTH_SERVICE_TIMEOUT` when `spec.config.env` already exists
  - creating `spec.config.env` when `spec.config` exists but `env` does not

## Merge criteria:

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for intermittent `500`/`503` errors during high-concurrency inference.
  * Included steps to increase the authentication timeout to improve request handling under load.
  * Expanded installation instructions with multiple configuration examples and rollout/retest guidance.
  * Updated troubleshooting content with a new high-concurrency issue entry and renumbered existing items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->