### PR TITLE
docs: add multi-tenant namespace install and validation guides

### DIFF
--- a/docs/content/install/multi-tenant-setup.md
+++ b/docs/content/install/multi-tenant-setup.md
@@ -1,0 +1,305 @@
+# Multi-Tenant Setup
+
+This guide covers deploying additional tenants beyond the default `models-as-a-service` tenant. Each tenant gets its own namespace, Gateway, maas-api instance, and isolated set of MaaS resources (subscriptions, auth policies, model refs).
+
+## Prerequisites
+
+Before creating additional tenants:
+
+- Default tenant is working (`oc get aitenant models-as-a-service -n ai-tenants` shows `Ready`)
+- Gateway API is available (`oc get gatewayclass openshift-default`)
+- cert-manager operator is installed (for TLS certificate provisioning)
+- MaaS controller is running with `--enable-tenant-namespace-discovery=true`
+
+## 1. Create a Tenant Gateway
+
+Each AITenant requires a dedicated Gateway. Gateways cannot be shared between AITenants.
+
+Get the cluster domain and create the Gateway:
+
+```bash
+TENANT_NAME="red-team"
+CLUSTER_DOMAIN=$(oc get ingresses.config.openshift.io cluster -o jsonpath='{.spec.domain}')
+GATEWAY_HOSTNAME="${TENANT_NAME}-maas.${CLUSTER_DOMAIN}"
+GATEWAY_NAMESPACE="openshift-ingress"
+CERT_NAME="router-certs-default"
+
+cat <<EOF | oc apply -f -
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: ${TENANT_NAME}
+  namespace: ${GATEWAY_NAMESPACE}
+  annotations:
+    opendatahub.io/managed: "false"
+    security.opendatahub.io/authorino-tls-bootstrap: "true"
+  labels:
+    app.kubernetes.io/name: maas
+    app.kubernetes.io/instance: ${TENANT_NAME}
+    app.kubernetes.io/component: gateway
+    opendatahub.io/managed: "false"
+spec:
+  gatewayClassName: openshift-default
+  listeners:
+    - name: http
+      hostname: ${GATEWAY_HOSTNAME}
+      port: 80
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: All
+    - name: https
+      hostname: ${GATEWAY_HOSTNAME}
+      port: 443
+      protocol: HTTPS
+      allowedRoutes:
+        namespaces:
+          from: All
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - group: ""
+            kind: Secret
+            name: ${CERT_NAME}
+EOF
+```
+
+Create an OpenShift Route for external access:
+
+```bash
+GATEWAY_SERVICE_NAME="${TENANT_NAME}-openshift-default"
+
+cat <<EOF | oc apply -f -
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: ${TENANT_NAME}-gateway
+  namespace: ${GATEWAY_NAMESPACE}
+  labels:
+    app.kubernetes.io/name: maas
+    app.kubernetes.io/instance: ${TENANT_NAME}
+    gateway.networking.k8s.io/gateway-name: ${TENANT_NAME}
+spec:
+  host: "${GATEWAY_HOSTNAME}"
+  to:
+    kind: Service
+    name: ${GATEWAY_SERVICE_NAME}
+    weight: 100
+  port:
+    targetPort: https
+  tls:
+    termination: reencrypt
+    insecureEdgeTerminationPolicy: Redirect
+  wildcardPolicy: None
+EOF
+```
+
+Verify the Gateway is Programmed:
+
+```bash
+oc get gateway ${TENANT_NAME} -n ${GATEWAY_NAMESPACE}
+```
+
+!!! tip "Automated script"
+    The `scripts/create-ai-tenant.sh` script automates Gateway, Route, and AITenant creation:
+    ```bash
+    ./scripts/create-ai-tenant.sh red-team
+    ```
+
+## 2. Create the AITenant CR
+
+AITenant resources must be created in the infrastructure namespace (`ai-tenants` by default):
+
+```bash
+cat <<EOF | oc apply -f -
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: AITenant
+metadata:
+  name: ${TENANT_NAME}
+  namespace: ai-tenants
+EOF
+```
+
+The controller bootstraps the following resources:
+
+| Resource | Location | Name |
+|----------|----------|------|
+| Namespace | Cluster | `ai-tenant-${TENANT_NAME}` |
+| Tenant CR | `ai-tenant-${TENANT_NAME}` | `default-tenant` |
+| maas-api Deployment | Operator namespace | `maas-api-${TENANT_NAME}` |
+| AuthPolicy | Gateway namespace | `${TENANT_NAME}-maas-auth` |
+| tenant-admin Role | `ai-tenant-${TENANT_NAME}` | `aitenant-${TENANT_NAME}-tenant-admin` |
+| object-admin Role | `ai-tenants` | `aitenant-${TENANT_NAME}-object-admin` |
+
+### Tenant Name Constraints
+
+- Must be a valid DNS-1123 label (lowercase alphanumeric and hyphens)
+- Maximum 41 characters (to fit derived resource names within the 63-character Kubernetes limit)
+- Must not conflict with existing AITenant names
+
+### Namespace Derivation
+
+The tenant namespace is derived from the AITenant name: `ai-tenant-<aitenant-name>`. The default tenant uses `models-as-a-service` as both the AITenant name and namespace.
+
+## 3. Verify Bootstrap Resources
+
+Wait for the AITenant to become Ready:
+
+```bash
+oc get aitenant ${TENANT_NAME} -n ai-tenants -w
+```
+
+Verify the tenant namespace was created with correct labels:
+
+```bash
+oc get namespace ai-tenant-${TENANT_NAME} --show-labels
+```
+
+Expected labels:
+
+- `ai-gateway.opendatahub.io/tenant=<tenant-name>`
+- `maas.opendatahub.io/managed-by-aitenant=true`
+
+Verify the Tenant CR exists:
+
+```bash
+oc get tenant default-tenant -n ai-tenant-${TENANT_NAME}
+```
+
+Verify the maas-api deployment is running:
+
+```bash
+oc get deployment maas-api-${TENANT_NAME} -n $(oc get dsci -o jsonpath='{.items[0].spec.applicationsNamespace}')
+```
+
+## 4. Grant Tenant-Admin Access
+
+The controller creates Roles but does not create RoleBindings. Grant access with standard Kubernetes RoleBindings:
+
+```bash
+oc create rolebinding ${TENANT_NAME}-tenant-admin \
+  --role=aitenant-${TENANT_NAME}-tenant-admin \
+  --group=red-team-admins \
+  -n ai-tenant-${TENANT_NAME}
+```
+
+See [Tenant RBAC](../configuration-and-management/tenant-rbac.md) for examples with users, groups, and ServiceAccounts.
+
+## 5. Configure Models
+
+Create MaaS resources in the tenant namespace to expose models:
+
+```bash
+TENANT_NS="ai-tenant-${TENANT_NAME}"
+
+# Create a MaaSModelRef
+cat <<EOF | oc apply -f -
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: MaaSModelRef
+metadata:
+  name: my-model
+  namespace: ${TENANT_NS}
+spec:
+  modelRef:
+    name: my-llm-inference-service
+    namespace: llm
+EOF
+
+# Create a MaaSAuthPolicy
+cat <<EOF | oc apply -f -
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: MaaSAuthPolicy
+metadata:
+  name: my-model-access
+  namespace: ${TENANT_NS}
+spec:
+  modelRefs:
+    - name: my-model
+      namespace: ${TENANT_NS}
+  subjects:
+    groups:
+      - name: system:authenticated
+    users: []
+EOF
+
+# Create a MaaSSubscription
+cat <<EOF | oc apply -f -
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: MaaSSubscription
+metadata:
+  name: my-subscription
+  namespace: ${TENANT_NS}
+spec:
+  owner:
+    groups:
+      - name: system:authenticated
+    users: []
+  modelRefs:
+    - name: my-model
+      namespace: ${TENANT_NS}
+      tokenRateLimits:
+        - limit: 1000
+          window: 1m
+EOF
+```
+
+!!! note
+    MaaSAuthPolicy and MaaSSubscription must be created in a namespace that contains a `Tenant` CR. The admission webhook rejects them otherwise.
+
+## Webhook Validation
+
+The AITenant admission webhook enforces two rules:
+
+1. **Namespace restriction**: AITenant must be created in the configured infrastructure namespace (default: `ai-tenants`). Creating it in any other namespace is rejected.
+
+2. **Gateway uniqueness**: Each AITenant must reference a unique Gateway. Two AITenants cannot use the same Gateway. The webhook checks all existing AITenants and rejects duplicates.
+
+## Operator Behavior
+
+### Self-Bootstrap
+
+On startup, the controller automatically creates `AITenant/models-as-a-service` in the infrastructure namespace for the default tenant. This AITenant bootstraps the default tenant namespace and Tenant CR.
+
+### Namespace Discovery
+
+When `--enable-tenant-namespace-discovery=true` is set, the controller watches for namespaces with the `ai-gateway.opendatahub.io/tenant` label. Changes to this label trigger tenant reconciliation.
+
+### Controller Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--aitenant-namespace` | `ai-tenants` | Infrastructure namespace for AITenant CRs |
+| `--enable-tenant-namespace-discovery` | `false` | Watch namespaces for tenant label changes |
+| `--gateway-namespace` | `openshift-ingress` | Namespace where Gateways are deployed |
+| `--gateway-name` | `maas-default-gateway` | Default Gateway name for the default tenant |
+
+## Delete a Tenant
+
+To remove a tenant:
+
+```bash
+oc delete aitenant ${TENANT_NAME} -n ai-tenants
+```
+
+The controller finalizer cleans up:
+
+- Tenant CR in the tenant namespace
+- Controller-created Roles and RoleBindings
+- Namespace labels and annotations (namespace itself is preserved)
+
+!!! warning
+    User-created RoleBindings are **not** deleted. Remove them manually before or after deleting the AITenant. Stale RoleBindings that reference recreated Roles can re-enable access.
+
+!!! tip "Automated cleanup"
+    Use the `scripts/delete-ai-tenant.sh` script for full cleanup including Gateway and Route:
+    ```bash
+    ./scripts/delete-ai-tenant.sh red-team
+    ```
+
+## See Also
+
+- [AITenant CRD Reference](../reference/crds/ai-tenant.md)
+- [Tenant CRD Reference](../reference/crds/tenant.md)
+- [Tenant RBAC](../configuration-and-management/tenant-rbac.md)
+- [Multi-Tenant Validation](multi-tenant-validation.md)
+- [API Reference](../reference/api-reference.md)

