### PR TITLE
fix: sync inference ExternalModel CRD and fix resolver fallback (RHOAIENG-75666)

### DIFF
--- a/deployment/base/maas-controller/crd/bases/inference.opendatahub.io_externalmodels.yaml
+++ b/deployment/base/maas-controller/crd/bases/inference.opendatahub.io_externalmodels.yaml
@@ -105,6 +105,16 @@ spec:
                         Config holds model-specific configuration as key-value pairs.
                         Overrides the ExternalProvider config for this model-provider binding.
                       type: object
+                    path:
+                      description: |-
+                        Path sets the outgoing request `:path` pseudo-header for this model-provider binding.
+                        Must be a valid absolute path (e.g. "/v1/chat/completions" or
+                        "/maas-default-gateway/v1/chat/completions").
+                        Supports {key} placeholders resolved from the merged Config map.
+                      maxLength: 512
+                      minLength: 1
+                      pattern: ^/.*
+                      type: string
                     ref:
                       description: Ref identifies the ExternalProvider CR (must be
                         in the same namespace).
@@ -135,6 +145,7 @@ spec:
                       type: integer
                   required:
                   - apiFormat
+                  - path
                   - ref
                   - targetModel
                   type: object
@@ -214,6 +225,12 @@ spec:
                   - type
                   type: object
                 type: array
+              httpRouteName:
+                description: |-
+                  HTTPRouteName is the name of the HTTPRoute created by the controller
+                  for this ExternalModel. Consumers (e.g., maas-controller) can read this
+                  to attach policies without assuming naming conventions.
+                type: string
               phase:
                 description: |-
                   Phase represents the current reconciliation phase.

