### PR TITLE
fix: resolve aitenant platform context outside tenant spec

### DIFF
--- a/deployment/base/maas-controller/crd/bases/maas.opendatahub.io_aitenants.yaml
+++ b/deployment/base/maas-controller/crd/bases/maas.opendatahub.io_aitenants.yaml
@@ -80,8 +80,8 @@ spec:
               oidc:
                 description: |-
                   OIDC contains non-MaaS-specific OIDC settings for this AI Gateway tenant.
-                  The controller mirrors this into the temporary Tenant config object until
-                  the MaaS config CR rename lands.
+                  AITenant is the source of truth for this derived platform context; the
+                  bridge Tenant config object owns MaaS-specific user config only.
                 properties:
                   clientId:
                     description: ClientID is the OAuth2 client ID.

--- a/deployment/base/maas-controller/crd/bases/maas.opendatahub.io_tenants.yaml
+++ b/deployment/base/maas-controller/crd/bases/maas.opendatahub.io_tenants.yaml
@@ -64,8 +64,9 @@ spec:
                     type: integer
                 type: object
               externalOIDC:
-                description: ExternalOIDC configures an external OIDC identity provider
-                  for the maas-api AuthPolicy.
+                description: |-
+                  ExternalOIDC configures an external OIDC identity provider for legacy/unmanaged
+                  Tenant resources. For AITenant-managed tenants, use AITenant.spec.oidc.
                 properties:
                   clientId:
                     description: ClientID is the OAuth2 client ID.
@@ -90,8 +91,9 @@ spec:
                 type: object
               gatewayRef:
                 description: |-
-                  GatewayRef specifies which Gateway (Gateway API) to use for exposing model endpoints.
-                  If omitted, defaults to openshift-ingress/maas-default-gateway.
+                  GatewayRef specifies which Gateway (Gateway API) to use for exposing model endpoints
+                  for legacy/unmanaged Tenant resources. For AITenant-managed tenants, AITenant
+                  owns this platform context and the controller ignores this field.
                 properties:
                   name:
                     default: maas-default-gateway

