### PR TITLE
feat: enforce stream_options.include_usage in IPP pipeline (RHOAIENG-70536)

### DIFF
--- a/deployment/base/payload-processing/manager/plugins-configmap.yaml
+++ b/deployment/base/payload-processing/manager/plugins-configmap.yaml
@@ -22,6 +22,7 @@ data:
     apiVersion: llm-d.ai/v1alpha1
     kind: PayloadProcessorConfig
     plugins:
+    - type: stream-usage-enforcer
     - type: model-provider-resolver
     - type: api-translation
     - type: apikey-injection
@@ -29,6 +30,7 @@ data:
     - name: default
       plugins:
         request:
+        - pluginRef: stream-usage-enforcer
         - pluginRef: model-provider-resolver
         - pluginRef: api-translation
         - pluginRef: apikey-injection


### PR DESCRIPTION
## Description
- Adds `stream-usage-enforcer` to the Stage 2 (post-auth) IPP pipeline ConfigMap, running first before `model-provider-resolver`
- Adds 3 e2e tests verifying token usage in streaming responses

## Problem                                                                     
Streaming chat completion responses lack token usage data because clients don't send `stream_options.include_usage=true`. This breaks `authorized_hits` metrics, Grafana dashboards, and token-based rate limiting.

Addresses: https://redhat.atlassian.net/browse/RHOAIENG-70536
Companion PR: https://github.com/opendatahub-io/ai-gateway-payload-processing/pull/364

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new request-processing plugin to the default payload processing flow, enabling additional usage enforcement during requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->