### PR TITLE
fix: make LLMInferenceService watch optional for KServe CRD

### DIFF
--- a/maas-controller/pkg/controller/maas/maasmodelref_controller.go
+++ b/maas-controller/pkg/controller/maas/maasmodelref_controller.go
@@ -411,13 +411,21 @@ func llmisvcReadyStatus(obj *kservev1alpha1.LLMInferenceService) string {
 }
 
 // SetupWithManager sets up the controller with the Manager.
+// crdExists checks if a CRD is registered in the cluster's REST mapper.
+// Used to make watches on optional CRDs (KServe, Kuadrant) conditional so the
+// controller can start when those operators are not installed.
+func crdExists(mapper apimeta.RESTMapper, group, version, kind string) bool {
+	_, err := mapper.RESTMapping(schema.GroupKind{Group: group, Kind: kind}, version)
+	return err == nil
+}
+
 func (r *MaaSModelRefReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	ctx := context.Background()
 	if err := mgr.GetFieldIndexer().IndexField(ctx, &maasv1alpha1.MaaSModelRef{}, modelRefNameIndex, modelRefNameIndexer); err != nil {
 		return fmt.Errorf("failed to create field index %s: %w", modelRefNameIndex, err)
 	}
 
-	return ctrl.NewControllerManagedBy(mgr).
+	b := ctrl.NewControllerManagedBy(mgr).
 		For(&maasv1alpha1.MaaSModelRef{}, builder.WithPredicates(predicate.Or(
 			predicate.GenerationChangedPredicate{},
 			predicate.Funcs{UpdateFunc: deletionTimestampSet},
@@ -426,13 +434,19 @@ func (r *MaaSModelRefReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		// (fixes race condition where MaaSModelRef is created before HTTPRoute exists).
 		Watches(&gatewayapiv1.HTTPRoute{}, handler.EnqueueRequestsFromMapFunc(
 			r.mapHTTPRouteToMaaSModelRefs,
-		)).
-		// Watch LLMInferenceServices so we re-reconcile when the backing service's Ready status changes
-		// (automatically updates MaaSModelRef status from Pending -> Ready and vice versa).
-		Watches(&kservev1alpha1.LLMInferenceService{},
+		))
+
+	// Watch LLMInferenceServices only if KServe is installed.
+	// Allows the controller to run without KServe (model inference disabled).
+	// Same optional pattern as TokenRateLimitPolicy for Kuadrant.
+	if crdExists(mgr.GetRESTMapper(), "serving.kserve.io", "v1alpha1", "LLMInferenceService") {
+		b = b.Watches(&kservev1alpha1.LLMInferenceService{},
 			handler.EnqueueRequestsFromMapFunc(r.mapLLMISvcToMaaSModelRefs),
 			builder.WithPredicates(predicate.Or(predicate.GenerationChangedPredicate{}, llmisvcReadyChangedPredicate{})),
-		).
+		)
+	}
+
+	return b.
 		// Watch MaaSSubscriptions so we re-reconcile when governance state changes
 		// (spec, status/phase, or deletion). No predicate filter — the reconciler's
 		// equality.Semantic.DeepEqual check gates unnecessary status writes.


### PR DESCRIPTION
## What changed

The `MaaSModelRefReconciler` watches `LLMInferenceService` (KServe) unconditionally in `SetupWithManager`. When KServe is not installed on the cluster, this causes a cache-sync timeout at startup and crashes the controller:

```
failed to wait for maasmodelref caches to sync kind source: *v1alpha1.LLMInferenceService:
timed out waiting for cache to be synced for Kind *v1alpha1.LLMInferenceService
```

## Fix

Gate the `LLMInferenceService` watch on KServe CRD presence using the same `crdExists()` pattern already established for the `TokenRateLimitPolicy` optional Kuadrant watch:

```go
if crdExists(mgr.GetRESTMapper(), "serving.kserve.io", "v1alpha1", "LLMInferenceService") {
    b = b.Watches(&kservev1alpha1.LLMInferenceService{}, ...)
}
```

Also adds the `crdExists()` helper to `maasmodelref_controller.go` (same implementation as in `maassubscription_controller.go`).

## Why it's needed, not a workaround

This is the correct long-term fix. KServe is an **optional** dependency for MaaS — model inference via KServe is one supported backend, but the controller must run without it. The watch is only useful when KServe is installed; otherwise it prevents the controller from starting.

The same principle applies to Kuadrant (`TokenRateLimitPolicy`) — already fixed in PR #somya-kuadrant-optional-fix. This PR extends that pattern to KServe.

## Testing

- Verified on live OpenShift cluster without KServe installed:
  - Before fix: `maas-controller` CrashLoopBackOff (LLMInferenceService cache sync timeout)
  - After fix: `maas-controller` 1/1 Running, 0 restarts
  - `AIGatewayReady: True` in DSC confirmed after fix

## Risk Analysis

**Risk rating:** 1

**Why:** Pure conditional — adds an `if crdExists(...)` gate around an existing watch. When KServe IS installed, behavior is identical to before. When KServe is absent, the watch is simply skipped. No logic changes, no data migration.

## Related

- Mirrors: PR #somya-kuadrant-optional-fix (TokenRateLimitPolicy optional watch)
- Required for: `maas-modularization-final-integration` integration testing
- Jira: [RHOAIENG-71342](https://redhat.atlassian.net/browse/RHOAIENG-71342) (MaaS modularization)

## Checklist

- [x] Fix tested on live cluster (KServe not installed)
- [x] Unit tests pass (`go test ./pkg/controller/maas/...`)
- [x] Commit message follows semantic format
- [x] Risk rating: 1 (conditional gate, no logic change)
