### PR TITLE
fix: resolve maas-api e2e infra namespace defaults

### DIFF
--- a/test/e2e/scripts/auth_utils.sh
+++ b/test/e2e/scripts/auth_utils.sh
@@ -28,7 +28,9 @@
 #   ./test/e2e/scripts/auth_utils.sh
 #
 # Environment:
-#   DEPLOYMENT_NAMESPACE       - MaaS API and controller namespace (default: opendatahub)
+#   DEPLOYMENT_NAMESPACE       - MaaS controller namespace (default: opendatahub)
+#   INFRA_NAMESPACE            - MaaS API infrastructure namespace, AUTO-derived by default
+#   E2E_MAAS_API_DEPLOYMENT_NAMESPACE - Override namespace where maas-api workloads run
 #   MAAS_SUBSCRIPTION_NAMESPACE - MaaS CRs namespace (default: models-as-a-service)
 #   AUTHORINO_NAMESPACE        - Authorino namespace (default: kuadrant-system)
 #   OPERATOR_NAMESPACE         - RHOAI operator namespace (default: redhat-ods-operator)
@@ -60,6 +62,46 @@ APPLICATIONS_NAMESPACE="${APPLICATIONS_NAMESPACE:-redhat-ods-applications}"
 GATEWAY_NAMESPACE="${GATEWAY_NAMESPACE:-openshift-ingress}"
 LLM_NAMESPACE="${LLM_NAMESPACE:-llm}"
 ISTIO_NAMESPACE="${ISTIO_NAMESPACE:-istio-system}"
+
+_auth_debug_derive_infra_namespace() {
+  local controller_ns="$1"
+  case "$controller_ns" in
+    redhat-ods-applications)
+      echo "redhat-ai-gateway-infra"
+      ;;
+    opendatahub)
+      echo "odh-ai-gateway-infra"
+      ;;
+    *)
+      echo "$controller_ns"
+      ;;
+  esac
+}
+
+_auth_debug_resolve_maas_api_deployment_namespace() {
+  if [[ -n "${E2E_MAAS_API_DEPLOYMENT_NAMESPACE:-}" ]]; then
+    echo "$E2E_MAAS_API_DEPLOYMENT_NAMESPACE"
+    return
+  fi
+
+  local infra_namespace_raw
+  if [[ "${INFRA_NAMESPACE+x}" == "x" ]]; then
+    infra_namespace_raw="$INFRA_NAMESPACE"
+  else
+    infra_namespace_raw="AUTO"
+  fi
+
+  if [[ "$infra_namespace_raw" == "AUTO" ]]; then
+    _auth_debug_derive_infra_namespace "$DEPLOYMENT_NAMESPACE"
+  elif [[ -z "$infra_namespace_raw" ]]; then
+    echo "$DEPLOYMENT_NAMESPACE"
+  else
+    echo "$infra_namespace_raw"
+  fi
+}
+
+MAAS_API_DEPLOYMENT_NAMESPACE="${MAAS_API_DEPLOYMENT_NAMESPACE:-$(_auth_debug_resolve_maas_api_deployment_namespace)}"
+
 # OpenShift CI/Prow use ARTIFACT_DIR; respect ARTIFACTS_DIR if already set by caller
 ARTIFACTS_DIR="${ARTIFACTS_DIR:-${ARTIFACT_DIR:-${ARTIFACTS:-${LOG_DIR:-$PROJECT_ROOT/test/e2e/reports}}}}"
 
