### PR TITLE
fix: add X-MaaS-Username and X-MaaS-Group to SensitiveHeaders (FIND-014)

### DIFF
--- a/maas-api/internal/logger/redaction.go
+++ b/maas-api/internal/logger/redaction.go
@@ -20,6 +20,8 @@ var (
 		"X-Api-Key",
 		"Cookie",
 		"Set-Cookie",
+		"X-MaaS-Username",
+		"X-MaaS-Group",
 	}
 
 	// hmacKey is a per-process random key used to prevent rainbow table attacks

--- a/maas-api/internal/logger/redaction_test.go
+++ b/maas-api/internal/logger/redaction_test.go
@@ -77,8 +77,8 @@ func TestRedactHeaders(t *testing.T) {
 		"Content-Type should pass through")
 	assert.Equal(t, "abc-123", redacted["X-Request-Id"],
 		"X-Request-ID should pass through")
-	assert.Equal(t, "user@example.com", redacted["X-Maas-Username"],
-		"X-MaaS-Username should pass through")
+	assert.Equal(t, "present", redacted["X-Maas-Username"],
+		"X-MaaS-Username should be redacted (PII)")
 }
 
 func TestRedactHeaders_WithHashPrefix(t *testing.T) {


### PR DESCRIPTION
## Summary
Add `X-MaaS-Username` and `X-MaaS-Group` to the `SensitiveHeaders` list so they are redacted in access logs. These headers contain PII (username and group membership) injected by the gateway after authentication.

## Finding
**FIND-014** — Full Request Path in Logs (CWE-532, CVSS 2.3 Low)

Remediation required:
- ~~Replace `gin.Logger()` with structured logger calling `logger.RedactHeaders`~~ — Already done (custom `AccessLogger` middleware)
- **Add `X-MaaS-Username`/`X-MaaS-Group` to `SensitiveHeaders`** — This PR

## Changes
- `redaction.go`: Added `X-MaaS-Username` and `X-MaaS-Group` to `SensitiveHeaders`
- `redaction_test.go`: Updated test to expect `X-MaaS-Username` to be redacted

## Test plan
- [x] All logger tests pass
- [x] `TestRedactHeaders` verifies `X-MaaS-Username` is redacted as "present" (not logged in full)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved log redaction so additional sensitive request headers are masked.
  * User and group-related header values are now handled as protected information in logs.
  * Updated validation to ensure these headers no longer appear in clear text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->