### PR TITLE
feat: wire up OIDC JWKS cache TTL from Tenant CR to Authorino

### DIFF
--- a/deployment/base/observability/authorino-maas-oidc-prometheusrule.yaml
+++ b/deployment/base/observability/authorino-maas-oidc-prometheusrule.yaml
@@ -1,0 +1,52 @@
+# PrometheusRule: alert when Authorino OIDC/JWT authentication fails often or becomes slow.
+#
+# Scraped metrics come from Authorino /server-metrics (see authorino-server-metrics-servicemonitor.yaml).
+# Requires Tenant.spec.externalOIDC configured (MaaS controller creates AuthConfig with JWT auth).
+#
+# Deployed by: scripts/observability/install-observability.sh (NOT kustomize base)
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: authorino-maas-oidc-authentication-high-failure-rate
+  namespace: kuadrant-system
+  labels:
+    app.kubernetes.io/part-of: maas-observability
+    app.kubernetes.io/component: alerting
+spec:
+  groups:
+  - name: maas.authorino.oidc
+    rules:
+    - alert: MaaSAuthorinoOIDCAuthenticationHighFailureRate
+      annotations:
+        summary: Authorino OIDC/JWT authentication is failing often
+        description: >-
+          Over the last 5 minutes, more than 10% of Authorino OIDC/JWT authentication attempts
+          resulted in UNAUTHENTICATED status. Investigate IdP (Keycloak/OIDC provider) health,
+          JWKS endpoint reachability, JWKS cache TTL configuration, and token validity.
+      expr: |
+        (
+          sum(rate(auth_server_authconfig_response_status{namespace=~"rh-connectivity-link|kuadrant-system",status="UNAUTHENTICATED"}[5m]))
+          /
+          sum(rate(auth_server_authconfig_response_status{namespace=~"rh-connectivity-link|kuadrant-system"}[5m]))
+        ) > 0.10
+        and
+        sum(rate(auth_server_authconfig_response_status{namespace=~"rh-connectivity-link|kuadrant-system"}[5m])) > 0.001
+      for: 5m
+      labels:
+        severity: warning
+    - alert: MaaSAuthorinoOIDCAuthenticationHighLatency
+      annotations:
+        summary: Authorino OIDC/JWT authentication latency is high
+        description: >-
+          Over the last 5 minutes, P95 latency for Authorino OIDC/JWT authentication
+          exceeded 2 seconds. Investigate IdP performance, network latency to JWKS endpoint,
+          and consider increasing JWKS cache TTL if IdP is slow but reliable.
+      expr: |
+        histogram_quantile(0.95,
+          sum(rate(auth_server_authconfig_duration_seconds_bucket{namespace=~"rh-connectivity-link|kuadrant-system"}[5m])) by (le)
+        ) > 2
+        and
+        sum(rate(auth_server_authconfig_duration_seconds_count{namespace=~"rh-connectivity-link|kuadrant-system"}[5m])) > 0.001
+      for: 5m
+      labels:
+        severity: warning

--- a/deployment/base/observability/authorino-maas-oidc-prometheusrule.yaml
+++ b/deployment/base/observability/authorino-maas-oidc-prometheusrule.yaml
@@ -1,28 +1,30 @@
-# PrometheusRule: alert when Authorino OIDC/JWT authentication fails often or becomes slow.
+# PrometheusRule: alert when Authorino gateway authentication fails often or becomes slow.
 #
 # Scraped metrics come from Authorino /server-metrics (see authorino-server-metrics-servicemonitor.yaml).
-# Requires Tenant.spec.externalOIDC configured (MaaS controller creates AuthConfig with JWT auth).
+# These alerts cover all gateway-level authentication methods (OIDC/JWT, API key, TokenReview)
+# because auth_server_authconfig_response_status does not carry evaluator-level labels.
 #
 # Deployed by: scripts/observability/install-observability.sh (NOT kustomize base)
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
-  name: authorino-maas-oidc-authentication-high-failure-rate
+  name: authorino-maas-authentication-alerts
   namespace: kuadrant-system
   labels:
     app.kubernetes.io/part-of: maas-observability
     app.kubernetes.io/component: alerting
 spec:
   groups:
-  - name: maas.authorino.oidc
+  - name: maas.authorino.authentication
     rules:
-    - alert: MaaSAuthorinoOIDCAuthenticationHighFailureRate
+    - alert: MaaSAuthorinoAuthenticationHighFailureRate
       annotations:
-        summary: Authorino OIDC/JWT authentication is failing often
+        summary: Authorino gateway authentication is failing often
         description: >-
