### PR TITLE
docs: update DSC config and architecture for MaaS modularization

### DIFF
--- a/docs/content/concepts/architecture.md
+++ b/docs/content/concepts/architecture.md
@@ -8,7 +8,7 @@ Our future plans include improved request routing and discovery—and we're alre
 
 ## Deployment Architecture
 
-MaaS is deployed as a sub-component of the **AI Gateway Operator** inside the OpenDataHub/RHOAI operator. Enabling `aigateway.modelsAsAService: Managed` in your `DataScienceCluster` triggers the following component chain:
+MaaS is deployed as a sub-component of the **AI Gateway Operator**, managed by the ODH/RHOAI operator. Enabling `aigateway.modelsAsAService: Managed` in your `DataScienceCluster` triggers the following component chain:
 
 ```
 DataScienceCluster

--- a/docs/content/concepts/architecture.md
+++ b/docs/content/concepts/architecture.md
@@ -6,6 +6,20 @@ The MaaS Platform is a Kubernetes-native layer for AI model serving built on [Ga
 
 Our future plans include improved request routing and discovery—and we're already sketching what comes after that.
 
+## Deployment Architecture
+
+MaaS is deployed as a sub-component of the **AI Gateway Operator** inside the OpenDataHub/RHOAI operator. Enabling `aigateway.modelsAsAService: Managed` in your `DataScienceCluster` triggers the following component chain:
+
+```
+DataScienceCluster
+  └── aigateway.modelsAsAService: Managed
+        └── AI Gateway Operator
+              └── maas-controller
+                    └── maas-api, Tenant, MaaSAuthPolicy, MaaSSubscription, ...
+```
+
+This replaces the previous `kserve.modelsAsService` nesting. KServe is no longer a prerequisite for MaaS — include it only if you need independent model serving.
+
 ## Architecture
 
 ### 🏗️ High-Level Architecture

--- a/docs/content/install/maas-setup.md
+++ b/docs/content/install/maas-setup.md
@@ -6,7 +6,7 @@ Complete [Operator Setup](platform-setup.md) before proceeding.
 
 1. [Database Setup](#database-setup) — Create the PostgreSQL connection Secret
 2. [Create Gateway](#create-gateway) — Deploy maas-default-gateway (required before modelsAsService)
-3. [Configure DataScienceCluster](#configure-datasciencecluster) — Enable KServe and modelsAsService in your DataScienceCluster
+3. [Configure DataScienceCluster](#configure-datasciencecluster) — Enable AI Gateway Operator and modelsAsAService in your DataScienceCluster
 4. [Model Setup](model-setup.md) — Deploy sample models
 5. [Validation](validation.md) — Verify the deployment
 
@@ -112,7 +112,10 @@ After creating the database Secret and Gateways, create or update your DataScien
 
 === "Managed (Recommended)"
 
-    The operator deploys `maas-controller`, which self-bootstraps `AITenant/models-as-a-service`; that AITenant creates or adopts `Tenant/default-tenant` and reconciles the MaaS platform workloads (maas-api, gateway policies, telemetry). Create or update your DataScienceCluster with `modelsAsService` in Managed state:
+    The AI Gateway Operator deploys `maas-controller`, which self-bootstraps `AITenant/models-as-a-service`; that AITenant creates or adopts `Tenant/default-tenant` and reconciles the MaaS platform workloads (maas-api, gateway policies, telemetry). Create or update your DataScienceCluster with `modelsAsAService` in Managed state:
+
+    !!! note "KServe not required for MaaS"
+        MaaS is now deployed as a sub-component of the **AI Gateway Operator** (`aigateway.modelsAsAService`), not KServe. You no longer need KServe enabled to use MaaS. Include KServe only if you need model serving capabilities independently.
 
     ```yaml
     kubectl apply -f - <<EOF
@@ -122,10 +125,9 @@ After creating the database Secret and Gateways, create or update your DataScien
       name: default-dsc
     spec:
       components:
-        kserve:
+        aigateway:
           managementState: Managed
-          rawDeploymentServiceConfig: Headed
-          modelsAsService:
+          modelsAsAService:
             managementState: Managed
         dashboard:
           managementState: Managed
@@ -172,7 +174,7 @@ After creating the database Secret and Gateways, create or update your DataScien
 
     ### Tenant CR
 