--- a/docs/content/install/multi-tenant-setup.md
+++ b/docs/content/install/multi-tenant-setup.md
@@ -126,7 +126,7 @@ The controller bootstraps the following resources:
 |----------|----------|------|
 | Namespace | Cluster | `ai-tenant-${TENANT_NAME}` |
 | Tenant CR | `ai-tenant-${TENANT_NAME}` | `default-tenant` |
-| maas-api Deployment | Operator namespace | `maas-api-${TENANT_NAME}` |
+| maas-api Deployment | Infrastructure namespace | `maas-api-${TENANT_NAME}` |
 | AuthPolicy | Gateway namespace | `${TENANT_NAME}-maas-auth` |
 | tenant-admin Role | `ai-tenant-${TENANT_NAME}` | `aitenant-${TENANT_NAME}-tenant-admin` |
 | object-admin Role | `ai-tenants` | `aitenant-${TENANT_NAME}-object-admin` |
@@ -166,10 +166,11 @@ Verify the Tenant CR exists:
 oc get tenant default-tenant -n ai-tenant-${TENANT_NAME}
 ```
 
-Verify the maas-api deployment is running:
+Verify the maas-api deployment is running in the infrastructure namespace:
 
 ```bash
-oc get deployment maas-api-${TENANT_NAME} -n $(oc get dsci -o jsonpath='{.items[0].spec.applicationsNamespace}')
+INFRA_NS=$(oc get deployment -A -o custom-columns=NS:.metadata.namespace,NAME:.metadata.name --no-headers | grep "maas-api-${TENANT_NAME}" | awk '{print $1}')
+oc get deployment maas-api-${TENANT_NAME} -n ${INFRA_NS}
 ```
 
 ## 4. Grant Tenant-Admin Access

--- a/docs/content/install/multi-tenant-validation.md
+++ b/docs/content/install/multi-tenant-validation.md
@@ -1,0 +1,185 @@
+# Multi-Tenant Validation
+
+Validation steps for additional tenants. For default (single-tenant) validation, see [Validation](validation.md).
+
+## 1. Verify AITenant Status
+
+```bash
+TENANT_NAME="red-team"
+oc get aitenant ${TENANT_NAME} -n ai-tenants
+```
+
+Expected: `READY` is `True`. If `False`, check conditions:
+
+```bash
+oc get aitenant ${TENANT_NAME} -n ai-tenants -o jsonpath='{.status.conditions}' | jq .
+```
+
+## 2. Verify Tenant Namespace
+
+```bash
+TENANT_NS="ai-tenant-${TENANT_NAME}"
+oc get namespace ${TENANT_NS} -o jsonpath='{.metadata.labels}' | jq .
+```
+
+Expected labels:
+
+- `ai-gateway.opendatahub.io/tenant: <tenant-name>`
+- `maas.opendatahub.io/managed-by-aitenant: "true"`
+
+Verify the Tenant CR:
+
+```bash
+oc get tenant default-tenant -n ${TENANT_NS} -o yaml
+```
+
+Expected: `status.phase` is `Active`.
+
+## 3. Verify maas-api Deployment
+
+```bash
+APP_NS=$(oc get dsci -o jsonpath='{.items[0].spec.applicationsNamespace}' 2>/dev/null || echo "redhat-ods-applications")
+oc get deployment maas-api-${TENANT_NAME} -n ${APP_NS}
+```
+
+Expected: `READY` is `1/1`.
+
+## 4. Verify Gateway
+
+```bash
+oc get gateway ${TENANT_NAME} -n openshift-ingress
+```
+
+Expected: `PROGRAMMED` is `True`.
+
+Verify the Route exists:
+
+```bash
+oc get route ${TENANT_NAME}-gateway -n openshift-ingress
+```
+
+## 5. Verify Policies
+
+```bash
+oc get authpolicy -n openshift-ingress -l maas.opendatahub.io/tenant-name=${TENANT_NAME}
+oc get tokenratelimitpolicy -n ${TENANT_NS}
+```
+
+## 6. Test Model Listing
+
+```bash
+GATEWAY_HOST=$(oc get gateway ${TENANT_NAME} -n openshift-ingress -o jsonpath='{.spec.listeners[0].hostname}')
+TOKEN=$(oc whoami -t)
+
+curl -sSk "https://${GATEWAY_HOST}/maas-api/v1/models" \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -H "Content-Type: application/json" | jq .
+```
+
+Expected: `200` with models configured for this tenant.
+
+## 7. Test Authentication
+
+Without a token (expected: `401`):
+
+```bash
+curl -sSk -o /dev/null -w "%{http_code}\n" "https://${GATEWAY_HOST}/maas-api/v1/models"
+```
+
+With a valid API key (expected: `200`):
+
+```bash
+API_KEY=$(curl -sSk \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -H "Content-Type: application/json" \
+  -X POST -d '{"name":"test-key","subscription":"my-subscription"}' \
+  "https://${GATEWAY_HOST}/maas-api/v1/api-keys" | jq -r .key)
+
+curl -sSk -w "\nHTTP: %{http_code}\n" \
+  -H "Authorization: Bearer ${API_KEY}" \
+  "https://${GATEWAY_HOST}/maas-api/v1/models"
+```
+
+## 8. Test Tenant Isolation
+
+Verify that a token minted for one tenant cannot access another tenant's models:
+
+```bash
+# Get default tenant gateway host
+DEFAULT_HOST=$(oc get gateway maas-default-gateway -n openshift-ingress -o jsonpath='{.spec.listeners[0].hostname}')
+
+# Try the additional tenant's API key against the default tenant (expected: 401 or 403)
+curl -sSk -o /dev/null -w "%{http_code}\n" \
+  -H "Authorization: Bearer ${API_KEY}" \
+  "https://${DEFAULT_HOST}/maas-api/v1/models"
+```
+
+Each tenant's maas-api instance serves only its own tenant's data. API keys are scoped to the tenant where they were created.
+
+## 9. Verify All Components
+
+```bash
+echo "=== AITenant ==="
+oc get aitenant ${TENANT_NAME} -n ai-tenants
+
+echo "=== Tenant CR ==="
+oc get tenant default-tenant -n ${TENANT_NS}
+
+echo "=== maas-api ==="
+oc get deployment maas-api-${TENANT_NAME} -n ${APP_NS}
+
+echo "=== Gateway ==="
+oc get gateway ${TENANT_NAME} -n openshift-ingress
+
+echo "=== AuthPolicies ==="
+oc get authpolicy -A -l maas.opendatahub.io/tenant-name=${TENANT_NAME}
+
+echo "=== Subscriptions ==="
+oc get maassubscription -n ${TENANT_NS}
+
+echo "=== Model Refs ==="
+oc get maasmodelref -n ${TENANT_NS}
+```
+
+## Troubleshooting
+
+### AITenant stuck in Pending
+
+Check the AITenant conditions for the specific reason:
+
+```bash
+oc get aitenant ${TENANT_NAME} -n ai-tenants -o jsonpath='{.status.conditions}' | jq .
+```
+
+Common causes:
+
+- Gateway not found or not Programmed
+- Database secret (`maas-db-config`) missing in operator namespace
+- Authorino not deployed or TLS not configured
+
+### Webhook rejects AITenant creation
+
+AITenant must be created in the configured infrastructure namespace (default: `ai-tenants`):
+
+```
+AITenant ai-tenants/red-team must be created in the configured AITenant infrastructure namespace ai-tenants
+```
+
+### Gateway uniqueness error
+
+Each AITenant requires its own Gateway:
+
+```
+gateway openshift-ingress/red-team is already in use by AITenant ai-tenants/other-tenant
+```
+
+### MaaSSubscription rejected
+
+MaaSSubscription and MaaSAuthPolicy must be created in a namespace that contains a `Tenant` CR. Wait for the AITenant controller to create the Tenant CR before creating these resources.
+
+## See Also
+
+- [Multi-Tenant Setup](multi-tenant-setup.md)
+- [Validation (Default Tenant)](validation.md)
+- [Tenant RBAC](../configuration-and-management/tenant-rbac.md)
+- [AITenant CRD Reference](../reference/crds/ai-tenant.md)

--- a/docs/content/install/multi-tenant-validation.md
+++ b/docs/content/install/multi-tenant-validation.md
@@ -38,8 +38,8 @@ Expected: `status.phase` is `Active`.
 ## 3. Verify maas-api Deployment
 
 ```bash