-          Over the last 5 minutes, more than 10% of Authorino OIDC/JWT authentication attempts
-          resulted in UNAUTHENTICATED status. Investigate IdP (Keycloak/OIDC provider) health,
-          JWKS endpoint reachability, JWKS cache TTL configuration, and token validity.
+          Over the last 5 minutes, more than 10% of Authorino authentication attempts
+          resulted in UNAUTHENTICATED status. This covers all gateway auth methods
+          (OIDC/JWT, API key, TokenReview). Investigate IdP health, JWKS endpoint
+          reachability, API key validity, and token expiration.
       expr: |
         (
           sum(rate(auth_server_authconfig_response_status{namespace=~"rh-connectivity-link|kuadrant-system",status="UNAUTHENTICATED"}[5m]))
@@ -34,13 +36,14 @@ spec:
       for: 5m
       labels:
         severity: warning
-    - alert: MaaSAuthorinoOIDCAuthenticationHighLatency
+    - alert: MaaSAuthorinoAuthenticationHighLatency
       annotations:
-        summary: Authorino OIDC/JWT authentication latency is high
+        summary: Authorino gateway authentication latency is high
         description: >-
-          Over the last 5 minutes, P95 latency for Authorino OIDC/JWT authentication
-          exceeded 2 seconds. Investigate IdP performance, network latency to JWKS endpoint,
-          and consider increasing JWKS cache TTL if IdP is slow but reliable.
+          Over the last 5 minutes, P95 latency for Authorino authentication
+          exceeded 2 seconds. This covers all gateway auth methods. Investigate
+          IdP performance, network latency to JWKS endpoint, maas-api metadata
+          callback latency, and consider increasing JWKS cache TTL if IdP is slow.
       expr: |
         histogram_quantile(0.95,
           sum(rate(auth_server_authconfig_duration_seconds_bucket{namespace=~"rh-connectivity-link|kuadrant-system"}[5m])) by (le)

--- a/deployment/base/observability/kustomization.yaml
+++ b/deployment/base/observability/kustomization.yaml
@@ -20,8 +20,9 @@ resources:
 # (rh-connectivity-link). The install-observability.sh script deploys it with
 # dynamic namespace substitution.
 #
-# NOTE: authorino-maas-oidc-prometheusrule.yaml is NOT included here for the
-# same reason — deployed by install-observability.sh with namespace substitution.
+# NOTE: authorino-maas-oidc-prometheusrule.yaml (authentication alerts) is NOT
+# included here for the same reason — deployed by install-observability.sh with
+# namespace substitution.
 - gateway-telemetry-policy.yaml
 - istio-gateway-telemetry.yaml
 

--- a/deployment/base/observability/kustomization.yaml
+++ b/deployment/base/observability/kustomization.yaml
@@ -19,6 +19,9 @@ resources:
 # It has a hardcoded namespace (kuadrant-system) which causes problems in RHOAI
 # (rh-connectivity-link). The install-observability.sh script deploys it with
 # dynamic namespace substitution.
+#
+# NOTE: authorino-maas-oidc-prometheusrule.yaml is NOT included here for the
+# same reason — deployed by install-observability.sh with namespace substitution.
 - gateway-telemetry-policy.yaml
 - istio-gateway-telemetry.yaml
 

--- a/docs/content/advanced-administration/external-oidc.md
+++ b/docs/content/advanced-administration/external-oidc.md
@@ -61,12 +61,12 @@ See [Tenant CRD reference](../reference/crds/tenant.md) for all fields.
 
 ## Monitoring
 
-Two PrometheusRule alerts monitor OIDC authentication health. They are deployed by `scripts/observability/install-observability.sh` (not by the kustomize base).
+Two PrometheusRule alerts monitor gateway authentication health. They cover all auth methods (OIDC/JWT, API key, TokenReview) because Authorino's `auth_server_authconfig_response_status` does not carry evaluator-level labels. They are deployed by `scripts/observability/install-observability.sh` (not by the kustomize base).
 
 | Alert | Condition | Severity |
 |-------|-----------|----------|
-| `MaaSAuthorinoOIDCAuthenticationHighFailureRate` | >10% of auth attempts return `UNAUTHENTICATED` over 5m | warning |
-| `MaaSAuthorinoOIDCAuthenticationHighLatency` | P95 auth latency >2s over 5m | warning |
+| `MaaSAuthorinoAuthenticationHighFailureRate` | >10% of auth attempts return `UNAUTHENTICATED` over 5m | warning |
+| `MaaSAuthorinoAuthenticationHighLatency` | P95 auth latency >2s over 5m | warning |
 
 **Common causes of high failure rate:**
 

--- a/docs/content/advanced-administration/external-oidc.md
+++ b/docs/content/advanced-administration/external-oidc.md
@@ -1,0 +1,84 @@
+# External OIDC Configuration
+
+Configure an external OIDC identity provider (e.g., Keycloak, Entra ID) for token-based authentication alongside OpenShift TokenReview and API keys.
+
+!!! info "Tech Preview"
+    OIDC JWT validation is optional alongside `kubernetesTokenReview`. Model routes rely on API-key auth; the typical flow is authenticate at `maas-api`, mint an API key, then use that key for discovery and inference.
+
+## JWKS Cache TTL
+
+Authorino validates OIDC tokens by fetching the IdP's JWKS (JSON Web Key Set). The `ttl` field controls how long Authorino caches the key set before re-fetching.
+
+```yaml
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: Tenant
+metadata:
+  name: default-tenant
+spec:
+  externalOIDC:
+    issuerUrl: "https://keycloak.example.com/realms/maas"
+    clientId: maas-api
+    ttl: 300  # seconds (default)
+```
+
+| Field | Default | Minimum | Description |
+|-------|---------|---------|-------------|
+| `ttl` | 300 | 30 | JWKS cache duration in seconds. CRD validation enforces the minimum. |
+
+**Choosing a TTL value:**
+
+- **Lower TTL** (30-60s): faster key rotation propagation, more frequent JWKS fetches.
+- **Default TTL** (300s): balanced for most deployments.
+- **Higher TTL** (600-3600s): reduced load on the IdP, but key rotations take longer to propagate.
+
+### IdP Outage Behavior
+
+When the IdP becomes unreachable:
+
+- Authorino continues using the **last successfully cached JWKS** indefinitely. Existing tokens signed with cached keys keep working.
+- The `ttl` controls refresh frequency, not cache expiration. Authorino does not evict cached keys on TTL expiry if the refresh fails.
+- Tokens signed with keys that were **never cached** (e.g., a key added to the IdP after the last successful fetch) will fail validation until the IdP is reachable again.
+
+### Multi-Tenant TTL
+
+In multi-tenant deployments, each tenant configures TTL independently via its own Tenant CR. The controller applies the per-tenant TTL to that tenant's gateway-level AuthPolicy:
+
+```yaml
+# Tenant in ai-tenant-team-a namespace
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: Tenant
+metadata:
+  name: default-tenant
+  namespace: ai-tenant-team-a
+spec:
+  externalOIDC:
+    issuerUrl: "https://keycloak.example.com/realms/team-a"
+    clientId: team-a-client
+    ttl: 60  # team-a uses aggressive refresh
+```
+
+See [Tenant CRD reference](../reference/crds/tenant.md) for all fields.
+
+## Monitoring
+
+Two PrometheusRule alerts monitor OIDC authentication health. They are deployed by `scripts/observability/install-observability.sh` (not by the kustomize base).
+
+| Alert | Condition | Severity |
+|-------|-----------|----------|
+| `MaaSAuthorinoOIDCAuthenticationHighFailureRate` | >10% of auth attempts return `UNAUTHENTICATED` over 5m | warning |
+| `MaaSAuthorinoOIDCAuthenticationHighLatency` | P95 auth latency >2s over 5m | warning |
+
+**Common causes of high failure rate:**
+
+- IdP (Keycloak/OIDC provider) is down or unreachable
+- JWKS endpoint unreachable (network policy, DNS)
+- Expired or revoked tokens in client applications
+- Incorrect `clientId` in the Tenant CR
+
+**Common causes of high latency:**
+
+- Slow IdP response times
+- Network latency to JWKS endpoint
+- Consider increasing `ttl` if the IdP is slow but reliable
+
+See [Metrics & Dashboards](../observability/metrics-and-dashboards.md) for all Authorino metrics.

--- a/docs/content/advanced-administration/external-oidc.md
+++ b/docs/content/advanced-administration/external-oidc.md
@@ -82,3 +82,20 @@ Two PrometheusRule alerts monitor gateway authentication health. They cover all 
 - Consider increasing `ttl` if the IdP is slow but reliable
 
 See [Metrics & Dashboards](../observability/metrics-and-dashboards.md) for all Authorino metrics.
+
+## Security controls and responsibilities
+
+This table covers the non-functional security requirements (NFRs) raised during GA refinement. Each row states who enforces the control and what an operator needs to know.
+
+| NFR | Enforced by | Details |
+|-----|-------------|---------|
+| **JWKS cache policy** | MaaS controller + Authorino | `ttl` is propagated from the Tenant CR to Authorino's `jwt.ttl` field. Minimum 30 s enforced server-side in the controller (independent of CRD admission validation). See [JWKS Cache TTL](#jwks-cache-ttl) above. |
+| **Client secret handling** | Not applicable | MaaS external OIDC uses **JWT bearer validation only**. Tokens are validated against the IdP's public JWKS. No `client_secret` is required or stored at runtime. The `clientId` field in the Tenant CR is configuration, not a credential. |
+| **OAuth client binding (`azp` claim)** | MaaS controller (gateway AuthPolicy) | The generated `maas-gateway-auth` AuthPolicy includes an `oidc-client-bound` rule that checks `auth.identity.azp == clientId`. Tokens issued to a different OAuth client are rejected with 403, even if they share the same issuer. An `has(auth.identity.azp)` guard ensures OpenShift TokenReview identities (which carry no `azp` claim) are unaffected. |
+| **SSRF on issuer URL** | CRD validation + Authorino HTTP client | The CRD enforces `^https://\S+$` on `issuerUrl`, blocking plain HTTP and empty URLs at admission time. Blocking of private IPs and loopback addresses in JWKS fetch is the responsibility of the Authorino HTTP client (outside MaaS). Operators in restricted environments should use network policies to constrain Authorino's egress. |
+| **Rate limiting on auth paths** | Kuadrant TokenRateLimitPolicy (model inference only) | The `gateway-default-deny` TRLP enforces a 0-token default on model inference routes and **explicitly excludes** `/maas-api` management paths. Authorino's internal JWKS refresh is not exposed as an external endpoint and is not subject to per-request rate limiting. If high-volume IdP calls are a concern, increase `ttl` to reduce refresh frequency. |
+| **Authentication audit trail** | Authorino metrics + PrometheusRule alerts | `auth_server_authconfig_response_status` provides aggregate counts by status (`OK`, `UNAUTHENTICATED`, `UNAUTHORIZED`). The `MaaSAuthorinoAuthenticationHighFailureRate` alert fires on sustained failure rates above 10%. Per-request auth decision logging requires capturing Authorino's structured log output at debug/info level outside MaaS. |
+
+### OAuth2 Client Credentials — out of scope
+
+The **OAuth2 Client Credentials** (`grant_type=client_credentials`) flow is **not supported** in this GA release. MaaS external OIDC targets interactive/bearer JWT flows where end users authenticate against their corporate IdP and present access tokens. Machine-to-machine use cases should use [API keys](../concepts/api-key-authentication.md) or a broker IdP that exchanges client credentials for bearer tokens compatible with the OIDC JWT path.

--- a/docs/content/observability/metrics-and-dashboards.md
+++ b/docs/content/observability/metrics-and-dashboards.md
@@ -75,6 +75,15 @@ Exposed on `/server-metrics` (port 8080):
 
 **Alert:** `authorino-maas-metadata-evaluator-prometheusrule.yaml` — **`MaaSAuthorinoMetadataEvaluatorHighFailureRate`** (`cancelled`/`total` > 10% over 5m, traffic guard, **`for: 5m`**). **Remediate:** maas-api health; Authorino → maas-api TLS/NetworkPolicy; confirm **`/server-metrics`** is scraped.
 
+**OIDC Alerts:** `authorino-maas-oidc-prometheusrule.yaml` — two alerts for OIDC/JWT authentication health:
+
+| Alert | Condition | Severity |
+|-------|-----------|----------|
+| **`MaaSAuthorinoOIDCAuthenticationHighFailureRate`** | >10% of auth attempts return `UNAUTHENTICATED` over 5m | warning |
+| **`MaaSAuthorinoOIDCAuthenticationHighLatency`** | P95 `auth_server_authconfig_duration_seconds` >2s over 5m | warning |
+
+**Remediate:** IdP (Keycloak/OIDC provider) health; JWKS endpoint reachability; token validity; consider increasing `Tenant.spec.externalOIDC.ttl` if IdP is slow but reliable. See [External OIDC Configuration](../advanced-administration/external-oidc.md).
+
 ### vLLM Metrics
 
 Exposed on `/metrics` (port 8000). Supported backends: vLLM v0.7.x, llm-d v0.1.x, llm-d-inference-sim v0.8.2.

--- a/docs/content/observability/metrics-and-dashboards.md
+++ b/docs/content/observability/metrics-and-dashboards.md
@@ -75,14 +75,14 @@ Exposed on `/server-metrics` (port 8080):
 
 **Alert:** `authorino-maas-metadata-evaluator-prometheusrule.yaml` — **`MaaSAuthorinoMetadataEvaluatorHighFailureRate`** (`cancelled`/`total` > 10% over 5m, traffic guard, **`for: 5m`**). **Remediate:** maas-api health; Authorino → maas-api TLS/NetworkPolicy; confirm **`/server-metrics`** is scraped.
 
-**OIDC Alerts:** `authorino-maas-oidc-prometheusrule.yaml` — two alerts for OIDC/JWT authentication health:
+**Authentication Alerts:** `authorino-maas-authentication-alerts` — two alerts for gateway authentication health (covers all auth methods: OIDC/JWT, API key, TokenReview):
 
 | Alert | Condition | Severity |
 |-------|-----------|----------|
-| **`MaaSAuthorinoOIDCAuthenticationHighFailureRate`** | >10% of auth attempts return `UNAUTHENTICATED` over 5m | warning |
-| **`MaaSAuthorinoOIDCAuthenticationHighLatency`** | P95 `auth_server_authconfig_duration_seconds` >2s over 5m | warning |
+| **`MaaSAuthorinoAuthenticationHighFailureRate`** | >10% of auth attempts return `UNAUTHENTICATED` over 5m | warning |
+| **`MaaSAuthorinoAuthenticationHighLatency`** | P95 `auth_server_authconfig_duration_seconds` >2s over 5m | warning |
 
-**Remediate:** IdP (Keycloak/OIDC provider) health; JWKS endpoint reachability; token validity; consider increasing `Tenant.spec.externalOIDC.ttl` if IdP is slow but reliable. See [External OIDC Configuration](../advanced-administration/external-oidc.md).
+**Remediate:** IdP (Keycloak/OIDC provider) health; JWKS endpoint reachability; API key / token validity; consider increasing `Tenant.spec.externalOIDC.ttl` if IdP is slow but reliable. See [External OIDC Configuration](../advanced-administration/external-oidc.md).
 
 ### vLLM Metrics
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -91,6 +91,7 @@ nav:
       - Subscription Cardinality: advanced-administration/subscription-cardinality.md
       - Limitador Persistence: advanced-administration/limitador-persistence.md
       - Authorino Caching: configuration-and-management/authorino-caching.md
+      - External OIDC: advanced-administration/external-oidc.md
   - Observability:
     - Overview: observability/index.md
     - Setup: observability/setup.md

--- a/docs/samples/install/keycloak/README.md
+++ b/docs/samples/install/keycloak/README.md
@@ -87,10 +87,10 @@ The easiest way to configure realms is through the web UI:
    - **Add to userinfo:** ON
    - Click "Save"
 
-6. **Get Client Credentials**
+6. **Note Client Credentials (for testing only)**
    - Navigate to: Clients → maas → Credentials tab
    - Copy the "Client secret"
-   - Save for MaaS OIDC configuration
+   - This secret is used when obtaining tokens from Keycloak (e.g., for testing with `curl`). MaaS does **not** require or store the client secret — only the `clientId` and `issuerUrl` are configured in the MaaS CR.
 
 ### Method 2: Import Test Realms (Development Only)
 
@@ -121,7 +121,7 @@ cp docs/samples/install/keycloak/custom-realm-template.json my-realm.json
 
 ## OIDC Configuration for MaaS
 
-Once you have a realm configured with groups and users, you'll need to configure MaaS to use Keycloak as an OIDC provider.
+Once you have a realm configured with groups and users, configure MaaS to use Keycloak as the OIDC provider via the `AITenant` or `Tenant` CR.
 
 ### Required Information
 
@@ -129,20 +129,40 @@ From your Keycloak configuration, you'll need:
 
 1. **Issuer URL:** `https://{keycloak-hostname}/realms/{realm-name}`
 2. **Client ID:** The client you created (e.g., `maas`)
-3. **Client Secret:** From the client credentials tab
-4. **Groups Claim:** `groups` (from the mapper configuration)
+3. **Groups Claim:** `groups` (from the mapper configuration)
 
-### Example Configuration
+MaaS validates OIDC tokens using **JWT bearer validation against the public JWKS** — no `client_secret` is needed at runtime. The `clientId` is configuration only; it is enforced by checking the `azp` claim in incoming tokens.
+
+### AITenant CR (operator-managed tenants)
 
 ```yaml
-# This will be configured in MaaS (implementation pending)
-oidc:
-  issuer: https://keycloak.apps.my-cluster.example.com/realms/my-company
-  clientId: maas
-  clientSecret: {from-keycloak-client-credentials}
-  groupsClaim: groups
-  usernameClaim: preferred_username  # or "sub" for user ID
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: AITenant
+metadata:
+  name: my-tenant
+  namespace: ai-tenants
+spec:
+  oidc:
+    issuerUrl: "https://keycloak.apps.my-cluster.example.com/realms/my-company"
+    clientId: maas
+    ttl: 300  # optional: JWKS cache TTL in seconds (default 300, minimum 30)
 ```
+
+### Tenant CR (legacy / unmanaged tenants)
+
+```yaml
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: Tenant
+metadata:
+  name: default-tenant
+spec:
+  externalOIDC:
+    issuerUrl: "https://keycloak.apps.my-cluster.example.com/realms/my-company"
+    clientId: maas
+    ttl: 300  # optional
+```
+
+For full configuration reference, IdP outage behavior, and security controls see [External OIDC Configuration](../../docs/content/advanced-administration/external-oidc.md).
 
 ## Verifying Realm Configuration
 
@@ -223,7 +243,7 @@ The secret persists as long as the Keycloak instance exists, so you can retrieve
 
 After configuring Keycloak realms:
 
-1. Configure MaaS to use Keycloak as OIDC provider (implementation pending)
+1. Configure MaaS to use Keycloak as OIDC provider — see [External OIDC Configuration](../../docs/content/advanced-administration/external-oidc.md)
 2. Create MaaSSubscription resources with groups matching Keycloak groups
 3. Create MaaSAuthPolicy resources to grant access to models
 4. Test authentication with OIDC tokens

--- a/docs/samples/install/keycloak/README.md
+++ b/docs/samples/install/keycloak/README.md
@@ -162,7 +162,7 @@ spec:
     ttl: 300  # optional
 ```
 
-For full configuration reference, IdP outage behavior, and security controls see [External OIDC Configuration](../../docs/content/advanced-administration/external-oidc.md).
+For full configuration reference, IdP outage behavior, and security controls see [External OIDC Configuration](../../../content/advanced-administration/external-oidc.md).
 
 ## Verifying Realm Configuration
 
@@ -243,7 +243,7 @@ The secret persists as long as the Keycloak instance exists, so you can retrieve
 
 After configuring Keycloak realms:
 
-1. Configure MaaS to use Keycloak as OIDC provider — see [External OIDC Configuration](../../docs/content/advanced-administration/external-oidc.md)
+1. Configure MaaS to use Keycloak as OIDC provider — see [External OIDC Configuration](../../../content/advanced-administration/external-oidc.md)
 2. Create MaaSSubscription resources with groups matching Keycloak groups
 3. Create MaaSAuthPolicy resources to grant access to models
 4. Test authentication with OIDC tokens

--- a/docs/samples/install/keycloak/test-realms/tenant-a-realm.json
+++ b/docs/samples/install/keycloak/test-realms/tenant-a-realm.json
@@ -31,12 +31,23 @@
           }
         }
       ]
+    },
+    {
+      "clientId": "wrong-client",
+      "enabled": true,
+      "publicClient": true,
+      "directAccessGrantsEnabled": true,
+      "standardFlowEnabled": false,
+      "redirectUris": [],
+      "webOrigins": [],
+      "description": "Test-only client used to verify oidc-client-bound enforcement. Tokens issued to this client carry azp=wrong-client and must be rejected by MaaS even though the issuer is valid."
     }
   ],
   "groups": [
     {"name": "Engineering"},
     {"name": "Site-Reliability"},
-    {"name": "Project-Alpha"}
+    {"name": "Project-Alpha"},
+    {"name": "unsafe;group"}
   ],
   "users": [
     {
@@ -54,6 +65,30 @@
       "requiredActions": [],
       "credentials": [{"type": "password", "value": "letmein", "temporary": false}],
       "groups": ["Site-Reliability"]
+    },
+    {
+      "username": "evil_user",
+      "enabled": true,
+      "emailVerified": true,
+      "requiredActions": [],
+      "credentials": [{"type": "password", "value": "letmein", "temporary": false}],
+      "groups": ["unsafe;group"]
+    },
+    {
+      "username": "dave_noaccess",
+      "enabled": true,
+      "emailVerified": true,
+      "requiredActions": [],
+      "credentials": [{"type": "password", "value": "letmein", "temporary": false}],
+      "groups": []
+    },
+    {
+      "username": "mixed_user",
+      "enabled": true,
+      "emailVerified": true,
+      "requiredActions": [],
+      "credentials": [{"type": "password", "value": "letmein", "temporary": false}],
+      "groups": ["Engineering", "unsafe;group"]
     }
   ]
 }

--- a/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
@@ -868,6 +868,30 @@ allow {
 }`,
 			},
 		}