--- a/maas-controller/pkg/controller/maas/maasauthpolicy_controller_test.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_controller_test.go
@@ -1542,7 +1542,7 @@ func TestBuildGatewayAuthPolicySpec_XAPIKeyEnabled(t *testing.T) {
 // gateway AuthPolicy spec.
 func TestBuildGatewayAuthPolicySpec_OIDCJWKsTTL(t *testing.T) {
 	r := &MaaSAuthPolicyReconciler{
-		InfraNamespace: "maas-system",
+		InfraNamespace:   "maas-system",
 		GatewayName:      "maas-default-gateway",
 		GatewayNamespace: "gateway-ns",
 		ClusterAudience:  "https://kubernetes.default.svc",

--- a/maas-controller/pkg/controller/maas/maasauthpolicy_controller_test.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_controller_test.go
@@ -1542,7 +1542,7 @@ func TestBuildGatewayAuthPolicySpec_XAPIKeyEnabled(t *testing.T) {
 // gateway AuthPolicy spec.
 func TestBuildGatewayAuthPolicySpec_OIDCJWKsTTL(t *testing.T) {
 	r := &MaaSAuthPolicyReconciler{
-		MaaSAPINamespace: "maas-system",
+		InfraNamespace: "maas-system",
 		GatewayName:      "maas-default-gateway",
 		GatewayNamespace: "gateway-ns",
 		ClusterAudience:  "https://kubernetes.default.svc",
@@ -1667,7 +1667,7 @@ func TestFetchOIDCConfig_TTLExtraction(t *testing.T) {
 				WithObjects(tenant).
 				Build()
 
-			r := &MaaSAuthPolicyReconciler{Client: c, Scheme: scheme, MaaSAPINamespace: namespace}
+			r := &MaaSAuthPolicyReconciler{Client: c, Scheme: scheme, InfraNamespace: namespace}
 			log := ctrl.Log.WithName("test")
 			got := r.fetchOIDCConfig(context.Background(), log, namespace)
 

--- a/maas-controller/pkg/controller/maas/providers_external.go
+++ b/maas-controller/pkg/controller/maas/providers_external.go
@@ -279,7 +279,11 @@ type externalModelRouteResolver struct{}
 func (externalModelRouteResolver) HTTPRouteForModel(ctx context.Context, c client.Reader, model *maasv1alpha1.MaaSModelRef) (routeName, routeNamespace string, err error) {
 	routeNamespace = model.Namespace
 
-	// Read route name from inference ExternalModel status if available
+	// Read route name from inference ExternalModel status if available.
+	// If the inference ExternalModel exists but status.httpRouteName is not set yet,
+	// signal not-ready rather than falling back to maas-<name>: that fallback only
+	// applies to the legacy maas.opendatahub.io/ExternalModel flow where the MaaS
+	// ExternalModel reconciler itself creates the maas-prefixed HTTPRoute.
 	if c != nil {
 		key := types.NamespacedName{Name: model.Spec.ModelRef.Name, Namespace: model.Namespace}
 		inferenceEM := &unstructured.Unstructured{}
@@ -288,12 +292,15 @@ func (externalModelRouteResolver) HTTPRouteForModel(ctx context.Context, c clien
 			if name, found, _ := unstructured.NestedString(inferenceEM.Object, "status", "httpRouteName"); found && name != "" {
 				return name, routeNamespace, nil
 			}
+			return "", routeNamespace, fmt.Errorf("%w: inference ExternalModel %s/%s status.httpRouteName not set yet",
+				ErrHTTPRouteNotFound, routeNamespace, model.Spec.ModelRef.Name)
 		} else if !apierrors.IsNotFound(err) && !apimeta.IsNoMatchError(err) {
 			return "", routeNamespace, fmt.Errorf("failed to get inference ExternalModel %s/%s: %w",
 				model.Namespace, model.Spec.ModelRef.Name, err)
 		}
 	}
 
+	// Inference ExternalModel not found — fall back to legacy maas.opendatahub.io naming.
 	routeName = modelnaming.ExternalModelResourceName(model.Spec.ModelRef.Name)
 	return routeName, routeNamespace, nil
 }

--- a/maas-controller/pkg/controller/maas/providers_external_test.go
+++ b/maas-controller/pkg/controller/maas/providers_external_test.go
@@ -18,6 +18,7 @@ package maas
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
@@ -428,5 +429,24 @@ func TestExternalModelRouteResolver_FromInferenceStatus(t *testing.T) {
 	}
 	if routeNS != "default" {
 		t.Errorf("routeNS = %q, want %q", routeNS, "default")
+	}
+}
+
+func TestExternalModelRouteResolver_InferenceStatusEmpty_ReturnsNotReady(t *testing.T) {
+	model := newExternalModel("gpt-4o", "default", "", "")
+
+	// Inference ExternalModel exists but status.httpRouteName is not set yet
+	inferenceEM := newInferenceExternalModelCR("gpt-4o", "default", "openai-provider")
+	inferenceEM.Object["status"] = map[string]any{}
+
+	_, c := newTestReconcilerWithMapper(model, inferenceEM)
+	resolver := externalModelRouteResolver{}
+
+	_, _, err := resolver.HTTPRouteForModel(context.Background(), c, model)
+	if err == nil {
+		t.Fatal("HTTPRouteForModel: expected ErrHTTPRouteNotFound when status.httpRouteName is empty, got nil")
+	}
+	if !errors.Is(err, ErrHTTPRouteNotFound) {
+		t.Errorf("HTTPRouteForModel: want ErrHTTPRouteNotFound, got %v", err)
 	}
 }


### PR DESCRIPTION
## Description
Update Inference ExternalModel CRD to match with CRDs in IPP.

Fixes https://redhat.atlassian.net/browse/RHOAIENG-75666
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * External model bindings now require a route path with stricter validation rules.
  * Expose the created HTTPRoute name in the custom resource status for better visibility.

* **Bug Fixes**
  * Improved handling when an external model exists but its route name is not yet available, returning “not found yet” instead of falling back.
  * Refined error handling to avoid masking unexpected lookup failures with fallback behavior.

* **Tests**
  * Added coverage for the “empty route name” scenario and updated assertions for clearer error checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->