-APP_NS=$(oc get dsci -o jsonpath='{.items[0].spec.applicationsNamespace}' 2>/dev/null || echo "redhat-ods-applications")
-oc get deployment maas-api-${TENANT_NAME} -n ${APP_NS}
+INFRA_NS=$(oc get deployment -A -o custom-columns=NS:.metadata.namespace,NAME:.metadata.name --no-headers | grep "maas-api-${TENANT_NAME}" | awk '{print $1}')
+oc get deployment maas-api-${TENANT_NAME} -n ${INFRA_NS}
 ```
 
 Expected: `READY` is `1/1`.
@@ -61,7 +61,7 @@ oc get route ${TENANT_NAME}-gateway -n openshift-ingress
 ## 5. Verify Policies
 
 ```bash
-oc get authpolicy -n openshift-ingress -l maas.opendatahub.io/tenant-name=${TENANT_NAME}
+oc get authpolicy ${TENANT_NAME}-maas-auth -n openshift-ingress
 oc get tokenratelimitpolicy -n ${TENANT_NS}
 ```
 
@@ -126,13 +126,13 @@ echo "=== Tenant CR ==="
 oc get tenant default-tenant -n ${TENANT_NS}
 
 echo "=== maas-api ==="
-oc get deployment maas-api-${TENANT_NAME} -n ${APP_NS}
+oc get deployment maas-api-${TENANT_NAME} -n ${INFRA_NS}
 
 echo "=== Gateway ==="
 oc get gateway ${TENANT_NAME} -n openshift-ingress
 
 echo "=== AuthPolicies ==="
-oc get authpolicy -A -l maas.opendatahub.io/tenant-name=${TENANT_NAME}
+oc get authpolicy ${TENANT_NAME}-maas-auth -n openshift-ingress
 
 echo "=== Subscriptions ==="
 oc get maassubscription -n ${TENANT_NS}

--- a/docs/content/install/validation.md
+++ b/docs/content/install/validation.md
@@ -167,3 +167,7 @@ openssl s_client -connect localhost:8443 \
 For detailed TLS configuration options, see [TLS Configuration](../configuration-and-management/tls-configuration.md).
 
 For troubleshooting common issues, see [Troubleshooting](troubleshooting.md).
+
+## Multi-Tenant Validation
+
+For validating additional tenants beyond the default, see [Multi-Tenant Validation](multi-tenant-validation.md).

--- a/docs/content/reference/crds/ai-tenant.md
+++ b/docs/content/reference/crds/ai-tenant.md
@@ -99,6 +99,8 @@ spec:
 
 ## Related Documentation
 
+- [Multi-Tenant Setup](../../install/multi-tenant-setup.md) - End-to-end guide for deploying additional tenants
+- [Multi-Tenant Validation](../../install/multi-tenant-validation.md) - Validation steps for additional tenants
 - [Tenant CRD](tenant.md) - Temporary MaaS runtime config object
 - [MaaSAuthPolicy CRD](maas-auth-policy.md) - Access control policies
 - [MaaSSubscription CRD](maas-subscription.md) - Subscription and rate limiting

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -74,6 +74,8 @@ nav:
       - Model Setup: install/model-setup.md
       - External Model Setup (Tech Preview): install/external-model-setup.md
       - Validation: install/validation.md
+      - Multi-Tenant Setup: install/multi-tenant-setup.md
+      - Multi-Tenant Validation: install/multi-tenant-validation.md
       - Troubleshooting: install/troubleshooting.md
   - Administration Guide:
     - Configuration & Management:


### PR DESCRIPTION
## Summary
Adds end-to-end documentation for Phase 1 multi-tenancy (S8, [RHOAIENG-62570](https://redhat.atlassian.net/browse/RHOAIENG-62570)):

- **`docs/content/install/multi-tenant-setup.md`**: Prerequisites, Gateway creation, AITenant CR, bootstrap verification, RBAC grants, model configuration, webhook validation rules, operator behavior notes (self-bootstrap, namespace discovery, controller flags), and tenant deletion
- **`docs/content/install/multi-tenant-validation.md`**: AITenant status verification, namespace labels/annotations, maas-api deployment, Gateway, auth testing (401/200), tenant isolation testing, component summary, and troubleshooting
- Updated `validation.md` with link to multi-tenant validation
- Updated `ai-tenant.md` CRD reference with links to new guides
- Updated `mkdocs.yml` navigation

## Content Sources
- `scripts/create-ai-tenant.sh` — authoritative tenant creation flow
- `maas-controller/pkg/webhook/aitenant_webhook.go` — webhook validation rules
- `test/e2e/tests/test_aitenant_lifecycle.py` — expected behavior
- Existing CRD docs (`ai-tenant.md`, `tenant.md`, `tenant-rbac.md`)

## Test plan
- [ ] `mkdocs serve` renders all pages without errors
- [ ] All internal links resolve correctly
- [ ] Webhook behavior matches `aitenant_webhook.go`
- [ ] curl examples use correct paths and headers

Ref: [RHOAIENG-62570](https://redhat.atlassian.net/browse/RHOAIENG-62570)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive guide for deploying and managing additional tenants, including required prerequisites, tenant-specific gateway/route setup, and tenant-scoped resource configuration.
  * Added end-to-end multi-tenant validation steps covering readiness checks, routing verification, authorization behavior, and tenant isolation troubleshooting.
  * Updated the AI tenant reference page and installation navigation to link the new multi-tenant guides, including a brief cross-reference from the general validation documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[RHOAIENG-62570]: https://redhat.atlassian.net/browse/RHOAIENG-62570?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHOAIENG-62570]: https://redhat.atlassian.net/browse/RHOAIENG-62570?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