### PR TITLE
fix: use Istio managed label in payload-processing NetworkPolicy

### DIFF
--- a/deployment/base/payload-processing/default/kustomization.yaml
+++ b/deployment/base/payload-processing/default/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 resources:
   - ../manager
   - ../rbac
+  - ../networking
 
 labels:
   - includeSelectors: true

--- a/deployment/base/payload-processing/networking/kustomization.yaml
+++ b/deployment/base/payload-processing/networking/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - networkpolicy.yaml

--- a/deployment/base/payload-processing/networking/networkpolicy.yaml
+++ b/deployment/base/payload-processing/networking/networkpolicy.yaml
@@ -1,0 +1,75 @@
+# NetworkPolicy for payload-processing pods in the gateway namespace.
+#
+# Required on OCP 4.22+ where openshift-ingress has a default deny-all
+# NetworkPolicy. Without this, payload-processing pods cannot receive
+# ext_proc traffic from the gateway or reach the Kubernetes API server.
+#
+# Security constraints:
+# - podSelector: covers payload-processing and payload-pre-processing pods
+# - ingress: gateway ext_proc traffic (port 9004), monitoring scrape (9005, 9090)
+# - egress: DNS + Kubernetes API server only (this container is a pure
+#   Kubernetes controller with no external HTTP/gRPC calls)
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: payload-processing
+  labels:
+    app.opendatahub.io/modelsasservice: "true"
+    app.kubernetes.io/part-of: maas
+    app.kubernetes.io/component: networking
+spec:
+  podSelector:
+    matchExpressions:
+      - key: app
+        operator: In
+        values:
+          - payload-processing
+          - payload-pre-processing
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Allow ext_proc traffic from any Istio-managed gateway pod in the
+    # ingress namespace. Uses the common label applied by the Istio gateway
+    # controller to all provisioned gateway pods, covering both
+    # data-science-gateway and maas-default-gateway.
+    - from:
+        - podSelector:
+            matchLabels:
+              gateway.istio.io/managed: istio.io-gateway-controller
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-ingress
+      ports:
+        - protocol: TCP
+          port: 9004
+    # Allow monitoring scrape from OpenShift monitoring namespaces
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-monitoring
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-user-workload-monitoring
+      ports:
+        - protocol: TCP
+          port: 9005
+        - protocol: TCP
+          port: 9090
+  egress:
+    # Allow DNS resolution (CoreDNS on OCP uses port 5353)
+    - ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+        - protocol: UDP
+          port: 5353
+        - protocol: TCP
+          port: 5353
+    # Allow Kubernetes API server access (controller-runtime client)
+    - ports:
+        - protocol: TCP
+          port: 443
+        - protocol: TCP
+          port: 6443