+		// oidc-client-bound enforces that OIDC JWTs were issued to the configured
+		// OAuth client (azp claim). The has(auth.identity.azp) guard is required so
+		// that OpenShift TokenReview identities (which carry no azp claim) are not
+		// matched by this rule and denied with 403.
+		authorizationRules["oidc-client-bound"] = map[string]any{
+			"when": []any{
+				map[string]any{
+					"predicate": celIsNotAPIKey +
+						` && request.headers.authorization.matches("^Bearer [^.]+\\.[^.]+\\.[^.]+$")` +
+						` && has(auth.identity.azp)`,
+				},
+			},
+			"metrics":  false,
+			"priority": int64(1),
+			"patternMatching": map[string]any{
+				"patterns": []any{
+					map[string]any{
+						"selector": "auth.identity.azp",
+						"operator": "eq",
+						"value":    oidc.ClientID,
+					},
+				},
+			},
+		}
 	}
 
 	defaultsRules := map[string]any{

--- a/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
@@ -90,6 +90,7 @@ type MaaSAuthPolicyReconciler struct {
 type oidcConfig struct {
 	IssuerURL string
 	ClientID  string
+	TTL       int
 }
 
 // authzCacheTTL returns the safe TTL for authorization caches that depend on metadata.
@@ -234,14 +235,21 @@ func (r *MaaSAuthPolicyReconciler) fetchOIDCConfig(ctx context.Context, log logr
 		return nil
 	}
 
+	ttl := oidc.TTL
+	if ttl == 0 {
+		ttl = 300
+	}
+
 	log.Info("OIDC configuration loaded from tenant platform context",
 		"issuerUrl", oidc.IssuerURL,
 		"clientId", oidc.ClientID,
+		"ttl", ttl,
 		"source", platformContext.Source)
 
 	return &oidcConfig{
 		IssuerURL: oidc.IssuerURL,
 		ClientID:  oidc.ClientID,
+		TTL:       ttl,
 	}
 }
 
@@ -675,7 +683,7 @@ func (r *MaaSAuthPolicyReconciler) buildGatewayAuthPolicySpec(modelAccessJSON st
 		authenticationRules["oidc-identities"] = map[string]any{
 			"jwt": map[string]any{
 				"issuerUrl": oidc.IssuerURL,
-				"ttl":       int64(300),
+				"ttl":       int64(oidc.TTL),
 			},
 			"when": []any{
 				map[string]any{

--- a/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
@@ -235,9 +235,21 @@ func (r *MaaSAuthPolicyReconciler) fetchOIDCConfig(ctx context.Context, log logr
 		return nil
 	}
 
+	const (
+		defaultOIDCJWKSTTL = 300
+		minOIDCJWKSTTL     = 30
+	)
+
 	ttl := oidc.TTL
-	if ttl == 0 {
-		ttl = 300
+	switch {
+	case ttl == 0:
+		ttl = defaultOIDCJWKSTTL
+	case ttl < minOIDCJWKSTTL:
+		log.Error(nil, "Tenant external OIDC ttl below minimum, rejecting OIDC config",
+			"ttl", ttl,
+			"minimum", minOIDCJWKSTTL,
+			"source", platformContext.Source)
+		return nil
 	}
 
 	log.Info("OIDC configuration loaded from tenant platform context",

--- a/maas-controller/pkg/controller/maas/maasauthpolicy_controller_test.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_controller_test.go
@@ -1404,6 +1404,7 @@ func TestBuildGatewayAuthPolicySpec_OIDCAuth(t *testing.T) {
 	oidc := &oidcConfig{
 		IssuerURL: "https://keycloak.example.com/realms/test",
 		ClientID:  "maas-client",
+		TTL:       300,
 	}
 	obj := gatewayAuthPolicySpecTestObject(t, oidc)
 
@@ -1617,6 +1618,24 @@ func TestFetchOIDCConfig_TTLExtraction(t *testing.T) {
 				TTL:       0,
 			},
 			wantTTL: 300,
+		},
+		{
+			name: "TTL below minimum returns nil",
+			oidc: &maasv1alpha1.TenantExternalOIDCConfig{
+				IssuerURL: "https://keycloak.example.com/realms/test",
+				ClientID:  "maas-client",
+				TTL:       10,
+			},
+			wantNil: true,
+		},
+		{
+			name: "negative TTL returns nil",
+			oidc: &maasv1alpha1.TenantExternalOIDCConfig{
+				IssuerURL: "https://keycloak.example.com/realms/test",
+				ClientID:  "maas-client",
+				TTL:       -1,
+			},
+			wantNil: true,
 		},
 		{
 			name:    "missing issuerUrl returns nil",

--- a/maas-controller/pkg/controller/maas/maasauthpolicy_controller_test.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_controller_test.go
@@ -1536,6 +1536,138 @@ func TestBuildGatewayAuthPolicySpec_XAPIKeyEnabled(t *testing.T) {
 	}
 }
 
+// TestBuildGatewayAuthPolicySpec_OIDCJWKsTTL verifies that the OIDC JWKS TTL from the
+// oidcConfig struct is correctly propagated to the JWT authentication block in the
+// gateway AuthPolicy spec.
+func TestBuildGatewayAuthPolicySpec_OIDCJWKsTTL(t *testing.T) {
+	r := &MaaSAuthPolicyReconciler{
+		MaaSAPINamespace: "maas-system",
+		GatewayName:      "maas-default-gateway",
+		GatewayNamespace: "gateway-ns",
+		ClusterAudience:  "https://kubernetes.default.svc",
+		MetadataCacheTTL: 60,
+		AuthzCacheTTL:    60,
+	}
+
+	tests := []struct {
+		name    string
+		ttl     int
+		wantTTL int64
+	}{
+		{name: "default TTL", ttl: 300, wantTTL: 300},
+		{name: "custom TTL 60s", ttl: 60, wantTTL: 60},
+		{name: "minimum TTL 30s", ttl: 30, wantTTL: 30},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			oidc := &oidcConfig{
+				IssuerURL: "https://keycloak.example.com/realms/test",
+				ClientID:  "maas-client",
+				TTL:       tc.ttl,
+			}
+			spec := r.buildGatewayAuthPolicySpec("{}", oidc, false, "", "models-as-a-service", "test-gateway-ns", "test-gateway")
+			obj := &unstructured.Unstructured{Object: map[string]any{"spec": spec}}
+
+			gotTTL, found, err := unstructured.NestedInt64(obj.Object, "spec", "defaults", "rules", "authentication", "oidc-identities", "jwt", "ttl")
+			if err != nil || !found {
+				t.Fatalf("oidc jwt.ttl missing: found=%v err=%v", found, err)
+			}
+			if gotTTL != tc.wantTTL {
+				t.Errorf("oidc jwt.ttl = %d, want %d", gotTTL, tc.wantTTL)
+			}
+		})
+	}
+}
+
+// TestFetchOIDCConfig_TTLExtraction verifies that fetchOIDCConfig correctly extracts the
+// TTL field from the Tenant CR's spec.externalOIDC and applies the default (300) when
+// the field is absent or zero.
+func TestFetchOIDCConfig_TTLExtraction(t *testing.T) {
+	const namespace = "default"
+
+	tests := []struct {
+		name    string
+		oidc    *maasv1alpha1.TenantExternalOIDCConfig
+		wantTTL int
+		wantNil bool
+	}{
+		{
+			name: "explicit TTL 600",
+			oidc: &maasv1alpha1.TenantExternalOIDCConfig{
+				IssuerURL: "https://keycloak.example.com/realms/test",
+				ClientID:  "maas-client",
+				TTL:       600,
+			},
+			wantTTL: 600,
+		},
+		{
+			name: "minimum TTL 30",
+			oidc: &maasv1alpha1.TenantExternalOIDCConfig{
+				IssuerURL: "https://keycloak.example.com/realms/test",
+				ClientID:  "maas-client",
+				TTL:       30,
+			},
+			wantTTL: 30,
+		},
+		{
+			name: "TTL zero defaults to 300",
+			oidc: &maasv1alpha1.TenantExternalOIDCConfig{
+				IssuerURL: "https://keycloak.example.com/realms/test",
+				ClientID:  "maas-client",
+				TTL:       0,
+			},
+			wantTTL: 300,
+		},
+		{
+			name:    "missing issuerUrl returns nil",
+			oidc:    &maasv1alpha1.TenantExternalOIDCConfig{ClientID: "maas-client", TTL: 120},
+			wantNil: true,
+		},
+		{
+			name:    "missing clientId returns nil",
+			oidc:    &maasv1alpha1.TenantExternalOIDCConfig{IssuerURL: "https://keycloak.example.com/realms/test", TTL: 120},
+			wantNil: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tenant := &maasv1alpha1.Tenant{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "default-tenant",
+					Namespace: namespace,
+				},
+				Spec: maasv1alpha1.TenantSpec{
+					ExternalOIDC: tc.oidc,
+				},
+			}
+
+			c := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithRESTMapper(testRESTMapper()).
+				WithObjects(tenant).
+				Build()
+
+			r := &MaaSAuthPolicyReconciler{Client: c, Scheme: scheme, MaaSAPINamespace: namespace}
+			log := ctrl.Log.WithName("test")
+			got := r.fetchOIDCConfig(context.Background(), log, namespace)
+
+			if tc.wantNil {
+				if got != nil {
+					t.Fatalf("expected nil oidcConfig, got %+v", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatal("expected non-nil oidcConfig, got nil")
+			}
+			if got.TTL != tc.wantTTL {
+				t.Errorf("TTL = %d, want %d", got.TTL, tc.wantTTL)
+			}
+		})
+	}
+}
+
 // contains is a helper to check if a string contains a substring (case-sensitive).
 // assertCacheKeyContains fetches a nested string from an unstructured object and asserts it
 // contains each of the required substrings. It is a test helper that reduces cyclomatic

--- a/maas-controller/pkg/controller/maas/maasauthpolicy_oidc_test.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_oidc_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -334,6 +335,79 @@ func TestCELExpressions_OrderMatters(t *testing.T) {
 	assert.True(t, userGroupsIdx >= 0, "should check for auth.identity.user.groups")
 	assert.True(t, identityGroupsIdx < userGroupsIdx,
 		"should check auth.identity.groups (OIDC) before auth.identity.user.groups (K8s)")
+}
+
+func TestBuildGatewayAuthPolicySpec_OIDCClientBound(t *testing.T) {
+	oidc := &oidcConfig{
+		IssuerURL: "https://keycloak.example.com/realms/test",
+		ClientID:  "my-maas-client",
+		TTL:       300,
+	}
+	obj := gatewayAuthPolicySpecTestObject(t, oidc)
+
+	authz := nestedMapRequired(t, obj, "spec", "defaults", "rules", "authorization")
+
+	rule, exists := authz["oidc-client-bound"]
+	assert.True(t, exists, "oidc-client-bound rule should be present when OIDC config is provided")
+
+	ruleMap, ok := rule.(map[string]any)
+	assert.True(t, ok, "oidc-client-bound should be a map")
+
+	// Verify patternMatching.patterns[0].value matches the configured clientId
+	patterns, _, _ := unstructured.NestedSlice(ruleMap, "patternMatching", "patterns")
+	assert.Len(t, patterns, 1, "should have exactly one pattern")
+	patternMap, ok := patterns[0].(map[string]any)
+	assert.True(t, ok, "pattern should be a map")
+	assert.Equal(t, "auth.identity.azp", patternMap["selector"], "selector should be auth.identity.azp")
+	assert.Equal(t, "eq", patternMap["operator"], "operator should be eq")
+	assert.Equal(t, "my-maas-client", patternMap["value"], "value should match clientId")
+
+	// Verify the when predicate guards on has(auth.identity.azp) so that
+	// OpenShift TokenReview identities (no azp claim) are not denied
+	whenSlice, _, _ := unstructured.NestedSlice(ruleMap, "when")
+	assert.Len(t, whenSlice, 1, "should have exactly one when predicate")
+	whenMap, ok := whenSlice[0].(map[string]any)
+	assert.True(t, ok)
+	predicate, _ := whenMap["predicate"].(string)
+	assert.Contains(t, predicate, "has(auth.identity.azp)",
+		"when predicate must guard on has(auth.identity.azp) to protect OpenShift TokenReview identities")
+	assert.Contains(t, predicate, `Bearer [^.]+\\.[^.]+\\.[^.]+`,
+		"when predicate should match only JWT-shaped Bearer tokens")
+}
+
+func TestBuildGatewayAuthPolicySpec_OIDCClientBound_AbsentWithoutOIDC(t *testing.T) {
+	obj := gatewayAuthPolicySpecTestObject(t, nil)
+	authz := nestedMapRequired(t, obj, "spec", "defaults", "rules", "authorization")
+	_, exists := authz["oidc-client-bound"]
+	assert.False(t, exists, "oidc-client-bound rule must not be present when OIDC is not configured")
+}
+
+func TestBuildGatewayAuthPolicySpec_OIDCTTLPropagated(t *testing.T) {
+	t.Run("custom TTL is emitted to AuthPolicy", func(t *testing.T) {
+		oidc := &oidcConfig{
+			IssuerURL: "https://keycloak.example.com/realms/test",
+			ClientID:  "maas-client",
+			TTL:       600,
+		}
+		obj := gatewayAuthPolicySpecTestObject(t, oidc)
+		ttl, found, err := unstructured.NestedInt64(obj.Object,
+			"spec", "defaults", "rules", "authentication", "oidc-identities", "jwt", "ttl")
+		assert.NoError(t, err)
+		assert.True(t, found, "jwt.ttl should be present")
+		assert.Equal(t, int64(600), ttl, "jwt.ttl should reflect the CRD TTL value")
+	})
+
+	t.Run("default TTL 300 is emitted when CRD TTL is 300", func(t *testing.T) {
+		oidc := &oidcConfig{
+			IssuerURL: "https://keycloak.example.com/realms/test",
+			ClientID:  "maas-client",
+			TTL:       300,
+		}
+		obj := gatewayAuthPolicySpecTestObject(t, oidc)
+		ttl, _, _ := unstructured.NestedInt64(obj.Object,
+			"spec", "defaults", "rules", "authentication", "oidc-identities", "jwt", "ttl")
+		assert.Equal(t, int64(300), ttl)
+	})
 }
 
 // Helper function to find substring index

--- a/scripts/observability/install-observability.sh
+++ b/scripts/observability/install-observability.sh
@@ -231,7 +231,7 @@ fi
 
 # Deploy OIDC authentication PrometheusRule (alerts on OIDC/JWT auth failures and latency)
 OIDC_RULE_FILE="$BASE_OBSERVABILITY_DIR/authorino-maas-oidc-prometheusrule.yaml"
-if ! kubectl get deploy -n "$AUTHORINO_NAMESPACE" authorino &>/dev/null 2>&1; then
+if ! kubectl get deploy -n "$AUTHORINO_NAMESPACE" authorino &>/dev/null; then
     echo "   ⚠️  Authorino deployment not found - skipping OIDC PrometheusRule"
 elif [ -f "$OIDC_RULE_FILE" ]; then
     yq eval ".metadata.namespace = \"$AUTHORINO_NAMESPACE\"" "$OIDC_RULE_FILE" | kubectl apply -f -
@@ -257,9 +257,9 @@ echo "   vLLM:      vllm:num_requests_running, vllm:num_requests_waiting, vllm:k
 echo ""
 
 echo "🚨 Alerting configured (if Authorino found):"
-echo "   MaaSAuthorinoMetadataEvaluatorHighFailureRate - maas-api metadata call failure rate > 10%"
-echo "   MaaSAuthorinoOIDCAuthenticationHighFailureRate - OIDC authentication failure rate > 10%"
-echo "   MaaSAuthorinoOIDCAuthenticationHighLatency - OIDC authentication P95 latency > 2s"
+echo "   MaaSAuthorinoMetadataEvaluatorHighFailureRate - maas-api metadata call failure rate above configured threshold"
+echo "   MaaSAuthorinoAuthenticationHighFailureRate - gateway authentication failure rate above configured threshold"
+echo "   MaaSAuthorinoAuthenticationHighLatency - gateway authentication P95 latency above configured threshold"
 echo ""
 
 echo "💡 To install MaaS Grafana dashboards (discovers Grafana cluster-wide, warn-only):"

--- a/scripts/observability/install-observability.sh
+++ b/scripts/observability/install-observability.sh
@@ -229,6 +229,17 @@ else
     echo "   ⚠️  Metadata evaluator PrometheusRule not found - skipping alert"
 fi
 
+# Deploy OIDC authentication PrometheusRule (alerts on OIDC/JWT auth failures and latency)
+OIDC_RULE_FILE="$BASE_OBSERVABILITY_DIR/authorino-maas-oidc-prometheusrule.yaml"
+if ! kubectl get deploy -n "$AUTHORINO_NAMESPACE" authorino &>/dev/null 2>&1; then
+    echo "   ⚠️  Authorino deployment not found - skipping OIDC PrometheusRule"
+elif [ -f "$OIDC_RULE_FILE" ]; then
+    yq eval ".metadata.namespace = \"$AUTHORINO_NAMESPACE\"" "$OIDC_RULE_FILE" | kubectl apply -f -
+    echo "   ✅ OIDC PrometheusRule deployed (namespace: $AUTHORINO_NAMESPACE)"
+else
+    echo "   ⚠️  OIDC PrometheusRule not found - skipping alert"
+fi
+
 # ==========================================
 # Summary
 # ==========================================
@@ -243,6 +254,12 @@ echo "   Limitador: authorized_hits, authorized_calls, limited_calls, limitador_
 echo "   Authorino: auth_server_authconfig_duration_seconds, auth_server_authconfig_response_status, auth_server_evaluator_* (metadata HTTP)"
 echo "   Istio:     istio_requests_total, istio_request_duration_milliseconds"
 echo "   vLLM:      vllm:num_requests_running, vllm:num_requests_waiting, vllm:kv_cache_usage_perc"
+echo ""
+
+echo "🚨 Alerting configured (if Authorino found):"
+echo "   MaaSAuthorinoMetadataEvaluatorHighFailureRate - maas-api metadata call failure rate > 10%"
+echo "   MaaSAuthorinoOIDCAuthenticationHighFailureRate - OIDC authentication failure rate > 10%"
+echo "   MaaSAuthorinoOIDCAuthenticationHighLatency - OIDC authentication P95 latency > 2s"
 echo ""
 
 echo "💡 To install MaaS Grafana dashboards (discovers Grafana cluster-wide, warn-only):"

--- a/test/e2e/scripts/prow_run_smoke_test.sh
+++ b/test/e2e/scripts/prow_run_smoke_test.sh
@@ -109,8 +109,9 @@ INGRESS_MODE="${INGRESS_MODE:-clusterip}"
 export INGRESS_MODE
 # Gateway programming can lag during fresh cluster bring-up; allow a generous timeout.
 GATEWAY_PROGRAMMED_TIMEOUT="${GATEWAY_PROGRAMMED_TIMEOUT:-600}"
-# OIDC readiness gate: by default do not block pytest if Keycloak/Authorino still returns 401
-OIDC_READINESS_STRICT="${OIDC_READINESS_STRICT:-false}"
+# OIDC readiness gate: fail before pytest if Keycloak/Authorino isn't ready.
+# Set to false to warn-only (useful during local development against a partially ready cluster).
+OIDC_READINESS_STRICT="${OIDC_READINESS_STRICT:-true}"
 # Multi-tenancy Phase 1: patch maas-controller for tenant namespace discovery E2E.
 ENABLE_TENANT_NAMESPACE_DISCOVERY="${ENABLE_TENANT_NAMESPACE_DISCOVERY:-true}"
 AITENANT_NAMESPACE="${AITENANT_NAMESPACE:-ai-tenants}"
@@ -165,6 +166,12 @@ apply_default_oidc_for_keycloak() {
     export OIDC_CLIENT_ID="${OIDC_CLIENT_ID:-test-client}"
     export OIDC_USERNAME="${OIDC_USERNAME:-alice_lead}"
     export OIDC_PASSWORD="${OIDC_PASSWORD:-letmein}"
+    # dave_noaccess has no group memberships — used by the empty-list test.
+    export OIDC_USERNAME_NO_ACCESS="${OIDC_USERNAME_NO_ACCESS:-dave_noaccess}"
+    export OIDC_PASSWORD_NO_ACCESS="${OIDC_PASSWORD_NO_ACCESS:-letmein}"
+    # tenant-b token URL for per-tenant OIDC isolation test.
+    local realm_b_base="https://keycloak.${cluster_domain}/realms/tenant-b"
+    export OIDC_TOKEN_URL_TENANT_B="${OIDC_TOKEN_URL_TENANT_B:-${realm_b_base}/protocol/openid-connect/token}"
     echo "OIDC for e2e (Keycloak tenant-a defaults): issuer=${OIDC_ISSUER_URL}"
 }
 

--- a/test/e2e/tests/test_external_oidc.py
+++ b/test/e2e/tests/test_external_oidc.py
@@ -220,14 +220,20 @@ def _wait_for_api_key_revocation(
 
 
 def _tenant_b_token_url() -> str:
-    """Derive the tenant-b token URL from the tenant-a issuer URL.
+    """Return the token endpoint URL for the tenant-b Keycloak realm.
 
-    The test infra sets OIDC_ISSUER_URL to the tenant-a realm. We swap
-    'tenant-a' → 'tenant-b' to get the sibling realm.
+    Resolution order:
+    1. OIDC_TOKEN_URL_TENANT_B — explicit override, set by prow_run_smoke_test.sh.
+    2. Derive from OIDC_ISSUER_URL by swapping 'tenant-a' → 'tenant-b' (fallback
+       for environments where only the tenant-a issuer URL is configured).
     """
+    explicit = os.environ.get("OIDC_TOKEN_URL_TENANT_B", "")
+    if explicit:
+        return explicit
     issuer = _required_env("OIDC_ISSUER_URL")
     assert "tenant-a" in issuer, (
-        f"Expected OIDC_ISSUER_URL to contain 'tenant-a', got: {issuer}"
+        f"Expected OIDC_ISSUER_URL to contain 'tenant-a' for tenant-b derivation, "
+        f"got: {issuer}. Set OIDC_TOKEN_URL_TENANT_B explicitly to avoid this."
     )
     tenant_b_issuer = issuer.replace("tenant-a", "tenant-b")
     return f"{tenant_b_issuer}/protocol/openid-connect/token"
@@ -1099,11 +1105,14 @@ class TestOIDCAlertingInfra:
     """
 
     def test_authorino_prometheusrule_exists(self):
-        """PrometheusRule maas-authorino-alerts is present in the MaaS subscription namespace."""
-        namespace = os.environ.get("MAAS_SUBSCRIPTION_NAMESPACE", "models-as-a-service")
+        """PrometheusRule authorino-maas-authentication-alerts is present in kuadrant-system."""
+        # The rule is deployed to kuadrant-system (where Authorino runs) by
+        # scripts/observability/install-observability.sh, not kustomize base.
+        namespace = os.environ.get("AUTHORINO_NAMESPACE", "kuadrant-system")
+        rule_name = "authorino-maas-authentication-alerts"
         result = subprocess.run(
             [
-                "kubectl", "get", "prometheusrule", "maas-authorino-alerts",
+                "kubectl", "get", "prometheusrule", rule_name,
                 "-n", namespace,
                 "--ignore-not-found",
                 "-o", "jsonpath={.metadata.name}",
@@ -1115,10 +1124,10 @@ class TestOIDCAlertingInfra:
         assert result.returncode == 0, (
             f"kubectl get prometheusrule failed (exit {result.returncode}): {result.stderr}"
         )
-        assert result.stdout.strip() == "maas-authorino-alerts", (
-            f"PrometheusRule 'maas-authorino-alerts' not found in namespace '{namespace}'. "
-            "Ensure PR #1076 (Authorino alerting) has been merged and the rule was applied."
+        assert result.stdout.strip() == rule_name, (
+            f"PrometheusRule '{rule_name}' not found in namespace '{namespace}'. "
+            "Ensure install-observability.sh has been run and the rule was applied to kuadrant-system."
         )
         log.info(
-            f"PrometheusRule maas-authorino-alerts present in namespace '{namespace}'"
+            f"PrometheusRule {rule_name} present in namespace '{namespace}'"
         )

--- a/test/e2e/tests/test_external_oidc.py
+++ b/test/e2e/tests/test_external_oidc.py
@@ -23,7 +23,11 @@ Test Realms:
   tenant-a:
     - alice_lead  (groups: Engineering, Project-Alpha)
     - bob_sre     (groups: Site-Reliability)
-    - client: test-client (public, direct access grants)
+    - evil_user   (groups: unsafe;group — semicolon triggers oidc-groups-safe rejection)
+    - dave_noaccess (groups: none — valid token, no group memberships → empty model list)
+    - client: test-client (public, direct access grants, groups mapper)
+    - client: wrong-client (public, direct access grants, no groups mapper —
+      used only to obtain tokens with azp=wrong-client for client-binding tests)
 
   tenant-b:
     - charlie_sec_lead  (groups: Product-Security, Project-Omega)
@@ -36,6 +40,7 @@ from __future__ import annotations
 import base64
 import json
 import os
+import subprocess
 import time
 import uuid
 import logging
@@ -673,6 +678,53 @@ class TestOIDCAPIKeyLifecycle:
         )
         log.info(f"API key {key_id} create→revoke lifecycle completed")
 
+    def test_api_key_owner_matches_oidc_username(self, maas_api_base_url: str):
+        """API key's owner field reflects the preferred_username from the OIDC token.
+
+        Verifies that the identity extracted from the JWT (preferred_username
+        claim) is stored as the key's owner when the key is minted. This
+        ensures identity propagation from OIDC → API key creation → stored
+        metadata works end-to-end.
+        """
+        token = _request_oidc_token()
+        expected_username = _decode_jwt_payload(token).get("preferred_username")
+        assert expected_username, "OIDC token is missing preferred_username claim"
+
+        key_data = _create_oidc_api_key(
+            maas_api_base_url, token,
+            name=f"e2e-owner-{uuid.uuid4().hex[:8]}"
+        )
+        key_id = key_data["id"]
+
+        try:
+            response = _oidc_request_with_retry(
+                requests.get,
+                f"{maas_api_base_url}/v1/api-keys/{key_id}",
+                token,
+                label="OIDC API key GET",
+            )
+            assert response.status_code == 200, (
+                f"GET /v1/api-keys/{key_id} failed: "
+                f"{response.status_code} {response.text}"
+            )
+            data = response.json()
+            owner = data.get("owner") or data.get("username") or data.get("userId")
+            assert owner == expected_username, (
+                f"Expected API key owner to be '{expected_username}' "
+                f"(preferred_username from OIDC token), got '{owner}'. "
+                f"Full response: {data}"
+            )
+            log.info(
+                f"API key owner '{owner}' correctly matches OIDC preferred_username"
+            )
+        finally:
+            _oidc_request_with_retry(
+                requests.delete,
+                f"{maas_api_base_url}/v1/api-keys/{key_id}",
+                token,
+                label="OIDC cleanup owner test key",
+            )
+
 
 # ---------------------------------------------------------------------------
 # Tests — Header Injection (Security)
@@ -843,4 +895,230 @@ class TestOIDCHeaderInjection:
         log.info(
             "API key minted successfully with injected X-MaaS-Username — "
             "gateway overwrote it with real OIDC identity"
+        )
+
+
+@pytest.mark.skipif(
+    os.environ.get("EXTERNAL_OIDC", "").lower() != "true",
+    reason="EXTERNAL_OIDC not enabled",
+)
+class TestOIDCClientBinding:
+    """Verify that oidc-client-bound rejects tokens from the wrong OAuth client.
+
+    MaaS is configured with OIDC_CLIENT_ID (e.g. test-client). The tenant-a
+    realm also contains wrong-client — a second public client with no groups
+    mapper. Tokens obtained via wrong-client carry azp=wrong-client. Because
+    the issuer is valid, authentication succeeds and Authorino verifies the
+    signature. The oidc-client-bound authorization rule then rejects the token
+    with 403 because auth.identity.azp != configured clientId.
+
+    A 401 (authentication failure) would mean the issuer check failed, which
+    would indicate wrong-client is on a different realm — that is not what this
+    test is checking. The assertion specifically requires 403.
+    """
+
+    def test_wrong_oauth_client_token_is_rejected(self, maas_api_base_url: str):
+        """Token from wrong OAuth client (azp mismatch) is rejected with 403.
+
+        The token has a valid signature and the correct issuer, so it passes
+        Authorino OIDC authentication. The oidc-client-bound authorization rule
+        then checks auth.identity.azp and denies with 403.
+        """
+        token = _request_oidc_token(client_id="wrong-client")
+
+        payload = _decode_jwt_payload(token)
+        assert payload.get("azp") == "wrong-client", (
+            f"Expected azp=wrong-client in token but got: {payload.get('azp')}. "
+            "Ensure wrong-client is configured in the tenant-a realm."
+        )
+
+        response = requests.post(
+            f"{maas_api_base_url}/v1/api-keys",
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Content-Type": "application/json",
+            },
+            json={"name": f"e2e-wrong-client-{uuid.uuid4().hex[:8]}"},
+            timeout=30,
+            verify=TLS_VERIFY,
+        )
+        assert response.status_code == 403, (
+            f"Expected 403 for wrong OAuth client token (azp=wrong-client, "
+            f"configured clientId={_oidc_client_id()}), "
+            f"got {response.status_code}: {response.text}"
+        )
+        log.info(
+            "wrong-client token correctly rejected with 403 "
+            "(oidc-client-bound azp enforcement working)"
+        )
+
+
+@pytest.mark.skipif(
+    os.environ.get("EXTERNAL_OIDC", "").lower() != "true",
+    reason="EXTERNAL_OIDC not enabled",
+)
+class TestOIDCGroupSafety:
+    """Verify that oidc-groups-safe rejects tokens containing unsafe group names.
+
+    evil_user belongs to 'unsafe;group'. The semicolon is outside
+    safeGroupNamePattern (^[A-Za-z0-9:._/-]+$), so the OPA rule denies
+    the request with 403 even though the token is otherwise fully valid
+    (correct issuer, correct azp, valid signature).
+
+    A 401 would mean authentication failed — that is not what this test checks.
+    403 is required: authentication passes, authorization denies.
+    """
+
+    def test_unsafe_group_name_is_rejected(self, maas_api_base_url: str):
+        """Token with unsafe group name (semicolon) is rejected with 403.
+
+        The oidc-groups-safe OPA rule fires because count(unsafe_group) != 0,
+        where unsafe_group is any group whose name does not match
+        ^[A-Za-z0-9:._/-]+$.
+        """
+        token = _request_oidc_token(username="evil_user", password="letmein")
+
+        payload = _decode_jwt_payload(token)
+        groups = payload.get("groups", [])
+        assert any(";" in g for g in groups), (
+            f"Expected token to contain a group with ';' but got: {groups}. "
+            "Ensure evil_user is a member of 'unsafe;group' in the tenant-a realm."
+        )
+
+        response = requests.post(
+            f"{maas_api_base_url}/v1/api-keys",
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Content-Type": "application/json",
+            },
+            json={"name": f"e2e-unsafe-group-{uuid.uuid4().hex[:8]}"},
+            timeout=30,
+            verify=TLS_VERIFY,
+        )
+        assert response.status_code == 403, (
+            f"Expected 403 for token with unsafe group name 'unsafe;group' "
+            f"(oidc-groups-safe enforcement), "
+            f"got {response.status_code}: {response.text}"
+        )
+        log.info(
+            "unsafe group name correctly rejected with 403 "
+            "(oidc-groups-safe OPA rule working)"
+        )
+
+    def test_mixed_safe_and_unsafe_groups_is_rejected(self, maas_api_base_url: str):
+        """Token with one safe group AND one unsafe group is still rejected with 403.
+
+        The oidc-groups-safe OPA rule uses count(unsafe_group) == 0 — even a
+        single unsafe group in an otherwise-valid groups list causes denial.
+        mixed_user belongs to ['Engineering', 'unsafe;group']; the safe group
+        must not be sufficient to bypass the rule.
+        """
+        token = _request_oidc_token(username="mixed_user", password="letmein")
+
+        payload = _decode_jwt_payload(token)
+        groups = payload.get("groups", [])
+        has_safe = any(";" not in g for g in groups)
+        has_unsafe = any(";" in g for g in groups)
+        assert has_safe and has_unsafe, (
+            f"Expected mixed_user token to contain both safe and unsafe groups, "
+            f"got: {groups}. Ensure mixed_user is a member of both Engineering "
+            f"and 'unsafe;group' in the tenant-a realm."
+        )
+
+        response = requests.post(
+            f"{maas_api_base_url}/v1/api-keys",
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Content-Type": "application/json",
+            },
+            json={"name": f"e2e-mixed-group-{uuid.uuid4().hex[:8]}"},
+            timeout=30,
+            verify=TLS_VERIFY,
+        )
+        assert response.status_code == 403, (
+            f"Expected 403 for token with mixed safe+unsafe groups "
+            f"(oidc-groups-safe must reject if ANY group is unsafe), "
+            f"got {response.status_code}: {response.text}"
+        )
+        log.info(
+            "mixed safe+unsafe groups correctly rejected with 403 "
+            "(oidc-groups-safe rejects on any unsafe group, not all)"
+        )
+
+
+@pytest.mark.skipif(
+    os.environ.get("EXTERNAL_OIDC", "").lower() != "true",
+    reason="EXTERNAL_OIDC not enabled",
+)
+class TestOIDCDirectModelAccess:
+    """Verify that an OIDC token can call GET /v1/models directly.
+
+    This mirrors the verification step in the official Red Hat docs (section
+    1.15.2): 'Use the OIDC token to list available models.' All other model
+    listing tests in this suite use a minted API key; this class ensures the
+    raw JWT bearer path through the gateway also works.
+    """
+
+    def test_oidc_token_can_list_models_directly(self, maas_api_base_url: str):
+        """OIDC bearer token is accepted by GET /v1/models without minting an API key first."""
+        token = _request_oidc_token()
+
+        response = _oidc_request_with_retry(
+            requests.get,
+            f"{maas_api_base_url}/v1/models",
+            token,
+            label="OIDC direct model list",
+        )
+        assert response.status_code == 200, (
+            f"Expected 200 when listing models with OIDC bearer token, "
+            f"got {response.status_code}: {response.text}"
+        )
+        data = response.json()
+        assert data.get("object") == "list", (
+            f"Expected object=list in response, got: {data.get('object')}"
+        )
+        assert isinstance(data.get("data"), list), (
+            f"Expected data array in response, got: {type(data.get('data'))}"
+        )
+        log.info(
+            f"OIDC token can list models directly — {len(data.get('data', []))} model(s) returned"
+        )
+
+
+@pytest.mark.skipif(
+    os.environ.get("EXTERNAL_OIDC", "").lower() != "true",
+    reason="EXTERNAL_OIDC not enabled",
+)
+class TestOIDCAlertingInfra:
+    """Verify that the Authorino alerting infrastructure is present in the cluster.
+
+    The MaaSAuthorinoAuthenticationHighFailureRate PrometheusRule was introduced
+    as part of RHOAIENG-60847. If it is accidentally deleted or misconfigured,
+    the auth failure rate alerting silently stops working. This class provides
+    a lightweight smoke check that the rule exists.
+    """
+
+    def test_authorino_prometheusrule_exists(self):
+        """PrometheusRule maas-authorino-alerts is present in the MaaS subscription namespace."""
+        namespace = os.environ.get("MAAS_SUBSCRIPTION_NAMESPACE", "models-as-a-service")
+        result = subprocess.run(
+            [
+                "kubectl", "get", "prometheusrule", "maas-authorino-alerts",
+                "-n", namespace,
+                "--ignore-not-found",
+                "-o", "jsonpath={.metadata.name}",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert result.returncode == 0, (
+            f"kubectl get prometheusrule failed (exit {result.returncode}): {result.stderr}"
+        )
+        assert result.stdout.strip() == "maas-authorino-alerts", (
+            f"PrometheusRule 'maas-authorino-alerts' not found in namespace '{namespace}'. "
+            "Ensure PR #1076 (Authorino alerting) has been merged and the rule was applied."
+        )
+        log.info(
+            f"PrometheusRule maas-authorino-alerts present in namespace '{namespace}'"
         )

--- a/test/e2e/tests/test_tenant_auth_isolation.py
+++ b/test/e2e/tests/test_tenant_auth_isolation.py
@@ -14,6 +14,7 @@ import os
 import uuid
 
 import pytest
+import requests
 
 from multitenancy_helpers import (
     create_api_key_at,
@@ -30,6 +31,56 @@ from multitenancy_helpers import (
     validate_api_key_at,
 )
 from test_helper import _get_cluster_token, _delete_cr
+
+
+def _mint_oidc_token_for_tenant(tenant: str) -> str:
+    """Return a fresh OIDC access token for the given tenant ('a' or 'b').
+
+    Resolution order:
+    1. OIDC_TOKEN_TENANT_A / OIDC_TOKEN_TENANT_B — pre-minted static tokens
+       (backward-compat; note these expire in ~60s so may be stale by test time).
+    2. OIDC_TOKEN_URL (tenant a) / OIDC_TOKEN_URL_TENANT_B — mint a fresh token
+       via the Resource Owner Password Grant.
+
+    Returns an empty string if no token source is available so the caller can
+    skip the test gracefully.
+    """
+    static_key = f"OIDC_TOKEN_TENANT_{tenant.upper()}"
+    static = os.environ.get(static_key, "")
+    if static:
+        return static
+
+    if tenant == "a":
+        token_url = os.environ.get("OIDC_TOKEN_URL", "")
+        username = os.environ.get("OIDC_USERNAME", "alice_lead")
+        password = os.environ.get("OIDC_PASSWORD", "letmein")
+        client_id = os.environ.get("OIDC_CLIENT_ID", "test-client")
+    else:
+        token_url = os.environ.get("OIDC_TOKEN_URL_TENANT_B", "")
+        username = os.environ.get("OIDC_USERNAME_TENANT_B", "charlie_sec_lead")
+        password = os.environ.get("OIDC_PASSWORD_TENANT_B", "letmein")
+        client_id = os.environ.get("OIDC_CLIENT_ID_TENANT_B", "test-client")
+
+    if not token_url:
+        return ""
+
+    verify = os.environ.get("E2E_SKIP_TLS_VERIFY", "").lower() != "true"
+    try:
+        resp = requests.post(
+            token_url,
+            data={
+                "grant_type": "password",
+                "client_id": client_id,
+                "username": username,
+                "password": password,
+            },
+            timeout=30,
+            verify=verify,
+        )
+        resp.raise_for_status()
+        return resp.json().get("access_token", "")
+    except Exception:
+        return ""
 
 
 # Tenant auth isolation tests are enabled by default (Phase 1 implementation)
@@ -152,10 +203,13 @@ class TestTenantAuthIsolation:
 
     def test_oidc_token_validation_per_tenant(self, tenant_env):
         """3.4: Tenant OIDC tokens are accepted only by their configured tenant endpoint."""
-        token_a = os.environ.get("OIDC_TOKEN_TENANT_A", "")
-        token_b = os.environ.get("OIDC_TOKEN_TENANT_B", "")
+        token_a = _mint_oidc_token_for_tenant("a")
+        token_b = _mint_oidc_token_for_tenant("b")
         if not token_a or not token_b:
-            pytest.skip("OIDC_TOKEN_TENANT_A and OIDC_TOKEN_TENANT_B are required for per-tenant OIDC validation")
+            pytest.skip(
+                "Per-tenant OIDC tokens unavailable — set OIDC_TOKEN_URL (tenant-a) and "
+                "OIDC_TOKEN_URL_TENANT_B (tenant-b), or OIDC_TOKEN_TENANT_A / OIDC_TOKEN_TENANT_B"
+            )
 
         tenant_a, tenant_b = tenant_env
         response_a = search_api_keys_at(tenant_a["base_url"], token_a)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Revamp https://github.com/opendatahub-io/models-as-a-service/pull/897 on the latest main branch.
https://redhat.atlassian.net/browse/RHOAIENG-60847
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tenant-specific External OIDC JWKS cache TTL controls (defaults/minimum) and enforced `azp`/clientId-bound OIDC JWT authorization.
  * Added two new gateway authentication Prometheus alerts (high failure rate and high P95 latency).
* **Documentation**
  * Published full External OIDC administration guidance, including monitoring and security responsibilities.
* **Bug Fixes**
  * Improved observability installation to conditionally apply the new OIDC alert rules only when applicable.
* **Tests**
  * Expanded unit and end-to-end coverage for TTL propagation, client binding, group safety, direct model access, alerting presence, and API key ownership.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->