@@ -186,8 +228,11 @@ collect_cluster_state() {
     kubectl get nodes -o wide 2>/dev/null || true
     kubectl get ns 2>/dev/null || true
     echo ""
-    echo "--- MaaS deployment namespace ($DEPLOYMENT_NAMESPACE) ---"
+    echo "--- MaaS controller namespace ($DEPLOYMENT_NAMESPACE) ---"
     kubectl get all -n "$DEPLOYMENT_NAMESPACE" 2>/dev/null || true
+    echo ""
+    echo "--- MaaS API deployment namespace ($MAAS_API_DEPLOYMENT_NAMESPACE) ---"
+    kubectl get all -n "$MAAS_API_DEPLOYMENT_NAMESPACE" 2>/dev/null || true
     echo ""
     echo "--- RHOAI Operator namespace ($OPERATOR_NAMESPACE) ---"
     kubectl get pods,deployments,csv -n "$OPERATOR_NAMESPACE" -o wide 2>/dev/null || true
@@ -252,6 +297,7 @@ collect_e2e_artifacts() {
   local ns
   for ns in \
     "$DEPLOYMENT_NAMESPACE" \
+    "$MAAS_API_DEPLOYMENT_NAMESPACE" \
     "$MAAS_SUBSCRIPTION_NAMESPACE" \
     "$OPERATOR_NAMESPACE" \
     "$APPLICATIONS_NAMESPACE" \
@@ -301,21 +347,22 @@ run_auth_debug_report() {
   _run "Logged-in user" "oc whoami 2>/dev/null || echo 'Not logged in'"
   _run "Cluster domain" "oc get ingresses.config.openshift.io cluster -o jsonpath='{.spec.domain}' 2>/dev/null || echo 'N/A'"
   _append "DEPLOYMENT_NAMESPACE: $DEPLOYMENT_NAMESPACE"
+  _append "MAAS_API_DEPLOYMENT_NAMESPACE: $MAAS_API_DEPLOYMENT_NAMESPACE"
   _append "MAAS_SUBSCRIPTION_NAMESPACE: $MAAS_SUBSCRIPTION_NAMESPACE"
   _append "AUTHORINO_NAMESPACE: $AUTHORINO_NAMESPACE"
   _append ""
 
   _section "MaaS API Deployment"
-  _run "maas-api pods" "kubectl get pods -n $DEPLOYMENT_NAMESPACE -l app.kubernetes.io/name=maas-api -o wide 2>/dev/null || true"
-  _run "maas-api service" "kubectl get svc maas-api -n $DEPLOYMENT_NAMESPACE -o wide 2>/dev/null || true"
+  _run "maas-api pods" "kubectl get pods -n $MAAS_API_DEPLOYMENT_NAMESPACE -l app.kubernetes.io/name=maas-api -o wide 2>/dev/null || true"
+  _run "maas-api service" "kubectl get svc maas-api -n $MAAS_API_DEPLOYMENT_NAMESPACE -o wide 2>/dev/null || true"
   _append ""
 
   _section "maas-controller"
   _run "maas-controller pods" "kubectl get pods -n $DEPLOYMENT_NAMESPACE -l app=maas-controller -o wide 2>/dev/null || true"
 
   local env_display
-  env_display=$(kubectl get deployment maas-controller -n $DEPLOYMENT_NAMESPACE -o jsonpath='{.spec.template.spec.containers[0].env}' 2>/dev/null | jq -r '.[] | select(.name=="MAAS_API_NAMESPACE") | if .value then "\(.name)=\(.value)" elif .valueFrom.fieldRef.fieldPath then "\(.name)=\(.valueFrom.fieldRef.fieldPath) (resolves to: '"$DEPLOYMENT_NAMESPACE"')" else "\(.name)=N/A" end' 2>/dev/null || echo 'MAAS_API_NAMESPACE=N/A')
-  _run "maas-controller MAAS_API_NAMESPACE" "echo '$env_display'"
+  env_display=$(kubectl get deployment maas-controller -n $DEPLOYMENT_NAMESPACE -o jsonpath='{.spec.template.spec.containers[0].env}' 2>/dev/null | jq -r '.[] | select(.name=="INFRA_NAMESPACE" or .name=="MAAS_API_NAMESPACE") | if .value then "\(.name)=\(.value)" elif .valueFrom.fieldRef.fieldPath then "\(.name)=\(.valueFrom.fieldRef.fieldPath)" else "\(.name)=N/A" end' 2>/dev/null || echo 'namespace env=N/A')
+  _run "maas-controller namespace env" "echo '$env_display'"
   _append ""
 
   _section "Kuadrant Policies"
@@ -405,38 +452,18 @@ EOF
 
   _section "Gateway / HTTPRoutes"
   _run "Gateway" "kubectl get gateway -n openshift-ingress maas-default-gateway -o wide 2>/dev/null || kubectl get gateway -A 2>/dev/null | head -10 || true"
-  _run "HTTPRoutes (maas-api)" "kubectl get httproute maas-api-route -n $DEPLOYMENT_NAMESPACE -o wide 2>/dev/null || true"
+  _run "HTTPRoutes (maas-api)" "kubectl get httproute maas-api-route -n $MAAS_API_DEPLOYMENT_NAMESPACE -o wide 2>/dev/null || true"
   _append ""
 
   _section "Authorino"
   _run "Authorino pods" "kubectl get pods -n $AUTHORINO_NAMESPACE -l 'app.kubernetes.io/name=authorino' --no-headers 2>/dev/null; kubectl get pods -n openshift-ingress -l 'app.kubernetes.io/name=authorino' --no-headers 2>/dev/null; echo '---'; kubectl get pods -A -l 'app.kubernetes.io/name=authorino' -o wide 2>/dev/null || true"
   _append ""
 
-  # Determine maas-api namespace from controller deployment
-  local maas_api_ns
-  local env_json
-  env_json=$(kubectl get deployment maas-controller -n $DEPLOYMENT_NAMESPACE -o jsonpath='{.spec.template.spec.containers[0].env}' 2>/dev/null || echo "[]")
-
-  # Try to get direct .value first
-  maas_api_ns=$(echo "$env_json" | jq -r '.[] | select(.name=="MAAS_API_NAMESPACE") | .value // empty' 2>/dev/null)
-
-  # If empty, check if using fieldRef (downward API)
-  if [[ -z "$maas_api_ns" ]]; then
-    local field_path
-    field_path=$(echo "$env_json" | jq -r '.[] | select(.name=="MAAS_API_NAMESPACE") | .valueFrom.fieldRef.fieldPath // empty' 2>/dev/null)
-    if [[ "$field_path" == "metadata.namespace" ]]; then
-      # Using downward API - the value is the controller's namespace
-      maas_api_ns="$DEPLOYMENT_NAMESPACE"
-    fi
-  fi
-
-  # Fallback to deployment namespace if still empty
-  [[ -z "$maas_api_ns" ]] && maas_api_ns="$DEPLOYMENT_NAMESPACE" || true
-
+  local maas_api_ns="$MAAS_API_DEPLOYMENT_NAMESPACE"
   local sub_select_url="https://maas-api.${maas_api_ns}.svc.cluster.local:8443/internal/v1/subscriptions/select"
   _section "Subscription Selector Endpoint Validation"
-  _append "Expected URL (from maas-controller config): $sub_select_url"
-  _append "  (MAAS_API_NAMESPACE resolved to: $maas_api_ns)"
+  _append "Expected URL (from resolved maas-api deployment namespace): $sub_select_url"
+  _append "  (MAAS_API_DEPLOYMENT_NAMESPACE resolved to: $maas_api_ns)"
   _append ""
 
   # Verify actual AuthPolicy configuration

--- a/test/e2e/scripts/prow_run_smoke_test.sh
+++ b/test/e2e/scripts/prow_run_smoke_test.sh
@@ -49,7 +49,8 @@
 #   OIDC_READINESS_STRICT - When true, exit if OIDC gateway readiness fails (default: false).
 #                           If false, log a warning and continue to pytest.
 #   OIDC_READINESS_STRICT - When true, exit before pytest if the OIDC readiness probe times out.
-#   DEPLOYMENT_NAMESPACE - Namespace of MaaS API and controller (default: opendatahub)
+#   DEPLOYMENT_NAMESPACE - Namespace of maas-controller (default: opendatahub)
+#   INFRA_NAMESPACE - Namespace of MaaS API infrastructure; AUTO derives from DEPLOYMENT_NAMESPACE (default: AUTO)
 #   MAAS_SUBSCRIPTION_NAMESPACE - Namespace of MaaS CRs and Tenant CR (default: models-as-a-service)
 #   ENABLE_TENANT_NAMESPACE_DISCOVERY - Patch maas-controller with discovery flag before pytest (default: true)
 #   AITENANT_NAMESPACE - Namespace for AITenant CRs (default: ai-tenants)
@@ -521,12 +522,12 @@ wait_for_auth_policies_enforced() {
 validate_deployment() {
     echo "Deployment Validation"
     echo "Using controller namespace: $DEPLOYMENT_NAMESPACE"
-    echo "Using maas-api namespace: $DEPLOYMENT_NAMESPACE"
+    echo "Using maas-api namespace: $MAAS_API_DEPLOYMENT_NAMESPACE"
     echo "Using AITenant namespace: $AITENANT_NAMESPACE"
 
     if [ "$SKIP_VALIDATION" = false ]; then
-        # maas-api deploys to operator namespace (opendatahub for ODH, redhat-ods-applications for RHOAI)
-        # validate-deployment.sh uses MAAS_API_NAMESPACE env var or defaults to opendatahub
+        # maas-api deploys to the resolved infrastructure namespace.
+        # validate-deployment.sh derives INFRA_NAMESPACE the same way.
         if ! "$PROJECT_ROOT/scripts/validate-deployment.sh"; then
             echo "⚠️  First validation attempt failed, waiting 30 seconds and retrying..."
             sleep 30

--- a/test/e2e/tests/conftest.py
+++ b/test/e2e/tests/conftest.py
@@ -5,6 +5,8 @@ from urllib.parse import urlparse
 import pytest
 import requests
 
+from test_helper import MAAS_API_DEPLOYMENT_NAMESPACE
+
 # TLS verification flag - set E2E_SKIP_TLS_VERIFY=true to disable cert verification
 TLS_VERIFY = os.environ.get("E2E_SKIP_TLS_VERIFY", "").lower() != "true"
 
@@ -128,7 +130,7 @@ def maas_api_internal_url() -> str:
 
     # Default: cluster-internal service URL
     # maas-api uses TLS on port 8443 (self-signed cert, use -k/verify=False)
-    namespace = os.environ.get("MAAS_NAMESPACE", "opendatahub")
+    namespace = os.environ.get("MAAS_NAMESPACE", MAAS_API_DEPLOYMENT_NAMESPACE)
     service_name = os.environ.get("MAAS_API_SERVICE_NAME", "maas-api")
     port = os.environ.get("MAAS_API_SERVICE_PORT", "8443")
 

--- a/test/e2e/tests/multitenancy_helpers.py
+++ b/test/e2e/tests/multitenancy_helpers.py
@@ -936,7 +936,7 @@ def parse_annotation_list(value: str) -> list[str]:
     return [item.strip() for item in (value or "").split(",") if item.strip()]
 
 
-def deployment_env(name: str, namespace: str = DEPLOYMENT_NAMESPACE, *, container_name: str = "maas-api") -> dict[str, str]:
+def deployment_env(name: str, namespace: str = INFRA_NAMESPACE, *, container_name: str = "maas-api") -> dict[str, str]:
     deployment = get_json_or_none("deployment", name, namespace)
     if not deployment:
         return {}
@@ -945,14 +945,14 @@ def deployment_env(name: str, namespace: str = DEPLOYMENT_NAMESPACE, *, containe
     return {entry.get("name"): entry.get("value") for entry in container.get("env") or [] if entry.get("name")}
 
 
-def http_route_parent_refs(name: str, namespace: str = DEPLOYMENT_NAMESPACE) -> list[dict]:
+def http_route_parent_refs(name: str, namespace: str = INFRA_NAMESPACE) -> list[dict]:
     route = get_json_or_none("httproute", name, namespace)
     if not route:
         return []
     return ((route.get("spec") or {}).get("parentRefs") or [])
 
 
-def http_route_backend_refs(name: str, namespace: str = DEPLOYMENT_NAMESPACE) -> list[dict]:
+def http_route_backend_refs(name: str, namespace: str = INFRA_NAMESPACE) -> list[dict]:
     route = get_json_or_none("httproute", name, namespace)
     if not route:
         return []
@@ -1030,7 +1030,7 @@ def cleanup_discovery_case(case: dict[str, str], *, delete_gateway: bool = True)
         delete_best_effort("gateway", case["gateway_name"], GATEWAY_NAMESPACE)
         delete_best_effort("configmap", f"{case['gateway_name']}-gw-options", GATEWAY_NAMESPACE)
         try:
-            remove_gateway_access_label(DEPLOYMENT_NAMESPACE, case["gateway_name"])
+            remove_gateway_access_label(INFRA_NAMESPACE, case["gateway_name"])
         except Exception as exc:  # noqa: BLE001
             print(f"[cleanup] failed to remove gateway access label for {case['gateway_name']}: {exc}")
 

--- a/test/e2e/tests/multitenancy_helpers.py
+++ b/test/e2e/tests/multitenancy_helpers.py
@@ -15,6 +15,8 @@ import pytest
 import requests
 
 from test_helper import (
+    DEPLOYMENT_NAMESPACE,
+    MAAS_API_DEPLOYMENT_NAMESPACE,
     MODEL_NAMESPACE,
     MODEL_REF,
     TIMEOUT,
@@ -45,19 +47,7 @@ AITENANT_NAMESPACE = os.environ.get("AITENANT_NAMESPACE", "ai-tenants")
 GATEWAY_NAMESPACE = os.environ.get("GATEWAY_NAMESPACE", "openshift-ingress")
 DEFAULT_GATEWAY_NAME = os.environ.get("GATEWAY_NAME", "maas-default-gateway")
 AITENANT_GATEWAY_CLASS_NAME = os.environ.get("AITENANT_GATEWAY_CLASS_NAME", "openshift-default")
-DEPLOYMENT_NAMESPACE = os.environ.get("DEPLOYMENT_NAMESPACE", "opendatahub")
-# Infrastructure namespace where maas-api deployment and HTTPRoutes are created
-# Handles: not set → AUTO-derived, "" → no separation (use DEPLOYMENT_NAMESPACE), "AUTO" → derive, explicit value → use it
-_infra_ns_raw = os.environ.get("INFRA_NAMESPACE")
-if _infra_ns_raw is None or _infra_ns_raw == "AUTO":
-    # Default to AUTO-derived (opendatahub → odh-ai-gateway-infra, redhat-ods-applications → redhat-ai-gateway-infra)
-    INFRA_NAMESPACE = "odh-ai-gateway-infra" if DEPLOYMENT_NAMESPACE == "opendatahub" else "redhat-ai-gateway-infra"
-elif _infra_ns_raw == "":
-    # Empty string means no separation (ROSA case)
-    INFRA_NAMESPACE = DEPLOYMENT_NAMESPACE
-else:
-    # Explicit custom namespace
-    INFRA_NAMESPACE = _infra_ns_raw
+INFRA_NAMESPACE = MAAS_API_DEPLOYMENT_NAMESPACE
 OC_TIMEOUT = int(os.environ.get("E2E_OC_TIMEOUT", "60"))
 
 DISCOVERY_ARG = "--enable-tenant-namespace-discovery=true"
@@ -301,7 +291,7 @@ def wait_for_status_condition(
     return wait_for_json(kind, name, namespace, predicate=_predicate, timeout=timeout, interval=interval)
 
 
-def wait_for_deployment_available(name: str, namespace: str = DEPLOYMENT_NAMESPACE, *, timeout: int = 180) -> dict:
+def wait_for_deployment_available(name: str, namespace: str = INFRA_NAMESPACE, *, timeout: int = 180) -> dict:
     def _predicate(obj: dict) -> bool:
         status = obj.get("status") or {}
         if status.get("availableReplicas", 0) < 1:

--- a/test/e2e/tests/test_aitenant_lifecycle.py
+++ b/test/e2e/tests/test_aitenant_lifecycle.py
@@ -9,6 +9,8 @@ import uuid
 
 import pytest
 
+from test_helper import DEPLOYMENT_NAMESPACE, MAAS_API_DEPLOYMENT_NAMESPACE
+
 AITENANT_CRD = "aitenants.maas.opendatahub.io"
 AITENANT_KIND = "aitenant"
 CONFIG_CRD = "configs.maas.opendatahub.io"
@@ -22,19 +24,7 @@ AITENANT_NAMESPACE = os.environ.get("AITENANT_NAMESPACE", "ai-tenants")
 MAAS_SUBSCRIPTION_NAMESPACE = os.environ.get("MAAS_SUBSCRIPTION_NAMESPACE", "models-as-a-service")
 GATEWAY_NAMESPACE = os.environ.get("GATEWAY_NAMESPACE", "openshift-ingress")
 GATEWAY_NAME = os.environ.get("GATEWAY_NAME", "maas-default-gateway")
-DEPLOYMENT_NAMESPACE = os.environ.get("DEPLOYMENT_NAMESPACE", "opendatahub")
-# Infrastructure namespace where maas-api deployment and HTTPRoutes are created
-# Handles: not set → AUTO-derived, "" → no separation (use DEPLOYMENT_NAMESPACE), "AUTO" → derive, explicit value → use it
-_infra_ns_raw = os.environ.get("INFRA_NAMESPACE")
-if _infra_ns_raw is None or _infra_ns_raw == "AUTO":
-    # Default to AUTO-derived (opendatahub → odh-ai-gateway-infra, redhat-ods-applications → redhat-ai-gateway-infra)
-    INFRA_NAMESPACE = "odh-ai-gateway-infra" if DEPLOYMENT_NAMESPACE == "opendatahub" else "redhat-ai-gateway-infra"
-elif _infra_ns_raw == "":
-    # Empty string means no separation (ROSA case)
-    INFRA_NAMESPACE = DEPLOYMENT_NAMESPACE
-else:
-    # Explicit custom namespace
-    INFRA_NAMESPACE = _infra_ns_raw
+INFRA_NAMESPACE = MAAS_API_DEPLOYMENT_NAMESPACE
 AITENANT_GATEWAY_CLASS_NAME = os.environ.get("AITENANT_GATEWAY_CLASS_NAME", "openshift-default")
 OC_TIMEOUT = int(os.environ.get("E2E_OC_TIMEOUT", "60"))
 

--- a/test/e2e/tests/test_api_keys.py
+++ b/test/e2e/tests/test_api_keys.py
@@ -904,7 +904,7 @@ class TestEphemeralKeyCleanup:
     oc exec into the maas-api pod.
 
     Environment Variables:
-    - DEPLOYMENT_NAMESPACE: Namespace where maas-api is deployed (default: opendatahub)
+    - E2E_MAAS_API_DEPLOYMENT_NAMESPACE: Namespace where maas-api is deployed (default: derived INFRA_NAMESPACE)
     """
 
     @pytest.fixture
@@ -912,7 +912,7 @@ class TestEphemeralKeyCleanup:
         """Return the namespace where maas-api is deployed.
 
         Controlled by E2E_MAAS_API_DEPLOYMENT_NAMESPACE env var,
-        defaults to DEPLOYMENT_NAMESPACE/opendatahub.
+        defaults to the derived INFRA_NAMESPACE.
         """
         from test_helper import MAAS_API_DEPLOYMENT_NAMESPACE
         return MAAS_API_DEPLOYMENT_NAMESPACE

--- a/test/e2e/tests/test_helper.py
+++ b/test/e2e/tests/test_helper.py
@@ -15,6 +15,8 @@ Environment variables (all optional unless noted):
   - MAAS_API_BASE_URL: MaaS API URL (auto-derived from GATEWAY_HOST if not set)
   - MAAS_SUBSCRIPTION_NAMESPACE: MaaS CRs namespace (default: models-as-a-service)
   - E2E_MAAS_API_DEPLOYMENT_NAMESPACE: Namespace where maas-api workloads run (default: derived INFRA_NAMESPACE)
+  - E2E_CURL_POD_NAMESPACE: Namespace for ephemeral kubectl-run curl probes (default: GATEWAY_NAMESPACE)
+  - GATEWAY_NAMESPACE: Gateway namespace (default: openshift-ingress)
   - E2E_TEST_TOKEN_SA_NAMESPACE, E2E_TEST_TOKEN_SA_NAME: SA token source for Prow
   - E2E_TIMEOUT: Request timeout in seconds (default: 45)
   - E2E_RECONCILE_WAIT: Wait time for reconciliation in seconds (default: 8)
@@ -88,6 +90,10 @@ def _resolve_maas_api_deployment_namespace() -> str:
 
 # Infrastructure namespace where maas-api workloads run.
 MAAS_API_DEPLOYMENT_NAMESPACE = _resolve_maas_api_deployment_namespace()
+GATEWAY_NAMESPACE = os.environ.get("GATEWAY_NAMESPACE", "openshift-ingress")
+# Ephemeral curl probes must run in a namespace allowed by maas-api NetworkPolicy
+# (openshift-ingress gateway namespace), not in the maas-api infra namespace.
+E2E_CURL_POD_NAMESPACE = os.environ.get("E2E_CURL_POD_NAMESPACE", GATEWAY_NAMESPACE)
 SIMULATOR_SUBSCRIPTION = os.environ.get("E2E_SIMULATOR_SUBSCRIPTION", "simulator-subscription")
 PREMIUM_MODEL_REF = os.environ.get("E2E_PREMIUM_MODEL_REF", "premium-simulated-simulated-premium")
 PREMIUM_SIMULATOR_SUBSCRIPTION = os.environ.get("E2E_PREMIUM_SIMULATOR_SUBSCRIPTION", "premium-simulator-subscription")

--- a/test/e2e/tests/test_helper.py
+++ b/test/e2e/tests/test_helper.py
@@ -14,7 +14,7 @@ Environment variables (all optional unless noted):
   - GATEWAY_HOST: Gateway hostname (required)
   - MAAS_API_BASE_URL: MaaS API URL (auto-derived from GATEWAY_HOST if not set)
   - MAAS_SUBSCRIPTION_NAMESPACE: MaaS CRs namespace (default: models-as-a-service)
-  - E2E_MAAS_API_DEPLOYMENT_NAMESPACE: Namespace where maas-api workloads run (default: DEPLOYMENT_NAMESPACE/opendatahub)
+  - E2E_MAAS_API_DEPLOYMENT_NAMESPACE: Namespace where maas-api workloads run (default: derived INFRA_NAMESPACE)
   - E2E_TEST_TOKEN_SA_NAMESPACE, E2E_TEST_TOKEN_SA_NAME: SA token source for Prow
   - E2E_TIMEOUT: Request timeout in seconds (default: 45)
   - E2E_RECONCILE_WAIT: Wait time for reconciliation in seconds (default: 8)
@@ -62,9 +62,32 @@ MODEL_PATH = os.environ.get("E2E_MODEL_PATH", "/llm/facebook-opt-125m-simulated"
 MODEL_NAME = os.environ.get("E2E_MODEL_NAME", "facebook/opt-125m")
 MODEL_REF = os.environ.get("E2E_MODEL_REF", "facebook-opt-125m-simulated")
 MODEL_NAMESPACE = os.environ.get("E2E_MODEL_NAMESPACE", "llm")
-# Infrastructure namespace where maas-api workloads run (uses operator namespace)
-# Defaults to DEPLOYMENT_NAMESPACE (controller namespace) since maas-api now deploys there
-MAAS_API_DEPLOYMENT_NAMESPACE = os.environ.get("E2E_MAAS_API_DEPLOYMENT_NAMESPACE", os.environ.get("DEPLOYMENT_NAMESPACE", "opendatahub"))
+DEPLOYMENT_NAMESPACE = os.environ.get("DEPLOYMENT_NAMESPACE", "opendatahub")
+
+
+def _derive_infra_namespace(controller_namespace: str) -> str:
+    if controller_namespace == "redhat-ods-applications":
+        return "redhat-ai-gateway-infra"
+    if controller_namespace == "opendatahub":
+        return "odh-ai-gateway-infra"
+    return controller_namespace
+
+
+def _resolve_maas_api_deployment_namespace() -> str:
+    explicit_namespace = os.environ.get("E2E_MAAS_API_DEPLOYMENT_NAMESPACE")
+    if explicit_namespace:
+        return explicit_namespace
+
+    infra_namespace = os.environ.get("INFRA_NAMESPACE")
+    if infra_namespace is None or infra_namespace == "AUTO":
+        return _derive_infra_namespace(DEPLOYMENT_NAMESPACE)
+    if infra_namespace == "":
+        return DEPLOYMENT_NAMESPACE
+    return infra_namespace
+
+
+# Infrastructure namespace where maas-api workloads run.
+MAAS_API_DEPLOYMENT_NAMESPACE = _resolve_maas_api_deployment_namespace()
 SIMULATOR_SUBSCRIPTION = os.environ.get("E2E_SIMULATOR_SUBSCRIPTION", "simulator-subscription")
 PREMIUM_MODEL_REF = os.environ.get("E2E_PREMIUM_MODEL_REF", "premium-simulated-simulated-premium")
 PREMIUM_SIMULATOR_SUBSCRIPTION = os.environ.get("E2E_PREMIUM_SIMULATOR_SUBSCRIPTION", "premium-simulator-subscription")

--- a/test/e2e/tests/test_tenant_discovery.py
+++ b/test/e2e/tests/test_tenant_discovery.py
@@ -18,16 +18,22 @@ import os
 import pytest
 import requests
 from conftest import TLS_VERIFY
+from test_helper import MAAS_API_DEPLOYMENT_NAMESPACE
 
 log = logging.getLogger(__name__)
 
 
-def _kubectl_curl(url: str, headers: dict = None, namespace: str = "opendatahub") -> tuple[int, str]:
+def _maas_api_namespace() -> str:
+    return os.environ.get("MAAS_NAMESPACE", MAAS_API_DEPLOYMENT_NAMESPACE)
+
+
+def _kubectl_curl(url: str, headers: dict = None, namespace: str = None) -> tuple[int, str]:
     """
     Execute curl request from inside the cluster using kubectl run.
 
     Returns (status_code, response_body)
     """
+    namespace = namespace or _maas_api_namespace()
     curl_args = ["-sk", "-m", "10"]
 
     # Add headers
@@ -82,7 +88,7 @@ def test_tenant_discovery_requires_auth(maas_api_internal_url: str):
     so we use kubectl run with curl to access it from inside the cluster.
     """
     url = maas_api_internal_url + "/v1/tenants"
-    namespace = os.environ.get("MAAS_NAMESPACE", "opendatahub")
+    namespace = _maas_api_namespace()
 
     # Attempt without Authorization header
     status_code, body = _kubectl_curl(url, namespace=namespace)
@@ -106,7 +112,7 @@ def test_tenant_discovery_with_invalid_token(maas_api_internal_url: str):
     Verify /v1/tenants endpoint rejects invalid tokens.
     """
     url = maas_api_internal_url + "/v1/tenants"
-    namespace = os.environ.get("MAAS_NAMESPACE", "opendatahub")
+    namespace = _maas_api_namespace()
 
     # Attempt with invalid bearer token
     headers = {"Authorization": "Bearer invalid-token-12345"}
@@ -136,7 +142,7 @@ def test_tenant_discovery_authenticated(maas_api_internal_url: str, headers: dic
         )
 
     url = maas_api_internal_url + "/v1/tenants"
-    namespace = os.environ.get("MAAS_NAMESPACE", "opendatahub")
+    namespace = _maas_api_namespace()
 
     status_code, body = _kubectl_curl(url, headers=headers, namespace=namespace)
 
@@ -213,7 +219,7 @@ def test_tenant_discovery_gateway_matches_deployment(maas_api_internal_url: str,
         )
 
     url = maas_api_internal_url + "/v1/tenants"
-    namespace = os.environ.get("MAAS_NAMESPACE", "opendatahub")
+    namespace = _maas_api_namespace()
 
     status_code, body = _kubectl_curl(url, headers=headers, namespace=namespace)
 

--- a/test/e2e/tests/test_tenant_discovery.py
+++ b/test/e2e/tests/test_tenant_discovery.py
@@ -18,13 +18,13 @@ import os
 import pytest
 import requests
 from conftest import TLS_VERIFY
-from test_helper import MAAS_API_DEPLOYMENT_NAMESPACE
+from test_helper import E2E_CURL_POD_NAMESPACE
 
 log = logging.getLogger(__name__)
 
 
-def _maas_api_namespace() -> str:
-    return os.environ.get("MAAS_NAMESPACE", MAAS_API_DEPLOYMENT_NAMESPACE)
+def _curl_pod_namespace() -> str:
+    return os.environ.get("E2E_CURL_POD_NAMESPACE", E2E_CURL_POD_NAMESPACE)
 
 
 def _kubectl_curl(url: str, headers: dict = None, namespace: str = None) -> tuple[int, str]:
@@ -33,7 +33,7 @@ def _kubectl_curl(url: str, headers: dict = None, namespace: str = None) -> tupl
 
     Returns (status_code, response_body)
     """
-    namespace = namespace or _maas_api_namespace()
+    namespace = namespace or _curl_pod_namespace()
     curl_args = ["-sk", "-m", "10"]
 
     # Add headers
@@ -71,9 +71,10 @@ def _kubectl_curl(url: str, headers: dict = None, namespace: str = None) -> tupl
             else:
                 log.error(f"Could not parse HTTP code from: {code_line}")
                 return 0, body.strip()
-        else:
-            # Fallback if format is unexpected
-            return 0, output
+        log.error(f"kubectl run failed (returncode={result.returncode})")
+        log.error(f"stdout: {output[:500]}")
+        log.error(f"stderr: {result.stderr[:500]}")
+        return 0, output
     except Exception as e:
         log.error(f"kubectl curl failed: {e}")
         return 0, str(e)
@@ -88,10 +89,8 @@ def test_tenant_discovery_requires_auth(maas_api_internal_url: str):
     so we use kubectl run with curl to access it from inside the cluster.
     """
     url = maas_api_internal_url + "/v1/tenants"
-    namespace = _maas_api_namespace()
-
     # Attempt without Authorization header
-    status_code, body = _kubectl_curl(url, namespace=namespace)
+    status_code, body = _kubectl_curl(url)
 
     log.info(f"[tenant] GET {url} (no auth) -> HTTP {status_code}")
     print(f"[tenant] GET /v1/tenants without auth: HTTP {status_code}")
@@ -112,11 +111,9 @@ def test_tenant_discovery_with_invalid_token(maas_api_internal_url: str):
     Verify /v1/tenants endpoint rejects invalid tokens.
     """
     url = maas_api_internal_url + "/v1/tenants"
-    namespace = _maas_api_namespace()
-
     # Attempt with invalid bearer token
     headers = {"Authorization": "Bearer invalid-token-12345"}
-    status_code, body = _kubectl_curl(url, headers=headers, namespace=namespace)
+    status_code, body = _kubectl_curl(url, headers=headers)
 
     log.info(f"[tenant] GET {url} (invalid token) -> HTTP {status_code}")
     print(f"[tenant] GET /v1/tenants with invalid token: HTTP {status_code}")
@@ -142,9 +139,8 @@ def test_tenant_discovery_authenticated(maas_api_internal_url: str, headers: dic
         )
 
     url = maas_api_internal_url + "/v1/tenants"
-    namespace = _maas_api_namespace()
 
-    status_code, body = _kubectl_curl(url, headers=headers, namespace=namespace)
+    status_code, body = _kubectl_curl(url, headers=headers)
 
     log.info(f"[tenant] GET {url} (authenticated) -> HTTP {status_code}")
     print(f"[tenant] GET /v1/tenants authenticated: HTTP {status_code}")
@@ -219,9 +215,8 @@ def test_tenant_discovery_gateway_matches_deployment(maas_api_internal_url: str,
         )
 
     url = maas_api_internal_url + "/v1/tenants"
-    namespace = _maas_api_namespace()
 
-    status_code, body = _kubectl_curl(url, headers=headers, namespace=namespace)
+    status_code, body = _kubectl_curl(url, headers=headers)
 
     assert status_code == 200, f"Expected 200, got {status_code}"
 

--- a/test/e2e/tests/test_tenant_discovery_isolation.py
+++ b/test/e2e/tests/test_tenant_discovery_isolation.py
@@ -16,7 +16,7 @@ import json
 import os
 
 from conftest import TLS_VERIFY
-from test_helper import E2E_CURL_POD_NAMESPACE, MAAS_API_DEPLOYMENT_NAMESPACE
+from test_helper import E2E_CURL_POD_NAMESPACE, MAAS_API_DEPLOYMENT_NAMESPACE, _get_cluster_token
 
 log = logging.getLogger(__name__)
 

--- a/test/e2e/tests/test_tenant_discovery_isolation.py
+++ b/test/e2e/tests/test_tenant_discovery_isolation.py
@@ -21,8 +21,9 @@ from test_helper import _get_cluster_token, MAAS_API_DEPLOYMENT_NAMESPACE
 log = logging.getLogger(__name__)
 
 
-def _kubectl_curl(url: str, headers: dict = None, namespace: str = "opendatahub") -> tuple[int, str]:
+def _kubectl_curl(url: str, headers: dict = None, namespace: str = None) -> tuple[int, str]:
     """Execute curl from inside cluster. Returns (status_code, response_body)"""
+    namespace = namespace or MAAS_API_DEPLOYMENT_NAMESPACE
     curl_args = ["-sk", "-m", "10"]
     if headers:
         for key, value in headers.items():
@@ -72,7 +73,7 @@ def tenant_service_urls(shared_test_tenants):
 
     # Construct internal service URLs
     # Format: https://{service-name}.{namespace}.svc.cluster.local:{port}
-    # AITenant maas-api services are deployed in MAAS_API_DEPLOYMENT_NAMESPACE (opendatahub),
+    # AITenant maas-api services are deployed in MAAS_API_DEPLOYMENT_NAMESPACE,
     # NOT in the tenant-specific namespace (ai-tenant-xxx)
     def service_url(tenant):
         # Service name follows pattern: maas-api-{tenant-name}

--- a/test/e2e/tests/test_tenant_discovery_isolation.py
+++ b/test/e2e/tests/test_tenant_discovery_isolation.py
@@ -16,14 +16,14 @@ import json
 import os
 
 from conftest import TLS_VERIFY
-from test_helper import _get_cluster_token, MAAS_API_DEPLOYMENT_NAMESPACE
+from test_helper import E2E_CURL_POD_NAMESPACE, MAAS_API_DEPLOYMENT_NAMESPACE
 
 log = logging.getLogger(__name__)
 
 
 def _kubectl_curl(url: str, headers: dict = None, namespace: str = None) -> tuple[int, str]:
     """Execute curl from inside cluster. Returns (status_code, response_body)"""
-    namespace = namespace or MAAS_API_DEPLOYMENT_NAMESPACE
+    namespace = namespace or os.environ.get("E2E_CURL_POD_NAMESPACE", E2E_CURL_POD_NAMESPACE)
     curl_args = ["-sk", "-m", "10"]
     if headers:
         for key, value in headers.items():
@@ -144,7 +144,7 @@ def test_tenant_discovery_same_tenant_access(tenant_service_urls, tenant_tokens)
 
         log.info(f"[isolation] Testing {tenant['name']} can access own endpoint")
 
-        status_code, body = _kubectl_curl(url, headers=headers, namespace=MAAS_API_DEPLOYMENT_NAMESPACE)
+        status_code, body = _kubectl_curl(url, headers=headers)
 
         # Should succeed (200) with system:authenticated authorization
         assert status_code == 200, \
@@ -191,7 +191,7 @@ def test_tenant_discovery_cross_tenant_isolation(tenant_service_urls, tenant_tok
     url_a = f"{tenant_a['service_url']}/v1/tenants"
     headers = {"Authorization": f"Bearer {cluster_token}"}
 
-    status_a, body_a = _kubectl_curl(url_a, headers=headers, namespace=MAAS_API_DEPLOYMENT_NAMESPACE)
+    status_a, body_a = _kubectl_curl(url_a, headers=headers)
 
     assert status_a == 200, f"Tenant A endpoint should return 200 (system:authenticated), got {status_a}"
     data_a = json.loads(body_a)
@@ -200,7 +200,7 @@ def test_tenant_discovery_cross_tenant_isolation(tenant_service_urls, tenant_tok
     # Test: Call tenant B's endpoint (same token - should also work)
     url_b = f"{tenant_b['service_url']}/v1/tenants"
 
-    status_b, body_b = _kubectl_curl(url_b, headers=headers, namespace=MAAS_API_DEPLOYMENT_NAMESPACE)
+    status_b, body_b = _kubectl_curl(url_b, headers=headers)
 
     assert status_b == 200, f"Tenant B endpoint should return 200 (system:authenticated), got {status_b}"
     data_b = json.loads(body_b)
@@ -240,13 +240,13 @@ def test_tenant_discovery_unauthorized_access(tenant_service_urls):
         url = f"{tenant['service_url']}/v1/tenants"
 
         # Test 1: No auth header
-        status_code, _ = _kubectl_curl(url, namespace=MAAS_API_DEPLOYMENT_NAMESPACE)
+        status_code, _ = _kubectl_curl(url)
         assert status_code == 401, \
             f"{tenant['name']} should reject no-auth request with 401, got {status_code}"
 
         # Test 2: Invalid token
         headers = {"Authorization": "Bearer invalid-token-12345"}
-        status_code, _ = _kubectl_curl(url, headers=headers, namespace=MAAS_API_DEPLOYMENT_NAMESPACE)
+        status_code, _ = _kubectl_curl(url, headers=headers)
         assert status_code == 401, \
             f"{tenant['name']} should reject invalid token with 401, got {status_code}"
 
@@ -277,7 +277,7 @@ def test_tenant_discovery_each_tenant_returns_own_gateway(tenant_service_urls, t
         url = f"{tenant['service_url']}/v1/tenants"
         headers = {"Authorization": f"Bearer {cluster_token}"}
 
-        status_code, body = _kubectl_curl(url, headers=headers, namespace=MAAS_API_DEPLOYMENT_NAMESPACE)
+        status_code, body = _kubectl_curl(url, headers=headers)
 
         # With system:authenticated authorization, 403 indicates auth/RBAC regression
         assert status_code == 200, \


### PR DESCRIPTION
## Description
Fix E2E namespace defaults after maas-api moved to the resolved infrastructure namespace. Tenant discovery URLs, curl pod namespaces, multitenancy helpers, debug artifact collection, and Prow logging now use the derived maas-api deployment namespace while preserving explicit overrides.

## How Has This Been Tested?
- `python3 -m py_compile` for modified E2E Python files
- `bash -n test/e2e/scripts/auth_utils.sh`
- `bash -n test/e2e/scripts/prow_run_smoke_test.sh`
- Resolver probes for ODH, RHOAI, custom infra namespace, `MAAS_NAMESPACE`, and `MAAS_API_INTERNAL_URL`
- `git diff --check`

## Risk analysis
**Risk rating**: 2

**Why**: E2E-only Python/shell changes. Runtime product behavior is unchanged; risk is limited to test namespace resolution and artifact/debug output. Existing explicit overrides remain supported.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for `E2E_MAAS_API_DEPLOYMENT_NAMESPACE` to control where MaaS API workloads run, plus `E2E_CURL_POD_NAMESPACE` for curl probe pods.
* **Bug Fixes**
  * Updated e2e namespace defaults and routing/tenant discovery helpers to consistently use the resolved MaaS API “infra” namespace.
  * Improved auth debug reporting, including expanded cluster/namespace information.
* **Improvements**
  * Enhanced E2E artifact collection and `cluster-state.log` to include both controller and resolved MaaS API namespaces.
* **Documentation**
  * Clarified environment variable behavior and defaults for E2E runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->