### PR TITLE
fix: pin all GitHub Actions to immutable commit SHAs

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -29,10 +29,10 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
     - name: Install kustomize
-      uses: imranismail/setup-kustomize@v2
+      uses: imranismail/setup-kustomize@2ba527d4d055ab63514ba50a99456fc35684947f # v2
       with:
         kustomize-version: '5.7.1'
 
@@ -50,9 +50,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
-    - uses: actions/setup-go@v6
+    - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
       with:
         go-version-file: maas-controller/go.mod
         cache: true

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -68,7 +68,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -126,7 +126,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -192,7 +192,7 @@ jobs:
     
     steps:
       - name: Checkout release branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
           ref: ${{ needs.create-release-branch.outputs.minor_release_branch }}
@@ -238,7 +238,7 @@ jobs:
 
       - name: Create GitHub Release
         if: inputs.create_release == true
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           tag_name: ${{ needs.create-release-branch.outputs.version_tag }}
           name: Release ${{ needs.create-release-branch.outputs.version_tag }}
@@ -269,20 +269,20 @@ jobs:
     
     steps:
       - name: Checkout release branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
           ref: ${{ needs.create-tag.outputs.version_tag }}
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: maas-api/go.mod
           cache: true
           cache-dependency-path: maas-api/go.sum
 
       - name: Login to Quay.io
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: quay.io
           username: ${{ secrets.APP_QUAY_USERNAME }}
@@ -314,7 +314,7 @@ jobs:
 
     steps:
       - name: Checkout version tag
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -322,12 +322,12 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'
 
       - name: Cache pip dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('docs/requirements.txt') }}

--- a/.github/workflows/disconnected-readiness.yml
+++ b/.github/workflows/disconnected-readiness.yml
@@ -7,6 +7,6 @@ on:
 
 jobs:
   check:
-    uses: opendatahub-io/disconnected-readiness-scorer/.github/workflows/disconnected-readiness-check.yml@v1
+    uses: opendatahub-io/disconnected-readiness-scorer/.github/workflows/disconnected-readiness-check.yml@6f7fc06230f5eeabfd134d819219314d54f0c7e7 # v1
     with:
       rules: ""

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,10 +34,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Check Internal Links
-        uses: becheran/mlc@v1.2.0
+        uses: becheran/mlc@7ec24825cefe0c9c8c6bac48430e1f69e3ec356e # v1.2.0
         with:
           # Only check local/internal links - these must pass
           args: --offline .
@@ -75,15 +75,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'
 
       - name: Cache pip dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('docs/requirements.txt') }}
@@ -134,17 +134,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0  # Fetch all history for mike
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'
 
       - name: Cache pip dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('docs/requirements.txt') }}

--- a/.github/workflows/pr-title-validation.yml
+++ b/.github/workflows/pr-title-validation.yml
@@ -16,10 +16,10 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Validate PR Title Format
-        uses: amannn/action-semantic-pull-request@v5
+        uses: amannn/action-semantic-pull-request@e32d7e603df1aa1ba07e981f2a23455dee596825 # v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/promote-main-to-stable.yml
+++ b/.github/workflows/promote-main-to-stable.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/promote-stable-to-rhoai.yml
+++ b/.github/workflows/promote-stable-to-rhoai.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,52 @@
+name: OpenSSF Scorecard
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '30 3 * * 1'  # Weekly on Mondays at 03:30 UTC
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+      actions: read
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2
+        with:
+          egress-policy: audit
+
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Run Scorecard
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload SARIF to Code Scanning
+        uses: github/codeql-action/upload-sarif@02c5e83432fe5497fd85b873b6c9f16a8578e1d9 # v3
+        with:
+          sarif_file: results.sarif
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: scorecard-results
+          path: results.sarif
+          retention-days: 5


### PR DESCRIPTION
## Summary

Pin all unpinned GitHub Actions references to full 40-char commit SHAs and add OpenSSF Scorecard workflow to mitigate supply-chain attacks via tag re-pointing ([RHOAIENG-69239](https://redhat.atlassian.net/browse/RHOAIENG-69239) / FIND-008).

## Description

- Pin every `uses:` reference in 7 workflow files to immutable commit SHAs, preserving mutable version tags as trailing comments for readability.
- The most critical file is `create-release.yml` which holds `secrets.APP_QUAY_TOKEN` and pushes images to `quay.io/opendatahub/maas-api`.
- Add `scorecard.yml` workflow with `ossf/scorecard-action` and `step-security/harden-runner` to continuously assess repository security posture.
- No workflow logic, triggers, or permissions are modified — only the action references change.
- All newly added actions (`scorecard.yml`) are also SHA-pinned from the start.

### Workflows pinned:
| File | Risk | Actions Pinned |
|------|------|---------------|
| `create-release.yml` | Critical (secrets + image push) | `actions/checkout`, `softprops/action-gh-release`, `actions/setup-go`, `docker/login-action`, `actions/setup-python`, `actions/cache` |
| `docs.yml` | Medium (contents: write) | `actions/checkout`, `becheran/mlc`, `actions/setup-python`, `actions/cache` |
| `promote-main-to-stable.yml` | Medium (PR write) | `actions/checkout` |
| `promote-stable-to-rhoai.yml` | Medium (PR write) | `actions/checkout` |
| `pr-title-validation.yml` | Low (read-only) | `actions/checkout`, `amannn/action-semantic-pull-request` |
| `build-test.yml` | Low (read-only) | `actions/checkout`, `imranismail/setup-kustomize`, `actions/setup-go` |
| `disconnected-readiness.yml` | Low (reusable workflow) | `opendatahub-io/disconnected-readiness-scorer` |

## How it was tested

- Verified all SHAs resolve to the correct commit for each action's current tag using `gh api repos/<owner>/<repo>/git/ref/tags/<tag>`.
- Validated no workflow logic changes — only `uses:` references are modified.
- Ran OpenSSF Scorecard workflow on fork to confirm successful execution.
- Cross-referenced pinned SHAs with existing SHA-pinned workflows in the same repository (`maas-api-ci.yml`, `maas-controller-ci.yml`, `update-docs-latest.yml`, `operator-chaos.yml`) for consistency.

Resolves: https://issues.redhat.com/browse/RHOAIENG-69239

[RHOAIENG-69239]: https://redhat.atlassian.net/browse/RHOAIENG-69239?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added automated OpenSSF Scorecard scanning to identify potential supply-chain security issues.
  * Security scan results are published to code scanning and retained as downloadable artifacts.

* **Chores**
  * Hardened CI/CD workflows by pinning automation actions to specific versions, improving build and release reproducibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->