-    With `modelsAsService` **Managed**, the [Open Data Hub operator](https://github.com/opendatahub-io/opendatahub-operator) deploys `maas-controller`, which self-bootstraps `AITenant/models-as-a-service` in `ai-tenants`. The AITenant reconciler creates or adopts a **namespace-scoped** `Tenant` object. The resource name **must** be `default-tenant` (enforced via CEL validation). The `Tenant` CR lives in the `models-as-a-service` namespace (same namespace as `MaaSSubscription` and `MaaSAuthPolicy`). The authoritative API definition is in the maas-controller repo: [`tenant_types.go`](https://github.com/opendatahub-io/models-as-a-service/blob/main/maas-controller/api/maas/v1alpha1/tenant_types.go).
+    With `modelsAsAService` **Managed**, the [AI Gateway Operator](https://github.com/opendatahub-io/opendatahub-operator) (via the `aigateway` component) deploys `maas-controller`, which self-bootstraps `AITenant/models-as-a-service` in `ai-tenants`. The AITenant reconciler creates or adopts a **namespace-scoped** `Tenant` object. The resource name **must** be `default-tenant` (enforced via CEL validation). The `Tenant` CR lives in the `models-as-a-service` namespace (same namespace as `MaaSSubscription` and `MaaSAuthPolicy`). The authoritative API definition is in the maas-controller repo: [`tenant_types.go`](https://github.com/opendatahub-io/models-as-a-service/blob/main/maas-controller/api/maas/v1alpha1/tenant_types.go).
 
     **Nothing in `spec` is required for a default install.** If you omit `spec`, the controller uses the same defaults as this guide: Gateway **`openshift-ingress` / `maas-default-gateway`**, and telemetry metric toggles use the defaults described below. During bootstrap, existing `Tenant/default-tenant.spec.externalOIDC` settings are automatically migrated to `AITenant/models-as-a-service.spec.oidc`. Going forward, set OIDC on `AITenant/models-as-a-service.spec.oidc`. For AITenant-managed tenants, Gateway and OIDC platform context comes from `AITenant`; existing `Tenant.spec.gatewayRef` and `Tenant.spec.externalOIDC` values are preserved for compatibility but ignored.
 
@@ -217,7 +219,7 @@ After creating the database Secret and Gateways, create or update your DataScien
     !!! note "Development and early testing"
         Kustomize deployment can be used for **development and early testing purposes**. For production, use the Managed tab above.
 
-    Set `modelsAsService` to **Removed** so the operator does not deploy the MaaS API, then deploy MaaS directly from the canonical build root:
+    Set `modelsAsAService` to **Removed** so the AI Gateway Operator does not deploy MaaS, then deploy MaaS directly from the canonical build root:
 
     ```yaml
     kubectl apply -f - <<EOF
@@ -227,10 +229,9 @@ After creating the database Secret and Gateways, create or update your DataScien
       name: default-dsc
     spec:
       components:
-        kserve:
+        aigateway:
           managementState: Managed
-          rawDeploymentServiceConfig: Headed
-          modelsAsService:
+          modelsAsAService:
             managementState: Removed
         dashboard:
           managementState: Managed

--- a/docs/content/install/maas-setup.md
+++ b/docs/content/install/maas-setup.md
@@ -6,7 +6,7 @@ Complete [Operator Setup](platform-setup.md) before proceeding.
 
 1. [Database Setup](#database-setup) — Create the PostgreSQL connection Secret
 2. [Create Gateway](#create-gateway) — Deploy maas-default-gateway (required before modelsAsService)
-3. [Configure DataScienceCluster](#configure-datasciencecluster) — Enable AI Gateway Operator and modelsAsAService in your DataScienceCluster
+3. [Configure DataScienceCluster](#configure-datasciencecluster) — Enable modelsAsAService in your DataScienceCluster
 4. [Model Setup](model-setup.md) — Deploy sample models
 5. [Validation](validation.md) — Verify the deployment
 
@@ -143,7 +143,7 @@ After creating the database Secret and Gateways, create or update your DataScien
         see [OdhDashboardConfig Feature Flags](#odhdashboardconfig-feature-flags) below.
 
     !!! note "Connectivity Link warning (ODH with Kuadrant)"
-        When using ODH with Kuadrant (upstream), you may see `Warning: Red Hat Connectivity Link is not installed, LLMInferenceService cannot be used` in the Kserve status initially. This typically resolves after a few minutes as the operator reconciles. If it persists, run `kubectl describe datasciencecluster default-dsc` and check that the Kuadrant/Connectivity Link operator is installed and healthy.
+        When using ODH with Kuadrant (upstream), you may see `Warning: Red Hat Connectivity Link is not installed, LLMInferenceService cannot be used` initially. This typically resolves after a few minutes as the operator reconciles. If it persists, run `kubectl describe datasciencecluster default-dsc` and check that the Kuadrant/Connectivity Link operator is installed and healthy.
 
     **Validate DataScienceCluster:**
 
@@ -151,9 +151,7 @@ After creating the database Secret and Gateways, create or update your DataScien
     # Check DataScienceCluster status
     kubectl get datasciencecluster default-dsc
 
-    # Wait for KServe and ModelsAsService to be ready (optional)
-    kubectl wait --for=jsonpath='{.status.conditions[?(@.type=="KserveReady")].status}'=True \
-      datasciencecluster/default-dsc --timeout=300s
+    # Wait for MaaS to be ready (optional)
     kubectl wait --for=jsonpath='{.status.conditions[?(@.type=="ModelControllerReady")].status}'=True \
       datasciencecluster/default-dsc --timeout=300s
 
@@ -174,7 +172,7 @@ After creating the database Secret and Gateways, create or update your DataScien
 
     ### Tenant CR
 
-    With `modelsAsAService` **Managed**, the [AI Gateway Operator](https://github.com/opendatahub-io/opendatahub-operator) (via the `aigateway` component) deploys `maas-controller`, which self-bootstraps `AITenant/models-as-a-service` in `ai-tenants`. The AITenant reconciler creates or adopts a **namespace-scoped** `Tenant` object. The resource name **must** be `default-tenant` (enforced via CEL validation). The `Tenant` CR lives in the `models-as-a-service` namespace (same namespace as `MaaSSubscription` and `MaaSAuthPolicy`). The authoritative API definition is in the maas-controller repo: [`tenant_types.go`](https://github.com/opendatahub-io/models-as-a-service/blob/main/maas-controller/api/maas/v1alpha1/tenant_types.go).
+    With `modelsAsAService` **Managed**, the ODH operator (via the `aigateway` component) deploys `maas-controller`, which self-bootstraps `AITenant/models-as-a-service` in `ai-tenants`. The AITenant reconciler creates or adopts a **namespace-scoped** `Tenant` object. The resource name **must** be `default-tenant` (enforced via CEL validation). The `Tenant` CR lives in the `models-as-a-service` namespace (same namespace as `MaaSSubscription` and `MaaSAuthPolicy`). The authoritative API definition is in the maas-controller repo: [`tenant_types.go`](https://github.com/opendatahub-io/models-as-a-service/blob/main/maas-controller/api/maas/v1alpha1/tenant_types.go).
 
     **Nothing in `spec` is required for a default install.** If you omit `spec`, the controller uses the same defaults as this guide: Gateway **`openshift-ingress` / `maas-default-gateway`**, and telemetry metric toggles use the defaults described below. During bootstrap, existing `Tenant/default-tenant.spec.externalOIDC` settings are automatically migrated to `AITenant/models-as-a-service.spec.oidc`. Going forward, set OIDC on `AITenant/models-as-a-service.spec.oidc`. For AITenant-managed tenants, Gateway and OIDC platform context comes from `AITenant`; existing `Tenant.spec.gatewayRef` and `Tenant.spec.externalOIDC` values are preserved for compatibility but ignored.
 


### PR DESCRIPTION
## Summary

Related to - https://redhat.atlassian.net/browse/RHOAIENG-66774

- Update `DataScienceCluster` YAML examples in `maas-setup.md`: `kserve.modelsAsService` → `aigateway.modelsAsAService` (both Managed and Kustomize tabs)
- Add inline note that KServe is no longer a prerequisite for MaaS
- Add **Deployment Architecture** section in `architecture.md` showing the new component chain: `DataScienceCluster → aigateway.modelsAsAService → AI Gateway Operator → maas-controller → maas-api`

These docs reflect the modularization landed in [opendatahub-io/opendatahub-operator#3723](https://github.com/opendatahub-io/opendatahub-operator/pull/3723), where MaaS moved from being a sub-component of KServe to a sub-component of the AI Gateway Operator.

## Risk analysis

**Risk rating: 0**

**Why:** Documentation-only change — no runtime code, no Kustomize manifests, no Go changes. The only risk is inaccurate content, which is mitigated by the changes matching the API field names confirmed in PR #3723 (`modelsAsAService` under `aigateway`).

## Test plan

- [ ] Verify rendered docs look correct (MkDocs preview)
- [ ] Confirm `aigateway.modelsAsAService` YAML matches the actual CRD schema in ODH operator post-#3723

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated deployment guidance to use the AI Gateway Operator for MaaS setup.
  * Clarified the recommended `DataScienceCluster` configuration and example manifests.
  * Added a new architecture section showing the MaaS component flow and how it fits into the operator stack.
  * Noted that KServe is no longer required for MaaS unless independent model serving is needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->