### PR TITLE
fix: disable SA token automount on cleanup CronJob (FIND-015)

### DIFF
--- a/deployment/base/maas-api/core/cronjob-cleanup.yaml
+++ b/deployment/base/maas-api/core/cronjob-cleanup.yaml
@@ -16,7 +16,8 @@ spec:
           labels:
             app: maas-api-cleanup
         spec:
-          serviceAccountName: maas-api
+          serviceAccountName: maas-api-cleanup
+          automountServiceAccountToken: false
           restartPolicy: OnFailure
           securityContext:
             runAsNonRoot: true

--- a/deployment/base/maas-api/rbac/kustomization.yaml
+++ b/deployment/base/maas-api/rbac/kustomization.yaml
@@ -6,6 +6,7 @@ metadata:
 
 resources:
 - serviceaccount.yaml
+- serviceaccount-cleanup.yaml
 - clusterrole.yaml
 - clusterrolebinding.yaml
 - supplemental-clusterrole.yaml

--- a/deployment/base/maas-api/rbac/serviceaccount-cleanup.yaml
+++ b/deployment/base/maas-api/rbac/serviceaccount-cleanup.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: maas-api-cleanup
+automountServiceAccountToken: false


### PR DESCRIPTION
## Summary
The `maas-api-key-cleanup` CronJob only runs `curl` to an internal endpoint (`/internal/v1/api-keys/cleanup`) and does not need Kubernetes API access. It was using the `maas-api` ServiceAccount which has broad RBAC permissions (read Gateways, Routes, create TokenReviews, etc.).

## Changes
- Created dedicated `maas-api-cleanup` ServiceAccount with `automountServiceAccountToken: false`
- Switched CronJob from `maas-api` SA to `maas-api-cleanup` SA (zero permissions)
- Added `automountServiceAccountToken: false` to CronJob pod spec (belt-and-suspenders)
- Added new SA to rbac kustomization

## Finding
**FIND-015** — ServiceAccount Token Automount (CWE-1188, CVSS 2.5 Low)

Remediation:
- ~~`spec.jobTemplate.spec.template.spec.automountServiceAccountToken: false`~~ — Done
- ~~Switch to dedicated zero-permission SA~~ — Done

## Test plan
- [ ] `kustomize build` succeeds
- [ ] CronJob runs successfully with the new SA (curl still works without SA token)
- [ ] No SA token mounted in cleanup pod (`ls /var/run/secrets/kubernetes.io/serviceaccount` should fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)