### PR TITLE
feat: add debounce last update at api keys

### DIFF
--- a/docs/content/concepts/api-key-authentication.md
+++ b/docs/content/concepts/api-key-authentication.md
@@ -97,6 +97,8 @@ The validation endpoint (`/internal/v1/api-keys/validate`) is called by Authorin
 2. Returns `valid: true` with `userId`, `groups`, and `subscription` if the key is active and not expired
 3. Returns `valid: false` with a reason if the key is invalid, revoked, or expired
 
+After a successful lookup, maas-api asynchronously updates `last_used_at` in the background. To prevent Postgres row-lock contention when many requests share a single key, these writes are **debounced**: at most one write is issued per key per `LAST_USED_DEBOUNCE_SECS` window (default 60 s). Set `LAST_USED_DEBOUNCE_SECS=0` on the maas-api Deployment to write on every validation.
+
 ---
 
 ## Subscription Binding and Priority

--- a/docs/content/configuration-and-management/authorino-caching.md
+++ b/docs/content/configuration-and-management/authorino-caching.md
@@ -4,6 +4,17 @@ This document describes how to tune Authorino cache TTLs for metadata and author
 
 ---
 
+## Caching and Write Debounce Overview
+
+MaaS has two complementary mechanisms that reduce database pressure under high request rates:
+
+1. **Authorino metadata cache** — Authorino caches the response from `POST /internal/v1/api-keys/validate` so that repeated requests with the same key do not call maas-api on every inference request.
+2. **`last_used_at` write debounce** — maas-api debounces the `UPDATE api_keys SET last_used_at` write so that a burst of requests sharing one key issues at most one DB write per window, preventing Postgres row-lock contention.
+
+Both mechanisms default to a 60-second window and should be kept in sync (see [Tuning](#when-to-tune)).
+
+---
+
 ## What is Cached
 
 MaaS-generated AuthPolicy resources enable caching on:
@@ -21,7 +32,7 @@ Caching reduces load on maas-api and OPA CPU by reusing results when the cache k
 
 ## Configuration
 
-### CLI Flags
+### Authorino cache TTLs (maas-controller CLI flags)
 
 The maas-controller deployment configures cache TTLs with command-line flags:
 

--- a/docs/content/configuration-and-management/authorino-caching.md
+++ b/docs/content/configuration-and-management/authorino-caching.md
@@ -4,17 +4,6 @@ This document describes how to tune Authorino cache TTLs for metadata and author
 
 ---
 
-## Caching and Write Debounce Overview
-
-MaaS has two complementary mechanisms that reduce database pressure under high request rates:
-
-1. **Authorino metadata cache** — Authorino caches the response from `POST /internal/v1/api-keys/validate` so that repeated requests with the same key do not call maas-api on every inference request.
-2. **`last_used_at` write debounce** — maas-api debounces the `UPDATE api_keys SET last_used_at` write so that a burst of requests sharing one key issues at most one DB write per window, preventing Postgres row-lock contention.
-
-Both mechanisms default to a 60-second window and should be kept in sync (see [Tuning](#when-to-tune)).
-
----
-
 ## What is Cached
 
 MaaS-generated AuthPolicy resources enable caching on:
@@ -32,7 +21,7 @@ Caching reduces load on maas-api and OPA CPU by reusing results when the cache k
 
 ## Configuration
 
-### Authorino cache TTLs (maas-controller CLI flags)
+### CLI Flags
 
 The maas-controller deployment configures cache TTLs with command-line flags:
 

--- a/maas-api/cmd/main.go
+++ b/maas-api/cmd/main.go
@@ -212,6 +212,7 @@ func registerHandlers(ctx context.Context, log *logger.Logger, router *gin.Engin
 	subscriptionHandler := subscription.NewHandler(log, subscriptionSelector)
 
 	apiKeyService := api_keys.NewServiceWithLogger(store, cfg, subscriptionSelector, log)
+	apiKeyService.StartDebounceCleanup(ctx)
 	apiKeyHandler := api_keys.NewHandler(log, apiKeyService, cluster.AdminChecker)
 
 	v1Routes.GET("/models", tokenHandler.ExtractUserInfo(), modelsHandler.ListLLMs)

--- a/maas-api/internal/api_keys/service.go
+++ b/maas-api/internal/api_keys/service.go
@@ -249,7 +249,7 @@ func (s *Service) ValidateAPIKey(ctx context.Context, key string) (*ValidationRe
 	// prevents hundreds of goroutines from racing to UPDATE the same row in Postgres,
 	// which causes row-lock contention and "context deadline exceeded" errors.
 	//nolint:contextcheck // Intentionally using background context - original may be cancelled.
-	if s.shouldUpdateLastUsed(metadata.ID) {
+	if proceed, slot := s.shouldUpdateLastUsed(metadata.ID); proceed {
 		go func() {
 			// Recover from panics to prevent crashing the entire process
 			defer func() {
@@ -263,8 +263,10 @@ func (s *Service) ValidateAPIKey(ctx context.Context, key string) (*ValidationRe
 			defer cancel()
 
 			if err := s.store.UpdateLastUsed(updateCtx, metadata.ID); err != nil {
-				// Reset the debounce timestamp so the next request retries.
-				s.lastUsedDebounce.Delete(metadata.ID)
+				// Clear only the slot this goroutine reserved (CWE-362/CWE-667 mitigation).
+				// A bare Delete would remove any newer slot written by a CAS refresh
+				// if this goroutine was delayed by the scheduler after its context expired.
+				s.clearDebounceSlot(metadata.ID, slot)
 				// Log warning but don't fail validation - this is best-effort tracking
 				s.logger.Warn("Failed to update last_used_at", "key_id", metadata.ID, "error", err)
 			}
@@ -371,20 +373,22 @@ func (s *Service) StartDebounceCleanup(ctx context.Context) {
 	}()
 }
 
-// shouldUpdateLastUsed returns true if a last_used_at DB write should be issued
-// for keyID. It records the current time in the debounce map when returning true,
-// so only one caller per TTL window proceeds.
-// When debouncing is disabled (TTL == 0) it always returns true.
-func (s *Service) shouldUpdateLastUsed(keyID string) bool {
+// shouldUpdateLastUsed returns (proceed, slot) where proceed is true when a
+// last_used_at DB write should be issued for keyID. slot is the timestamp value
+// written into the debounce map for this reservation; callers must pass it to
+// clearDebounceSlot on write failure so only the reserving goroutine can evict
+// its own slot (CWE-362/CWE-667 mitigation).
+// When debouncing is disabled (TTL == 0) it always returns (true, zero time).
+func (s *Service) shouldUpdateLastUsed(keyID string) (bool, time.Time) {
 	if s.lastUsedDebounceTTL == 0 {
-		return true
+		return true, time.Time{}
 	}
 	now := time.Now()
 	// LoadOrStore is atomic: the first caller stores `now` and gets loaded=false,
 	// all concurrent callers within the same window get loaded=true and skip.
 	actual, loaded := s.lastUsedDebounce.LoadOrStore(keyID, now)
 	if !loaded {
-		return true // we were the first — proceed with the write
+		return true, now // we were the first — proceed with the write
 	}
 	lastTime, ok := actual.(time.Time)
 	if ok && now.Sub(lastTime) >= s.lastUsedDebounceTTL {
@@ -393,10 +397,22 @@ func (s *Service) shouldUpdateLastUsed(keyID string) bool {
 		// where many goroutines could all observe the same stale timestamp and
 		// all return true simultaneously (CWE-362).
 		if s.lastUsedDebounce.CompareAndSwap(keyID, actual, now) {
-			return true
+			return true, now
 		}
 	}
-	return false
+	return false, time.Time{}
+}
+
+// clearDebounceSlot removes the debounce entry for keyID only if it still holds
+// slotTime — the value this goroutine stored via shouldUpdateLastUsed. Using
+// CompareAndDelete instead of bare Delete prevents a delayed goroutine from
+// evicting a newer slot written by a concurrent CAS refresh after TTL expiry
+// (CWE-362/CWE-667 mitigation). No-op when debouncing is disabled.
+func (s *Service) clearDebounceSlot(keyID string, slotTime time.Time) {
+	if s.lastUsedDebounceTTL == 0 {
+		return
+	}
+	s.lastUsedDebounce.CompareAndDelete(keyID, slotTime)
 }
 
 // CleanupExpiredEphemeral deletes expired ephemeral keys from storage.

--- a/maas-api/internal/api_keys/service.go
+++ b/maas-api/internal/api_keys/service.go
@@ -354,10 +354,13 @@ func (s *Service) shouldUpdateLastUsed(keyID string) bool {
 	}
 	lastTime, ok := actual.(time.Time)
 	if ok && now.Sub(lastTime) >= s.lastUsedDebounceTTL {
-		// TTL expired; attempt to replace the stored timestamp.
-		// A tiny race here is acceptable for best-effort tracking.
-		s.lastUsedDebounce.Store(keyID, now)
-		return true
+		// TTL expired. Use CompareAndSwap so only one concurrent caller wins
+		// the refresh slot — prevents a TOCTOU storm at every debounce boundary
+		// where many goroutines could all observe the same stale timestamp and
+		// all return true simultaneously (CWE-362).
+		if s.lastUsedDebounce.CompareAndSwap(keyID, actual, now) {
+			return true
+		}
 	}
 	return false
 }

--- a/maas-api/internal/api_keys/service.go
+++ b/maas-api/internal/api_keys/service.go
@@ -337,6 +337,40 @@ func (s *Service) BulkRevokeAPIKeys(ctx context.Context, username string, tenant
 	return s.store.InvalidateAll(ctx, username, tenant)
 }
 
+// StartDebounceCleanup starts a background goroutine that periodically evicts
+// stale entries from the lastUsedDebounce map. Without this the map grows
+// indefinitely — one entry per unique key ID that has ever been validated.
+// Entries older than lastUsedDebounceTTL are already logically expired (the
+// next validation would re-add them), so deleting them is safe and has no
+// effect on debounce correctness.
+// The goroutine stops when ctx is cancelled (server shutdown). It is a no-op
+// when debouncing is disabled (TTL == 0).
+func (s *Service) StartDebounceCleanup(ctx context.Context) {
+	if s.lastUsedDebounceTTL == 0 {
+		return
+	}
+	go func() {
+		// Sweep once per hour regardless of TTL — stale entries are cheap to
+		// hold, so high-frequency sweeps are unnecessary.
+		ticker := time.NewTicker(time.Hour)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				cutoff := time.Now().Add(-s.lastUsedDebounceTTL)
+				s.lastUsedDebounce.Range(func(key, value any) bool {
+					if t, ok := value.(time.Time); ok && t.Before(cutoff) {
+						s.lastUsedDebounce.Delete(key)
+					}
+					return true
+				})
+			}
+		}
+	}()
+}
+
 // shouldUpdateLastUsed returns true if a last_used_at DB write should be issued
 // for keyID. It records the current time in the debounce map when returning true,
 // so only one caller per TTL window proceeds.

--- a/maas-api/internal/api_keys/service.go
+++ b/maas-api/internal/api_keys/service.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -33,6 +34,12 @@ type Service struct {
 	logger      *logger.Logger
 	config      *config.Config
 	subSelector SubscriptionSelector
+
+	// lastUsedDebounce throttles last_used_at writes per key.
+	// Maps key ID (string) → time.Time of last successful DB write.
+	// Prevents Postgres row-lock storms when many requests share one key.
+	lastUsedDebounce    sync.Map
+	lastUsedDebounceTTL time.Duration
 }
 
 func (s *Service) GetMaxExpirationDays() int {
@@ -51,11 +58,18 @@ func NewServiceWithLogger(store MetadataStore, cfg *config.Config, sub Subscript
 	if log == nil {
 		log = logger.Production()
 	}
+
+	debounceTTL := 60 * time.Second
+	if cfg != nil && cfg.LastUsedDebounceSecs >= 0 {
+		debounceTTL = time.Duration(cfg.LastUsedDebounceSecs) * time.Second
+	}
+
 	return &Service{
-		store:       store,
-		logger:      log,
-		config:      cfg,
-		subSelector: sub,
+		store:               store,
+		logger:              log,
+		config:              cfg,
+		subSelector:         sub,
+		lastUsedDebounceTTL: debounceTTL,
 	}
 }
 
@@ -229,25 +243,33 @@ func (s *Service) ValidateAPIKey(ctx context.Context, key string) (*ValidationRe
 		return nil, fmt.Errorf("validation lookup failed: %w", err)
 	}
 
-	// Update last_used_at asynchronously (don't block validation response)
+	// Update last_used_at asynchronously (don't block validation response).
+	// Debounce: skip the DB write if we already wrote within lastUsedDebounceTTL for
+	// this key. Under high concurrency with a shared key (e.g. load tests) this
+	// prevents hundreds of goroutines from racing to UPDATE the same row in Postgres,
+	// which causes row-lock contention and "context deadline exceeded" errors.
 	//nolint:contextcheck // Intentionally using background context - original may be cancelled.
-	go func() {
-		// Recover from panics to prevent crashing the entire process
-		defer func() {
-			if r := recover(); r != nil {
-				s.logger.Error("Panic in UpdateLastUsed goroutine", "panic", r, "key_id", metadata.ID)
+	if s.shouldUpdateLastUsed(metadata.ID) {
+		go func() {
+			// Recover from panics to prevent crashing the entire process
+			defer func() {
+				if r := recover(); r != nil {
+					s.logger.Error("Panic in UpdateLastUsed goroutine", "panic", r, "key_id", metadata.ID)
+				}
+			}()
+
+			// Use background context with timeout since original may be cancelled
+			updateCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+
+			if err := s.store.UpdateLastUsed(updateCtx, metadata.ID); err != nil {
+				// Reset the debounce timestamp so the next request retries.
+				s.lastUsedDebounce.Delete(metadata.ID)
+				// Log warning but don't fail validation - this is best-effort tracking
+				s.logger.Warn("Failed to update last_used_at", "key_id", metadata.ID, "error", err)
 			}
 		}()
-
-		// Use background context with timeout since original may be cancelled
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-		defer cancel()
-
-		if err := s.store.UpdateLastUsed(ctx, metadata.ID); err != nil {
-			// Log warning but don't fail validation - this is best-effort tracking
-			s.logger.Warn("Failed to update last_used_at", "key_id", metadata.ID, "error", err)
-		}
-	}()
+	}
 
 	// Return the user's groups (stored at key creation time)
 	// These groups are used directly by subscription-based authorization
@@ -313,6 +335,31 @@ func (s *Service) BulkRevokeAPIKeys(ctx context.Context, username string, tenant
 		return 0, errors.New("username is required")
 	}
 	return s.store.InvalidateAll(ctx, username, tenant)
+}
+
+// shouldUpdateLastUsed returns true if a last_used_at DB write should be issued
+// for keyID. It records the current time in the debounce map when returning true,
+// so only one caller per TTL window proceeds.
+// When debouncing is disabled (TTL == 0) it always returns true.
+func (s *Service) shouldUpdateLastUsed(keyID string) bool {
+	if s.lastUsedDebounceTTL == 0 {
+		return true
+	}
+	now := time.Now()
+	// LoadOrStore is atomic: the first caller stores `now` and gets loaded=false,
+	// all concurrent callers within the same window get loaded=true and skip.
+	actual, loaded := s.lastUsedDebounce.LoadOrStore(keyID, now)
+	if !loaded {
+		return true // we were the first — proceed with the write
+	}
+	lastTime, ok := actual.(time.Time)
+	if ok && now.Sub(lastTime) >= s.lastUsedDebounceTTL {
+		// TTL expired; attempt to replace the stored timestamp.
+		// A tiny race here is acceptable for best-effort tracking.
+		s.lastUsedDebounce.Store(keyID, now)
+		return true
+	}
+	return false
 }
 
 // CleanupExpiredEphemeral deletes expired ephemeral keys from storage.

--- a/maas-api/internal/api_keys/service_test.go
+++ b/maas-api/internal/api_keys/service_test.go
@@ -210,7 +210,7 @@ func TestValidateAPIKey_UpdatesLastUsed(t *testing.T) {
 	assert.NotEmpty(t, metaAfter.LastUsedAt, "LastUsedAt should be updated after validation")
 }
 
-// TestValidateAPIKey_DebounceSuppressesExtraWrites verifies that rapid consecutive
+// TestValidateAPIKey_DebounceSuppressesExtraWrites verifies that rapid concurrent
 // validations of the same key only trigger one last_used_at DB write within the
 // debounce window (simulating a high-concurrency single-key scenario).
 func TestValidateAPIKey_DebounceSuppressesExtraWrites(t *testing.T) {
@@ -237,39 +237,79 @@ func TestValidateAPIKey_DebounceSuppressesExtraWrites(t *testing.T) {
 	}
 	wg.Wait()
 
-	// Give async goroutines time to complete their DB writes.
-	time.Sleep(100 * time.Millisecond)
-
-	// Only one write should have reached the store within the debounce window.
-	assert.Equal(t, 1, store.UpdateLastUsedCount,
+	// Poll instead of a fixed sleep: wait until the single debounced write completes.
+	require.Eventually(t, func() bool {
+		return store.GetUpdateLastUsedCount() == 1
+	}, time.Second, 10*time.Millisecond,
 		"debounce should collapse %d concurrent validations into a single DB write", concurrentRequests)
 }
 
-// TestValidateAPIKey_DebounceAllowsWriteAfterTTLExpires verifies that after the
-// debounce TTL expires a new validation does issue a fresh last_used_at write.
-func TestValidateAPIKey_DebounceAllowsWriteAfterTTLExpires(t *testing.T) {
+// TestValidateAPIKey_DebounceDisabled_WritesEveryTime verifies that when
+// LAST_USED_DEBOUNCE_SECS=0 every validation issues a last_used_at write.
+func TestValidateAPIKey_DebounceDisabled_WritesEveryTime(t *testing.T) {
 	ctx := context.Background()
 
 	store := api_keys.NewMockStore()
-	// Very short TTL so the test can advance past it quickly.
 	cfg := &config.Config{LastUsedDebounceSecs: 0} // 0 == disabled, always write
 	svc := api_keys.NewServiceWithLogger(store, cfg, serviceTestSubSelector{}, logger.Development())
 
 	keyID := "550e8400-e29b-41d4-a716-446655440021"
 	plainKey, hash := createTestAPIKey(t)
-	err := store.AddKey(ctx, "grace", keyID, hash, "Debounce TTL Test", "", []string{"tier-basic"}, "default-sub", "", nil, false)
+	err := store.AddKey(ctx, "grace", keyID, hash, "Debounce Disabled Test", "", []string{"tier-basic"}, "default-sub", "", nil, false)
 	require.NoError(t, err)
 
-	// With debouncing disabled every call should write.
-	for range 3 {
+	const calls = 3
+	for range calls {
 		result, validateErr := svc.ValidateAPIKey(ctx, plainKey)
 		require.NoError(t, validateErr)
 		assert.True(t, result.Valid)
 	}
-	time.Sleep(100 * time.Millisecond)
 
-	assert.Equal(t, 3, store.UpdateLastUsedCount,
-		"with debounce disabled all validations should write to the DB")
+	require.Eventually(t, func() bool {
+		return store.GetUpdateLastUsedCount() == calls
+	}, time.Second, 10*time.Millisecond,
+		"with debounce disabled all %d validations should write to the DB", calls)
+}
+
+// TestValidateAPIKey_DebounceWritesAfterTTLExpiry verifies that after the debounce
+// TTL expires a second validation issues a fresh last_used_at write.
+func TestValidateAPIKey_DebounceWritesAfterTTLExpiry(t *testing.T) {
+	ctx := context.Background()
+
+	store := api_keys.NewMockStore()
+	cfg := &config.Config{LastUsedDebounceSecs: 1} // 1-second TTL
+	svc := api_keys.NewServiceWithLogger(store, cfg, serviceTestSubSelector{}, logger.Development())
+
+	keyID := "550e8400-e29b-41d4-a716-446655440022"
+	plainKey, hash := createTestAPIKey(t)
+	err := store.AddKey(ctx, "henry", keyID, hash, "TTL Expiry Test", "", []string{"tier-basic"}, "default-sub", "", nil, false)
+	require.NoError(t, err)
+
+	// First validation triggers a write.
+	result, err := svc.ValidateAPIKey(ctx, plainKey)
+	require.NoError(t, err)
+	assert.True(t, result.Valid)
+	require.Eventually(t, func() bool {
+		return store.GetUpdateLastUsedCount() == 1
+	}, time.Second, 10*time.Millisecond, "first write should complete")
+
+	// Second validation within the TTL window should NOT trigger a write.
+	result, err = svc.ValidateAPIKey(ctx, plainKey)
+	require.NoError(t, err)
+	assert.True(t, result.Valid)
+	time.Sleep(50 * time.Millisecond)
+	assert.Equal(t, 1, store.GetUpdateLastUsedCount(), "no write should occur within debounce window")
+
+	// Wait for the TTL to expire.
+	time.Sleep(1100 * time.Millisecond)
+
+	// Third validation — TTL has expired, a new write should be issued.
+	result, err = svc.ValidateAPIKey(ctx, plainKey)
+	require.NoError(t, err)
+	assert.True(t, result.Valid)
+	require.Eventually(t, func() bool {
+		return store.GetUpdateLastUsedCount() == 2
+	}, time.Second, 10*time.Millisecond, "write should happen after TTL expiry")
 }
 
 // TestValidateAPIKey_ReturnsTenant verifies that a valid key's tenant is included

--- a/maas-api/internal/api_keys/service_test.go
+++ b/maas-api/internal/api_keys/service_test.go
@@ -3,6 +3,7 @@ package api_keys_test
 import (
 	"context"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -207,6 +208,68 @@ func TestValidateAPIKey_UpdatesLastUsed(t *testing.T) {
 	metaAfter, err := store.Get(ctx, keyID)
 	require.NoError(t, err)
 	assert.NotEmpty(t, metaAfter.LastUsedAt, "LastUsedAt should be updated after validation")
+}
+
+// TestValidateAPIKey_DebounceSuppressesExtraWrites verifies that rapid consecutive
+// validations of the same key only trigger one last_used_at DB write within the
+// debounce window (simulating a high-concurrency single-key scenario).
+func TestValidateAPIKey_DebounceSuppressesExtraWrites(t *testing.T) {
+	ctx := context.Background()
+
+	store := api_keys.NewMockStore()
+	// 1-second debounce window — long enough for the test to stay within it.
+	cfg := &config.Config{LastUsedDebounceSecs: 1}
+	svc := api_keys.NewServiceWithLogger(store, cfg, serviceTestSubSelector{}, logger.Development())
+
+	keyID := "550e8400-e29b-41d4-a716-446655440020"
+	plainKey, hash := createTestAPIKey(t)
+	err := store.AddKey(ctx, "frank", keyID, hash, "Debounce Test", "", []string{"tier-basic"}, "default-sub", "", nil, false)
+	require.NoError(t, err)
+
+	const concurrentRequests = 10
+	var wg sync.WaitGroup
+	for range concurrentRequests {
+		wg.Go(func() {
+			result, validateErr := svc.ValidateAPIKey(ctx, plainKey)
+			require.NoError(t, validateErr)
+			assert.True(t, result.Valid)
+		})
+	}
+	wg.Wait()
+
+	// Give async goroutines time to complete their DB writes.
+	time.Sleep(100 * time.Millisecond)
+
+	// Only one write should have reached the store within the debounce window.
+	assert.Equal(t, 1, store.UpdateLastUsedCount,
+		"debounce should collapse %d concurrent validations into a single DB write", concurrentRequests)
+}
+
+// TestValidateAPIKey_DebounceAllowsWriteAfterTTLExpires verifies that after the
+// debounce TTL expires a new validation does issue a fresh last_used_at write.
+func TestValidateAPIKey_DebounceAllowsWriteAfterTTLExpires(t *testing.T) {
+	ctx := context.Background()
+
+	store := api_keys.NewMockStore()
+	// Very short TTL so the test can advance past it quickly.
+	cfg := &config.Config{LastUsedDebounceSecs: 0} // 0 == disabled, always write
+	svc := api_keys.NewServiceWithLogger(store, cfg, serviceTestSubSelector{}, logger.Development())
+
+	keyID := "550e8400-e29b-41d4-a716-446655440021"
+	plainKey, hash := createTestAPIKey(t)
+	err := store.AddKey(ctx, "grace", keyID, hash, "Debounce TTL Test", "", []string{"tier-basic"}, "default-sub", "", nil, false)
+	require.NoError(t, err)
+
+	// With debouncing disabled every call should write.
+	for range 3 {
+		result, validateErr := svc.ValidateAPIKey(ctx, plainKey)
+		require.NoError(t, validateErr)
+		assert.True(t, result.Valid)
+	}
+	time.Sleep(100 * time.Millisecond)
+
+	assert.Equal(t, 3, store.UpdateLastUsedCount,
+		"with debounce disabled all validations should write to the DB")
 }
 
 // TestValidateAPIKey_ReturnsTenant verifies that a valid key's tenant is included

--- a/maas-api/internal/api_keys/store_mock.go
+++ b/maas-api/internal/api_keys/store_mock.go
@@ -477,6 +477,14 @@ func (m *MockStore) UpdateLastUsed(ctx context.Context, keyID string) error {
 	return nil
 }
 
+// GetUpdateLastUsedCount returns the current call count under the store's read lock,
+// safe for concurrent use with in-flight UpdateLastUsed calls.
+func (m *MockStore) GetUpdateLastUsedCount() int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.UpdateLastUsedCount
+}
+
 // DeleteExpiredEphemeral removes expired ephemeral keys from the mock store.
 // Mirrors PostgresStore: only deletes keys expired for at least 30 minutes.
 func (m *MockStore) DeleteExpiredEphemeral(ctx context.Context) (int64, error) {

--- a/maas-api/internal/api_keys/store_mock.go
+++ b/maas-api/internal/api_keys/store_mock.go
@@ -15,6 +15,10 @@ import (
 type MockStore struct {
 	mu   sync.RWMutex
 	keys map[string]*storedKey // keyed by ID
+
+	// UpdateLastUsedCount tracks how many times UpdateLastUsed has been called.
+	// Useful for asserting debounce behavior in tests.
+	UpdateLastUsedCount int
 }
 
 type storedKey struct {
@@ -469,6 +473,7 @@ func (m *MockStore) UpdateLastUsed(ctx context.Context, keyID string) error {
 
 	now := time.Now().UTC()
 	k.lastUsedAt = &now
+	m.UpdateLastUsedCount++
 	return nil
 }
 

--- a/maas-api/internal/config/config.go
+++ b/maas-api/internal/config/config.go
@@ -61,6 +61,13 @@ type Config struct {
 	// Bounds memory usage under high-cardinality user traffic. Default: 8192.
 	SARCacheMaxSize int
 
+	// LastUsedDebounceSecs is the minimum number of seconds between consecutive
+	// last_used_at writes to Postgres for the same API key. When many requests
+	// share a single key (e.g. load tests), only one UPDATE is issued per window
+	// instead of one per request, preventing row-lock contention.
+	// Set to 0 to disable debouncing (every validation writes to DB). Default: 60.
+	LastUsedDebounceSecs int
+
 	MetricsPort int
 
 	// Deprecated flag (backward compatibility with pre-TLS version)
@@ -75,6 +82,7 @@ func Load() *Config {
 	maxExpirationDays, _ := env.GetInt("API_KEY_MAX_EXPIRATION_DAYS", constant.DefaultAPIKeyMaxExpirationDays)
 	accessCheckTimeoutSeconds, _ := env.GetInt("ACCESS_CHECK_TIMEOUT_SECONDS", 15)
 	sarCacheMaxSize, _ := env.GetInt("SAR_CACHE_MAX_SIZE", constant.DefaultSARCacheMaxSize)
+	lastUsedDebounceSecs, _ := env.GetInt("LAST_USED_DEBOUNCE_SECS", 60)
 	metricsPort, _ := env.GetInt("METRICS_PORT", constant.DefaultMetricsPort)
 
 	tenantName := strings.TrimSpace(env.GetString("TENANT_NAME", "models-as-a-service"))
@@ -97,6 +105,7 @@ func Load() *Config {
 		APIKeyMaxExpirationDays:   maxExpirationDays,
 		AccessCheckTimeoutSeconds: accessCheckTimeoutSeconds,
 		SARCacheMaxSize:           sarCacheMaxSize,
+		LastUsedDebounceSecs:      lastUsedDebounceSecs,
 		MetricsPort:               metricsPort,
 		// Deprecated env var (backward compatibility with pre-TLS version)
 		deprecatedHTTPPort: env.GetString("PORT", ""),

--- a/maas-api/internal/config/config.go
+++ b/maas-api/internal/config/config.go
@@ -188,6 +188,10 @@ func (c *Config) Validate() error {
 		return errors.New("ACCESS_CHECK_TIMEOUT_SECONDS must be at least 1")
 	}
 
+	if c.LastUsedDebounceSecs < 0 {
+		return errors.New("LAST_USED_DEBOUNCE_SECS must be greater than or equal to 0")
+	}
+
 	if c.MetricsPort < 1 || c.MetricsPort > 65535 {
 		return errors.New("METRICS_PORT must be between 1 and 65535")
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
## Problem
A customer running 256 concurrent requests against a single API key hit a `context deadline exceeded` while maas-api tried to update `last_used_at` in Postgres.  Every successful validation — including for ephemeral keys — fires an async goroutine that issues:

```sql
UPDATE api_keys SET last_used_at = $1 WHERE id = $2 AND tenant = $3
```

With 256 goroutines racing to UPDATE the same row, Postgres row-level locking causes all but the first to queue up. The 2-second goroutine timeout expires before most of them acquire the lock.

## Solution
Add a lightweight in-memory debounce to Service (sync.Map keyed by key ID) so only one UpdateLastUsed goroutine is spawned per key per configurable window instead of one per request.
```
Authorino cache (60 s TTL)
  └─ validate called on cache miss
       ├─ [SYNC]  GetByHash → SELECT (unchanged)
       └─ [ASYNC, debounced] UpdateLastUsed → UPDATE  ← at most 1/window per key
```
**Key properties:**
- Default window: 60 s (LAST_USED_DEBOUNCE_SECS=60), matching Authorino's metadata-cache TTL — no observable loss of last_used_at precision relative to what callers already see.
- LAST_USED_DEBOUNCE_SECS=0 disables debouncing (write on every validation) for backward compatibility.
- If the write fails, the debounce entry is evicted so the next request retries — no permanent suppression on errors.
- sync.Map.LoadOrStore is atomic, so the "first caller wins" selection is race-free.
[RHOAIENG-72575](https://redhat.atlassian.net/browse/RHOAIENG-72575)

## How Has This Been Tested?
- Local manual testing

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * API key validation now refreshes `last_used_at` in a throttled background manner to reduce backend contention during high traffic.
  * Added `LAST_USED_DEBOUNCE_SECS` (`0` disables throttling; default is `60`) to control the minimum time between `last_used_at` updates per key.

* **Bug Fixes**
  * Improved consistency of `last_used_at` updates under concurrent validations, including recovery when background updates fail.

* **Documentation**
  * Updated API key authentication docs to explain the debounced behavior and configuration override.

* **Tests**
  * Added coverage for throttled vs non-throttled and TTL-expiry scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->