### PR TITLE
fix: sync api-key-max-expiration-days from Tenant CR to ConfigMap

### DIFF
--- a/maas-controller/pkg/platform/tenantreconcile/pipeline.go
+++ b/maas-controller/pkg/platform/tenantreconcile/pipeline.go
@@ -8,10 +8,12 @@ import (
 
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
@@ -87,6 +89,10 @@ func RunPlatform(
 		return nil, fmt.Errorf("apply: %w", err)
 	}
 
+	if err := syncMaaSParametersConfigMap(ctx, c, appNs, params, log); err != nil {
+		return nil, fmt.Errorf("sync maas-parameters ConfigMap: %w", err)
+	}
+
 	tenantID, err := TenantIdentifierFor(tenant)
 	if err != nil {
 		return nil, fmt.Errorf("resolve tenant identifier: %w", err)
@@ -138,6 +144,42 @@ func Run(
 	}
 
 	return RunPlatform(ctx, log, c, scheme, tenant, platformContext, manifestPath, appNs, clusterAudience, mcfg)
+}
+
+const maasParametersConfigMapName = "maas-parameters"
+
+// syncMaaSParametersConfigMap patches the maas-parameters ConfigMap with
+// tenant-specific values. The RHOAI operator creates this ConfigMap with
+// defaults from params.env; the maas-controller updates keys that the
+// Tenant CR overrides (e.g., api-key-max-expiration-days).
+func syncMaaSParametersConfigMap(ctx context.Context, c client.Client, namespace string, params PlatformParams, log logr.Logger) error {
+	key := types.NamespacedName{Namespace: namespace, Name: maasParametersConfigMapName}
+
+	// Quick check: skip if already correct (avoids unnecessary writes).
+	cm := &corev1.ConfigMap{}
+	if err := c.Get(ctx, key, cm); err != nil {
+		if apierrors.IsNotFound(err) {
+			log.V(4).Info("maas-parameters ConfigMap not found, skipping sync")
+			return nil
+		}
+		return fmt.Errorf("get maas-parameters ConfigMap: %w", err)
+	}
+	if cm.Data["api-key-max-expiration-days"] == params.APIKeyMaxExpirationDays {
+		return nil
+	}
+
+	log.Info("Updating maas-parameters ConfigMap", "api-key-max-expiration-days", params.APIKeyMaxExpirationDays)
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		latest := &corev1.ConfigMap{}
+		if err := c.Get(ctx, key, latest); err != nil {
+			return err
+		}
+		if latest.Data == nil {
+			latest.Data = make(map[string]string)
+		}
+		latest.Data["api-key-max-expiration-days"] = params.APIKeyMaxExpirationDays
+		return c.Update(ctx, latest)
+	})
 }
 
 // MaasAPIDeploymentReady mirrors ODH deployments action for maas-api.

--- a/maas-controller/pkg/platform/tenantreconcile/pipeline_test.go
+++ b/maas-controller/pkg/platform/tenantreconcile/pipeline_test.go
@@ -1,0 +1,67 @@
+package tenantreconcile
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestSyncMaaSParametersConfigMap_NotFound(t *testing.T) {
+	c := fake.NewClientBuilder().Build()
+	params := PlatformParams{APIKeyMaxExpirationDays: "365"}
+
+	err := syncMaaSParametersConfigMap(context.Background(), c, "test-ns", params, logr.Discard())
+
+	assert.NoError(t, err)
+}
+
+func TestSyncMaaSParametersConfigMap_AlreadyCorrect(t *testing.T) {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      maasParametersConfigMapName,
+			Namespace: "test-ns",
+		},
+		Data: map[string]string{
+			"api-key-max-expiration-days": "365",
+		},
+	}
+	c := fake.NewClientBuilder().WithObjects(cm).Build()
+	params := PlatformParams{APIKeyMaxExpirationDays: "365"}
+
+	err := syncMaaSParametersConfigMap(context.Background(), c, "test-ns", params, logr.Discard())
+
+	assert.NoError(t, err)
+
+	var updated corev1.ConfigMap
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: maasParametersConfigMapName, Namespace: "test-ns"}, &updated))
+	assert.Equal(t, "365", updated.Data["api-key-max-expiration-days"])
+}
+
+func TestSyncMaaSParametersConfigMap_UpdatesValue(t *testing.T) {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      maasParametersConfigMapName,
+			Namespace: "test-ns",
+		},
+		Data: map[string]string{
+			"api-key-max-expiration-days": "90",
+		},
+	}
+	c := fake.NewClientBuilder().WithObjects(cm).Build()
+	params := PlatformParams{APIKeyMaxExpirationDays: "365"}
+
+	err := syncMaaSParametersConfigMap(context.Background(), c, "test-ns", params, logr.Discard())
+
+	assert.NoError(t, err)
+
+	var updated corev1.ConfigMap
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: maasParametersConfigMapName, Namespace: "test-ns"}, &updated))
+	assert.Equal(t, "365", updated.Data["api-key-max-expiration-days"])
+}


### PR DESCRIPTION
## Summary
- Fix `api-key-max-expiration-days` being hardcoded to 90 in the `maas-parameters` ConfigMap
- Add `syncMaaSParametersConfigMap` to the `RunPlatform` pipeline that reads `maxExpirationDays` from the Tenant CR (via `PlatformParams`) and patches the ConfigMap
- Follows the same pattern as OIDC: reads from Tenant CR → patches target resource during reconcile
- No-op if the ConfigMap doesn't exist (upstream/non-RHOAI deployments)

## Root Cause
The RHOAI operator creates `maas-parameters` ConfigMap with `api-key-max-expiration-days=90` from `params.env`. The maas-controller reads `maxExpirationDays` from the Tenant CR and patches the Deployment env var directly, but the operator overwrites the ConfigMap back to 90 on next reconcile. Since maas-api reads `API_KEY_MAX_EXPIRATION_DAYS` via `configMapKeyRef`, the Tenant CR value never takes effect.

## Test plan
- [x] Unit tests pass (`TestBuildPlatformParams`, `TestPatchMaaSAPIDeployment`)
- [x] Validated on cluster with custom image:
  1. Set `spec.apiKeys.maxExpirationDays: 365` on Tenant CR
  2. Operator reconciles → ConfigMap resets to 90
  3. maas-controller reconciles → reads Tenant CR → patches ConfigMap to 365
  4. maas-api picks up 365 via configMapKeyRef
- [ ] Backport to 3.4 z-stream

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * MaaS platform synchronization now immediately updates the API key expiration setting in the target application configuration.
  * Existing settings are preserved when already correct, while outdated values are refreshed automatically.
  * Platform reconciliation now reports synchronization failures before proceeding with deployment readiness checks.

* **Tests**
  * Added coverage for missing, up-to-date, and outdated configuration scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->