--- a/test/e2e/tests/test_networkpolicy.py
+++ b/test/e2e/tests/test_networkpolicy.py
@@ -1,0 +1,207 @@
+"""
+E2E tests for payload-processing NetworkPolicy in the gateway namespace.
+
+Validates that the NetworkPolicy allows ext_proc gRPC traffic from all
+Istio-managed gateway pods (not just data-science-gateway), and that
+MaaS API endpoints are reachable through maas-default-gateway.
+"""
+
+import json
+
+import pytest
+import requests
+
+from conftest import TLS_VERIFY
+from multitenancy_helpers import (
+    DEFAULT_GATEWAY_NAME,
+    GATEWAY_NAMESPACE,
+    _oc_run,
+    get_json_or_none,
+    list_json,
+)
+
+NETWORKPOLICY_NAME = "payload-processing"
+EXPECTED_MANAGED_LABEL = "gateway.istio.io/managed"
+EXPECTED_MANAGED_VALUE = "istio.io-gateway-controller"
+EXT_PROC_PORT = 9004
+
+
+class TestPayloadProcessingNetworkPolicyExists:
+    """Verify the payload-processing NetworkPolicy exists with correct selectors."""
+
+    def test_networkpolicy_exists(self):
+        np = get_json_or_none("networkpolicy", NETWORKPOLICY_NAME, GATEWAY_NAMESPACE)
+        assert np is not None, (
+            f"NetworkPolicy {NETWORKPOLICY_NAME} must exist in {GATEWAY_NAMESPACE}"
+        )
+
+    def test_pod_selector_covers_both_processors(self):
+        np = get_json_or_none("networkpolicy", NETWORKPOLICY_NAME, GATEWAY_NAMESPACE)
+        assert np is not None
+        pod_selector = np["spec"]["podSelector"]
+        match_exprs = pod_selector.get("matchExpressions") or []
+        app_expr = next(
+            (e for e in match_exprs if e.get("key") == "app" and e.get("operator") == "In"),
+            None,
+        )
+        if app_expr:
+            values = set(app_expr.get("values") or [])
+            assert "payload-processing" in values, "podSelector must include payload-processing"
+            assert "payload-pre-processing" in values, "podSelector must include payload-pre-processing"
+        else:
+            match_labels = pod_selector.get("matchLabels") or {}
+            assert "app" in match_labels, (
+                f"podSelector must select payload-processing pods, got {pod_selector!r}"
+            )
+
+    def test_ingress_uses_istio_managed_label(self):
+        """Ingress must use gateway.istio.io/managed to cover all gateways."""
+        np = get_json_or_none("networkpolicy", NETWORKPOLICY_NAME, GATEWAY_NAMESPACE)
+        assert np is not None
+        ingress_rules = np["spec"].get("ingress") or []
+        assert len(ingress_rules) > 0, "NetworkPolicy must have ingress rules"
+
+        ext_proc_rule = None
+        for rule in ingress_rules:
+            ports = rule.get("ports") or []
+            if any(p.get("port") == EXT_PROC_PORT for p in ports):
+                ext_proc_rule = rule
+                break
+
+        assert ext_proc_rule is not None, (
+            f"Must have an ingress rule for ext_proc port {EXT_PROC_PORT}"
+        )
+
+        from_selectors = ext_proc_rule.get("from") or []
+        assert len(from_selectors) > 0, "ext_proc ingress rule must have 'from' selectors"
+
+        pod_selector = from_selectors[0].get("podSelector", {})
+        match_labels = pod_selector.get("matchLabels") or {}
+        assert match_labels.get(EXPECTED_MANAGED_LABEL) == EXPECTED_MANAGED_VALUE, (
+            f"ext_proc ingress must use {EXPECTED_MANAGED_LABEL}: {EXPECTED_MANAGED_VALUE} "
+            f"to cover all Istio-managed gateways, got matchLabels: {match_labels!r}"
+        )
+
+    def test_ingress_does_not_hardcode_single_gateway(self):
+        """Ingress must NOT use gateway-name label that restricts to one gateway."""
+        np = get_json_or_none("networkpolicy", NETWORKPOLICY_NAME, GATEWAY_NAMESPACE)
+        assert np is not None
+        ingress_rules = np["spec"].get("ingress") or []
+
+        for rule in ingress_rules:
+            ports = rule.get("ports") or []
+            if not any(p.get("port") == EXT_PROC_PORT for p in ports):
+                continue
+            for from_selector in rule.get("from") or []:
+                pod_labels = (from_selector.get("podSelector") or {}).get("matchLabels") or {}
+                assert "gateway.networking.k8s.io/gateway-name" not in pod_labels, (
+                    "ext_proc ingress must NOT use gateway.networking.k8s.io/gateway-name "
+                    "as pod selector — this restricts traffic to a single gateway. "
+                    f"Found: {pod_labels!r}"
+                )
+
+
+class TestPayloadProcessingConnectivity:
+    """Verify that MaaS gateway pods can reach payload-processing."""
+
+    def test_maas_gateway_pod_exists(self):
+        """maas-default-gateway pod must exist in the gateway namespace."""
+        pods = list_json(
+            "pod",
+            GATEWAY_NAMESPACE,
+            labels=f"gateway.networking.k8s.io/gateway-name={DEFAULT_GATEWAY_NAME}",
+        )
+        assert len(pods) > 0, (
+            f"No pods found for gateway {DEFAULT_GATEWAY_NAME} in {GATEWAY_NAMESPACE}"
+        )
+        ready_pods = [
+            p for p in pods
+            if any(
+                cs.get("ready")
+                for cs in (p.get("status") or {}).get("containerStatuses") or []
+            )
+        ]
+        assert len(ready_pods) > 0, (
+            f"Gateway {DEFAULT_GATEWAY_NAME} has pods but none are ready"
+        )
+
+    def test_maas_gateway_has_istio_managed_label(self):
+        """maas-default-gateway pods must carry the Istio managed label."""
+        pods = list_json(
+            "pod",
+            GATEWAY_NAMESPACE,
+            labels=f"gateway.networking.k8s.io/gateway-name={DEFAULT_GATEWAY_NAME}",
+        )
+        assert len(pods) > 0
+        pod = pods[0]
+        labels = pod.get("metadata", {}).get("labels") or {}
+        assert labels.get(EXPECTED_MANAGED_LABEL) == EXPECTED_MANAGED_VALUE, (
+            f"Gateway pod must have label {EXPECTED_MANAGED_LABEL}={EXPECTED_MANAGED_VALUE}, "
+            f"got labels: {json.dumps({k: v for k, v in labels.items() if 'gateway' in k.lower() or 'istio' in k.lower() or 'managed' in k.lower()})}"
+        )
+
+    def test_payload_processing_pods_running(self):
+        """payload-processing pods must be running in the gateway namespace."""
+        pods = list_json("pod", GATEWAY_NAMESPACE, labels="app=payload-processing")
+        assert len(pods) > 0, (
+            f"No payload-processing pods found in {GATEWAY_NAMESPACE}"
+        )
+        running = [
+            p for p in pods
+            if (p.get("status") or {}).get("phase") == "Running"
+        ]
+        assert len(running) > 0, "payload-processing pods exist but none are Running"
+
+
+class TestMaaSGatewayFunctional:
+    """Verify MaaS API is reachable through the gateway (ext_proc not blocked)."""
+
+    def test_maas_api_health(self, maas_api_base_url: str):
+        """MaaS API health endpoint must respond (not hang on ext_proc timeout)."""
+        for path in ("/health", "/healthz"):
+            try:
+                r = requests.get(
+                    f"{maas_api_base_url}{path}",
+                    timeout=15,
+                    verify=TLS_VERIFY,
+                )
+                assert r.status_code in (200, 401, 404), (
+                    f"Health endpoint returned {r.status_code}, expected 200/401/404. "
+                    f"A 500 or timeout indicates ext_proc connectivity failure "
+                    f"(NetworkPolicy may be blocking gateway -> payload-processing)."
+                )
+                return
+            except requests.exceptions.Timeout:
+                pytest.fail(
+                    f"Health endpoint {path} timed out after 15s. "
+                    "This typically indicates the NetworkPolicy is blocking "
+                    "ext_proc traffic from the gateway to payload-processing pods."
+                )
+            except requests.exceptions.ConnectionError:
+                continue
+
+        pytest.fail("Neither /health nor /healthz responded")
+
+    def test_maas_api_models_reachable(self, maas_api_base_url: str, headers: dict):
+        """GET /v1/models must respond without ext_proc timeout."""
+        try:
+            r = requests.get(
+                f"{maas_api_base_url}/v1/models",
+                headers=headers,
+                timeout=15,
+                verify=TLS_VERIFY,
+            )
+        except requests.exceptions.Timeout:
+            pytest.fail(
+                "/v1/models timed out after 15s — ext_proc connectivity failure. "
+                "Check that the payload-processing NetworkPolicy allows ingress "
+                "from maas-default-gateway pods."
+            )
+        assert r.status_code != 500, (
+            f"/v1/models returned 500: {r.text[:300]}. "
+            "If body contains 'ext_proc error', the NetworkPolicy is likely "
+            "blocking gateway -> payload-processing traffic."
+        )
+        assert r.status_code in (200, 401, 403), (
+            f"/v1/models returned unexpected {r.status_code}: {r.text[:300]}"
+        )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- The payload-processing NetworkPolicy only allowed ext_proc ingress (port 9004) from pods labeled `gateway.networking.k8s.io/gateway-name: data-science-gateway`, blocking traffic from `maas-default-gateway` and any per-tenant gateways                                             
- This caused gRPC error 14 (UNAVAILABLE) on all requests routed through `maas-default-gateway`, resulting in 500s and 10s+ timeouts on the SmokeSet5 Cypress E2E tests                                                                                                                 
- Switch the pod selector to `gateway.istio.io/managed: istio.io-gateway-controller` which covers all Istio-provisioned gateway pods in the ingress namespace                                                                                                                           
- Add E2E tests validating the NetworkPolicy selector and ext_proc connectivity                                                             
                                                                                                                                            
## Root cause
The `maas-default-gateway` pod has label `gateway.networking.k8s.io/gateway-name: maas-default-gateway`, not `data-science-gateway`. The NetworkPolicy dropped every connection from this gateway to payload-processing. Envoy cluster stats confirmed: `cx_connect_fail` equaled `cx_total` (100% connection failures).                              

## How Has This Been Tested?
Verified on `dash-e2e-rhoai` cluster — applying the fix changed requests from 10s hang + 500 to 30ms + 200. 

Fixes https://redhat.atlassian.net/browse/RHOAIENG-71268 and https://redhat.atlassian.net/browse/RHOAIENG-75511

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added network access controls for payload processing services, limiting inbound traffic to approved gateways and monitoring sources while allowing only required outbound connections.
* **Bug Fixes**
  * Improved reliability of payload-processing connectivity so health and model endpoints remain reachable under the new network restrictions.
* **Tests**
  * Added end-to-end coverage to verify the new network policy and confirm MaaS gateway access continues to work as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->