--- a/docs/content/install/maas-setup.md
+++ b/docs/content/install/maas-setup.md
@@ -174,15 +174,15 @@ After creating the database Secret and Gateways, create or update your DataScien
 
     With `modelsAsService` **Managed**, the [Open Data Hub operator](https://github.com/opendatahub-io/opendatahub-operator) deploys `maas-controller`, which self-bootstraps `AITenant/models-as-a-service` in `ai-tenants`. The AITenant reconciler creates or adopts a **namespace-scoped** `Tenant` object. The resource name **must** be `default-tenant` (enforced via CEL validation). The `Tenant` CR lives in the `models-as-a-service` namespace (same namespace as `MaaSSubscription` and `MaaSAuthPolicy`). The authoritative API definition is in the maas-controller repo: [`tenant_types.go`](https://github.com/opendatahub-io/models-as-a-service/blob/main/maas-controller/api/maas/v1alpha1/tenant_types.go).
 
-    **Nothing in `spec` is required for a default install.** If you omit `spec`, the controller uses the same defaults as this guide: Gateway **`openshift-ingress` / `maas-default-gateway`**, and telemetry metric toggles use the defaults described below. During bootstrap, existing `Tenant/default-tenant.spec.externalOIDC` settings are automatically migrated to `AITenant/models-as-a-service.spec.oidc`. Going forward, set OIDC on `AITenant/models-as-a-service.spec.oidc`; the controller mirrors it into `Tenant/default-tenant.spec.externalOIDC` until the Tenant API is replaced.
+    **Nothing in `spec` is required for a default install.** If you omit `spec`, the controller uses the same defaults as this guide: Gateway **`openshift-ingress` / `maas-default-gateway`**, and telemetry metric toggles use the defaults described below. During bootstrap, existing `Tenant/default-tenant.spec.externalOIDC` settings are automatically migrated to `AITenant/models-as-a-service.spec.oidc`. Going forward, set OIDC on `AITenant/models-as-a-service.spec.oidc`. For AITenant-managed tenants, Gateway and OIDC platform context comes from `AITenant`; existing `Tenant.spec.gatewayRef` and `Tenant.spec.externalOIDC` values are preserved for compatibility but ignored.
 
     | Field | What to set |
     | ----- | ----------- |
-    | `spec.gatewayRef.namespace` | Namespace of your Gateway API `Gateway` (default `openshift-ingress`). |
-    | `spec.gatewayRef.name` | Name of that `Gateway` (default `maas-default-gateway`). Set these if your MaaS hostname is exposed through a different Gateway than the default. |
+    | `spec.gatewayRef.namespace` | Legacy/unmanaged Tenant Gateway namespace. Ignored for AITenant-managed tenants. |
+    | `spec.gatewayRef.name` | Legacy/unmanaged Tenant Gateway name. For AITenant-managed tenants, use `AITenant.spec.gateway.name`. |
     | `spec.apiKeys.maxExpirationDays` | Maximum allowed API key lifetime in **days**. When set, users cannot mint keys with a longer lifetime than this value (via `expiresIn`). Optional; if unset, the controller does not apply a cap through this field (see also `maas-api` / `API_KEY_MAX_EXPIRATION_DAYS` in your deployment). |
-    | `spec.externalOIDC.issuerUrl` | OIDC issuer URL for external identity provider (optional; enables OIDC on the maas-api AuthPolicy). |
-    | `spec.externalOIDC.clientId` | OIDC client ID (required when `issuerUrl` is set). |
+    | `spec.externalOIDC.issuerUrl` | Legacy/unmanaged Tenant OIDC issuer URL. For AITenant-managed tenants, use `AITenant.spec.oidc.issuerUrl`. |
+    | `spec.externalOIDC.clientId` | Legacy/unmanaged Tenant OIDC client ID. For AITenant-managed tenants, use `AITenant.spec.oidc.clientId`. |
     | `spec.telemetry.enabled` | Enable TelemetryPolicy and Istio Telemetry (default `true`). |
     | `spec.telemetry.metrics.captureOrganization` | Include `organization_id` on metrics (default `true`). |
     | `spec.telemetry.metrics.captureUser` | Include user labels on metrics (default `false`; privacy-sensitive). |
@@ -198,9 +198,6 @@ After creating the database Secret and Gateways, create or update your DataScien
       name: default-tenant
       namespace: models-as-a-service
     spec:
-      gatewayRef:
-        namespace: openshift-ingress
-        name: maas-default-gateway
       apiKeys:
         maxExpirationDays: 90
       telemetry:

--- a/docs/content/migration/upgrade-to-3.4.md
+++ b/docs/content/migration/upgrade-to-3.4.md
@@ -282,24 +282,23 @@ The following happen without admin intervention during the upgrade:
 
 1. **Old CR cleanup**: The operator's garbage collection removes the old `ModelsAsService` CR (the operator no longer creates it).
 2. **maas-controller deployment**: The operator deploys `maas-controller` (CRDs, RBAC, Deployment) when `modelsAsService: Managed`.
-3. **Default tenant creation**: `maas-controller` automatically creates `AITenant/models-as-a-service`; that AITenant creates or adopts `Tenant/default-tenant` with default values.
+3. **Default tenant creation**: `maas-controller` automatically creates `AITenant/models-as-a-service`; that AITenant creates or adopts `Tenant/default-tenant`.
 4. **Platform reconciliation**: `maas-controller` deploys maas-api, gateway policies, telemetry, and all other platform resources via the default Tenant CR.
 
 ### Manual Steps: Re-applying Custom Configuration
 
-If you had customized the `ModelsAsService` CR spec in 3.3 (e.g., custom gateway, external OIDC, telemetry settings), those values are **not** migrated automatically to the new Tenant CR. The Tenant is created with defaults.
+If you had customized the `ModelsAsService` CR spec in 3.3 (e.g., custom gateway, external OIDC, telemetry settings), re-apply those values to the new ownership locations. Gateway and external OIDC are AITenant-owned platform context; API key and telemetry settings are Tenant-owned MaaS config.
 
 **If all fields were at defaults, no manual steps are needed.**
 
-The following table maps old `ModelsAsService` spec fields to new `Tenant` spec fields:
+The following table maps old `ModelsAsService` spec fields to new fields:
 
-| Old ModelsAsService field | New Tenant field | Default value |
-|---------------------------|------------------|---------------|
-| `spec.gatewayRef.namespace` | `spec.gatewayRef.namespace` | `openshift-ingress` |
-| `spec.gatewayRef.name` | `spec.gatewayRef.name` | `maas-default-gateway` |
-| `spec.externalOIDC.issuerUrl` | `spec.externalOIDC.issuerUrl` | (not set) |
-| `spec.externalOIDC.clientId` | `spec.externalOIDC.clientId` | (not set) |
-| `spec.externalOIDC.ttl` | `spec.externalOIDC.ttl` | `300` |
+| Old ModelsAsService field | New field | Default value |
+|---------------------------|-----------|---------------|
+| `spec.gatewayRef.name` | `AITenant/models-as-a-service.spec.gateway.name` | `maas-default-gateway` |
+| `spec.externalOIDC.issuerUrl` | `AITenant/models-as-a-service.spec.oidc.issuerUrl` | (not set) |
+| `spec.externalOIDC.clientId` | `AITenant/models-as-a-service.spec.oidc.clientId` | (not set) |
+| `spec.externalOIDC.ttl` | `AITenant/models-as-a-service.spec.oidc.ttl` | `300` |
 | `spec.telemetry.enabled` | `spec.telemetry.enabled` | `true` |
 | `spec.telemetry.metrics.captureOrganization` | `spec.telemetry.metrics.captureOrganization` | `true` |
 | `spec.telemetry.metrics.captureUser` | `spec.telemetry.metrics.captureUser` | `false` |
@@ -307,17 +306,26 @@ The following table maps old `ModelsAsService` spec fields to new `Tenant` spec 
 | `spec.telemetry.metrics.captureModelUsage` | `spec.telemetry.metrics.captureModelUsage` | `true` |
 | `spec.apiKeys.maxExpirationDays` | `spec.apiKeys.maxExpirationDays` | (not set) |
 
-To re-apply custom values, patch the Tenant CR after the upgrade:
+Gateway namespace is controller configuration (`--gateway-namespace`), not an AITenant spec field. If you previously used a non-default Gateway namespace, configure the controller with that namespace.
+
+To re-apply custom values, patch the AITenant and Tenant CRs after the upgrade:
 
 ```bash
-# Example: Re-apply external OIDC and API key configuration
+# Example: Re-apply external OIDC platform context
+kubectl patch aitenant models-as-a-service -n ai-tenants --type merge \
+  -p '{
+    "spec": {
+      "oidc": {
+        "issuerUrl": "https://keycloak.example.com/realms/maas",
+        "clientId": "maas-client"
+      }
+    }
+  }'
+
+# Example: Re-apply API key configuration
 kubectl patch tenant default-tenant -n models-as-a-service --type merge \
   -p '{
     "spec": {
-      "externalOIDC": {
-        "issuerUrl": "https://keycloak.example.com/realms/maas",
-        "clientId": "maas-client"
-      },
       "apiKeys": {
         "maxExpirationDays": 90
       }

--- a/docs/content/reference/crds/ai-tenant.md
+++ b/docs/content/reference/crds/ai-tenant.md
@@ -1,6 +1,6 @@
 # AITenant
 
-Bootstraps a MaaS tenant from an infrastructure namespace. `AITenant` creates or labels the derived tenant namespace, validates an existing tenant Gateway, creates the temporary `Tenant/default-tenant` MaaS config object, and grants tenant-admin RBAC.
+Bootstraps a MaaS tenant from an infrastructure namespace. `AITenant` creates or labels the derived tenant namespace, validates an existing tenant Gateway, owns tenant platform context such as Gateway and OIDC configuration, creates the temporary `Tenant/default-tenant` MaaS config object, and grants tenant-admin RBAC.
 
 `AITenant` resources must be created in the controller-configured infrastructure namespace, which defaults to `ai-tenants`. The controller creates this namespace if it does not already exist. Set the controller `--aitenant-namespace` flag to use a different infrastructure namespace.
 
@@ -17,7 +17,7 @@ The controller automatically creates `AITenant/models-as-a-service` for the defa
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | gateway | AITenantGatewayRef | No | Existing Gateway to reference. If omitted, the Gateway name defaults to the `AITenant` name. |
-| oidc | TenantExternalOIDCConfig | No | OIDC settings mirrored into the temporary `Tenant/default-tenant` config object while the MaaS config CR rename is pending. |
+| oidc | TenantExternalOIDCConfig | No | OIDC settings for this tenant's AI Gateway platform context. AITenant-managed tenants do not mirror this into `Tenant.spec.externalOIDC`. |
 | rbac | AITenantRBACConfig | No | Tenant-admin subjects that receive RBAC in the tenant namespace and read access to this `AITenant`. |
 
 ---
@@ -32,7 +32,19 @@ The controller does not delete the tenant namespace when an `AITenant` is delete
 
 ## Namespace Discovery
 
-`AITenant` labels tenant namespaces with `ai-gateway.opendatahub.io/tenant=<aitenant-name>` and `maas.opendatahub.io/managed-by-aitenant=true`. When `maas-controller` runs with `--enable-tenant-namespace-discovery=true`, `MaaSAuthPolicy` and `MaaSSubscription` resources in those namespaces are reconciled against the namespace's `Tenant/default-tenant.spec.gatewayRef`.
+`AITenant` labels tenant namespaces with `ai-gateway.opendatahub.io/tenant=<aitenant-name>` and `maas.opendatahub.io/managed-by-aitenant=true`. When `maas-controller` runs with `--enable-tenant-namespace-discovery=true`, `MaaSAuthPolicy` and `MaaSSubscription` resources in those namespaces are reconciled against the owning `AITenant` platform context (`status.gatewayRef` and `spec.oidc`), not the bridge `Tenant.spec.gatewayRef` or `Tenant.spec.externalOIDC` fields.
+
+---
+
+## Ownership Semantics
+
+`AITenant` owns derived platform context for AITenant-managed tenants:
+
+- Gateway context: `spec.gateway` intent and resolved `status.gatewayRef`
+- External OIDC context: `spec.oidc`
+- Tenant namespace metadata and tenant-admin RBAC
+
+The temporary `Tenant/default-tenant` object in each tenant namespace owns MaaS-specific user configuration, such as API key and telemetry settings. For backward compatibility, old `Tenant.spec.gatewayRef` and `Tenant.spec.externalOIDC` values may remain on existing objects, but AITenant-managed reconciliation ignores them.
 
 ---
 

--- a/docs/content/reference/crds/tenant.md
+++ b/docs/content/reference/crds/tenant.md
@@ -1,6 +1,6 @@
 # Tenant
 
-Configures the MaaS platform tenant. The Tenant CRD is a namespace-scoped singleton — the resource name must be `default-tenant` (enforced by CEL validation). It specifies the gateway used to expose model endpoints, API key policies, external OIDC authentication, and telemetry settings.
+Configures MaaS-specific tenant settings. The Tenant CRD is a namespace-scoped singleton — the resource name must be `default-tenant` (enforced by CEL validation). For AITenant-managed tenants, platform-derived context such as Gateway and external OIDC is owned by `AITenant`; `Tenant` owns MaaS-specific user configuration such as API key policies and telemetry settings.
 
 ## Multi-Tenant Deployment
 
@@ -18,6 +18,7 @@ In multi-tenant deployments, each tenant has its own Tenant CR in a dedicated na
 - All maas-api Services deploy to the operator namespace (opendatahub for ODH, redhat-ods-applications for RHOAI), not to tenant namespaces
 - Each tenant has an isolated maas-api instance for API key and subscription management
 - Tenant CRs for additional tenants have the finalizer `maas.opendatahub.io/tenant-cleanup`
+- For AITenant-managed tenants, `Tenant.spec.gatewayRef` and `Tenant.spec.externalOIDC` are ignored. Gateway comes from the owning `AITenant.status.gatewayRef`; OIDC comes from `AITenant.spec.oidc`.
 
 **Naming conventions:**
 - `TenantIdentifier`: Used for Kubernetes resource naming (empty string for default, `{tenantID}` for additional tenants)
@@ -33,16 +34,16 @@ See [AITenant CRD](ai-tenant.md) for creating additional tenants.
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| gatewayRef | TenantGatewayRef | No | Reference to the Gateway (Gateway API) used for exposing model endpoints. Defaults to `openshift-ingress/maas-default-gateway`. |
+| gatewayRef | TenantGatewayRef | No | Legacy/unmanaged Tenant reference to the Gateway (Gateway API) used for exposing model endpoints. Ignored for AITenant-managed tenants. |
 | apiKeys | TenantAPIKeysConfig | No | Configuration for API key management |
-| externalOIDC | TenantExternalOIDCConfig | No | External OIDC identity provider settings for the maas-api AuthPolicy |
+| externalOIDC | TenantExternalOIDCConfig | No | Legacy/unmanaged Tenant external OIDC identity provider settings for the maas-api AuthPolicy. Ignored for AITenant-managed tenants; use `AITenant.spec.oidc`. |
 | telemetry | TenantTelemetryConfig | No | Telemetry and metrics collection configuration |
 
 ---
 
 ## TenantGatewayRef
 
-`spec.gatewayRef` identifies the Gateway API Gateway resource that the controller uses for model endpoint routing.
+`spec.gatewayRef` identifies the Gateway API Gateway resource that the controller uses for model endpoint routing only for legacy/unmanaged Tenant resources. For AITenant-managed tenants, this value comes from the owning `AITenant.status.gatewayRef`.
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
@@ -63,7 +64,7 @@ See [AITenant CRD](ai-tenant.md) for creating additional tenants.
 
 ## TenantExternalOIDCConfig
 
-`spec.externalOIDC` configures an external OIDC identity provider for token-based authentication.
+`spec.externalOIDC` configures an external OIDC identity provider for token-based authentication only for legacy/unmanaged Tenant resources. For AITenant-managed tenants, configure `AITenant.spec.oidc`.
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
@@ -123,15 +124,8 @@ metadata:
   name: default-tenant
   namespace: models-as-a-service
 spec:
-  gatewayRef:
-    namespace: openshift-ingress
-    name: maas-default-gateway
   apiKeys:
     maxExpirationDays: 90
-  externalOIDC:
-    issuerUrl: "https://keycloak.example.com/realms/maas"
-    clientId: maas-api
-    ttl: 300
   telemetry:
     enabled: true
     metrics:

--- a/maas-api/internal/api_keys/handler.go
+++ b/maas-api/internal/api_keys/handler.go
@@ -236,8 +236,11 @@ func (h *Handler) CreateAPIKey(c *gin.Context) {
 		var notFound *subscription.SubscriptionNotFoundError
 		var accessDenied *subscription.AccessDeniedError
 		var noSub *subscription.NoSubscriptionError
+		var multipleSubs *subscription.MultipleSubscriptionsError
+		var modelNotInSub *subscription.ModelNotInSubscriptionError
 		var modelUnhealthy *subscription.ModelUnhealthyError
-		if errors.As(err, &notFound) || errors.As(err, &accessDenied) || errors.As(err, &noSub) {
+		if errors.As(err, &notFound) || errors.As(err, &accessDenied) || errors.As(err, &noSub) ||
+			errors.As(err, &multipleSubs) || errors.As(err, &modelNotInSub) {
 			c.JSON(http.StatusBadRequest, gin.H{
 				"error": apiKeySubscriptionResolutionErrMsg,
 				"code":  apiKeySubscriptionResolutionErrCode,

--- a/maas-api/internal/api_keys/handler_test.go
+++ b/maas-api/internal/api_keys/handler_test.go
@@ -1081,6 +1081,25 @@ func TestCreateAPIKey_SubscriptionSelectErrors(t *testing.T) {
 			},
 			body: `{"name": "k1"}`,
 		},
+		{
+			name: "multiple accessible subscriptions when omitting field",
+			sel: errSubSelector{
+				highestPriorityErr: &subscription.MultipleSubscriptionsError{
+					Subscriptions: []string{"sub-a", "sub-b"},
+				},
+			},
+			body: `{"name": "k1"}`,
+		},
+		{
+			name: "requested model not in explicit subscription",
+			sel: errSubSelector{
+				selectErr: &subscription.ModelNotInSubscriptionError{
+					Subscription: "custom-sub",
+					Model:        "llm/missing-model",
+				},
+			},
+			body: `{"name": "k1", "subscription": "custom-sub"}`,
+		},
 	}
 
 	for _, tt := range tests {
@@ -2158,9 +2177,9 @@ func TestCreateAPIKey_NameValidation(t *testing.T) {
 	}
 
 	invalidNames := []struct {
-		name      string
-		reason    string
-		errMsg    string
+		name   string
+		reason string
+		errMsg string
 	}{
 		{"   ", "whitespace only", "whitespace only"},
 		{"\t\t", "tabs only", "whitespace only"},

--- a/maas-controller/README.md
+++ b/maas-controller/README.md
@@ -501,4 +501,5 @@ The controller accepts the following command-line flags:
 - **AITenant infrastructure namespace**: Default is `ai-tenants`. The controller creates it if missing. Override via the `--aitenant-namespace` flag.
 - **AITenant tenant namespace**: For non-default tenants, the controller derives the tenant namespace as `ai-tenant-<aitenant-name>`. The default tenant keeps the configured MaaS subscription namespace, usually `models-as-a-service`.
 - **Image**: Default is `quay.io/opendatahub/maas-controller:latest`. Override the live `maas-controller` Deployment image directly.
-- **Gateway name/namespace**: Legacy/default Tenant routing uses `spec.gatewayRef` with controller defaults. `AITenant` validates an existing tenant Gateway in `--gateway-namespace`; `spec.gateway.name` defaults to the `AITenant` name.
+- **Gateway name/namespace**: Legacy/unmanaged Tenant routing uses `spec.gatewayRef` with controller defaults. AITenant-managed tenants use the owning `AITenant` as the platform context source: `spec.gateway.name` is intent, `status.gatewayRef` is the resolved Gateway, and the bridge `Tenant.spec.gatewayRef` is ignored.
+- **External OIDC**: For AITenant-managed tenants, configure OIDC on `AITenant.spec.oidc`. Existing `Tenant.spec.externalOIDC` values are preserved for compatibility but ignored once the Tenant is AITenant-managed.

--- a/maas-controller/api/maas/v1alpha1/aitenant_types.go
+++ b/maas-controller/api/maas/v1alpha1/aitenant_types.go
@@ -61,8 +61,8 @@ type AITenantSpec struct {
 	Gateway *AITenantGatewayRef `json:"gateway,omitempty"`
 
 	// OIDC contains non-MaaS-specific OIDC settings for this AI Gateway tenant.
-	// The controller mirrors this into the temporary Tenant config object until
-	// the MaaS config CR rename lands.
+	// AITenant is the source of truth for this derived platform context; the
+	// bridge Tenant config object owns MaaS-specific user config only.
 	// +kubebuilder:validation:Optional
 	OIDC *TenantExternalOIDCConfig `json:"oidc,omitempty"`
 

--- a/maas-controller/api/maas/v1alpha1/tenant_types.go
+++ b/maas-controller/api/maas/v1alpha1/tenant_types.go
@@ -49,8 +49,9 @@ type Tenant struct {
 
 // TenantSpec defines the desired state of Tenant.
 type TenantSpec struct {
-	// GatewayRef specifies which Gateway (Gateway API) to use for exposing model endpoints.
-	// If omitted, defaults to openshift-ingress/maas-default-gateway.
+	// GatewayRef specifies which Gateway (Gateway API) to use for exposing model endpoints
+	// for legacy/unmanaged Tenant resources. For AITenant-managed tenants, AITenant
+	// owns this platform context and the controller ignores this field.
 	// +kubebuilder:validation:Optional
 	GatewayRef TenantGatewayRef `json:"gatewayRef,omitempty"`
 
@@ -58,7 +59,8 @@ type TenantSpec struct {
 	// +kubebuilder:validation:Optional
 	APIKeys *TenantAPIKeysConfig `json:"apiKeys,omitempty"`
 
-	// ExternalOIDC configures an external OIDC identity provider for the maas-api AuthPolicy.
+	// ExternalOIDC configures an external OIDC identity provider for legacy/unmanaged
+	// Tenant resources. For AITenant-managed tenants, use AITenant.spec.oidc.
 	// +kubebuilder:validation:Optional
 	ExternalOIDC *TenantExternalOIDCConfig `json:"externalOIDC,omitempty"`
 

--- a/maas-controller/pkg/controller/maas/aitenant_controller.go
+++ b/maas-controller/pkg/controller/maas/aitenant_controller.go
@@ -50,11 +50,9 @@ const (
 	aitenantManagedLabel = "maas.opendatahub.io/managed-by-aitenant"
 	aiGatewayTenantLabel = "ai-gateway.opendatahub.io/tenant"
 
-	aitenantNameAnnotation      = "maas.opendatahub.io/aitenant-name"
-	aitenantNamespaceAnnotation = "maas.opendatahub.io/aitenant-namespace"
+	aitenantNameAnnotation      = tenantreconcile.AnnotationAITenantName
+	aitenantNamespaceAnnotation = tenantreconcile.AnnotationAITenantNamespace
 	aitenantCreatedAnnotation   = "maas.opendatahub.io/created-by-aitenant"
-
-	tenantNamespacePrefix = "ai-tenant-"
 
 	aitenantTenantAdminRoleSuffix = "tenant-admin"
 	aitenantAccessRoleSuffix      = "object-admin"
@@ -126,6 +124,10 @@ func (r *AITenantReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		}
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 	}
+	if err := r.updateAITenantStatus(ctx, &aitenant, statusSnapshot); err != nil {
+		return ctrl.Result{}, err
+	}
+	statusSnapshot = aitenant.Status.DeepCopy()
 
 	if err := r.ensureTenantNamespace(ctx, &aitenant); err != nil {
 		setAITenantPhase(&aitenant, "Failed", "TenantNamespaceFailed", err.Error())
@@ -135,7 +137,7 @@ func (r *AITenantReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 	}
 
-	if err := r.ensureTenantConfig(ctx, &aitenant, gatewayRef); err != nil {
+	if err := r.ensureTenantConfig(ctx, &aitenant); err != nil {
 		setAITenantPhase(&aitenant, "Failed", "TenantConfigReconcileFailed", err.Error())
 		if err2 := r.updateAITenantStatus(ctx, &aitenant, statusSnapshot); err2 != nil {
 			return ctrl.Result{}, err2
@@ -202,28 +204,7 @@ func (r *AITenantReconciler) aitenantNamespace() string {
 }
 
 func (r *AITenantReconciler) tenantNamespaceName(aitenant *maasv1alpha1.AITenant) string {
-	if r.isDefaultAITenant(aitenant) {
-		return r.defaultTenantNamespace()
-	}
-	return derivedTenantNamespaceName(aitenant.Name)
-}
-
-func (r *AITenantReconciler) isDefaultAITenant(aitenant *maasv1alpha1.AITenant) bool {
-	if aitenant.Name == tenantreconcile.DefaultAITenantName {
-		return true
-	}
-	return r.TenantNamespace != "" && aitenant.Name == r.TenantNamespace
-}
-
-func (r *AITenantReconciler) defaultTenantNamespace() string {
-	if r.TenantNamespace != "" {
-		return r.TenantNamespace
-	}
-	return tenantreconcile.DefaultAITenantName
-}
-
-func derivedTenantNamespaceName(aitenantName string) string {
-	return tenantNamespacePrefix + aitenantName
+	return tenantreconcile.TenantNamespaceForAITenant(aitenant.Name, r.TenantNamespace)
 }
 
 func (r *AITenantReconciler) ensureTenantNamespace(ctx context.Context, aitenant *maasv1alpha1.AITenant) error {
@@ -304,7 +285,7 @@ func (r *AITenantReconciler) gatewayRefFor(aitenant *maasv1alpha1.AITenant) maas
 	return ref
 }
 
-func (r *AITenantReconciler) ensureTenantConfig(ctx context.Context, aitenant *maasv1alpha1.AITenant, gatewayRef maasv1alpha1.TenantGatewayRef) error {
+func (r *AITenantReconciler) ensureTenantConfig(ctx context.Context, aitenant *maasv1alpha1.AITenant) error {
 	tenantNamespace := r.tenantNamespaceName(aitenant)
 	tenant := &maasv1alpha1.Tenant{
 		TypeMeta: metav1.TypeMeta{
@@ -322,11 +303,6 @@ func (r *AITenantReconciler) ensureTenantConfig(ctx context.Context, aitenant *m
 			return fmt.Errorf("expected Tenant, got %T", obj)
 		}
 		applyAITenantMetadata(t, aitenant, tenantNamespace)
-		// TODO: Move these mirrored platform values out of Tenant spec in a
-		// follow-up Jira once the MaaS config/status API is settled. The current
-		// post-render path still reads Tenant.spec.gatewayRef and externalOIDC.
-		t.Spec.GatewayRef = gatewayRef
-		t.Spec.ExternalOIDC = aitenant.Spec.OIDC
 		return nil
 	})
 }

--- a/maas-controller/pkg/controller/maas/aitenant_controller_test.go
+++ b/maas-controller/pkg/controller/maas/aitenant_controller_test.go
@@ -149,14 +149,11 @@ func TestAITenantReconcile_ValidatesExistingGatewayAndCreatesBootstrapResources(
 
 	var tenant maasv1alpha1.Tenant
 	g.Expect(cl.Get(context.Background(), client.ObjectKey{Name: maasv1alpha1.TenantInstanceName, Namespace: "ai-tenant-team-a"}, &tenant)).To(Succeed())
-	g.Expect(tenant.Spec.GatewayRef).To(Equal(maasv1alpha1.TenantGatewayRef{
-		Namespace: "openshift-ingress",
-		Name:      "team-a",
-	}))
-	g.Expect(tenant.Spec.ExternalOIDC).NotTo(BeNil())
-	g.Expect(tenant.Spec.ExternalOIDC.IssuerURL).To(Equal("https://issuer.example.com/realms/team-a"))
-	g.Expect(tenant.Spec.ExternalOIDC.ClientID).To(Equal("team-a-client"))
+	g.Expect(tenant.Spec.GatewayRef).To(Equal(maasv1alpha1.TenantGatewayRef{}))
+	g.Expect(tenant.Spec.ExternalOIDC).To(BeNil())
 	g.Expect(tenant.Labels).To(HaveKeyWithValue(aiGatewayTenantLabel, "team-a"))
+	g.Expect(tenant.Annotations).To(HaveKeyWithValue(aitenantNameAnnotation, "team-a"))
+	g.Expect(tenant.Annotations).To(HaveKeyWithValue(aitenantNamespaceAnnotation, tenantreconcile.DefaultAITenantNamespace))
 
 	var tenantRole rbacv1.Role
 	g.Expect(cl.Get(context.Background(), client.ObjectKey{Name: tenantAdminRoleName(aitenant), Namespace: "ai-tenant-team-a"}, &tenantRole)).To(Succeed())
@@ -196,6 +193,49 @@ func TestAITenantReconcile_ValidatesExistingGatewayAndCreatesBootstrapResources(
 	g.Expect(ready).NotTo(BeNil())
 	g.Expect(ready.Status).To(Equal(metav1.ConditionTrue))
 	g.Expect(ready.Reason).To(Equal("Reconciled"))
+}
+
+func TestAITenantReconcile_PersistsGatewayStatusBeforeTenantCreate(t *testing.T) {
+	g := NewWithT(t)
+	s := aitenantTestScheme(t)
+
+	aitenant := &maasv1alpha1.AITenant{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "team-a",
+			Namespace: tenantreconcile.DefaultAITenantNamespace,
+		},
+	}
+	key := types.NamespacedName{Name: aitenant.Name, Namespace: aitenant.Namespace}
+	gateway := existingAITenantGateway("team-a")
+
+	cl := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(&maasv1alpha1.AITenant{}).
+		WithObjects(aitenant, gateway).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+				if _, ok := obj.(*maasv1alpha1.Tenant); ok {
+					var current maasv1alpha1.AITenant
+					g.Expect(c.Get(ctx, key, &current)).To(Succeed())
+					g.Expect(current.Status.GatewayRef).To(Equal(maasv1alpha1.TenantGatewayRef{
+						Name:      "team-a",
+						Namespace: "openshift-ingress",
+					}))
+				}
+				return c.Create(ctx, obj, opts...)
+			},
+		}).
+		Build()
+	r := &AITenantReconciler{
+		Client:           cl,
+		Scheme:           s,
+		APIReader:        cl,
+		AppNamespace:     "opendatahub",
+		TenantNamespace:  "models-as-a-service",
+		GatewayNamespace: "openshift-ingress",
+	}
+
+	reconcileAITenantTwice(t, r, key)
 }
 
 func TestAITenantReconcile_MissingGatewaySetsFailedStatus(t *testing.T) {
@@ -292,7 +332,7 @@ func TestAITenantReconcile_ExplicitGatewayNameResolvesExistingGateway(t *testing
 
 	var tenant maasv1alpha1.Tenant
 	g.Expect(cl.Get(context.Background(), client.ObjectKey{Name: maasv1alpha1.TenantInstanceName, Namespace: "ai-tenant-team-explicit"}, &tenant)).To(Succeed())
-	g.Expect(tenant.Spec.GatewayRef.Name).To(Equal("network-approved-gw"))
+	g.Expect(tenant.Spec.GatewayRef).To(Equal(maasv1alpha1.TenantGatewayRef{}))
 }
 
 func TestAITenantReconcile_UpdatesPreExistingTenant(t *testing.T) {
@@ -345,10 +385,10 @@ func TestAITenantReconcile_UpdatesPreExistingTenant(t *testing.T) {
 	g.Expect(cl.Get(context.Background(), client.ObjectKey{Name: maasv1alpha1.TenantInstanceName, Namespace: "ai-tenant-team-adoptcfg"}, &tenant)).To(Succeed())
 	g.Expect(tenant.Annotations).To(HaveKeyWithValue(aitenantNameAnnotation, "team-adoptcfg"))
 	g.Expect(tenant.Spec.GatewayRef).To(Equal(maasv1alpha1.TenantGatewayRef{
-		Namespace: "openshift-ingress",
-		Name:      "team-adoptcfg",
+		Namespace: "old-gateway-ns",
+		Name:      "old-gateway",
 	}))
-	g.Expect(tenant.Spec.ExternalOIDC).To(Equal(aitenant.Spec.OIDC))
+	g.Expect(tenant.Spec.ExternalOIDC).To(BeNil())
 }
 
 func TestAITenantReconcile_LabelsPreExistingDerivedNamespace(t *testing.T) {
@@ -496,7 +536,7 @@ func TestAITenantReconcile_RejectsDerivedNamespaceOverDNSLabelLimit(t *testing.T
 	g.Expect(ready.Reason).To(Equal("InvalidPlacement"))
 	g.Expect(ready.Message).To(ContainSubstring("derived tenant namespace"))
 	g.Expect(ready.Message).To(ContainSubstring("must be no more than 63 characters"))
-	g.Expect(apierrors.IsNotFound(cl.Get(context.Background(), client.ObjectKey{Name: tenantNamespacePrefix + aitenantName}, &corev1.Namespace{}))).To(BeTrue())
+	g.Expect(apierrors.IsNotFound(cl.Get(context.Background(), client.ObjectKey{Name: tenantreconcile.TenantNamespaceForAITenant(aitenantName, "models-as-a-service")}, &corev1.Namespace{}))).To(BeTrue())
 }
 
 func TestAITenantReconcile_AllowsDefaultTenantNamespaceFromInfraNamespace(t *testing.T) {
@@ -911,7 +951,7 @@ func TestAITenantUpsert_PatchesAfterCreateAlreadyExistsRace(t *testing.T) {
 		},
 	}
 	err := r.upsert(context.Background(), configMap, aitenant, func(obj client.Object) error {
-		applyAITenantMetadata(obj, aitenant, derivedTenantNamespaceName(aitenant.Name))
+		applyAITenantMetadata(obj, aitenant, tenantreconcile.TenantNamespaceForAITenant(aitenant.Name, ""))
 		cm, ok := obj.(*corev1.ConfigMap)
 		g.Expect(ok).To(BeTrue())
 		cm.Data = map[string]string{"fresh": "true"}
@@ -925,7 +965,7 @@ func TestAITenantUpsert_PatchesAfterCreateAlreadyExistsRace(t *testing.T) {
 	g.Expect(updated.Data).To(HaveKeyWithValue("fresh", "true"))
 }
 
-func TestAITenantReconcile_OIDCFullMirror(t *testing.T) {
+func TestAITenantReconcile_OIDCStaysInAITenantSpec(t *testing.T) {
 	g := NewWithT(t)
 	s := aitenantTestScheme(t)
 
@@ -961,7 +1001,7 @@ func TestAITenantReconcile_OIDCFullMirror(t *testing.T) {
 
 	var tenant maasv1alpha1.Tenant
 	g.Expect(cl.Get(context.Background(), client.ObjectKey{Name: maasv1alpha1.TenantInstanceName, Namespace: "ai-tenant-team-oidc"}, &tenant)).To(Succeed())
-	g.Expect(tenant.Spec.ExternalOIDC).To(Equal(aitenant.Spec.OIDC))
+	g.Expect(tenant.Spec.ExternalOIDC).To(BeNil())
 }
 
 func TestAITenantReconcile_NoOIDCSetsTenantOIDCNil(t *testing.T) {

--- a/maas-controller/pkg/controller/maas/helpers.go
+++ b/maas-controller/pkg/controller/maas/helpers.go
@@ -211,14 +211,11 @@ func tenantGatewayRefForNamespace(
 ) (maasv1alpha1.TenantGatewayRef, error) {
 	tenant, err := fetchTenantForNamespace(ctx, c, tenantNamespace)
 	if err == nil {
-		ref := tenant.Spec.GatewayRef
-		if ref.Name != "" && ref.Namespace != "" {
-			return ref, nil
+		platformContext, err := tenantreconcile.ResolvePlatformContext(ctx, c, tenant, fallbackTenantGatewayRef(fallbackGatewayName, fallbackGatewayNamespace))
+		if err != nil {
+			return maasv1alpha1.TenantGatewayRef{}, err
 		}
-		if ref.Name == "" && ref.Namespace == "" && (tenantNamespace == defaultTenantNamespace || !discoveryEnabled) {
-			return fallbackTenantGatewayRef(fallbackGatewayName, fallbackGatewayNamespace), nil
-		}
-		return maasv1alpha1.TenantGatewayRef{}, fmt.Errorf("tenant %s/%s spec.gatewayRef must set both name and namespace", tenantNamespace, maasv1alpha1.TenantInstanceName)
+		return platformContext.GatewayRef, nil
 	}
 	if apierrors.IsNotFound(err) && (tenantNamespace == defaultTenantNamespace || !discoveryEnabled) {
 		return fallbackTenantGatewayRef(fallbackGatewayName, fallbackGatewayNamespace), nil

--- a/maas-controller/pkg/controller/maas/helpers.go
+++ b/maas-controller/pkg/controller/maas/helpers.go
@@ -221,6 +221,13 @@ func tenantGatewayRefForNamespace(
 		return fallbackTenantGatewayRef(fallbackGatewayName, fallbackGatewayNamespace), nil
 	}
 	if apierrors.IsNotFound(err) {
+		allowed, allowErr := tenantNamespaceAllowed(ctx, c, tenantNamespace, defaultTenantNamespace, discoveryEnabled)
+		if allowErr != nil {
+			return maasv1alpha1.TenantGatewayRef{}, allowErr
+		}
+		if !allowed {
+			return fallbackTenantGatewayRef(fallbackGatewayName, fallbackGatewayNamespace), nil
+		}
 		return maasv1alpha1.TenantGatewayRef{}, fmt.Errorf("tenant %s/%s not found for discovered tenant namespace", tenantNamespace, maasv1alpha1.TenantInstanceName)
 	}
 	return maasv1alpha1.TenantGatewayRef{}, err

--- a/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
@@ -290,16 +290,19 @@ const (
 		`? auth.metadata.apiKeyValidation.groups ` +
 		`: (has(auth.identity.groups) ? auth.identity.groups : auth.identity.user.groups)`
 
+	safeGroupNamePattern = `^[A-Za-z0-9:._/-]+$`
+	celOIDCGroupsSafe    = `auth.identity.groups.all(g, g.matches('` + safeGroupNamePattern + `'))`
+
 	// celTokenGroupsHeaderJSON renders the X-MaaS-Group header for non-API-key
 	// identities. OIDC tokens may omit or provide an empty groups claim, but API
 	// key minting still requires at least system:authenticated to match the
 	// default subscription.
 	celTokenGroupsHeaderJSON = `has(auth.identity.groups) ? ` +
-		`(size(auth.identity.groups) > 0 ? ` +
+		`(size(auth.identity.groups) > 0 && ` + celOIDCGroupsSafe + ` ? ` +
 		`'["system:authenticated","' + auth.identity.groups.join('","') + '"]' : ` +
 		`'["system:authenticated"]') : ` +
 		`(has(auth.identity.user.groups) && size(auth.identity.user.groups) > 0 ? ` +
-		`'["' + auth.identity.user.groups.join('","') + '"]' : ` +
+		`'["system:authenticated","' + auth.identity.user.groups.join('","') + '"]' : ` +
 		`'["system:authenticated"]')`
 
 	celSubscription = `(has(auth.metadata) && has(auth.metadata.apiKeyValidation)) ` +
@@ -764,6 +767,87 @@ allow {
 }
 `, modelAccessJSON)
 
+	authorizationRules := map[string]any{
+		"tenant-gateway-isolation": tenantGatewayIsolationRule,
+		"auth-valid": map[string]any{
+			"metrics":  false,
+			"priority": int64(0),
+			"opa": map[string]any{
+				"rego": `allow {
+  object.get(input.auth.metadata, "apiKeyValidation", {})
+  input.auth.metadata.apiKeyValidation.valid == true
+}
+allow {
+  not input.auth.metadata.apiKeyValidation
+}`,
+			},
+			"cache": map[string]any{
+				"key": map[string]any{
+					"selector": authValidCacheKey,
+				},
+				"ttl": r.authzCacheTTL(),
+			},
+		},
+		"subscription-valid": map[string]any{
+			"when": []any{
+				map[string]any{
+					"predicate": celModelIdentityAvailable,
+				},
+			},
+			"metrics":  false,
+			"priority": int64(0),
+			"opa": map[string]any{
+				"rego": `allow {
+	object.get(input.auth.metadata["subscription-info"], "name", "") != ""
+	object.get(input.auth.metadata["subscription-info"], "error", "") == ""
+	phase := object.get(input.auth.metadata["subscription-info"], "phase", "")
+	any([phase == "Active", phase == "Degraded"])
+	object.get(input.auth.metadata["subscription-info"], "deletionTimestamp", "") == ""
+}`,
+			},
+			"cache": map[string]any{
+				"key": map[string]any{
+					"selector": subscriptionGatewayCacheKeySelector(),
+				},
+				"ttl": r.authzCacheTTL(),
+			},
+		},
+		"require-group-membership": map[string]any{
+			"metrics":  false,
+			"priority": int64(0),
+			"opa": map[string]any{
+				"rego": requireGroupMembershipRego,
+			},
+			"cache": map[string]any{
+				"key": map[string]any{
+					"selector": gatewayAuthzCacheKeySelector(),
+				},
+				"ttl": r.authzCacheTTL(),
+			},
+		},
+	}
+	if oidc != nil {
+		authorizationRules["oidc-groups-safe"] = map[string]any{
+			"when": []any{
+				map[string]any{
+					"predicate": celIsNotAPIKey + ` && has(auth.identity.groups) && size(auth.identity.groups) > 0`,
+				},
+			},
+			"metrics":  false,
+			"priority": int64(0),
+			"opa": map[string]any{
+				"rego": `unsafe_group[g] {
+	g := input.auth.identity.groups[_]
+	not regex.match("` + safeGroupNamePattern + `", g)
+}
+
+allow {
+	count(unsafe_group) == 0
+}`,
+			},
+		}
+	}
+
 	defaultsRules := map[string]any{
 		"metadata": map[string]any{
 			"apiKeyValidation": map[string]any{
@@ -814,65 +898,7 @@ allow {
 			},
 		},
 		"authentication": authenticationRules,
-		"authorization": map[string]any{
-			"tenant-gateway-isolation": tenantGatewayIsolationRule,
-			"auth-valid": map[string]any{
-				"metrics":  false,
-				"priority": int64(0),
-				"opa": map[string]any{
-					"rego": `allow {
-  object.get(input.auth.metadata, "apiKeyValidation", {})
-  input.auth.metadata.apiKeyValidation.valid == true
-}
-allow {
-  not input.auth.metadata.apiKeyValidation
-}`,
-				},
-				"cache": map[string]any{
-					"key": map[string]any{
-						"selector": authValidCacheKey,
-					},
-					"ttl": r.authzCacheTTL(),
-				},
-			},
-			"subscription-valid": map[string]any{
-				"when": []any{
-					map[string]any{
-						"predicate": celModelIdentityAvailable,
-					},
-				},
-				"metrics":  false,
-				"priority": int64(0),
-				"opa": map[string]any{
-					"rego": `allow {
-	object.get(input.auth.metadata["subscription-info"], "name", "") != ""
-	object.get(input.auth.metadata["subscription-info"], "error", "") == ""
-	phase := object.get(input.auth.metadata["subscription-info"], "phase", "")
-	any([phase == "Active", phase == "Degraded"])
-	object.get(input.auth.metadata["subscription-info"], "deletionTimestamp", "") == ""
-}`,
-				},
-				"cache": map[string]any{
-					"key": map[string]any{
-						"selector": subscriptionGatewayCacheKeySelector(),
-					},
-					"ttl": r.authzCacheTTL(),
-				},
-			},
-			"require-group-membership": map[string]any{
-				"metrics":  false,
-				"priority": int64(0),
-				"opa": map[string]any{
-					"rego": requireGroupMembershipRego,
-				},
-				"cache": map[string]any{
-					"key": map[string]any{
-						"selector": gatewayAuthzCacheKeySelector(),
-					},
-					"ttl": r.authzCacheTTL(),
-				},
-			},
-		},
+		"authorization":  authorizationRules,
 		"response": map[string]any{
 			"success": map[string]any{
 				"headers": map[string]any{

--- a/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
@@ -156,11 +156,39 @@ func (r *MaaSAuthPolicyReconciler) fetchTenantPlatformContext(ctx context.Contex
 		Name:      maasv1alpha1.TenantInstanceName,
 		Namespace: tenantNamespace,
 	}
+	defaultTenantNamespace := r.TenantNamespace
+	if defaultTenantNamespace == "" {
+		defaultTenantNamespace = tenantreconcile.DefaultAITenantName
+	}
 	if err := r.Get(ctx, tenantKey, tenant); err != nil {
-		if apierrors.IsNotFound(err) || apimeta.IsNoMatchError(err) {
-			log.V(1).Info("Tenant CRD not installed or Tenant not found, using default platform context",
+		if apimeta.IsNoMatchError(err) {
+			log.V(1).Info("Tenant CRD not installed, using default platform context",
 				"tenantName", maasv1alpha1.TenantInstanceName,
 				"tenantNamespace", tenantNamespace)
+			platformContext := tenantreconcile.PlatformContext{
+				GatewayRef: fallbackTenantGatewayRef(r.GatewayName, r.GatewayNamespace),
+				Source:     "default",
+			}
+			return &platformContext, nil
+		}
+		if apierrors.IsNotFound(err) {
+			if !r.TenantNamespaceDiscoveryEnabled || tenantNamespace == defaultTenantNamespace {
+				log.V(1).Info("Tenant not found in default namespace, using default platform context",
+					"tenantName", maasv1alpha1.TenantInstanceName,
+					"tenantNamespace", tenantNamespace)
+				platformContext := tenantreconcile.PlatformContext{
+					GatewayRef: fallbackTenantGatewayRef(r.GatewayName, r.GatewayNamespace),
+					Source:     "default",
+				}
+				return &platformContext, nil
+			}
+			allowed, allowErr := tenantNamespaceAllowed(ctx, r.Client, tenantNamespace, defaultTenantNamespace, r.TenantNamespaceDiscoveryEnabled)
+			if allowErr != nil {
+				return nil, allowErr
+			}
+			if allowed {
+				return nil, fmt.Errorf("tenant %s/%s not found; refusing to use default platform context for discovered tenant namespace", tenantNamespace, maasv1alpha1.TenantInstanceName)
+			}
 			platformContext := tenantreconcile.PlatformContext{
 				GatewayRef: fallbackTenantGatewayRef(r.GatewayName, r.GatewayNamespace),
 				Source:     "default",

--- a/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
@@ -150,117 +150,85 @@ func (r *MaaSAuthPolicyReconciler) fetchTenantIdentifier(ctx context.Context, lo
 	return tenantIdentifier, nil
 }
 
-// fetchOIDCConfig fetches OIDC configuration from the Tenant CR in the given
-// namespace. Each tenant namespace has its own Tenant/default-tenant with
-// per-tenant OIDC settings. Returns nil if the Tenant CR doesn't exist or
-// doesn't have externalOIDC configured.
-func (r *MaaSAuthPolicyReconciler) fetchOIDCConfig(ctx context.Context, log logr.Logger, policyNamespace string) *oidcConfig {
-	tenant := &unstructured.Unstructured{}
-	tenant.SetGroupVersionKind(schema.GroupVersionKind{
-		Group:   "maas.opendatahub.io",
-		Version: "v1alpha1",
-		Kind:    "Tenant",
-	})
-
-	tenantKey := client.ObjectKey{
-		Name:      maasv1alpha1.TenantInstanceName,
-		Namespace: policyNamespace,
-	}
-
-	if err := r.Get(ctx, tenantKey, tenant); err != nil {
-		if apimeta.IsNoMatchError(err) || apierrors.IsNotFound(err) {
-			log.V(1).Info("Tenant CRD not installed or Tenant not found, OIDC support disabled",
-				"tenantName", maasv1alpha1.TenantInstanceName,
-				"tenantNamespace", policyNamespace)
-			return nil
-		}
-		log.Error(err, "failed to get Tenant resource",
-			"tenantName", maasv1alpha1.TenantInstanceName,
-			"tenantNamespace", policyNamespace)
-		return nil
-	}
-
-	// Extract spec.externalOIDC if present
-	oidcSpec, found, err := unstructured.NestedMap(tenant.Object, "spec", "externalOIDC")
-	if err != nil {
-		log.Error(err, "failed to extract spec.externalOIDC from Tenant")
-		return nil
-	}
-	if !found || oidcSpec == nil {
-		log.V(1).Info("Tenant CR has no externalOIDC configuration")
-		return nil
-	}
-
-	// Extract issuerUrl and clientId
-	issuerURL, _, err := unstructured.NestedString(oidcSpec, "issuerUrl")
-	if err != nil {
-		log.Error(err, "Tenant externalOIDC.issuerUrl has invalid type (expected string)",
-			"oidcSpec", oidcSpec)
-		return nil
-	}
-
-	clientID, _, err := unstructured.NestedString(oidcSpec, "clientId")
-	if err != nil {
-		log.Error(err, "Tenant externalOIDC.clientId has invalid type (expected string)",
-			"oidcSpec", oidcSpec)
-		return nil
-	}
-
-	if issuerURL == "" {
-		log.V(1).Info("Tenant externalOIDC has no issuerUrl")
-		return nil
-	}
-
-	if clientID == "" {
-		log.Error(nil, "Tenant externalOIDC has no clientId - audience validation is required for security")
-		return nil
-	}
-
-	log.Info("OIDC configuration loaded from Tenant CR",
-		"issuerUrl", issuerURL,
-		"clientId", clientID)
-
-	return &oidcConfig{
-		IssuerURL: issuerURL,
-		ClientID:  clientID,
-	}
-}
-
-// fetchGatewayInfo fetches gateway namespace and name from the Tenant CR.
-// Returns (gatewayNamespace, gatewayName, error).
-// Falls back to controller defaults if Tenant CR not found or missing gateway ref.
-func (r *MaaSAuthPolicyReconciler) fetchGatewayInfo(ctx context.Context, log logr.Logger, tenantNamespace string) (string, string, error) {
+func (r *MaaSAuthPolicyReconciler) fetchTenantPlatformContext(ctx context.Context, log logr.Logger, tenantNamespace string) (*tenantreconcile.PlatformContext, error) {
 	tenant := &maasv1alpha1.Tenant{}
 	tenantKey := client.ObjectKey{
 		Name:      maasv1alpha1.TenantInstanceName,
 		Namespace: tenantNamespace,
 	}
-
 	if err := r.Get(ctx, tenantKey, tenant); err != nil {
-		if apierrors.IsNotFound(err) {
-			// No Tenant CR - use controller defaults
-			log.V(1).Info("Tenant not found, using default gateway",
-				"gatewayNamespace", r.GatewayNamespace,
-				"gatewayName", r.GatewayName)
-			return r.GatewayNamespace, r.GatewayName, nil
+		if apierrors.IsNotFound(err) || apimeta.IsNoMatchError(err) {
+			log.V(1).Info("Tenant CRD not installed or Tenant not found, using default platform context",
+				"tenantName", maasv1alpha1.TenantInstanceName,
+				"tenantNamespace", tenantNamespace)
+			platformContext := tenantreconcile.PlatformContext{
+				GatewayRef: fallbackTenantGatewayRef(r.GatewayName, r.GatewayNamespace),
+				Source:     "default",
+			}
+			return &platformContext, nil
 		}
-		return "", "", fmt.Errorf("failed to get Tenant CR: %w", err)
+		return nil, fmt.Errorf("failed to get Tenant CR: %w", err)
 	}
 
-	// Check if Tenant has GatewayRef
-	if tenant.Spec.GatewayRef.Namespace == "" || tenant.Spec.GatewayRef.Name == "" {
-		// Tenant exists but no gateway ref - use controller defaults
-		log.V(1).Info("Tenant has no gatewayRef, using defaults",
-			"gatewayNamespace", r.GatewayNamespace,
-			"gatewayName", r.GatewayName)
-		return r.GatewayNamespace, r.GatewayName, nil
+	platformContext, err := tenantreconcile.ResolvePlatformContext(ctx, r.Client, tenant, fallbackTenantGatewayRef(r.GatewayName, r.GatewayNamespace))
+	if err != nil {
+		return nil, err
+	}
+	return &platformContext, nil
+}
+
+// fetchOIDCConfig fetches OIDC configuration for the tenant namespace. AITenant-
+// managed tenants read this from AITenant.spec.oidc; legacy tenants continue to
+// use Tenant.spec.externalOIDC.
+func (r *MaaSAuthPolicyReconciler) fetchOIDCConfig(ctx context.Context, log logr.Logger, policyNamespace string) *oidcConfig {
+	platformContext, err := r.fetchTenantPlatformContext(ctx, log, policyNamespace)
+	if err != nil {
+		log.Error(err, "failed to resolve tenant platform context for OIDC",
+			"tenantNamespace", policyNamespace)
+		return nil
+	}
+	oidc := platformContext.ExternalOIDC
+	if oidc == nil {
+		log.V(1).Info("Tenant platform context has no external OIDC configuration",
+			"tenantNamespace", policyNamespace,
+			"source", platformContext.Source)
+		return nil
 	}
 
-	// Use tenant's gateway
-	log.V(1).Info("Using tenant's gateway",
-		"gatewayNamespace", tenant.Spec.GatewayRef.Namespace,
-		"gatewayName", tenant.Spec.GatewayRef.Name)
-	return tenant.Spec.GatewayRef.Namespace, tenant.Spec.GatewayRef.Name, nil
+	if oidc.IssuerURL == "" {
+		log.V(1).Info("Tenant external OIDC has no issuerUrl")
+		return nil
+	}
+
+	if oidc.ClientID == "" {
+		log.Error(nil, "Tenant external OIDC has no clientId - audience validation is required for security")
+		return nil
+	}
+
+	log.Info("OIDC configuration loaded from tenant platform context",
+		"issuerUrl", oidc.IssuerURL,
+		"clientId", oidc.ClientID,
+		"source", platformContext.Source)
+
+	return &oidcConfig{
+		IssuerURL: oidc.IssuerURL,
+		ClientID:  oidc.ClientID,
+	}
+}
+
+// fetchGatewayInfo fetches gateway namespace and name from tenant platform context.
+// Returns (gatewayNamespace, gatewayName, error).
+func (r *MaaSAuthPolicyReconciler) fetchGatewayInfo(ctx context.Context, log logr.Logger, tenantNamespace string) (string, string, error) {
+	platformContext, err := r.fetchTenantPlatformContext(ctx, log, tenantNamespace)
+	if err != nil {
+		return "", "", err
+	}
+	ref := platformContext.GatewayRef
+	log.V(1).Info("Using tenant platform gateway",
+		"gatewayNamespace", ref.Namespace,
+		"gatewayName", ref.Name,
+		"source", platformContext.Source)
+	return ref.Namespace, ref.Name, nil
 }
 
 // CEL sub-expressions reused across Authorino cache-key selectors.
@@ -1623,6 +1591,11 @@ func (r *MaaSAuthPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		// Watch Tenant so OIDC configuration changes trigger reconciles.
 		Watches(tenant, handler.EnqueueRequestsFromMapFunc(
 			r.mapTenantToMaaSAuthPolicies,
+		)).
+		// Watch AITenant so gateway/OIDC platform context changes trigger
+		// reconciles for policies in the affected tenant namespace.
+		Watches(&maasv1alpha1.AITenant{}, handler.EnqueueRequestsFromMapFunc(
+			r.mapAITenantToMaaSAuthPolicies,
 		))
 	if r.TenantNamespaceDiscoveryEnabled {
 		// Watch Namespaces so that policies in newly labeled tenant
@@ -1632,6 +1605,28 @@ func (r *MaaSAuthPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		), builder.WithPredicates(predicate.LabelChangedPredicate{}))
 	}
 	return b.Complete(r)
+}
+
+func (r *MaaSAuthPolicyReconciler) mapAITenantToMaaSAuthPolicies(ctx context.Context, obj client.Object) []reconcile.Request {
+	aitenant, ok := obj.(*maasv1alpha1.AITenant)
+	if !ok {
+		return nil
+	}
+	tenantNamespace := tenantreconcile.TenantNamespaceForAITenant(aitenant.Name, r.TenantNamespace)
+	policyList := &maasv1alpha1.MaaSAuthPolicyList{}
+	if err := r.List(ctx, policyList, client.InNamespace(tenantNamespace)); err != nil {
+		ctrl.LoggerFrom(ctx).Error(err, "failed to list MaaSAuthPolicy resources for AITenant change",
+			"tenantNamespace", tenantNamespace,
+			"aitenant", obj.GetNamespace()+"/"+obj.GetName())
+		return nil
+	}
+	policyList.Items = filterAuthPoliciesByTenantNamespace(ctx, r.Client, policyList.Items, r.TenantNamespace, r.TenantNamespaceDiscoveryEnabled)
+
+	requests := make([]reconcile.Request, len(policyList.Items))
+	for i, policy := range policyList.Items {
+		requests[i] = reconcile.Request{NamespacedName: types.NamespacedName{Name: policy.Name, Namespace: policy.Namespace}}
+	}
+	return requests
 }
 
 // mapTenantToMaaSAuthPolicies enqueues MaaSAuthPolicy resources in the same

--- a/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
@@ -290,6 +290,18 @@ const (
 		`? auth.metadata.apiKeyValidation.groups ` +
 		`: (has(auth.identity.groups) ? auth.identity.groups : auth.identity.user.groups)`
 
+	// celTokenGroupsHeaderJSON renders the X-MaaS-Group header for non-API-key
+	// identities. OIDC tokens may omit or provide an empty groups claim, but API
+	// key minting still requires at least system:authenticated to match the
+	// default subscription.
+	celTokenGroupsHeaderJSON = `has(auth.identity.groups) ? ` +
+		`(size(auth.identity.groups) > 0 ? ` +
+		`'["system:authenticated","' + auth.identity.groups.join('","') + '"]' : ` +
+		`'["system:authenticated"]') : ` +
+		`(has(auth.identity.user.groups) && size(auth.identity.user.groups) > 0 ? ` +
+		`'["' + auth.identity.user.groups.join('","') + '"]' : ` +
+		`'["system:authenticated"]')`
+
 	celSubscription = `(has(auth.metadata) && has(auth.metadata.apiKeyValidation)) ` +
 		`? auth.metadata.apiKeyValidation.subscription : ` +
 		`("x-maas-subscription" in request.headers ? request.headers["x-maas-subscription"] : "")`
@@ -911,9 +923,7 @@ allow {
 							},
 						},
 						"plain": map[string]any{
-							"expression": `has(auth.identity.groups) ?` +
-								` '["system:authenticated","' + auth.identity.groups.join('","') + '"]'` +
-								` : '["' + auth.identity.user.groups.join('","') + '"]'`,
+							"expression": celTokenGroupsHeaderJSON,
 						},
 						"key":      "X-MaaS-Group",
 						"metrics":  false,

--- a/maas-controller/pkg/controller/maas/maasauthpolicy_controller_test.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_controller_test.go
@@ -1214,7 +1214,8 @@ func TestMaaSAuthPolicyReconciler_IdentityHeadersUpstream(t *testing.T) {
 	})
 }
 
-func TestBuildGatewayAuthPolicySpec_K8sAndOIDCAuth(t *testing.T) {
+func gatewayAuthPolicySpecTestObject(t *testing.T, oidc *oidcConfig) *unstructured.Unstructured {
+	t.Helper()
 	r := &MaaSAuthPolicyReconciler{
 		MaaSAPINamespace: "maas-system",
 		GatewayName:      "maas-default-gateway",
@@ -1223,101 +1224,98 @@ func TestBuildGatewayAuthPolicySpec_K8sAndOIDCAuth(t *testing.T) {
 		MetadataCacheTTL: 60,
 		AuthzCacheTTL:    60,
 	}
+	spec := r.buildGatewayAuthPolicySpec("{}", oidc, false, "", "models-as-a-service", "test-gateway-ns", "test-gateway")
+	return &unstructured.Unstructured{Object: map[string]any{"spec": spec}}
+}
 
-	gwSpecToUnstructured := func(t *testing.T, spec map[string]any) *unstructured.Unstructured {
-		t.Helper()
-		obj := &unstructured.Unstructured{Object: map[string]any{"spec": spec}}
-		return obj
+func nestedMapRequired(t *testing.T, obj *unstructured.Unstructured, fields ...string) map[string]any {
+	t.Helper()
+	got, found, err := unstructured.NestedMap(obj.Object, fields...)
+	if err != nil || !found {
+		t.Fatalf("nested map %v missing: found=%v err=%v", fields, found, err)
+	}
+	return got
+}
+
+func nestedStringRequired(t *testing.T, obj *unstructured.Unstructured, fields ...string) string {
+	t.Helper()
+	got, found, err := unstructured.NestedString(obj.Object, fields...)
+	if err != nil || !found {
+		t.Fatalf("nested string %v missing: found=%v err=%v", fields, found, err)
+	}
+	return got
+}
+
+func nestedWhenPredicateRequired(t *testing.T, obj *unstructured.Unstructured, fields ...string) string {
+	t.Helper()
+	when, found, err := unstructured.NestedSlice(obj.Object, fields...)
+	if err != nil || !found || len(when) == 0 {
+		t.Fatalf("when condition %v missing: found=%v err=%v", fields, found, err)
+	}
+	firstWhen, ok := when[0].(map[string]any)
+	if !ok {
+		t.Fatalf("when[0] for %v is not a map: %T", fields, when[0])
+	}
+	pred, ok := firstWhen["predicate"].(string)
+	if !ok {
+		t.Fatalf("when[0] for %v has no predicate string", fields)
+	}
+	return pred
+}
+
+func TestBuildGatewayAuthPolicySpec_K8sAuth(t *testing.T) {
+	obj := gatewayAuthPolicySpecTestObject(t, nil)
+
+	auth := nestedMapRequired(t, obj, "spec", "defaults", "rules", "authentication")
+	if _, exists := auth["api-keys"]; !exists {
+		t.Error("api-keys authentication should always be present")
+	}
+	if _, exists := auth["openshift-identities"]; !exists {
+		t.Error("openshift-identities should always be present")
+	}
+	if _, exists := auth["oidc-identities"]; exists {
+		t.Error("oidc-identities should NOT be present when OIDC config is nil")
+	}
+	if _, exists := auth["api-keys-x-api-key"]; exists {
+		t.Error("api-keys-x-api-key should NOT be present when xAPIKeyEnabled is false")
 	}
 
-	t.Run("without OIDC", func(t *testing.T) {
-		spec := r.buildGatewayAuthPolicySpec("{}", nil, false, "", "models-as-a-service", "test-gateway-ns", "test-gateway")
-		obj := gwSpecToUnstructured(t, spec)
+	authz := nestedMapRequired(t, obj, "spec", "defaults", "rules", "authorization")
+	if _, exists := authz["oidc-groups-safe"]; exists {
+		t.Error("oidc-groups-safe should NOT be present when OIDC config is nil")
+	}
+}
 
-		auth, found, err := unstructured.NestedMap(obj.Object, "spec", "defaults", "rules", "authentication")
-		if err != nil || !found {
-			t.Fatalf("authentication block missing: found=%v err=%v", found, err)
-		}
-		if _, exists := auth["api-keys"]; !exists {
-			t.Error("api-keys authentication should always be present")
-		}
-		if _, exists := auth["openshift-identities"]; !exists {
-			t.Error("openshift-identities should always be present")
-		}
-		if _, exists := auth["oidc-identities"]; exists {
-			t.Error("oidc-identities should NOT be present when OIDC config is nil")
-		}
-		if _, exists := auth["api-keys-x-api-key"]; exists {
-			t.Error("api-keys-x-api-key should NOT be present when xAPIKeyEnabled is false")
-		}
-		authz, found, err := unstructured.NestedMap(obj.Object, "spec", "defaults", "rules", "authorization")
-		if err != nil || !found {
-			t.Fatalf("authorization block missing: found=%v err=%v", found, err)
-		}
-		if _, exists := authz["oidc-groups-safe"]; exists {
-			t.Error("oidc-groups-safe should NOT be present when OIDC config is nil")
-		}
-	})
+func TestBuildGatewayAuthPolicySpec_OIDCAuth(t *testing.T) {
+	oidc := &oidcConfig{
+		IssuerURL: "https://keycloak.example.com/realms/test",
+		ClientID:  "maas-client",
+	}
+	obj := gatewayAuthPolicySpecTestObject(t, oidc)
 
-	t.Run("with OIDC", func(t *testing.T) {
-		oidc := &oidcConfig{
-			IssuerURL: "https://keycloak.example.com/realms/test",
-			ClientID:  "maas-client",
-		}
-		spec := r.buildGatewayAuthPolicySpec("{}", oidc, false, "", "models-as-a-service", "test-gateway-ns", "test-gateway")
-		obj := gwSpecToUnstructured(t, spec)
+	auth := nestedMapRequired(t, obj, "spec", "defaults", "rules", "authentication")
+	if _, exists := auth["oidc-identities"]; !exists {
+		t.Fatal("oidc-identities should be present when OIDC config is provided")
+	}
+	issuer := nestedStringRequired(t, obj, "spec", "defaults", "rules", "authentication", "oidc-identities", "jwt", "issuerUrl")
+	if issuer != oidc.IssuerURL {
+		t.Errorf("oidc issuerUrl = %v, want %v", issuer, oidc.IssuerURL)
+	}
+	rego := nestedStringRequired(t, obj, "spec", "defaults", "rules", "authorization", "oidc-groups-safe", "opa", "rego")
+	if !contains(rego, safeGroupNamePattern) || !contains(rego, "unsafe_group") {
+		t.Errorf("oidc-groups-safe rego should reject unsafe group names, got: %s", rego)
+	}
+	predicate := nestedWhenPredicateRequired(t, obj, "spec", "defaults", "rules", "authorization", "oidc-groups-safe", "when")
+	if !contains(predicate, "has(auth.identity.groups)") {
+		t.Errorf("oidc-groups-safe should only run for OIDC group identities, got: %s", predicate)
+	}
+}
 
-		auth, found, err := unstructured.NestedMap(obj.Object, "spec", "defaults", "rules", "authentication")
-		if err != nil || !found {
-			t.Fatalf("authentication block missing: found=%v err=%v", found, err)
-		}
-		if _, exists := auth["oidc-identities"]; !exists {
-			t.Fatal("oidc-identities should be present when OIDC config is provided")
-		}
-		issuer, found, err := unstructured.NestedString(obj.Object, "spec", "defaults", "rules", "authentication", "oidc-identities", "jwt", "issuerUrl")
-		if err != nil || !found {
-			t.Fatalf("oidc issuerUrl missing: found=%v err=%v", found, err)
-		}
-		if issuer != oidc.IssuerURL {
-			t.Errorf("oidc issuerUrl = %v, want %v", issuer, oidc.IssuerURL)
-		}
-		rego, found, err := unstructured.NestedString(obj.Object, "spec", "defaults", "rules", "authorization", "oidc-groups-safe", "opa", "rego")
-		if err != nil || !found {
-			t.Fatalf("oidc-groups-safe rego missing: found=%v err=%v", found, err)
-		}
-		if !contains(rego, safeGroupNamePattern) || !contains(rego, "unsafe_group") {
-			t.Errorf("oidc-groups-safe rego should reject unsafe group names, got: %s", rego)
-		}
-		when, found, err := unstructured.NestedSlice(obj.Object, "spec", "defaults", "rules", "authorization", "oidc-groups-safe", "when")
-		if err != nil || !found || len(when) == 0 {
-			t.Fatalf("oidc-groups-safe when condition missing: found=%v err=%v", found, err)
-		}
-		firstWhen, ok := when[0].(map[string]any)
-		if !ok {
-			t.Fatalf("oidc-groups-safe when[0] is not a map: %T", when[0])
-		}
-		predicate, _ := firstWhen["predicate"].(string)
-		if !contains(predicate, "has(auth.identity.groups)") {
-			t.Errorf("oidc-groups-safe should only run for OIDC group identities, got: %s", predicate)
-		}
-	})
+func TestBuildGatewayAuthPolicySpec_RouteScopedRules(t *testing.T) {
+	obj := gatewayAuthPolicySpecTestObject(t, nil)
 
 	t.Run("subscription-info has model-route scoped when condition", func(t *testing.T) {
-		spec := r.buildGatewayAuthPolicySpec("{}", nil, false, "", "models-as-a-service", "test-gateway-ns", "test-gateway")
-		obj := gwSpecToUnstructured(t, spec)
-
-		when, found, err := unstructured.NestedSlice(obj.Object, "spec", "defaults", "rules", "metadata", "subscription-info", "when")
-		if err != nil || !found || len(when) == 0 {
-			t.Fatalf("subscription-info when condition missing: found=%v err=%v", found, err)
-		}
-		firstWhen, ok := when[0].(map[string]any)
-		if !ok {
-			t.Fatalf("subscription-info when[0] is not a map: %T", when[0])
-		}
-		pred, ok := firstWhen["predicate"].(string)
-		if !ok {
-			t.Fatal("subscription-info when[0] has no predicate string")
-		}
+		pred := nestedWhenPredicateRequired(t, obj, "spec", "defaults", "rules", "metadata", "subscription-info", "when")
 		if !contains(pred, "x-gateway-model-name") || !contains(pred, "maas-api") || !contains(pred, "v1") {
 			t.Errorf("subscription-info when should scope to model routes and exclude management paths, got: %s", pred)
 		}
@@ -1327,21 +1325,7 @@ func TestBuildGatewayAuthPolicySpec_K8sAndOIDCAuth(t *testing.T) {
 	})
 
 	t.Run("subscription-valid has model-route scoped when condition", func(t *testing.T) {
-		spec := r.buildGatewayAuthPolicySpec("{}", nil, false, "", "models-as-a-service", "test-gateway-ns", "test-gateway")
-		obj := gwSpecToUnstructured(t, spec)
-
-		when, found, err := unstructured.NestedSlice(obj.Object, "spec", "defaults", "rules", "authorization", "subscription-valid", "when")
-		if err != nil || !found || len(when) == 0 {
-			t.Fatalf("subscription-valid when condition missing: found=%v err=%v", found, err)
-		}
-		firstWhen, ok := when[0].(map[string]any)
-		if !ok {
-			t.Fatalf("subscription-valid when[0] is not a map: %T", when[0])
-		}
-		pred, ok := firstWhen["predicate"].(string)
-		if !ok {
-			t.Fatal("subscription-valid when[0] has no predicate string")
-		}
+		pred := nestedWhenPredicateRequired(t, obj, "spec", "defaults", "rules", "authorization", "subscription-valid", "when")
 		if !contains(pred, "x-gateway-model-name") || !contains(pred, "maas-api") || !contains(pred, "v1") {
 			t.Errorf("subscription-valid when should scope to model routes and exclude management paths, got: %s", pred)
 		}
@@ -1351,13 +1335,7 @@ func TestBuildGatewayAuthPolicySpec_K8sAndOIDCAuth(t *testing.T) {
 	})
 
 	t.Run("require-group-membership recognizes tenant model paths", func(t *testing.T) {
-		spec := r.buildGatewayAuthPolicySpec("{}", nil, false, "", "models-as-a-service", "test-gateway-ns", "test-gateway")
-		obj := gwSpecToUnstructured(t, spec)
-
-		rego, found, err := unstructured.NestedString(obj.Object, "spec", "defaults", "rules", "authorization", "require-group-membership", "opa", "rego")
-		if err != nil || !found {
-			t.Fatalf("require-group-membership rego missing: found=%v err=%v", found, err)
-		}
+		rego := nestedStringRequired(t, obj, "spec", "defaults", "rules", "authorization", "require-group-membership", "opa", "rego")
 		if !contains(rego, `path_parts[0] != "maas-api"`) || !contains(rego, `path_parts[0] != "v1"`) {
 			t.Errorf("require-group-membership rego should treat tenant model paths as model routes and exclude management paths, got: %s", rego)
 		}
@@ -1367,13 +1345,7 @@ func TestBuildGatewayAuthPolicySpec_K8sAndOIDCAuth(t *testing.T) {
 	})
 
 	t.Run("auth-valid supports non-API-key tokens", func(t *testing.T) {
-		spec := r.buildGatewayAuthPolicySpec("{}", nil, false, "", "models-as-a-service", "test-gateway-ns", "test-gateway")
-		obj := gwSpecToUnstructured(t, spec)
-
-		rego, found, err := unstructured.NestedString(obj.Object, "spec", "defaults", "rules", "authorization", "auth-valid", "opa", "rego")
-		if err != nil || !found {
-			t.Fatalf("auth-valid rego missing: found=%v err=%v", found, err)
-		}
+		rego := nestedStringRequired(t, obj, "spec", "defaults", "rules", "authorization", "auth-valid", "opa", "rego")
 		if !contains(rego, "not input.auth.metadata.apiKeyValidation") {
 			t.Errorf("auth-valid rego should allow non-API-key tokens, got: %s", rego)
 		}

--- a/maas-controller/pkg/controller/maas/maasauthpolicy_controller_test.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_controller_test.go
@@ -1250,6 +1250,13 @@ func TestBuildGatewayAuthPolicySpec_K8sAndOIDCAuth(t *testing.T) {
 		if _, exists := auth["api-keys-x-api-key"]; exists {
 			t.Error("api-keys-x-api-key should NOT be present when xAPIKeyEnabled is false")
 		}
+		authz, found, err := unstructured.NestedMap(obj.Object, "spec", "defaults", "rules", "authorization")
+		if err != nil || !found {
+			t.Fatalf("authorization block missing: found=%v err=%v", found, err)
+		}
+		if _, exists := authz["oidc-groups-safe"]; exists {
+			t.Error("oidc-groups-safe should NOT be present when OIDC config is nil")
+		}
 	})
 
 	t.Run("with OIDC", func(t *testing.T) {
@@ -1273,6 +1280,25 @@ func TestBuildGatewayAuthPolicySpec_K8sAndOIDCAuth(t *testing.T) {
 		}
 		if issuer != oidc.IssuerURL {
 			t.Errorf("oidc issuerUrl = %v, want %v", issuer, oidc.IssuerURL)
+		}
+		rego, found, err := unstructured.NestedString(obj.Object, "spec", "defaults", "rules", "authorization", "oidc-groups-safe", "opa", "rego")
+		if err != nil || !found {
+			t.Fatalf("oidc-groups-safe rego missing: found=%v err=%v", found, err)
+		}
+		if !contains(rego, safeGroupNamePattern) || !contains(rego, "unsafe_group") {
+			t.Errorf("oidc-groups-safe rego should reject unsafe group names, got: %s", rego)
+		}
+		when, found, err := unstructured.NestedSlice(obj.Object, "spec", "defaults", "rules", "authorization", "oidc-groups-safe", "when")
+		if err != nil || !found || len(when) == 0 {
+			t.Fatalf("oidc-groups-safe when condition missing: found=%v err=%v", found, err)
+		}
+		firstWhen, ok := when[0].(map[string]any)
+		if !ok {
+			t.Fatalf("oidc-groups-safe when[0] is not a map: %T", when[0])
+		}
+		predicate, _ := firstWhen["predicate"].(string)
+		if !contains(predicate, "has(auth.identity.groups)") {
+			t.Errorf("oidc-groups-safe should only run for OIDC group identities, got: %s", predicate)
 		}
 	})
 

--- a/maas-controller/pkg/controller/maas/maasauthpolicy_oidc_test.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_oidc_test.go
@@ -22,13 +22,23 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	maasv1alpha1 "github.com/opendatahub-io/models-as-a-service/maas-controller/api/maas/v1alpha1"
+	"github.com/opendatahub-io/models-as-a-service/maas-controller/pkg/platform/tenantreconcile"
 )
 
-func TestFetchOIDCConfig_NoTenant(t *testing.T) {
+func maasAuthPolicyOIDCTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
 	scheme := runtime.NewScheme()
+	assert.NoError(t, maasv1alpha1.AddToScheme(scheme))
+	return scheme
+}
+
+func TestFetchOIDCConfig_NoTenant(t *testing.T) {
+	scheme := maasAuthPolicyOIDCTestScheme(t)
 	client := fake.NewClientBuilder().WithScheme(scheme).Build()
 
 	reconciler := &MaaSAuthPolicyReconciler{
@@ -42,20 +52,13 @@ func TestFetchOIDCConfig_NoTenant(t *testing.T) {
 }
 
 func TestFetchOIDCConfig_NoExternalOIDC(t *testing.T) {
-	scheme := runtime.NewScheme()
+	scheme := maasAuthPolicyOIDCTestScheme(t)
 
 	// Create Tenant without externalOIDC
-	tenant := &unstructured.Unstructured{
-		Object: map[string]any{
-			"apiVersion": "maas.opendatahub.io/v1alpha1",
-			"kind":       "Tenant",
-			"metadata": map[string]any{
-				"name":      "default-tenant",
-				"namespace": "models-as-a-service",
-			},
-			"spec": map[string]any{
-				"otherField": "value",
-			},
+	tenant := &maasv1alpha1.Tenant{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      maasv1alpha1.TenantInstanceName,
+			Namespace: "models-as-a-service",
 		},
 	}
 
@@ -75,22 +78,18 @@ func TestFetchOIDCConfig_NoExternalOIDC(t *testing.T) {
 }
 
 func TestFetchOIDCConfig_WithExternalOIDC(t *testing.T) {
-	scheme := runtime.NewScheme()
+	scheme := maasAuthPolicyOIDCTestScheme(t)
 
 	// Create Tenant with externalOIDC
-	tenant := &unstructured.Unstructured{
-		Object: map[string]any{
-			"apiVersion": "maas.opendatahub.io/v1alpha1",
-			"kind":       "Tenant",
-			"metadata": map[string]any{
-				"name":      "default-tenant",
-				"namespace": "models-as-a-service",
-			},
-			"spec": map[string]any{
-				"externalOIDC": map[string]any{
-					"issuerUrl": "https://keycloak.example.com/realms/test",
-					"clientId":  "test-client",
-				},
+	tenant := &maasv1alpha1.Tenant{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      maasv1alpha1.TenantInstanceName,
+			Namespace: "models-as-a-service",
+		},
+		Spec: maasv1alpha1.TenantSpec{
+			ExternalOIDC: &maasv1alpha1.TenantExternalOIDCConfig{
+				IssuerURL: "https://keycloak.example.com/realms/test",
+				ClientID:  "test-client",
 			},
 		},
 	}
@@ -112,23 +111,79 @@ func TestFetchOIDCConfig_WithExternalOIDC(t *testing.T) {
 	assert.Equal(t, "test-client", config.ClientID)
 }
 
+func TestFetchOIDCConfig_WithAITenantOIDC(t *testing.T) {
+	scheme := maasAuthPolicyOIDCTestScheme(t)
+
+	tenant := &maasv1alpha1.Tenant{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      maasv1alpha1.TenantInstanceName,
+			Namespace: "ai-tenant-team-a",
+			Labels: map[string]string{
+				tenantreconcile.LabelManagedByAITenant: "true",
+				tenantreconcile.LabelTenantName:        "team-a",
+				tenantreconcile.LabelTenantNamespace:   "ai-tenant-team-a",
+			},
+			Annotations: map[string]string{
+				tenantreconcile.AnnotationAITenantName:      "team-a",
+				tenantreconcile.AnnotationAITenantNamespace: tenantreconcile.DefaultAITenantNamespace,
+			},
+		},
+		Spec: maasv1alpha1.TenantSpec{
+			ExternalOIDC: &maasv1alpha1.TenantExternalOIDCConfig{
+				IssuerURL: "https://stale.example.com",
+				ClientID:  "stale-client",
+			},
+		},
+	}
+	aitenant := &maasv1alpha1.AITenant{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "team-a",
+			Namespace: tenantreconcile.DefaultAITenantNamespace,
+		},
+		Spec: maasv1alpha1.AITenantSpec{
+			OIDC: &maasv1alpha1.TenantExternalOIDCConfig{
+				IssuerURL: "https://keycloak.example.com/realms/team-a",
+				ClientID:  "team-a-client",
+			},
+		},
+		Status: maasv1alpha1.AITenantStatus{
+			GatewayRef: maasv1alpha1.TenantGatewayRef{
+				Namespace: "openshift-ingress",
+				Name:      "team-a-gateway",
+			},
+		},
+	}
+
+	client := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(tenant, aitenant).
+		Build()
+
+	reconciler := &MaaSAuthPolicyReconciler{
+		Client:          client,
+		Scheme:          scheme,
+		TenantNamespace: "models-as-a-service",
+	}
+
+	config := reconciler.fetchOIDCConfig(context.Background(), logr.Discard(), "ai-tenant-team-a")
+	assert.NotNil(t, config, "should return config from AITenant")
+	assert.Equal(t, "https://keycloak.example.com/realms/team-a", config.IssuerURL)
+	assert.Equal(t, "team-a-client", config.ClientID)
+}
+
 func TestFetchOIDCConfig_EmptyIssuerURL(t *testing.T) {
-	scheme := runtime.NewScheme()
+	scheme := maasAuthPolicyOIDCTestScheme(t)
 
 	// Create Tenant with empty issuerUrl
-	tenant := &unstructured.Unstructured{
-		Object: map[string]any{
-			"apiVersion": "maas.opendatahub.io/v1alpha1",
-			"kind":       "Tenant",
-			"metadata": map[string]any{
-				"name":      "default-tenant",
-				"namespace": "models-as-a-service",
-			},
-			"spec": map[string]any{
-				"externalOIDC": map[string]any{
-					"issuerUrl": "",
-					"clientId":  "test-client",
-				},
+	tenant := &maasv1alpha1.Tenant{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      maasv1alpha1.TenantInstanceName,
+			Namespace: "models-as-a-service",
+		},
+		Spec: maasv1alpha1.TenantSpec{
+			ExternalOIDC: &maasv1alpha1.TenantExternalOIDCConfig{
+				IssuerURL: "",
+				ClientID:  "test-client",
 			},
 		},
 	}
@@ -149,22 +204,18 @@ func TestFetchOIDCConfig_EmptyIssuerURL(t *testing.T) {
 }
 
 func TestFetchOIDCConfig_EmptyClientID(t *testing.T) {
-	scheme := runtime.NewScheme()
+	scheme := maasAuthPolicyOIDCTestScheme(t)
 
 	// Create Tenant with empty clientId
-	tenant := &unstructured.Unstructured{
-		Object: map[string]any{
-			"apiVersion": "maas.opendatahub.io/v1alpha1",
-			"kind":       "Tenant",
-			"metadata": map[string]any{
-				"name":      "default-tenant",
-				"namespace": "models-as-a-service",
-			},
-			"spec": map[string]any{
-				"externalOIDC": map[string]any{
-					"issuerUrl": "https://keycloak.example.com/realms/test",
-					"clientId":  "",
-				},
+	tenant := &maasv1alpha1.Tenant{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      maasv1alpha1.TenantInstanceName,
+			Namespace: "models-as-a-service",
+		},
+		Spec: maasv1alpha1.TenantSpec{
+			ExternalOIDC: &maasv1alpha1.TenantExternalOIDCConfig{
+				IssuerURL: "https://keycloak.example.com/realms/test",
+				ClientID:  "",
 			},
 		},
 	}

--- a/maas-controller/pkg/controller/maas/maasauthpolicy_oidc_test.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_oidc_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -33,6 +34,7 @@ import (
 func maasAuthPolicyOIDCTestScheme(t *testing.T) *runtime.Scheme {
 	t.Helper()
 	scheme := runtime.NewScheme()
+	assert.NoError(t, corev1.AddToScheme(scheme))
 	assert.NoError(t, maasv1alpha1.AddToScheme(scheme))
 	return scheme
 }
@@ -49,6 +51,32 @@ func TestFetchOIDCConfig_NoTenant(t *testing.T) {
 
 	config := reconciler.fetchOIDCConfig(context.Background(), logr.Discard(), "models-as-a-service")
 	assert.Nil(t, config, "should return nil when Tenant doesn't exist")
+}
+
+func TestFetchTenantPlatformContext_DiscoveredTenantMissingBridgeFailsClosed(t *testing.T) {
+	scheme := maasAuthPolicyOIDCTestScheme(t)
+	namespace := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "ai-tenant-team-a",
+			Labels: map[string]string{tenantreconcile.LabelManagedByAITenant: "true"},
+		},
+	}
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(namespace).Build()
+
+	reconciler := &MaaSAuthPolicyReconciler{
+		Client:                          client,
+		Scheme:                          scheme,
+		TenantNamespace:                 "models-as-a-service",
+		TenantNamespaceDiscoveryEnabled: true,
+		GatewayName:                     "maas-default-gateway",
+		GatewayNamespace:                "openshift-ingress",
+	}
+
+	platformContext, err := reconciler.fetchTenantPlatformContext(context.Background(), logr.Discard(), "ai-tenant-team-a")
+
+	assert.Nil(t, platformContext)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "refusing to use default platform context")
 }
 
 func TestFetchOIDCConfig_NoExternalOIDC(t *testing.T) {

--- a/maas-controller/pkg/controller/maas/maasauthpolicy_oidc_test.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_oidc_test.go
@@ -283,6 +283,12 @@ func TestCELExpressions_SupportOIDC(t *testing.T) {
 		"celGroups should check for OIDC groups claim")
 	assert.Contains(t, celGroups, "auth.identity.user.groups",
 		"celGroups should fall back to K8s user.groups")
+	assert.Contains(t, celTokenGroupsHeaderJSON, "size(auth.identity.groups) > 0",
+		"X-MaaS-Group expression should handle empty OIDC groups claim")
+	assert.Contains(t, celTokenGroupsHeaderJSON, `'["system:authenticated"]'`,
+		"X-MaaS-Group expression should preserve default subscription access for OIDC tokens with no groups")
+	assert.Contains(t, celTokenGroupsHeaderJSON, "size(auth.identity.user.groups) > 0",
+		"X-MaaS-Group expression should avoid empty JSON group values for K8s tokens")
 }
 
 func TestCELExpressions_UserIDVsUsername(t *testing.T) {

--- a/maas-controller/pkg/controller/maas/maasauthpolicy_oidc_test.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_oidc_test.go
@@ -289,6 +289,12 @@ func TestCELExpressions_SupportOIDC(t *testing.T) {
 		"X-MaaS-Group expression should preserve default subscription access for OIDC tokens with no groups")
 	assert.Contains(t, celTokenGroupsHeaderJSON, "size(auth.identity.user.groups) > 0",
 		"X-MaaS-Group expression should avoid empty JSON group values for K8s tokens")
+	assert.Contains(t, celTokenGroupsHeaderJSON, `'["system:authenticated","' + auth.identity.user.groups.join('","') + '"]'`,
+		"X-MaaS-Group expression should preserve default subscription access for K8s user.groups tokens")
+	assert.Contains(t, celTokenGroupsHeaderJSON, "auth.identity.groups.all",
+		"X-MaaS-Group expression should validate OIDC groups before JSON string construction")
+	assert.Contains(t, celTokenGroupsHeaderJSON, safeGroupNamePattern,
+		"X-MaaS-Group expression should use the safe group-name pattern")
 }
 
 func TestCELExpressions_UserIDVsUsername(t *testing.T) {

--- a/maas-controller/pkg/controller/maas/maassubscription_controller.go
+++ b/maas-controller/pkg/controller/maas/maassubscription_controller.go
@@ -48,6 +48,7 @@ import (
 	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	maasv1alpha1 "github.com/opendatahub-io/models-as-a-service/maas-controller/api/maas/v1alpha1"
+	"github.com/opendatahub-io/models-as-a-service/maas-controller/pkg/platform/tenantreconcile"
 )
 
 // MaaSSubscriptionReconciler reconciles a MaaSSubscription object
@@ -71,6 +72,7 @@ type MaaSSubscriptionReconciler struct {
 //+kubebuilder:rbac:groups=maas.opendatahub.io,resources=maassubscriptions/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=maas.opendatahub.io,resources=maassubscriptions/finalizers,verbs=update
 //+kubebuilder:rbac:groups=maas.opendatahub.io,resources=maasmodelrefs,verbs=get;list;watch
+//+kubebuilder:rbac:groups=maas.opendatahub.io,resources=aitenants,verbs=get;list;watch
 //+kubebuilder:rbac:groups=kuadrant.io,resources=tokenratelimitpolicies,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=httproutes,verbs=get;list;watch
 //+kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=httproutes/finalizers,verbs=update
@@ -1092,6 +1094,11 @@ func (r *MaaSSubscriptionReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		// Watch generated TokenRateLimitPolicies so manual edits get overwritten by the controller.
 		Watches(generatedTRLP, handler.EnqueueRequestsFromMapFunc(
 			r.mapGeneratedTRLPToParent,
+		)).
+		// Watch AITenants so gateway/OIDC platform-context changes refresh subscription
+		// gateway validation for the affected tenant namespace.
+		Watches(&maasv1alpha1.AITenant{}, handler.EnqueueRequestsFromMapFunc(
+			r.mapAITenantToMaaSSubscriptions,
 		))
 
 	if r.TenantNamespaceDiscoveryEnabled {
@@ -1103,6 +1110,28 @@ func (r *MaaSSubscriptionReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 
 	return b.Complete(r)
+}
+
+func (r *MaaSSubscriptionReconciler) mapAITenantToMaaSSubscriptions(ctx context.Context, obj client.Object) []reconcile.Request {
+	aitenant, ok := obj.(*maasv1alpha1.AITenant)
+	if !ok {
+		return nil
+	}
+	tenantNamespace := tenantreconcile.TenantNamespaceForAITenant(aitenant.Name, r.DefaultTenantNamespace)
+	subList := &maasv1alpha1.MaaSSubscriptionList{}
+	if err := r.List(ctx, subList, client.InNamespace(tenantNamespace)); err != nil {
+		ctrl.LoggerFrom(ctx).Error(err, "failed to list MaaSSubscription resources for AITenant change",
+			"tenantNamespace", tenantNamespace,
+			"aitenant", obj.GetNamespace()+"/"+obj.GetName())
+		return nil
+	}
+	subList.Items = filterSubscriptionsByTenantNamespace(ctx, r.Client, subList.Items, r.DefaultTenantNamespace, r.TenantNamespaceDiscoveryEnabled)
+
+	requests := make([]reconcile.Request, len(subList.Items))
+	for i, sub := range subList.Items {
+		requests[i] = reconcile.Request{NamespacedName: types.NamespacedName{Name: sub.Name, Namespace: sub.Namespace}}
+	}
+	return requests
 }
 
 // duplicatePriorityScanHandler runs a full duplicate-priority scan without enqueuing reconciles.

--- a/maas-controller/pkg/controller/maas/multitenancy_test.go
+++ b/maas-controller/pkg/controller/maas/multitenancy_test.go
@@ -672,6 +672,15 @@ func TestTenantGatewayRefForNamespace(t *testing.T) {
 			Name: "partial-gateway",
 		}},
 	}
+	discoveredNamespaceWithoutTenant := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "ai-tenant-missing",
+			Labels: map[string]string{tenantreconcile.LabelManagedByAITenant: "true"},
+		},
+	}
+	modelNamespace := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: "llm"},
+	}
 
 	tests := []struct {
 		name             string
@@ -729,9 +738,20 @@ func TestTenantGatewayRefForNamespace(t *testing.T) {
 		},
 		{
 			name:             "missing discovered tenant is an error",
-			tenantNamespace:  tenantNamespace,
+			tenantNamespace:  discoveredNamespaceWithoutTenant.Name,
 			discoveryEnabled: true,
+			objects:          []client.Object{discoveredNamespaceWithoutTenant},
 			wantErr:          true,
+		},
+		{
+			name:             "unlabeled model namespace without tenant falls back to flags",
+			tenantNamespace:  modelNamespace.Name,
+			discoveryEnabled: true,
+			objects:          []client.Object{modelNamespace},
+			want: maasv1alpha1.TenantGatewayRef{
+				Name:      fallbackName,
+				Namespace: fallbackNS,
+			},
 		},
 		{
 			name:             "discovery disabled uses legacy fallback",

--- a/maas-controller/pkg/controller/maas/multitenancy_test.go
+++ b/maas-controller/pkg/controller/maas/multitenancy_test.go
@@ -545,6 +545,57 @@ func TestMapNamespaceToMaaSSubscriptions_EnqueuesWhenDiscoveryEnabled(t *testing
 	}
 }
 
+func TestMapAITenantToMaaSSubscriptions(t *testing.T) {
+	tenantNS := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "ai-tenant-team-a",
+			Labels: map[string]string{tenantreconcile.LabelManagedByAITenant: "true"},
+		},
+	}
+	tenantSub := &maasv1alpha1.MaaSSubscription{
+		ObjectMeta: metav1.ObjectMeta{Name: "sub-a", Namespace: tenantNS.Name},
+		Spec: maasv1alpha1.MaaSSubscriptionSpec{
+			ModelRefs: []maasv1alpha1.ModelSubscriptionRef{{Name: "llm", Namespace: "models"}},
+		},
+	}
+	defaultSub := &maasv1alpha1.MaaSSubscription{
+		ObjectMeta: metav1.ObjectMeta{Name: "sub-default", Namespace: "models-as-a-service"},
+		Spec: maasv1alpha1.MaaSSubscriptionSpec{
+			ModelRefs: []maasv1alpha1.ModelSubscriptionRef{{Name: "llm", Namespace: "models"}},
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(tenantNS, tenantSub, defaultSub).Build()
+	r := &MaaSSubscriptionReconciler{
+		Client:                          c,
+		Scheme:                          scheme,
+		DefaultTenantNamespace:          "models-as-a-service",
+		TenantNamespaceDiscoveryEnabled: true,
+	}
+
+	requests := r.mapAITenantToMaaSSubscriptions(context.Background(), &maasv1alpha1.AITenant{
+		ObjectMeta: metav1.ObjectMeta{Name: "team-a", Namespace: tenantreconcile.DefaultAITenantNamespace},
+	})
+	if len(requests) != 1 || requests[0].Name != "sub-a" || requests[0].Namespace != tenantNS.Name {
+		t.Fatalf("team AITenant should enqueue tenant subscription, got %#v", requests)
+	}
+
+	requests = r.mapAITenantToMaaSSubscriptions(context.Background(), &maasv1alpha1.AITenant{
+		ObjectMeta: metav1.ObjectMeta{Name: tenantreconcile.DefaultAITenantName, Namespace: tenantreconcile.DefaultAITenantNamespace},
+	})
+	if len(requests) != 1 || requests[0].Name != "sub-default" || requests[0].Namespace != "models-as-a-service" {
+		t.Fatalf("default AITenant should enqueue default subscription, got %#v", requests)
+	}
+
+	r.TenantNamespaceDiscoveryEnabled = false
+	requests = r.mapAITenantToMaaSSubscriptions(context.Background(), &maasv1alpha1.AITenant{
+		ObjectMeta: metav1.ObjectMeta{Name: "team-a", Namespace: tenantreconcile.DefaultAITenantNamespace},
+	})
+	if len(requests) != 0 {
+		t.Fatalf("discovered AITenant should not enqueue subscriptions when discovery is disabled, got %#v", requests)
+	}
+}
+
 func TestFetchTenantForNamespace(t *testing.T) {
 	tenant := &maasv1alpha1.Tenant{
 		ObjectMeta: metav1.ObjectMeta{
@@ -593,6 +644,28 @@ func TestTenantGatewayRefForNamespace(t *testing.T) {
 	defaultTenantWithoutRef := &maasv1alpha1.Tenant{
 		ObjectMeta: metav1.ObjectMeta{Name: maasv1alpha1.TenantInstanceName, Namespace: defaultNamespace},
 	}
+	managedTenant := &maasv1alpha1.Tenant{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      maasv1alpha1.TenantInstanceName,
+			Namespace: "ai-tenant-team-managed",
+			Labels: map[string]string{
+				tenantreconcile.LabelManagedByAITenant: "true",
+				tenantreconcile.LabelTenantName:        "team-managed",
+				tenantreconcile.LabelTenantNamespace:   "ai-tenant-team-managed",
+			},
+			Annotations: map[string]string{
+				tenantreconcile.AnnotationAITenantName:      "team-managed",
+				tenantreconcile.AnnotationAITenantNamespace: tenantreconcile.DefaultAITenantNamespace,
+			},
+		},
+	}
+	managedAITenant := &maasv1alpha1.AITenant{
+		ObjectMeta: metav1.ObjectMeta{Name: "team-managed", Namespace: tenantreconcile.DefaultAITenantNamespace},
+		Status: maasv1alpha1.AITenantStatus{GatewayRef: maasv1alpha1.TenantGatewayRef{
+			Name:      "team-managed-gateway",
+			Namespace: "team-managed-gateway-ns",
+		}},
+	}
 	partialTenant := &maasv1alpha1.Tenant{
 		ObjectMeta: metav1.ObjectMeta{Name: maasv1alpha1.TenantInstanceName, Namespace: "partial-ns"},
 		Spec: maasv1alpha1.TenantSpec{GatewayRef: maasv1alpha1.TenantGatewayRef{
@@ -616,6 +689,16 @@ func TestTenantGatewayRefForNamespace(t *testing.T) {
 			want: maasv1alpha1.TenantGatewayRef{
 				Name:      "team-a-gateway",
 				Namespace: "team-a-gateway-ns",
+			},
+		},
+		{
+			name:             "AITenant-managed tenant resolves gateway from AITenant status",
+			tenantNamespace:  "ai-tenant-team-managed",
+			discoveryEnabled: true,
+			objects:          []client.Object{managedTenant, managedAITenant},
+			want: maasv1alpha1.TenantGatewayRef{
+				Name:      "team-managed-gateway",
+				Namespace: "team-managed-gateway-ns",
 			},
 		},
 		{

--- a/maas-controller/pkg/controller/maas/providers_llmisvc.go
+++ b/maas-controller/pkg/controller/maas/providers_llmisvc.go
@@ -60,18 +60,24 @@ func (h *llmisvcHandler) validateLLMISvcHTTPRoute(ctx context.Context, log logr.
 	route := &routeList.Items[0]
 	routeName := route.Name
 
-	// Get expected gateway from tenant's configuration
 	expectedGatewayName := h.r.gatewayName()
 	expectedGatewayNamespace := h.r.gatewayNamespace()
-
-	// For multi-tenant deployments, fetch the tenant's gateway
-	tenant, err := fetchTenantForNamespace(ctx, h.r.Client, model.Namespace)
-	if err == nil && tenant.Spec.GatewayRef.Name != "" {
-		expectedGatewayName = tenant.Spec.GatewayRef.Name
-		expectedGatewayNamespace = tenant.Spec.GatewayRef.Namespace
-		log.V(4).Info("Using tenant-specific gateway", "gateway", fmt.Sprintf("%s/%s", expectedGatewayNamespace, expectedGatewayName), "tenant", tenant.Name)
-	} else if err != nil {
-		log.V(4).Info("No tenant found for namespace, using default gateway", "namespace", model.Namespace, "error", err)
+	gatewayRef, err := tenantGatewayRefForNamespace(
+		ctx,
+		h.r.Client,
+		model.Namespace,
+		h.r.DefaultTenantNamespace,
+		h.r.gatewayName(),
+		h.r.gatewayNamespace(),
+		h.r.TenantNamespaceDiscoveryEnabled,
+	)
+	if err != nil {
+		return fmt.Errorf("resolve tenant gateway for namespace %s: %w", model.Namespace, err)
+	}
+	if gatewayRef.Name != "" {
+		expectedGatewayName = gatewayRef.Name
+		expectedGatewayNamespace = gatewayRef.Namespace
+		log.V(4).Info("Using tenant gateway", "gateway", fmt.Sprintf("%s/%s", expectedGatewayNamespace, expectedGatewayName), "tenantNamespace", model.Namespace)
 	}
 
 	gatewayFound := false

--- a/maas-controller/pkg/controller/maas/tenant_controller.go
+++ b/maas-controller/pkg/controller/maas/tenant_controller.go
@@ -140,6 +140,17 @@ func (r *TenantReconciler) enqueueDefaultTenant(_ context.Context, _ client.Obje
 	}}}
 }
 
+func (r *TenantReconciler) enqueueTenantForAITenant(_ context.Context, obj client.Object) []reconcile.Request {
+	aitenant, ok := obj.(*maasv1alpha1.AITenant)
+	if !ok {
+		return nil
+	}
+	return []reconcile.Request{{NamespacedName: types.NamespacedName{
+		Name:      maasv1alpha1.TenantInstanceName,
+		Namespace: tenantreconcile.TenantNamespaceForAITenant(aitenant.Name, r.TenantNamespace),
+	}}}
+}
+
 // crdLabeledForMaaSComponent matches CRDs labeled app.opendatahub.io/modelsasservice=true.
 func crdLabeledForMaaSComponent() predicate.Predicate {
 	key := tenantreconcile.LabelODHAppPrefix + "/" + tenantreconcile.ComponentName
@@ -210,6 +221,10 @@ func (r *TenantReconciler) SetupWithManager(mgr ctrl.Manager) error {
 				}}}
 			}),
 			builder.WithPredicates(configResourceDefault()),
+		).
+		Watches(
+			&maasv1alpha1.AITenant{},
+			handler.EnqueueRequestsFromMapFunc(r.enqueueTenantForAITenant),
 		).
 		Watches(
 			&extv1.CustomResourceDefinition{},

--- a/maas-controller/pkg/controller/maas/tenant_reconcile.go
+++ b/maas-controller/pkg/controller/maas/tenant_reconcile.go
@@ -147,6 +147,9 @@ func (r *TenantReconciler) reconcile(ctx context.Context, req ctrl.Request) (ctr
 	if result != nil {
 		return *result, err
 	}
+	if err != nil {
+		return ctrl.Result{}, err
+	}
 
 	// Check dependencies and prerequisites
 	if result, err := r.checkDependenciesAndPrerequisites(ctx, &tenant); result != nil {
@@ -154,8 +157,12 @@ func (r *TenantReconciler) reconcile(ctx context.Context, req ctrl.Request) (ctr
 	}
 
 	// Run platform reconciliation
-	if result, err := r.reconcilePlatform(ctx, log, &tenant, platformContext, mcfg); result != nil {
+	result, err = r.reconcilePlatform(ctx, log, &tenant, platformContext, mcfg)
+	if result != nil {
 		return *result, err
+	}
+	if err != nil {
+		return ctrl.Result{}, err
 	}
 
 	// Cleanup legacy resources

--- a/maas-controller/pkg/controller/maas/tenant_reconcile.go
+++ b/maas-controller/pkg/controller/maas/tenant_reconcile.go
@@ -143,7 +143,7 @@ func (r *TenantReconciler) reconcile(ctx context.Context, req ctrl.Request) (ctr
 	}
 
 	// Validate config and gateway
-	mcfg, result, err := r.validateConfigAndGateway(ctx, log, &tenant, req)
+	mcfg, platformContext, result, err := r.validateConfigAndGateway(ctx, log, &tenant, req)
 	if result != nil {
 		return *result, err
 	}
@@ -154,7 +154,7 @@ func (r *TenantReconciler) reconcile(ctx context.Context, req ctrl.Request) (ctr
 	}
 
 	// Run platform reconciliation
-	if result, err := r.reconcilePlatform(ctx, log, &tenant, mcfg); result != nil {
+	if result, err := r.reconcilePlatform(ctx, log, &tenant, platformContext, mcfg); result != nil {
 		return *result, err
 	}
 
@@ -204,61 +204,73 @@ func (r *TenantReconciler) handleManagementState(ctx context.Context, log logr.L
 	return nil, nil
 }
 
-func (r *TenantReconciler) validateConfigAndGateway(ctx context.Context, log logr.Logger, tenant *maasv1alpha1.Tenant, req ctrl.Request) (*maasv1alpha1.Config, *ctrl.Result, error) {
+func (r *TenantReconciler) validateConfigAndGateway(ctx context.Context, log logr.Logger, tenant *maasv1alpha1.Tenant, req ctrl.Request) (*maasv1alpha1.Config, tenantreconcile.PlatformContext, *ctrl.Result, error) {
 	mcfg, wait, err := r.readyConfigOrWait(ctx, log, tenant)
 	if err != nil {
-		return nil, nil, err
+		return nil, tenantreconcile.PlatformContext{}, nil, err
 	}
 	if wait != nil {
-		return nil, wait, nil
+		return nil, tenantreconcile.PlatformContext{}, wait, nil
 	}
 
 	if managementState(tenant.Annotations) == managementStateRemoved {
 		log.V(1).Info("Tenant in Removed management state with live Config; waiting for anchor teardown")
 		if err := r.patchStatus(ctx, tenant, "Pending", metav1.ConditionFalse, "WaitingForRemovedTeardown",
 			"management state is Removed; platform reconcile is suspended until the Config anchor is deleted by component GC"); err != nil {
-			return nil, nil, err
+			return nil, tenantreconcile.PlatformContext{}, nil, err
 		}
 		res := ctrl.Result{RequeueAfter: 10 * time.Second}
-		return nil, &res, nil
+		return nil, tenantreconcile.PlatformContext{}, &res, nil
 	}
 
-	orig := tenant.DeepCopy()
-	if err := r.applyGatewayDefaults(tenant); err != nil {
+	fallbackGatewayRef := fallbackTenantGatewayRef(r.GatewayName, r.GatewayNamespace)
+	platformContext, err := tenantreconcile.ResolvePlatformContext(ctx, r.Client, tenant, fallbackGatewayRef)
+	if err != nil {
 		if err2 := r.patchStatus(ctx, tenant, "Failed", metav1.ConditionFalse, "InvalidGateway", err.Error()); err2 != nil {
-			return nil, nil, err2
+			return nil, tenantreconcile.PlatformContext{}, nil, err2
 		}
 		res := ctrl.Result{RequeueAfter: 30 * time.Second}
-		return nil, &res, nil
+		return nil, tenantreconcile.PlatformContext{}, &res, nil
 	}
-	if orig.Spec.GatewayRef != tenant.Spec.GatewayRef {
-		if err := r.Patch(ctx, tenant, client.MergeFrom(orig)); err != nil {
-			return nil, nil, err
+
+	if !tenantreconcile.TenantUsesAITenantPlatformContext(tenant) {
+		orig := tenant.DeepCopy()
+		if err := r.applyGatewayDefaults(tenant); err != nil {
+			if err2 := r.patchStatus(ctx, tenant, "Failed", metav1.ConditionFalse, "InvalidGateway", err.Error()); err2 != nil {
+				return nil, tenantreconcile.PlatformContext{}, nil, err2
+			}
+			res := ctrl.Result{RequeueAfter: 30 * time.Second}
+			return nil, tenantreconcile.PlatformContext{}, &res, nil
 		}
-		if err := r.Get(ctx, req.NamespacedName, tenant); err != nil {
-			return nil, nil, err
+		if orig.Spec.GatewayRef != tenant.Spec.GatewayRef {
+			if err := r.Patch(ctx, tenant, client.MergeFrom(orig)); err != nil {
+				return nil, tenantreconcile.PlatformContext{}, nil, err
+			}
+			if err := r.Get(ctx, req.NamespacedName, tenant); err != nil {
+				return nil, tenantreconcile.PlatformContext{}, nil, err
+			}
 		}
 	}
 
-	if err := validateGatewayExists(ctx, r.Client, tenant.Spec.GatewayRef.Namespace, tenant.Spec.GatewayRef.Name); err != nil {
+	if err := validateGatewayExists(ctx, r.Client, platformContext.GatewayRef.Namespace, platformContext.GatewayRef.Name); err != nil {
 		log.Info("gateway validation failed", "error", err)
 		if err2 := r.patchStatus(ctx, tenant, "Pending", metav1.ConditionFalse, "GatewayNotReady", err.Error()); err2 != nil {
-			return nil, nil, err2
+			return nil, tenantreconcile.PlatformContext{}, nil, err2
 		}
 		res := ctrl.Result{RequeueAfter: 30 * time.Second}
-		return nil, &res, nil
+		return nil, tenantreconcile.PlatformContext{}, &res, nil
 	}
 
 	if r.ManifestPath == "" {
 		if err := r.patchStatus(ctx, tenant, "Failed", metav1.ConditionFalse, "ManifestPathUnset",
 			"MAAS_PLATFORM_MANIFESTS is not set and no default kustomize path resolved; cannot apply platform manifests"); err != nil {
-			return nil, nil, err
+			return nil, tenantreconcile.PlatformContext{}, nil, err
 		}
 		res := ctrl.Result{RequeueAfter: 2 * time.Minute}
-		return nil, &res, nil
+		return nil, tenantreconcile.PlatformContext{}, &res, nil
 	}
 
-	return mcfg, nil, nil
+	return mcfg, platformContext, nil, nil
 }
 
 func (r *TenantReconciler) checkDependenciesAndPrerequisites(ctx context.Context, tenant *maasv1alpha1.Tenant) (*ctrl.Result, error) {
@@ -299,9 +311,9 @@ func (r *TenantReconciler) checkDependenciesAndPrerequisites(ctx context.Context
 	return nil, nil
 }
 
-func (r *TenantReconciler) reconcilePlatform(ctx context.Context, log logr.Logger, tenant *maasv1alpha1.Tenant, mcfg *maasv1alpha1.Config) (*ctrl.Result, error) {
+func (r *TenantReconciler) reconcilePlatform(ctx context.Context, log logr.Logger, tenant *maasv1alpha1.Tenant, platformContext tenantreconcile.PlatformContext, mcfg *maasv1alpha1.Config) (*ctrl.Result, error) {
 	appNs := r.appNamespaceForTenant()
-	runRes, err := tenantreconcile.RunPlatform(ctx, log, r.Client, r.Scheme, tenant, r.ManifestPath, appNs, r.ClusterAudience, mcfg)
+	runRes, err := tenantreconcile.RunPlatform(ctx, log, r.Client, r.Scheme, tenant, platformContext, r.ManifestPath, appNs, r.ClusterAudience, mcfg)
 	if err != nil {
 		log.Error(err, "Tenant platform reconcile failed")
 		setDeploymentsAvailableCondition(tenant, false, "PlatformReconcileFailed", err.Error())

--- a/maas-controller/pkg/platform/tenantreconcile/naming_test.go
+++ b/maas-controller/pkg/platform/tenantreconcile/naming_test.go
@@ -235,7 +235,11 @@ func TestBuildPlatformParamsIncludesTenantIdentifier(t *testing.T) {
 			},
 		}
 
-		params, err := BuildPlatformParams(tenant, "opendatahub", "https://kubernetes.default.svc", logr.Discard())
+		platformContext := PlatformContext{GatewayRef: maasv1alpha1.TenantGatewayRef{
+			Namespace: "openshift-ingress",
+			Name:      "maas-default-gateway",
+		}}
+		params, err := BuildPlatformParams(tenant, platformContext, "opendatahub", "https://kubernetes.default.svc", logr.Discard())
 		assert.NoError(t, err)
 
 		assert.Equal(t, "", params.TenantIdentifier)
@@ -260,7 +264,11 @@ func TestBuildPlatformParamsIncludesTenantIdentifier(t *testing.T) {
 			},
 		}
 
-		params, err := BuildPlatformParams(tenant, "opendatahub", "https://kubernetes.default.svc", logr.Discard())
+		platformContext := PlatformContext{GatewayRef: maasv1alpha1.TenantGatewayRef{
+			Namespace: "openshift-ingress",
+			Name:      "maas-default-gateway",
+		}}
+		params, err := BuildPlatformParams(tenant, platformContext, "opendatahub", "https://kubernetes.default.svc", logr.Discard())
 		assert.NoError(t, err)
 
 		assert.Equal(t, "", params.TenantIdentifier)
@@ -284,7 +292,11 @@ func TestBuildPlatformParamsIncludesTenantIdentifier(t *testing.T) {
 			},
 		}
 
-		params, err := BuildPlatformParams(tenant, "redhat-ai-gateway-infra", "https://kubernetes.default.svc", logr.Discard())
+		platformContext := PlatformContext{GatewayRef: maasv1alpha1.TenantGatewayRef{
+			Namespace: "openshift-ingress",
+			Name:      "redteam-gateway",
+		}}
+		params, err := BuildPlatformParams(tenant, platformContext, "redhat-ai-gateway-infra", "https://kubernetes.default.svc", logr.Discard())
 		assert.NoError(t, err)
 
 		assert.Equal(t, "redteam", params.TenantIdentifier)

--- a/maas-controller/pkg/platform/tenantreconcile/params.go
+++ b/maas-controller/pkg/platform/tenantreconcile/params.go
@@ -20,6 +20,7 @@ type PlatformParams struct {
 	GatewayName           string
 	ClusterAudience       string
 	SubscriptionNamespace string
+	ExternalOIDC          *maasv1alpha1.TenantExternalOIDCConfig
 
 	// TenantIdentifier is the tenant name used for per-tenant resource naming.
 	// Empty string ("") for default/legacy tenant, non-empty (e.g., "redteam") for AITenant-managed tenants.
@@ -33,8 +34,8 @@ type PlatformParams struct {
 }
 
 // BuildPlatformParams resolves all runtime parameters from the Tenant CR,
-// cluster state, and RELATED_IMAGE_* env vars. No disk I/O.
-func BuildPlatformParams(tenant *maasv1alpha1.Tenant, appNamespace, clusterAudience string, log logr.Logger) (PlatformParams, error) {
+// platform context, cluster state, and RELATED_IMAGE_* env vars. No disk I/O.
+func BuildPlatformParams(tenant *maasv1alpha1.Tenant, platformContext PlatformContext, appNamespace, clusterAudience string, log logr.Logger) (PlatformParams, error) {
 	tenantID, err := TenantIdentifierFor(tenant)
 	if err != nil {
 		return PlatformParams{}, fmt.Errorf("resolve tenant identifier: %w", err)
@@ -42,10 +43,11 @@ func BuildPlatformParams(tenant *maasv1alpha1.Tenant, appNamespace, clusterAudie
 
 	params := PlatformParams{
 		AppNamespace:            appNamespace,
-		GatewayNamespace:        tenant.Spec.GatewayRef.Namespace,
-		GatewayName:             tenant.Spec.GatewayRef.Name,
+		GatewayNamespace:        platformContext.GatewayRef.Namespace,
+		GatewayName:             platformContext.GatewayRef.Name,
 		ClusterAudience:         clusterAudience,
 		SubscriptionNamespace:   tenant.Namespace,
+		ExternalOIDC:            platformContext.ExternalOIDC.DeepCopy(),
 		TenantIdentifier:        tenantID,
 		MaaSAPIImage:            firstNonEmpty(os.Getenv("RELATED_IMAGE_ODH_MAAS_API_IMAGE"), DefaultMaaSAPIImage),
 		PayloadProcessingImage:  firstNonEmpty(os.Getenv("RELATED_IMAGE_ODH_AI_GATEWAY_PAYLOAD_PROCESSING_IMAGE"), DefaultPayloadProcessingImage),

--- a/maas-controller/pkg/platform/tenantreconcile/params_test.go
+++ b/maas-controller/pkg/platform/tenantreconcile/params_test.go
@@ -30,7 +30,11 @@ func TestBuildPlatformParams(t *testing.T) {
 			},
 		}
 
-		got, err := BuildPlatformParams(tenant, "opendatahub", "https://kubernetes.default.svc", logr.Discard())
+		platformContext := PlatformContext{GatewayRef: maasv1alpha1.TenantGatewayRef{
+			Namespace: "openshift-ingress",
+			Name:      "maas-default-gateway",
+		}}
+		got, err := BuildPlatformParams(tenant, platformContext, "opendatahub", "https://kubernetes.default.svc", logr.Discard())
 		assert.NoError(t, err)
 
 		assert.Equal(t, "opendatahub", got.AppNamespace)
@@ -61,7 +65,11 @@ func TestBuildPlatformParams(t *testing.T) {
 			},
 		}
 
-		got, err := BuildPlatformParams(tenant, "tenant-ns", "cluster-audience", logr.Discard())
+		platformContext := PlatformContext{GatewayRef: maasv1alpha1.TenantGatewayRef{
+			Namespace: "gateway-ns",
+			Name:      "gateway-name",
+		}}
+		got, err := BuildPlatformParams(tenant, platformContext, "tenant-ns", "cluster-audience", logr.Discard())
 		assert.NoError(t, err)
 
 		assert.Equal(t, "tenant-ns", got.AppNamespace)

--- a/maas-controller/pkg/platform/tenantreconcile/pipeline.go
+++ b/maas-controller/pkg/platform/tenantreconcile/pipeline.go
@@ -42,6 +42,7 @@ func RunPlatform(
 	c client.Client,
 	scheme *runtime.Scheme,
 	tenant *maasv1alpha1.Tenant,
+	platformContext PlatformContext,
 	manifestPath string,
 	appNs string,
 	clusterAudience string,
@@ -56,18 +57,18 @@ func RunPlatform(
 		return nil, fmt.Errorf("invalid application namespace %q: %v", appNs, errs)
 	}
 
-	if tenant.Spec.GatewayRef.Namespace == "" || tenant.Spec.GatewayRef.Name == "" {
-		return nil, errors.New("gateway ref must be set (reconciler should default gateway before calling RunPlatform)")
+	if platformContext.GatewayRef.Namespace == "" || platformContext.GatewayRef.Name == "" {
+		return nil, errors.New("gateway ref must be set before calling RunPlatform")
 	}
 	gw := &gwapiv1.Gateway{}
-	if err := c.Get(ctx, types.NamespacedName{Namespace: tenant.Spec.GatewayRef.Namespace, Name: tenant.Spec.GatewayRef.Name}, gw); err != nil {
+	if err := c.Get(ctx, types.NamespacedName{Namespace: platformContext.GatewayRef.Namespace, Name: platformContext.GatewayRef.Name}, gw); err != nil {
 		if apierrors.IsNotFound(err) {
-			return nil, fmt.Errorf("gateway %s/%s not found", tenant.Spec.GatewayRef.Namespace, tenant.Spec.GatewayRef.Name)
+			return nil, fmt.Errorf("gateway %s/%s not found", platformContext.GatewayRef.Namespace, platformContext.GatewayRef.Name)
 		}
 		return nil, fmt.Errorf("gateway lookup: %w", err)
 	}
 
-	params, err := BuildPlatformParams(tenant, appNs, clusterAudience, log)
+	params, err := BuildPlatformParams(tenant, platformContext, appNs, clusterAudience, log)
 	if err != nil {
 		return nil, fmt.Errorf("build params: %w", err)
 	}
@@ -102,7 +103,17 @@ func RunPlatform(
 
 // Run executes the Tenant platform pipeline (dependencies → prerequisites → render → apply → status).
 // The application namespace is derived from tenant.Namespace (Tenant CR is co-located with workloads).
-func Run(ctx context.Context, log logr.Logger, c client.Client, scheme *runtime.Scheme, tenant *maasv1alpha1.Tenant, manifestPath string, clusterAudience string, mcfg *maasv1alpha1.Config) (*RunResult, error) {
+func Run(
+	ctx context.Context,
+	log logr.Logger,
+	c client.Client,
+	scheme *runtime.Scheme,
+	tenant *maasv1alpha1.Tenant,
+	fallbackGatewayRef maasv1alpha1.TenantGatewayRef,
+	manifestPath string,
+	clusterAudience string,
+	mcfg *maasv1alpha1.Config,
+) (*RunResult, error) {
 	manifestPath, err := filepath.Abs(manifestPath)
 	if err != nil {
 		return nil, fmt.Errorf("manifest path: %w", err)
@@ -121,7 +132,12 @@ func Run(ctx context.Context, log logr.Logger, c client.Client, scheme *runtime.
 		return nil, fmt.Errorf("prerequisites: %w", err)
 	}
 
-	return RunPlatform(ctx, log, c, scheme, tenant, manifestPath, appNs, clusterAudience, mcfg)
+	platformContext, err := ResolvePlatformContext(ctx, c, tenant, fallbackGatewayRef)
+	if err != nil {
+		return nil, err
+	}
+
+	return RunPlatform(ctx, log, c, scheme, tenant, platformContext, manifestPath, appNs, clusterAudience, mcfg)
 }
 
 // MaasAPIDeploymentReady mirrors ODH deployments action for maas-api.

--- a/maas-controller/pkg/platform/tenantreconcile/platform_context.go
+++ b/maas-controller/pkg/platform/tenantreconcile/platform_context.go
@@ -1,0 +1,124 @@
+package tenantreconcile
+
+import (
+	"context"
+	"fmt"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	maasv1alpha1 "github.com/opendatahub-io/models-as-a-service/maas-controller/api/maas/v1alpha1"
+)
+
+const (
+	// AnnotationAITenantName identifies the AITenant that owns an AITenant-managed
+	// bridge Tenant/default-tenant object.
+	AnnotationAITenantName = "maas.opendatahub.io/aitenant-name"
+
+	// AnnotationAITenantNamespace identifies the namespace of the owning AITenant.
+	AnnotationAITenantNamespace = "maas.opendatahub.io/aitenant-namespace"
+
+	tenantNamespacePrefix = "ai-tenant-"
+)
+
+// PlatformContext contains platform-derived tenant values used when rendering
+// and reconciling tenant infrastructure. AITenant-managed tenants receive these
+// values from AITenant; legacy tenants receive them from Tenant spec/defaults.
+type PlatformContext struct {
+	GatewayRef   maasv1alpha1.TenantGatewayRef
+	ExternalOIDC *maasv1alpha1.TenantExternalOIDCConfig
+	Source       string
+}
+
+// ResolvePlatformContext resolves the gateway and OIDC values for a Tenant.
+//
+// AITenant-managed Tenants use their owning AITenant as the source of platform
+// context. Legacy/unmanaged Tenants preserve the previous behavior and use
+// Tenant.spec values, falling back to fallbackGatewayRef when gatewayRef is
+// omitted.
+func ResolvePlatformContext(ctx context.Context, c client.Reader, tenant *maasv1alpha1.Tenant, fallbackGatewayRef maasv1alpha1.TenantGatewayRef) (PlatformContext, error) {
+	if tenant == nil {
+		return PlatformContext{GatewayRef: fallbackGatewayRef, Source: "default"}, nil
+	}
+
+	if isAITenantManagedTenant(tenant) {
+		return resolveAITenantPlatformContext(ctx, c, tenant)
+	}
+
+	ref := tenant.Spec.GatewayRef
+	switch {
+	case ref.Name == "" && ref.Namespace == "":
+		ref = fallbackGatewayRef
+	case ref.Name == "" || ref.Namespace == "":
+		return PlatformContext{}, fmt.Errorf("tenant %s/%s spec.gatewayRef must set both name and namespace", tenant.Namespace, tenant.Name)
+	}
+
+	return PlatformContext{
+		GatewayRef:   ref,
+		ExternalOIDC: tenant.Spec.ExternalOIDC.DeepCopy(),
+		Source:       "tenant-spec",
+	}, nil
+}
+
+func resolveAITenantPlatformContext(ctx context.Context, c client.Reader, tenant *maasv1alpha1.Tenant) (PlatformContext, error) {
+	tenantName := tenant.GetLabels()[LabelTenantName]
+	if tenantName == "" {
+		return PlatformContext{}, fmt.Errorf("AITenant-managed tenant %s/%s is missing %s", tenant.Namespace, tenant.Name, LabelTenantName)
+	}
+
+	aitenantName := annotationValue(tenant, AnnotationAITenantName)
+	if aitenantName == "" {
+		aitenantName = tenantName
+	}
+	aitenantNamespace := annotationValue(tenant, AnnotationAITenantNamespace)
+	if aitenantNamespace == "" {
+		return PlatformContext{}, fmt.Errorf("AITenant-managed tenant %s/%s is missing %s", tenant.Namespace, tenant.Name, AnnotationAITenantNamespace)
+	}
+
+	var aitenant maasv1alpha1.AITenant
+	key := client.ObjectKey{Name: aitenantName, Namespace: aitenantNamespace}
+	if err := c.Get(ctx, key, &aitenant); err != nil {
+		return PlatformContext{}, fmt.Errorf("get owning AITenant %s/%s for tenant %s/%s: %w", key.Namespace, key.Name, tenant.Namespace, tenant.Name, err)
+	}
+
+	ref := aitenant.Status.GatewayRef
+	if ref.Name == "" || ref.Namespace == "" {
+		return PlatformContext{}, fmt.Errorf("AITenant %s/%s status.gatewayRef is not ready", aitenant.Namespace, aitenant.Name)
+	}
+
+	return PlatformContext{
+		GatewayRef:   ref,
+		ExternalOIDC: aitenant.Spec.OIDC.DeepCopy(),
+		Source:       "aitenant",
+	}, nil
+}
+
+func isAITenantManagedTenant(tenant *maasv1alpha1.Tenant) bool {
+	labels := tenant.GetLabels()
+	return labels != nil && labels[LabelManagedByAITenant] == "true"
+}
+
+// TenantUsesAITenantPlatformContext reports whether gateway/OIDC platform
+// context should be read from the owning AITenant rather than Tenant.spec.
+func TenantUsesAITenantPlatformContext(tenant *maasv1alpha1.Tenant) bool {
+	return isAITenantManagedTenant(tenant)
+}
+
+// TenantNamespaceForAITenant returns the tenant admin namespace derived from an
+// AITenant name and the configured default tenant namespace.
+func TenantNamespaceForAITenant(name, defaultTenantNamespace string) string {
+	if name == DefaultAITenantName || (defaultTenantNamespace != "" && name == defaultTenantNamespace) {
+		if defaultTenantNamespace != "" {
+			return defaultTenantNamespace
+		}
+		return DefaultAITenantName
+	}
+	return tenantNamespacePrefix + name
+}
+
+func annotationValue(obj client.Object, key string) string {
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		return ""
+	}
+	return annotations[key]
+}

--- a/maas-controller/pkg/platform/tenantreconcile/platform_context.go
+++ b/maas-controller/pkg/platform/tenantreconcile/platform_context.go
@@ -67,7 +67,7 @@ func resolveAITenantPlatformContext(ctx context.Context, c client.Reader, tenant
 
 	aitenantName := annotationValue(tenant, AnnotationAITenantName)
 	if aitenantName == "" {
-		aitenantName = tenantName
+		return PlatformContext{}, fmt.Errorf("AITenant-managed tenant %s/%s is missing %s", tenant.Namespace, tenant.Name, AnnotationAITenantName)
 	}
 	aitenantNamespace := annotationValue(tenant, AnnotationAITenantNamespace)
 	if aitenantNamespace == "" {

--- a/maas-controller/pkg/platform/tenantreconcile/platform_context_test.go
+++ b/maas-controller/pkg/platform/tenantreconcile/platform_context_test.go
@@ -130,3 +130,26 @@ func TestResolvePlatformContext_AITenantStatusGatewayRequired(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "status.gatewayRef is not ready")
 }
+
+func TestResolvePlatformContext_AITenantNameAnnotationRequired(t *testing.T) {
+	scheme := platformContextTestScheme(t)
+	tenant := &maasv1alpha1.Tenant{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      maasv1alpha1.TenantInstanceName,
+			Namespace: "ai-tenant-redteam",
+			Labels: map[string]string{
+				LabelManagedByAITenant: "true",
+				LabelTenantName:        "redteam",
+			},
+			Annotations: map[string]string{
+				AnnotationAITenantNamespace: DefaultAITenantNamespace,
+			},
+		},
+	}
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(tenant).Build()
+
+	_, err := ResolvePlatformContext(context.Background(), client, tenant, maasv1alpha1.TenantGatewayRef{})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), AnnotationAITenantName)
+}

--- a/maas-controller/pkg/platform/tenantreconcile/platform_context_test.go
+++ b/maas-controller/pkg/platform/tenantreconcile/platform_context_test.go
@@ -1,0 +1,132 @@
+package tenantreconcile
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	maasv1alpha1 "github.com/opendatahub-io/models-as-a-service/maas-controller/api/maas/v1alpha1"
+)
+
+func platformContextTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, maasv1alpha1.AddToScheme(scheme))
+	return scheme
+}
+
+func TestResolvePlatformContext_AITenantManagedTenantUsesAITenant(t *testing.T) {
+	scheme := platformContextTestScheme(t)
+	tenant := &maasv1alpha1.Tenant{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      maasv1alpha1.TenantInstanceName,
+			Namespace: "ai-tenant-redteam",
+			Labels: map[string]string{
+				LabelManagedByAITenant: "true",
+				LabelTenantName:        "redteam",
+				LabelTenantNamespace:   "ai-tenant-redteam",
+			},
+			Annotations: map[string]string{
+				AnnotationAITenantName:      "redteam",
+				AnnotationAITenantNamespace: DefaultAITenantNamespace,
+			},
+		},
+		Spec: maasv1alpha1.TenantSpec{
+			GatewayRef: maasv1alpha1.TenantGatewayRef{
+				Namespace: "stale-gateway-ns",
+				Name:      "stale-gateway",
+			},
+			ExternalOIDC: &maasv1alpha1.TenantExternalOIDCConfig{
+				IssuerURL: "https://stale.example.com",
+				ClientID:  "stale-client",
+			},
+		},
+	}
+	aitenant := &maasv1alpha1.AITenant{
+		ObjectMeta: metav1.ObjectMeta{Name: "redteam", Namespace: DefaultAITenantNamespace},
+		Spec: maasv1alpha1.AITenantSpec{
+			OIDC: &maasv1alpha1.TenantExternalOIDCConfig{
+				IssuerURL: "https://issuer.example.com/realms/redteam",
+				ClientID:  "redteam-client",
+			},
+		},
+		Status: maasv1alpha1.AITenantStatus{
+			GatewayRef: maasv1alpha1.TenantGatewayRef{
+				Namespace: "openshift-ingress",
+				Name:      "redteam-gateway",
+			},
+		},
+	}
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(tenant, aitenant).Build()
+
+	got, err := ResolvePlatformContext(context.Background(), client, tenant, maasv1alpha1.TenantGatewayRef{
+		Namespace: "fallback-ns",
+		Name:      "fallback-gateway",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, maasv1alpha1.TenantGatewayRef{Namespace: "openshift-ingress", Name: "redteam-gateway"}, got.GatewayRef)
+	require.NotNil(t, got.ExternalOIDC)
+	assert.Equal(t, "https://issuer.example.com/realms/redteam", got.ExternalOIDC.IssuerURL)
+	assert.Equal(t, "redteam-client", got.ExternalOIDC.ClientID)
+	assert.Equal(t, "aitenant", got.Source)
+}
+
+func TestResolvePlatformContext_LegacyTenantUsesTenantSpec(t *testing.T) {
+	tenant := &maasv1alpha1.Tenant{
+		ObjectMeta: metav1.ObjectMeta{Name: maasv1alpha1.TenantInstanceName, Namespace: "models-as-a-service"},
+		Spec: maasv1alpha1.TenantSpec{
+			GatewayRef: maasv1alpha1.TenantGatewayRef{
+				Namespace: "custom-ingress",
+				Name:      "custom-gateway",
+			},
+			ExternalOIDC: &maasv1alpha1.TenantExternalOIDCConfig{
+				IssuerURL: "https://issuer.example.com/realms/default",
+				ClientID:  "default-client",
+			},
+		},
+	}
+
+	got, err := ResolvePlatformContext(context.Background(), nil, tenant, maasv1alpha1.TenantGatewayRef{
+		Namespace: "fallback-ns",
+		Name:      "fallback-gateway",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, maasv1alpha1.TenantGatewayRef{Namespace: "custom-ingress", Name: "custom-gateway"}, got.GatewayRef)
+	require.NotNil(t, got.ExternalOIDC)
+	assert.Equal(t, "default-client", got.ExternalOIDC.ClientID)
+	assert.Equal(t, "tenant-spec", got.Source)
+}
+
+func TestResolvePlatformContext_AITenantStatusGatewayRequired(t *testing.T) {
+	scheme := platformContextTestScheme(t)
+	tenant := &maasv1alpha1.Tenant{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      maasv1alpha1.TenantInstanceName,
+			Namespace: "ai-tenant-redteam",
+			Labels: map[string]string{
+				LabelManagedByAITenant: "true",
+				LabelTenantName:        "redteam",
+			},
+			Annotations: map[string]string{
+				AnnotationAITenantName:      "redteam",
+				AnnotationAITenantNamespace: DefaultAITenantNamespace,
+			},
+		},
+	}
+	aitenant := &maasv1alpha1.AITenant{
+		ObjectMeta: metav1.ObjectMeta{Name: "redteam", Namespace: DefaultAITenantNamespace},
+	}
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(tenant, aitenant).Build()
+
+	_, err := ResolvePlatformContext(context.Background(), client, tenant, maasv1alpha1.TenantGatewayRef{})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "status.gatewayRef is not ready")
+}

--- a/maas-controller/pkg/platform/tenantreconcile/postrender.go
+++ b/maas-controller/pkg/platform/tenantreconcile/postrender.go
@@ -15,8 +15,8 @@ import (
 // dynamic values (images, gateway config, namespace, audience, env vars) and
 // applies OIDC, telemetry, and managed-annotation customizations.
 func PostRender(ctx context.Context, log logr.Logger, tenant *maasv1alpha1.Tenant, resources []unstructured.Unstructured, params PlatformParams) ([]unstructured.Unstructured, error) {
-	gatewayNamespace := tenant.Spec.GatewayRef.Namespace
-	gatewayName := tenant.Spec.GatewayRef.Name
+	gatewayNamespace := params.GatewayNamespace
+	gatewayName := params.GatewayName
 	tenantID := params.TenantIdentifier
 
 	var filteredResources []unstructured.Unstructured
@@ -58,13 +58,13 @@ func PostRender(ctx context.Context, log logr.Logger, tenant *maasv1alpha1.Tenan
 		filteredResources = append(filteredResources, *resource)
 	}
 
-	if err := configureExternalOIDC(log, tenant, filteredResources); err != nil {
+	if err := configureExternalOIDC(log, params, filteredResources); err != nil {
 		return nil, err
 	}
-	if err := configureTelemetryPolicyResources(log, tenant, &filteredResources, tenantID); err != nil {
+	if err := configureTelemetryPolicyResources(log, tenant, &filteredResources, params); err != nil {
 		return nil, err
 	}
-	if err := configureIstioTelemetryResources(log, tenant, &filteredResources, tenantID); err != nil {
+	if err := configureIstioTelemetryResources(log, tenant, &filteredResources, params); err != nil {
 		return nil, err
 	}
 	if err := applyPlatformParams(log, filteredResources, params); err != nil {
@@ -155,8 +155,8 @@ func configureMaaSAPIDeployment(log logr.Logger, resource *unstructured.Unstruct
 	return nil
 }
 
-func configureExternalOIDC(log logr.Logger, tenant *maasv1alpha1.Tenant, resources []unstructured.Unstructured) error {
-	if tenant.Spec.ExternalOIDC == nil {
+func configureExternalOIDC(log logr.Logger, params PlatformParams, resources []unstructured.Unstructured) error {
+	if params.ExternalOIDC == nil {
 		return nil
 	}
 	// OIDC is configured in the singleton maas-gateway-auth AuthPolicy managed by
@@ -245,13 +245,14 @@ func isTelemetryEnabled(t *maasv1alpha1.TenantTelemetryConfig) bool {
 	return *t.Enabled
 }
 
-func configureTelemetryPolicyResources(log logr.Logger, tenant *maasv1alpha1.Tenant, resources *[]unstructured.Unstructured, tenantID string) error {
+func configureTelemetryPolicyResources(log logr.Logger, tenant *maasv1alpha1.Tenant, resources *[]unstructured.Unstructured, params PlatformParams) error {
 	if !isTelemetryEnabled(tenant.Spec.Telemetry) {
 		return nil
 	}
 	// Caller should have checked CRD; still skip if API missing at apply time.
-	gatewayNamespace := tenant.Spec.GatewayRef.Namespace
-	gatewayName := tenant.Spec.GatewayRef.Name
+	gatewayNamespace := params.GatewayNamespace
+	gatewayName := params.GatewayName
+	tenantID := params.TenantIdentifier
 	metricLabels := buildTelemetryLabels(log, tenant.Spec.Telemetry)
 	tp := &unstructured.Unstructured{
 		Object: map[string]any{
@@ -286,12 +287,13 @@ func configureTelemetryPolicyResources(log logr.Logger, tenant *maasv1alpha1.Ten
 	return nil
 }
 
-func configureIstioTelemetryResources(log logr.Logger, tenant *maasv1alpha1.Tenant, resources *[]unstructured.Unstructured, tenantID string) error {
+func configureIstioTelemetryResources(log logr.Logger, tenant *maasv1alpha1.Tenant, resources *[]unstructured.Unstructured, params PlatformParams) error {
 	if !isTelemetryEnabled(tenant.Spec.Telemetry) {
 		return nil
 	}
-	gatewayNamespace := tenant.Spec.GatewayRef.Namespace
-	gatewayName := tenant.Spec.GatewayRef.Name
+	gatewayNamespace := params.GatewayNamespace
+	gatewayName := params.GatewayName
+	tenantID := params.TenantIdentifier
 	istioTelemetry := &unstructured.Unstructured{
 		Object: map[string]any{
 			"apiVersion": "telemetry.istio.io/v1",

--- a/maas-controller/pkg/platform/tenantreconcile/postrender.go
+++ b/maas-controller/pkg/platform/tenantreconcile/postrender.go
@@ -222,10 +222,12 @@ func patchAuthPolicyWithOIDC(log logr.Logger, resource *unstructured.Unstructure
 		return fmt.Errorf("failed to set X-MaaS-Username-OC: %w", err)
 	}
 	groupsExpr := `has(auth.identity.groups) ? ` +
-		`(size(auth.identity.groups) > 0 ? ` +
+		`(size(auth.identity.groups) > 0 && auth.identity.groups.all(g, g.matches('^[A-Za-z0-9:._/-]+$')) ? ` +
 		`'["system:authenticated","' + auth.identity.groups.join('","') + '"]' : ` +
 		`'["system:authenticated"]') : ` +
-		`'["' + auth.identity.user.groups.join('","') + '"]'`
+		`(has(auth.identity.user.groups) && size(auth.identity.user.groups) > 0 ? ` +
+		`'["system:authenticated","' + auth.identity.user.groups.join('","') + '"]' : ` +
+		`'["system:authenticated"]')`
 	if err := unstructured.SetNestedField(resource.Object, map[string]any{
 		"expression": groupsExpr,
 	}, "spec", "rules", "response", "success", "headers", "X-MaaS-Group-OC", "plain"); err != nil {

--- a/maas-controller/pkg/platform/tenantreconcile/postrender.go
+++ b/maas-controller/pkg/platform/tenantreconcile/postrender.go
@@ -58,7 +58,7 @@ func PostRender(ctx context.Context, log logr.Logger, tenant *maasv1alpha1.Tenan
 		filteredResources = append(filteredResources, *resource)
 	}
 
-	if err := configureExternalOIDC(log, params, filteredResources); err != nil {
+	if err := configureExternalOIDC(log, params); err != nil {
 		return nil, err
 	}
 	if err := configureTelemetryPolicyResources(log, tenant, &filteredResources, params); err != nil {
@@ -155,7 +155,7 @@ func configureMaaSAPIDeployment(log logr.Logger, resource *unstructured.Unstruct
 	return nil
 }
 
-func configureExternalOIDC(log logr.Logger, params PlatformParams, resources []unstructured.Unstructured) error {
+func configureExternalOIDC(log logr.Logger, params PlatformParams) error {
 	if params.ExternalOIDC == nil {
 		return nil
 	}

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -37,7 +37,7 @@ Automated deployment script for OpenShift clusters supporting both operator-base
 - `--operator-type <odh|rhoai>` - Which operator to install (default: odh)
 - `--deployment-mode <operator|kustomize>` - Deployment method (default: operator)
 - `--namespace <namespace>` - Target namespace for deployment
-- `--external-oidc` - Enable external OIDC on the `maas-api` AuthPolicy (kustomize mode only; in operator mode, configure `spec.externalOIDC` on the `Tenant` CR)
+- `--external-oidc` - Enable external OIDC on the `maas-api` AuthPolicy (kustomize mode only; in operator mode, configure `spec.oidc` on the default `AITenant`)
 - `--enable-keycloak` - Deploy a Keycloak instance for external OIDC testing
 - `--enable-tls-backend` - Enable TLS backend (default)
 - `--disable-tls-backend` - Disable TLS backend
@@ -155,8 +155,9 @@ Results:
 
 External OIDC can be enabled in two ways:
 
-**Operator mode:** Edit the `Tenant` CR to add `spec.externalOIDC` with
-`issuerUrl` and `clientId`. The Tenant reconciler patches the AuthPolicy automatically.
+**Operator mode:** Edit `AITenant/models-as-a-service` in the configured AITenant namespace
+(default `ai-tenants`) to add `spec.oidc` with `issuerUrl` and `clientId`. The controller
+uses that AITenant platform context when reconciling the AuthPolicy.
 
 **Kustomize mode:** Use `--external-oidc` with env vars:
 ```bash
@@ -409,4 +410,3 @@ For issues or questions:
 2. Check the main project [README](../README.md)
 3. Review [deployment documentation](../docs/content/quickstart.md)
 4. Check sample model configurations in [docs/samples/models/](../docs/samples/models/)
-

--- a/scripts/validate-deployment.sh
+++ b/scripts/validate-deployment.sh
@@ -234,6 +234,31 @@ print_info() {
     echo -e "${BLUE}ℹ️  $1${NC}"
 }
 
+should_retry_api_key_mint() {
+    local http_code="$1"
+    local body="$2"
+    local compact_body
+    compact_body="$(echo "$body" | tr -d '[:space:]')"
+
+    # Empty 403 = gateway/AuthPolicy propagation delay.
+    if [[ "$http_code" == "403" ]] && [[ -z "$compact_body" ]]; then
+        return 0
+    fi
+
+    # 401 and the two 500 bodies below are observed while Authorino/Envoy has
+    # accepted the policy but identity headers are not consistently injected yet.
+    if [[ "$http_code" == "401" ]]; then
+        return 0
+    fi
+    if [[ "$http_code" == "500" ]] && {
+        [[ "$body" == *"AUTH_FAILURE"* ]] || [[ "$body" == *"Internal Server Error."* ]]
+    }; then
+        return 0
+    fi
+
+    return 1
+}
+
 # Check if running on OpenShift
 # First check if kubectl is working, then check for OpenShift-specific API resources
 api_resources=$(kubectl api-resources 2>/dev/null)
@@ -465,7 +490,7 @@ else
     if [ -n "$OC_TOKEN" ]; then
         print_check "MaaS API key creation"
         API_KEY_NAME="validate-test-$(date +%s)"
-        mint_retries=6
+        mint_retries=12
         mint_delay=5
         for mint_attempt in $(seq 1 $mint_retries); do
             API_KEY_RESPONSE=$(curl -sSk --connect-timeout 10 --max-time 30 \
@@ -477,10 +502,9 @@ else
                 "${HOST}/maas-api/v1/api-keys" 2>/dev/null || echo "")
             API_KEY_HTTP_CODE=$(echo "$API_KEY_RESPONSE" | tail -n1)
             API_KEY_BODY=$(echo "$API_KEY_RESPONSE" | sed '$d')
-            # Empty 403 = gateway propagation delay, retry
-            if [[ "$API_KEY_HTTP_CODE" == "403" ]] && [[ -z "$(echo "$API_KEY_BODY" | tr -d '[:space:]')" ]]; then
+            if should_retry_api_key_mint "$API_KEY_HTTP_CODE" "$API_KEY_BODY"; then
                 if [[ $mint_attempt -lt $mint_retries ]]; then
-                    echo "  Gateway returned empty 403 (attempt $mint_attempt/$mint_retries), retrying in ${mint_delay}s..."
+                    echo "  API key mint auth path not ready yet (HTTP $API_KEY_HTTP_CODE, attempt $mint_attempt/$mint_retries), retrying in ${mint_delay}s..."
                     sleep $mint_delay
                     continue
                 fi

--- a/test/e2e/tests/multitenancy_helpers.py
+++ b/test/e2e/tests/multitenancy_helpers.py
@@ -33,6 +33,8 @@ LABEL_AI_GATEWAY_TENANT = "ai-gateway.opendatahub.io/tenant"
 LABEL_MANAGED_BY_AITENANT = "maas.opendatahub.io/managed-by-aitenant"
 LABEL_TENANT_NAME = "maas.opendatahub.io/tenant-name"
 LABEL_TENANT_NAMESPACE = "maas.opendatahub.io/tenant-namespace"
+ANNOTATION_AITENANT_NAME = "maas.opendatahub.io/aitenant-name"
+ANNOTATION_AITENANT_NAMESPACE = "maas.opendatahub.io/aitenant-namespace"
 
 FINALIZER_SUBSCRIPTION = "maas.opendatahub.io/subscription-cleanup"
 FINALIZER_AUTHPOLICY = "maas.opendatahub.io/authpolicy-cleanup"
@@ -498,7 +500,6 @@ def apply_tenant_cr(
     *,
     gateway_namespace: str = GATEWAY_NAMESPACE,
     external_oidc: Optional[dict[str, str]] = None,
-    tenant_label_name: Optional[str] = None,
 ) -> None:
     spec: dict[str, Any] = {
         "gatewayRef": {
@@ -510,18 +511,11 @@ def apply_tenant_cr(
         external_oidc = external_oidc_from_env()
     if external_oidc:
         spec["externalOIDC"] = external_oidc
-    metadata: dict[str, Any] = {"name": TENANT_CR_NAME, "namespace": namespace}
-    if tenant_label_name:
-        metadata["labels"] = {
-            LABEL_MANAGED_BY_AITENANT: "true",
-            LABEL_TENANT_NAME: tenant_label_name,
-            LABEL_TENANT_NAMESPACE: namespace,
-        }
     _apply(
         {
             "apiVersion": "maas.opendatahub.io/v1alpha1",
             "kind": "Tenant",
-            "metadata": metadata,
+            "metadata": {"name": TENANT_CR_NAME, "namespace": namespace},
             "spec": spec,
         }
     )
@@ -747,6 +741,22 @@ def aitenant_ready(obj: dict) -> bool:
     )
 
 
+def bridge_tenant_owned_by_aitenant(case: dict[str, str]):
+    def _predicate(obj: dict) -> bool:
+        metadata = obj.get("metadata") or {}
+        labels = metadata.get("labels") or {}
+        annotations = metadata.get("annotations") or {}
+        return (
+            labels.get(LABEL_MANAGED_BY_AITENANT) == "true"
+            and labels.get(LABEL_TENANT_NAME) == case["tenant_label_name"]
+            and labels.get(LABEL_TENANT_NAMESPACE) == case["tenant_ns"]
+            and annotations.get(ANNOTATION_AITENANT_NAME) == case["tenant_label_name"]
+            and annotations.get(ANNOTATION_AITENANT_NAMESPACE) == AITENANT_NAMESPACE
+        )
+
+    return _predicate
+
+
 def bootstrap_aitenant_tenant(case: dict[str, str], *, use_default_gateway: bool = False) -> None:
     if not use_default_gateway:
         apply_gateway_fixture(case["gateway_name"], fixture_label=case["tenant_label_name"])
@@ -754,7 +764,12 @@ def bootstrap_aitenant_tenant(case: dict[str, str], *, use_default_gateway: bool
         apply_gateway_route_fixture(case["gateway_name"], fixture_label=case["tenant_label_name"])
     apply_aitenant(case)
     wait_for_json(AITENANT_KIND, case["tenant_label_name"], AITENANT_NAMESPACE, predicate=aitenant_ready)
-    wait_for_json("tenant", TENANT_CR_NAME, case["tenant_ns"])
+    wait_for_json(
+        "tenant",
+        TENANT_CR_NAME,
+        case["tenant_ns"],
+        predicate=bridge_tenant_owned_by_aitenant(case),
+    )
     if not use_default_gateway:
         apply_gateway_access_label(case["tenant_ns"], case["gateway_name"])
         wait_for_httproute_accepted(

--- a/test/e2e/tests/test_aitenant_lifecycle.py
+++ b/test/e2e/tests/test_aitenant_lifecycle.py
@@ -231,8 +231,10 @@ def _assert_aitenant_bootstrap_resources(case):
     assert labels["maas.opendatahub.io/tenant-namespace"] == case["tenant_ns"]
     assert annotations[ANNOTATION_AITENANT_NAME] == case["aitenant_name"]
     assert annotations[ANNOTATION_AITENANT_NAMESPACE] == AITENANT_NAMESPACE
-    tenant_gateway_ref = (tenant.get("spec") or {}).get("gatewayRef") or {}
-    assert tenant_gateway_ref.get("name") != case["gateway_name"]
+    assert tenant["spec"]["gatewayRef"] == {
+        "namespace": GATEWAY_NAMESPACE,
+        "name": GATEWAY_NAME,
+    }
 
     assert _get_json_or_none("role", case["tenant_admin_role"], case["tenant_ns"]) is not None
     assert _get_json_or_none("rolebinding", case["tenant_admin_role"], case["tenant_ns"]) is not None

--- a/test/e2e/tests/test_aitenant_lifecycle.py
+++ b/test/e2e/tests/test_aitenant_lifecycle.py
@@ -14,6 +14,8 @@ AITENANT_KIND = "aitenant"
 CONFIG_CRD = "configs.maas.opendatahub.io"
 CONFIG_NAME = "default"
 DEFAULT_AITENANT_BOOTSTRAPPED_ANNOTATION = "maas.opendatahub.io/default-aitenant-bootstrapped"
+ANNOTATION_AITENANT_NAME = "maas.opendatahub.io/aitenant-name"
+ANNOTATION_AITENANT_NAMESPACE = "maas.opendatahub.io/aitenant-namespace"
 TENANT_NAME = "default-tenant"
 DEFAULT_AITENANT_NAME = "models-as-a-service"
 AITENANT_NAMESPACE = os.environ.get("AITENANT_NAMESPACE", "ai-tenants")
@@ -221,11 +223,16 @@ def _assert_aitenant_bootstrap_resources(case):
     assert namespace["metadata"]["labels"]["ai-gateway.opendatahub.io/tenant"] == case["aitenant_name"]
 
     tenant = _wait_for_json("tenant", TENANT_NAME, case["tenant_ns"])
-    assert tenant["spec"]["gatewayRef"] == {
-        "namespace": GATEWAY_NAMESPACE,
-        "name": case["gateway_name"],
-    }
-    assert tenant["metadata"]["labels"]["maas.opendatahub.io/managed-by-aitenant"] == "true"
+    labels = tenant["metadata"].get("labels") or {}
+    annotations = tenant["metadata"].get("annotations") or {}
+    assert labels["maas.opendatahub.io/managed-by-aitenant"] == "true"
+    assert labels["ai-gateway.opendatahub.io/tenant"] == case["aitenant_name"]
+    assert labels["maas.opendatahub.io/tenant-name"] == case["aitenant_name"]
+    assert labels["maas.opendatahub.io/tenant-namespace"] == case["tenant_ns"]
+    assert annotations[ANNOTATION_AITENANT_NAME] == case["aitenant_name"]
+    assert annotations[ANNOTATION_AITENANT_NAMESPACE] == AITENANT_NAMESPACE
+    tenant_gateway_ref = (tenant.get("spec") or {}).get("gatewayRef") or {}
+    assert tenant_gateway_ref.get("name") != case["gateway_name"]
 
     assert _get_json_or_none("role", case["tenant_admin_role"], case["tenant_ns"]) is not None
     assert _get_json_or_none("rolebinding", case["tenant_admin_role"], case["tenant_ns"]) is not None
@@ -283,6 +290,9 @@ class TestAITenantLifecycle:
         assert tenant["metadata"]["labels"]["maas.opendatahub.io/managed-by-aitenant"] == "true"
         assert tenant["metadata"]["labels"]["ai-gateway.opendatahub.io/tenant"] == DEFAULT_AITENANT_NAME
         assert tenant["metadata"]["labels"]["maas.opendatahub.io/tenant-name"] == DEFAULT_AITENANT_NAME
+        tenant_annotations = tenant["metadata"].get("annotations") or {}
+        assert tenant_annotations[ANNOTATION_AITENANT_NAME] == DEFAULT_AITENANT_NAME
+        assert tenant_annotations[ANNOTATION_AITENANT_NAMESPACE] == AITENANT_NAMESPACE
         assert tenant["spec"]["gatewayRef"] == {
             "namespace": GATEWAY_NAMESPACE,
             "name": GATEWAY_NAME,
@@ -305,24 +315,11 @@ class TestAITenantLifecycle:
                     not expected_client_id or oidc.get("clientId") == expected_client_id
                 )
 
-            def tenant_oidc_converged(obj):
-                oidc = obj.get("spec", {}).get("externalOIDC") or {}
-                return oidc.get("issuerUrl") == expected_issuer and (
-                    not expected_client_id or oidc.get("clientId") == expected_client_id
-                )
-
             _wait_for_json(
                 AITENANT_KIND,
                 DEFAULT_AITENANT_NAME,
                 AITENANT_NAMESPACE,
                 predicate=aitenant_oidc_converged,
-                timeout=180,
-            )
-            _wait_for_json(
-                "tenant",
-                TENANT_NAME,
-                MAAS_SUBSCRIPTION_NAMESPACE,
-                predicate=tenant_oidc_converged,
                 timeout=180,
             )
 

--- a/test/e2e/tests/test_aitenant_lifecycle.py
+++ b/test/e2e/tests/test_aitenant_lifecycle.py
@@ -231,10 +231,13 @@ def _assert_aitenant_bootstrap_resources(case):
     assert labels["maas.opendatahub.io/tenant-namespace"] == case["tenant_ns"]
     assert annotations[ANNOTATION_AITENANT_NAME] == case["aitenant_name"]
     assert annotations[ANNOTATION_AITENANT_NAMESPACE] == AITENANT_NAMESPACE
+    # AITenant-managed bridge Tenants keep legacy/default spec values. The
+    # tenant Gateway under test is reported in AITenant.status.gatewayRef.
     assert tenant["spec"]["gatewayRef"] == {
         "namespace": GATEWAY_NAMESPACE,
         "name": GATEWAY_NAME,
     }
+    assert tenant["spec"]["gatewayRef"]["name"] != case["gateway_name"]
 
     assert _get_json_or_none("role", case["tenant_admin_role"], case["tenant_ns"]) is not None
     assert _get_json_or_none("rolebinding", case["tenant_admin_role"], case["tenant_ns"]) is not None

--- a/test/e2e/tests/test_multi_tenant_integration.py
+++ b/test/e2e/tests/test_multi_tenant_integration.py
@@ -15,15 +15,19 @@ import uuid
 import pytest
 
 from multitenancy_helpers import (
+    ANNOTATION_AITENANT_NAME,
+    ANNOTATION_AITENANT_NAMESPACE,
     AITENANT_KIND,
     AITENANT_NAMESPACE,
     DEFAULT_GATEWAY_NAME,
     FINALIZER_AUTHPOLICY,
     FINALIZER_SUBSCRIPTION,
+    LABEL_MANAGED_BY_AITENANT,
+    LABEL_TENANT_NAME,
+    LABEL_TENANT_NAMESPACE,
     MODEL_NAMESPACE,
     MODEL_REF,
     TENANT_CR_NAME,
-    apply_discovery_labels,
     apply_maas_auth_policy,
     apply_maas_subscription,
     apply_tenant_cr,
@@ -67,7 +71,15 @@ class TestMultiTenantIntegration:
             bootstrap_aitenant_tenant(case)
 
             tenant = wait_for_json("tenant", TENANT_CR_NAME, case["tenant_ns"], timeout=180)
-            assert tenant["spec"]["gatewayRef"]["name"] == case["gateway_name"]
+            tenant_labels = tenant["metadata"].get("labels") or {}
+            tenant_annotations = tenant["metadata"].get("annotations") or {}
+            assert tenant_labels[LABEL_MANAGED_BY_AITENANT] == "true"
+            assert tenant_labels[LABEL_TENANT_NAME] == case["tenant_label_name"]
+            assert tenant_labels[LABEL_TENANT_NAMESPACE] == case["tenant_ns"]
+            assert tenant_annotations[ANNOTATION_AITENANT_NAME] == case["tenant_label_name"]
+            assert tenant_annotations[ANNOTATION_AITENANT_NAMESPACE] == AITENANT_NAMESPACE
+            aitenant = wait_for_json(AITENANT_KIND, case["tenant_label_name"], AITENANT_NAMESPACE, timeout=180)
+            assert aitenant["status"]["gatewayRef"]["name"] == case["gateway_name"]
             assert get_json_or_none("role", role_name, case["tenant_ns"]) is not None
 
             model_name = f"e2e-lifecycle-model-{case['suffix']}"
@@ -132,8 +144,7 @@ class TestMultiTenantIntegration:
 
         try:
             for case in (case_a, case_b):
-                apply_discovery_labels(case["tenant_ns"], case["tenant_label_name"])
-                apply_tenant_cr(case["tenant_ns"], DEFAULT_GATEWAY_NAME, tenant_label_name=case["tenant_label_name"])
+                bootstrap_aitenant_tenant(case, use_default_gateway=True)
                 apply_maas_auth_policy(shared_policy, case["tenant_ns"])
                 apply_maas_subscription(shared_sub, case["tenant_ns"])
                 wait_for_finalizer("maasauthpolicy", shared_policy, case["tenant_ns"], FINALIZER_AUTHPOLICY)
@@ -159,14 +170,14 @@ class TestMultiTenantIntegration:
         second_policy = f"e2e-label-return-{case['suffix']}"
         try:
             ensure_namespace(case["tenant_ns"])
-            apply_tenant_cr(case["tenant_ns"], DEFAULT_GATEWAY_NAME, tenant_label_name=case["tenant_label_name"])
+            apply_tenant_cr(case["tenant_ns"], DEFAULT_GATEWAY_NAME)
             apply_maas_auth_policy(first_policy, case["tenant_ns"])
             _wait_reconcile(10)
             first = get_json_or_none("maasauthpolicy", first_policy, case["tenant_ns"])
             assert first is not None
             assert FINALIZER_AUTHPOLICY not in ((first.get("metadata") or {}).get("finalizers") or [])
 
-            apply_discovery_labels(case["tenant_ns"], case["tenant_label_name"])
+            bootstrap_aitenant_tenant(case, use_default_gateway=True)
             wait_for_finalizer("maasauthpolicy", first_policy, case["tenant_ns"], FINALIZER_AUTHPOLICY)
             wait_for_status_phase("maasauthpolicy", first_policy, case["tenant_ns"], expected_phase="Active")
 

--- a/test/e2e/tests/test_multi_tenant_integration.py
+++ b/test/e2e/tests/test_multi_tenant_integration.py
@@ -28,6 +28,7 @@ from multitenancy_helpers import (
     MODEL_NAMESPACE,
     MODEL_REF,
     TENANT_CR_NAME,
+    apply_discovery_labels,
     apply_maas_auth_policy,
     apply_maas_subscription,
     apply_tenant_cr,
@@ -144,7 +145,8 @@ class TestMultiTenantIntegration:
 
         try:
             for case in (case_a, case_b):
-                bootstrap_aitenant_tenant(case, use_default_gateway=True)
+                apply_discovery_labels(case["tenant_ns"], case["tenant_label_name"])
+                apply_tenant_cr(case["tenant_ns"], DEFAULT_GATEWAY_NAME)
                 apply_maas_auth_policy(shared_policy, case["tenant_ns"])
                 apply_maas_subscription(shared_sub, case["tenant_ns"])
                 wait_for_finalizer("maasauthpolicy", shared_policy, case["tenant_ns"], FINALIZER_AUTHPOLICY)
@@ -177,7 +179,7 @@ class TestMultiTenantIntegration:
             assert first is not None
             assert FINALIZER_AUTHPOLICY not in ((first.get("metadata") or {}).get("finalizers") or [])
 
-            bootstrap_aitenant_tenant(case, use_default_gateway=True)
+            apply_discovery_labels(case["tenant_ns"], case["tenant_label_name"])
             wait_for_finalizer("maasauthpolicy", first_policy, case["tenant_ns"], FINALIZER_AUTHPOLICY)
             wait_for_status_phase("maasauthpolicy", first_policy, case["tenant_ns"], expected_phase="Active")
 

--- a/test/e2e/tests/test_multi_tenant_maas_api.py
+++ b/test/e2e/tests/test_multi_tenant_maas_api.py
@@ -11,9 +11,10 @@ These tests validate the Phase 1 multi-tenant contract:
 import pytest
 
 from multitenancy_helpers import (
+    AITENANT_KIND,
+    AITENANT_NAMESPACE,
     DEPLOYMENT_NAMESPACE,
     GATEWAY_NAMESPACE,
-    TENANT_CR_NAME,
     apply_maas_auth_policy,
     bootstrap_aitenant_tenant,
     cleanup_discovery_case,
@@ -81,8 +82,8 @@ class TestPerTenantMaaSAPI:
             # Verify it targets the tenant Gateway
             assert auth["spec"]["targetRef"]["name"] == case["gateway_name"]
 
-            tenant = wait_for_json("tenant", TENANT_CR_NAME, case["tenant_ns"], timeout=180)
-            assert tenant["spec"]["gatewayRef"]["name"] == case["gateway_name"]
+            aitenant = wait_for_json(AITENANT_KIND, case["tenant_label_name"], AITENANT_NAMESPACE, timeout=180)
+            assert aitenant["status"]["gatewayRef"]["name"] == case["gateway_name"]
 
     def test_tenant_name_environment_variable_set(self, tenant_cases):
         """2.2: TENANT_NAME env var identifies the tenant served by each maas-api Deployment."""

--- a/test/e2e/tests/test_tenant_namespace_discovery.py
+++ b/test/e2e/tests/test_tenant_namespace_discovery.py
@@ -79,8 +79,7 @@ class TestTenantNamespaceDiscovery:
         """1.1: Controller discovers labeled tenant namespaces and reconciles CRs."""
         case = new_discovery_case(use_default_gateway=True)
         try:
-            apply_discovery_labels(case["tenant_ns"], case["tenant_label_name"])
-            apply_tenant_cr(case["tenant_ns"], DEFAULT_GATEWAY_NAME, tenant_label_name=case["tenant_label_name"])
+            bootstrap_aitenant_tenant(case, use_default_gateway=True)
             apply_maas_auth_policy(case["policy_name"], case["tenant_ns"])
             apply_maas_subscription(case["subscription_name"], case["tenant_ns"])
 
@@ -107,8 +106,7 @@ class TestTenantNamespaceDiscovery:
         """1.2: Removing discovery labels stops new reconciliation activity."""
         case = new_discovery_case(use_default_gateway=True)
         try:
-            apply_discovery_labels(case["tenant_ns"], case["tenant_label_name"])
-            apply_tenant_cr(case["tenant_ns"], DEFAULT_GATEWAY_NAME, tenant_label_name=case["tenant_label_name"])
+            bootstrap_aitenant_tenant(case, use_default_gateway=True)
             apply_maas_auth_policy(case["policy_name"], case["tenant_ns"])
             wait_for_finalizer("maasauthpolicy", case["policy_name"], case["tenant_ns"], FINALIZER_AUTHPOLICY)
 
@@ -158,18 +156,18 @@ class TestTenantNamespaceDiscovery:
             delete_namespace_best_effort(unlabeled_ns)
 
     def test_dynamic_discovery_after_label_added(self):
-        """1.2 variant: Pre-existing CRs reconcile after namespace gains discovery labels."""
+        """1.2 variant: Pre-existing CRs reconcile after AITenant adopts and labels the namespace."""
         case = new_discovery_case(use_default_gateway=True)
         try:
             ensure_namespace(case["tenant_ns"])
-            apply_tenant_cr(case["tenant_ns"], DEFAULT_GATEWAY_NAME, tenant_label_name=case["tenant_label_name"])
+            apply_tenant_cr(case["tenant_ns"], DEFAULT_GATEWAY_NAME)
             apply_maas_auth_policy(case["policy_name"], case["tenant_ns"])
             _wait_reconcile(10)
             before = get_json_or_none("maasauthpolicy", case["policy_name"], case["tenant_ns"])
             assert before is not None
             assert FINALIZER_AUTHPOLICY not in ((before.get("metadata") or {}).get("finalizers") or [])
 
-            apply_discovery_labels(case["tenant_ns"], case["tenant_label_name"])
+            bootstrap_aitenant_tenant(case, use_default_gateway=True)
             wait_for_finalizer("maasauthpolicy", case["policy_name"], case["tenant_ns"], FINALIZER_AUTHPOLICY)
             wait_for_status_phase(
                 "maasauthpolicy",
@@ -181,21 +179,15 @@ class TestTenantNamespaceDiscovery:
             cleanup_discovery_case(case, delete_gateway=False)
 
     def test_per_tenant_oidc_configuration(self):
-        """1.4: Gateway-scoped maas-gateway-auth issuerUrl reflects Tenant externalOIDC (#912)."""
-        if not os.environ.get("OIDC_ISSUER_URL"):
+        """1.4: Gateway-scoped maas-gateway-auth issuerUrl reflects AITenant OIDC (#912)."""
+        if os.environ.get("EXTERNAL_OIDC") != "true" or not os.environ.get("OIDC_ISSUER_URL"):
             pytest.skip("OIDC_ISSUER_URL not set; per-tenant OIDC E2E requires external OIDC deploy")
 
         issuer = os.environ["OIDC_ISSUER_URL"]
         case = new_discovery_case(use_default_gateway=True)
 
         try:
-            apply_discovery_labels(case["tenant_ns"], case["tenant_label_name"])
-            apply_tenant_cr(
-                case["tenant_ns"],
-                DEFAULT_GATEWAY_NAME,
-                external_oidc={"issuerUrl": issuer, "clientId": os.environ.get("OIDC_CLIENT_ID", "test-client")},
-                tenant_label_name=case["tenant_label_name"],
-            )
+            bootstrap_aitenant_tenant(case, use_default_gateway=True)
             apply_maas_auth_policy(case["policy_name"], case["tenant_ns"])
             _wait_for_maas_auth_policy_phase(case["policy_name"], namespace=case["tenant_ns"], timeout=180)
 
@@ -223,8 +215,7 @@ class TestTenantNamespaceDiscovery:
 
         try:
             for case in (case_a, case_b):
-                apply_discovery_labels(case["tenant_ns"], case["tenant_label_name"])
-                apply_tenant_cr(case["tenant_ns"], DEFAULT_GATEWAY_NAME, tenant_label_name=case["tenant_label_name"])
+                bootstrap_aitenant_tenant(case, use_default_gateway=True)
                 apply_maas_auth_policy(shared_policy_name, case["tenant_ns"])
                 apply_maas_subscription(shared_sub_name, case["tenant_ns"])
                 wait_for_finalizer("maasauthpolicy", shared_policy_name, case["tenant_ns"], FINALIZER_AUTHPOLICY)
@@ -365,7 +356,7 @@ class TestTenantDiscoveryDormantMode:
         policy_name = f"e2e-dormant-{case['suffix']}"
         try:
             apply_discovery_labels(case["tenant_ns"], case["tenant_label_name"])
-            apply_tenant_cr(case["tenant_ns"], DEFAULT_GATEWAY_NAME, tenant_label_name=case["tenant_label_name"])
+            apply_tenant_cr(case["tenant_ns"], DEFAULT_GATEWAY_NAME)
 
             patch_controller_tenant_namespace_discovery(enabled=False)
             apply_maas_auth_policy(policy_name, case["tenant_ns"])

--- a/test/e2e/tests/test_tenant_namespace_discovery.py
+++ b/test/e2e/tests/test_tenant_namespace_discovery.py
@@ -79,7 +79,8 @@ class TestTenantNamespaceDiscovery:
         """1.1: Controller discovers labeled tenant namespaces and reconciles CRs."""
         case = new_discovery_case(use_default_gateway=True)
         try:
-            bootstrap_aitenant_tenant(case, use_default_gateway=True)
+            apply_discovery_labels(case["tenant_ns"], case["tenant_label_name"])
+            apply_tenant_cr(case["tenant_ns"], DEFAULT_GATEWAY_NAME)
             apply_maas_auth_policy(case["policy_name"], case["tenant_ns"])
             apply_maas_subscription(case["subscription_name"], case["tenant_ns"])
 
@@ -106,7 +107,8 @@ class TestTenantNamespaceDiscovery:
         """1.2: Removing discovery labels stops new reconciliation activity."""
         case = new_discovery_case(use_default_gateway=True)
         try:
-            bootstrap_aitenant_tenant(case, use_default_gateway=True)
+            apply_discovery_labels(case["tenant_ns"], case["tenant_label_name"])
+            apply_tenant_cr(case["tenant_ns"], DEFAULT_GATEWAY_NAME)
             apply_maas_auth_policy(case["policy_name"], case["tenant_ns"])
             wait_for_finalizer("maasauthpolicy", case["policy_name"], case["tenant_ns"], FINALIZER_AUTHPOLICY)
 
@@ -156,7 +158,7 @@ class TestTenantNamespaceDiscovery:
             delete_namespace_best_effort(unlabeled_ns)
 
     def test_dynamic_discovery_after_label_added(self):
-        """1.2 variant: Pre-existing CRs reconcile after AITenant adopts and labels the namespace."""
+        """1.2 variant: Pre-existing CRs reconcile after namespace gains discovery labels."""
         case = new_discovery_case(use_default_gateway=True)
         try:
             ensure_namespace(case["tenant_ns"])
@@ -167,7 +169,7 @@ class TestTenantNamespaceDiscovery:
             assert before is not None
             assert FINALIZER_AUTHPOLICY not in ((before.get("metadata") or {}).get("finalizers") or [])
 
-            bootstrap_aitenant_tenant(case, use_default_gateway=True)
+            apply_discovery_labels(case["tenant_ns"], case["tenant_label_name"])
             wait_for_finalizer("maasauthpolicy", case["policy_name"], case["tenant_ns"], FINALIZER_AUTHPOLICY)
             wait_for_status_phase(
                 "maasauthpolicy",
@@ -179,7 +181,7 @@ class TestTenantNamespaceDiscovery:
             cleanup_discovery_case(case, delete_gateway=False)
 
     def test_per_tenant_oidc_configuration(self):
-        """1.4: Gateway-scoped maas-gateway-auth issuerUrl reflects AITenant OIDC (#912)."""
+        """1.4: Gateway-scoped maas-gateway-auth issuerUrl reflects Tenant externalOIDC (#912)."""
         if os.environ.get("EXTERNAL_OIDC") != "true" or not os.environ.get("OIDC_ISSUER_URL"):
             pytest.skip("OIDC_ISSUER_URL not set; per-tenant OIDC E2E requires external OIDC deploy")
 
@@ -187,7 +189,12 @@ class TestTenantNamespaceDiscovery:
         case = new_discovery_case(use_default_gateway=True)
 
         try:
-            bootstrap_aitenant_tenant(case, use_default_gateway=True)
+            apply_discovery_labels(case["tenant_ns"], case["tenant_label_name"])
+            apply_tenant_cr(
+                case["tenant_ns"],
+                DEFAULT_GATEWAY_NAME,
+                external_oidc={"issuerUrl": issuer, "clientId": os.environ.get("OIDC_CLIENT_ID", "test-client")},
+            )
             apply_maas_auth_policy(case["policy_name"], case["tenant_ns"])
             _wait_for_maas_auth_policy_phase(case["policy_name"], namespace=case["tenant_ns"], timeout=180)
 
@@ -215,7 +222,8 @@ class TestTenantNamespaceDiscovery:
 
         try:
             for case in (case_a, case_b):
-                bootstrap_aitenant_tenant(case, use_default_gateway=True)
+                apply_discovery_labels(case["tenant_ns"], case["tenant_label_name"])
+                apply_tenant_cr(case["tenant_ns"], DEFAULT_GATEWAY_NAME)
                 apply_maas_auth_policy(shared_policy_name, case["tenant_ns"])
                 apply_maas_subscription(shared_sub_name, case["tenant_ns"])
                 wait_for_finalizer("maasauthpolicy", shared_policy_name, case["tenant_ns"], FINALIZER_AUTHPOLICY)


### PR DESCRIPTION
## Description

This pr updates the AITenant/Tenant ownership split for [RHOAIENG-65808](https://redhat.atlassian.net/browse/RHOAIENG-65808) so Gateway and OIDC values derived from AITenant are no longer mirrored into `Tenant.spec`.

Main changes:

- Add shared platform-context resolution for Gateway/OIDC values.
- Use AITenant-owned platform context for AITenant-managed tenants.
- Preserve legacy behavior for unmanaged `Tenant` resources by continuing to honor `Tenant.spec.gatewayRef` and `Tenant.spec.externalOIDC`.
- Stop the AITenant reconciler from overwriting existing `Tenant.spec.gatewayRef` and `Tenant.spec.externalOIDC` values.
- Persist `AITenant.status.gatewayRef` before creating/updating the bridge Tenant to avoid a first-reconcile ordering race.
- Thread the resolved platform context through platform rendering, AuthPolicy OIDC/Gateway lookup, subscription/model route validation, and gateway helper paths.
- Add AITenant watches for affected Tenant/AuthPolicy/Subscription reconciliation paths.
- Document ownership and migration behavior in CRD docs, install docs, upgrade docs, and controller docs.
- Regenerate CRD manifests after API comment updates.

## How Has This Been Tested?

Tested locally from the repository checkout.

Commands run:

```bash
GOTOOLCHAIN=auto GOSUMDB=sum.golang.org GOCACHE=/tmp/maas-go-build GOMODCACHE=/tmp/maas-go-mod go test ./pkg/controller/maas ./pkg/platform/tenantreconcile
GOTOOLCHAIN=auto GOSUMDB=sum.golang.org GOCACHE=/tmp/maas-go-build GOMODCACHE=/tmp/maas-go-mod make -C maas-controller test
GOTOOLCHAIN=auto GOSUMDB=sum.golang.org GOCACHE=/tmp/maas-go-build GOMODCACHE=/tmp/maas-go-mod make -C maas-controller generate manifests
./scripts/ci/validate-manifests.sh
git diff --check
```

Coverage added/updated for:

- AITenant reconciliation no longer mirroring Gateway/OIDC into `Tenant.spec`.
- AITenant status GatewayRef being persisted before bridge Tenant creation.
- Platform context resolution for AITenant-managed and legacy/unmanaged tenants.
- AuthPolicy OIDC lookup from AITenant context.
- Gateway resolution for AITenant-managed tenants.
- AITenant-to-subscription requeue mapping.

## Risk analysis

**Risk rating**: 3

**Why**: This changes controller behavior and reconciliation data flow for tenant Gateway/OIDC ownership, including platform rendering, AuthPolicy generation, subscription route validation, and generated manifests. The change is covered by focused unit tests, full `maas-controller` tests, and manifest validation. Risk is moderate because it touches tenant reconciliation semantics, but legacy/unmanaged `Tenant.spec.gatewayRef` and `Tenant.spec.externalOIDC` behavior is preserved for compatibility.

## Merge criteria:

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reconciliation now responds to AITenant updates, including triggering MaaSSubscription and platform/Tenant reconciliation flows.
  * Consolidated platform-context handling for AITenant-managed tenants (Gateway and External OIDC).
* **Bug Fixes**
  * For AITenant-managed tenants, Tenant `gatewayRef`/`externalOIDC` are ignored; Gateway and OIDC are sourced from AITenant.
  * Improved reconciliation ordering so AITenant status is available before creating the related Tenant, with stricter gateway validation.
  * API key creation now returns consistent errors for additional subscription-selection failure cases.
* **Documentation**
  * Updated install, migration, controller, and CRD reference docs/examples to reflect AITenant ownership and OIDC configuration.
* **Tests**
  * Updated and expanded unit and E2E coverage to validate the new reconciliation, OIDC, and platform-context behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->