### PR TITLE
fix: use BUFFERED request body mode in ext_proc EnvoyFilter

### DIFF
--- a/deployment/base/payload-processing/manager/envoy-filter.yaml
+++ b/deployment/base/payload-processing/manager/envoy-filter.yaml
@@ -30,7 +30,7 @@ spec:
             processing_mode:
               request_header_mode: "SEND"
               response_header_mode: "SKIP"
-              request_body_mode: "FULL_DUPLEX_STREAMED"
+              request_body_mode: "BUFFERED"
               response_body_mode: "NONE"
               request_trailer_mode: "SEND"
             grpc_service:
@@ -57,7 +57,7 @@ spec:
             processing_mode:
               request_header_mode: "SEND"
               response_header_mode: "SEND"
-              request_body_mode: "FULL_DUPLEX_STREAMED"
+              request_body_mode: "BUFFERED"
               response_body_mode: "FULL_DUPLEX_STREAMED"
               request_trailer_mode: "SEND"
               response_trailer_mode: "SEND"


### PR DESCRIPTION
## Summary

Change `request_body_mode` from `FULL_DUPLEX_STREAMED` to `BUFFERED` in the payload-processing EnvoyFilter for both ext_proc stages. Response body mode is **unchanged** — `FULL_DUPLEX_STREAMED` is preserved for SSE streaming.

## What this changes (and what it doesn't)

| | Before | After |
|---|---|---|
| **Request** body mode | `FULL_DUPLEX_STREAMED` | `BUFFERED` |
| **Response** body mode (stage 2) | `FULL_DUPLEX_STREAMED` | `FULL_DUPLEX_STREAMED` (unchanged) |
| Response chunk processing (metering SSE) | Works | Works (unchanged) |
| Request body parsing | Framework accumulates chunks | Envoy delivers complete body |

This is **not** reverting the streaming architecture. The move to `FULL_DUPLEX_STREAMED` (PR #38, PR #169) was driven by **response** streaming needs — SSE metering via `ResponseChunkProcessor`. That remains untouched. The ext_proc spec allows setting request and response body modes independently; this PR only changes the request direction.

## Why this is safe

The framework already accumulates the **full** request body in memory before parsing (`server.go:162-168`):

```go
case *extProcPb.ProcessingRequest_RequestBody:
    requestBody = append(requestBody, v.RequestBody.Body...)
    if !v.RequestBody.EndOfStream {
        continue  // keep accumulating
    }
    responses, err = s.HandleRequestBody(ctx, reqCtx, requestBody)
```

`BUFFERED` mode matches this actual behavior — it moves the buffering from the Go framework to Envoy, where HTTP/1.1 chunked transfer-encoding is properly decoded before delivery to ext_proc. No framework code changes needed.

## What this fixes

When clients send `Transfer-Encoding: chunked` (common in Codex CLI WebSocket→HTTP fallback), `FULL_DUPLEX_STREAMED` causes two failure modes:

**Bug 1 — Framing contamination (100% reproducible):** Envoy passes raw chunked framing (hex chunk sizes + CRLF) into ext_proc body bytes. `json.Unmarshal` fails with `"invalid character 'a'"`.

**Bug 2 — Cross-stage truncation (~7 per 48h):** With two chained ext_proc filters, the second filter receives a truncated body. Traced via single `x-request-id`:
- `payload-pre-processing`: ~170 body chunks → parses `model: gpt-5.5` ✅
- `payload-processing`: 1 truncated chunk → `"unexpected end of JSON input"` ❌

`BUFFERED` mode fixes both by having Envoy deliver the complete, de-chunked body.

## Reproduction

```bash
# FAILS with FULL_DUPLEX_STREAMED (100% failure rate)
curl -T body.json -H "Transfer-Encoding: chunked" \
  -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
  https://<gateway>/v1/responses

# WORKS (same body, Content-Length)
curl -d @body.json \
  -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
  https://<gateway>/v1/responses
```

## Test plan

- [x] Validated on OpenShift sandbox311 cluster — 15/15 chunked TE requests pass after fix
- [x] Response streaming (SSE metering) unaffected — `response_body_mode` unchanged
- [x] Content-Length requests continue to work (50/50 at 2.5MB)
- [ ] CI manifest validation

Ref: llm-d/llm-d-inference-payload-processor#209

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated request-body handling for the payload-processing pipeline so both processing stages now buffer request bodies consistently.
  * This may improve reliability and compatibility for requests passing through the external processing flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->