### PR TITLE
feat: new base manifest entry point for AI Gateway

### DIFF
--- a/deployment/base/maas-controller/base/kustomization.yaml
+++ b/deployment/base/maas-controller/base/kustomization.yaml
@@ -1,0 +1,33 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../default
+
+labels:
+  - pairs:
+      app.kubernetes.io/name: maas-controller
+      app.kubernetes.io/component: models-as-a-service
+      app.kubernetes.io/part-of: models-as-a-service
+
+configMapGenerator:
+  # Keep a stable name because manager.yaml references this ConfigMap directly
+  # through configMapKeyRef.
+  - name: maas-parameters
+    envs:
+      - params.env
+
+generatorOptions:
+  disableNameSuffixHash: true
+
+replacements:
+  - source:
+      kind: ConfigMap
+      name: maas-parameters
+      fieldPath: data.maas-controller-image
+    targets:
+      - select:
+          kind: Deployment
+          name: maas-controller
+        fieldPaths:
+          - spec.template.spec.containers.[name=manager].image

--- a/deployment/base/maas-controller/base/params.env
+++ b/deployment/base/maas-controller/base/params.env
@@ -1,0 +1,5 @@
+maas-api-image=quay.io/opendatahub/maas-api:odh-stable
+maas-controller-image=quay.io/opendatahub/maas-controller:odh-stable
+payload-processing-image=quay.io/opendatahub/odh-ai-gateway-payload-processing:odh-stable
+maas-api-key-cleanup-image=registry.redhat.io/ubi9/ubi-minimal:9.7
+monitoring-namespace=opendatahub


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
As part of our move from ODH to AI Gateway, we should take back the control of image injection by generating the ConfigMap ourselves, instead of using MaaS-aware functions in the upper controller.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new Kustomize base configuration for the controller component.
  * Pinned container image references for the controller, API, payload processing, and cleanup using environment-driven parameters.
  * Set the monitoring namespace to `opendatahub`.
  * Ensured stable generated ConfigMap naming and automatically wired the controller’s manager image from the generated configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->