### PR TITLE
fix: remove database credentials from error messages (FIND-006)

### DIFF
--- a/maas-api/internal/api_keys/db_driver.go
+++ b/maas-api/internal/api_keys/db_driver.go
@@ -32,9 +32,8 @@ func NewPostgresStoreFromURL(ctx context.Context, log *logger.Logger, databaseUR
 	databaseURL = strings.TrimSpace(databaseURL)
 
 	if !strings.HasPrefix(databaseURL, "postgresql://") && !strings.HasPrefix(databaseURL, "postgres://") {
-		return nil, fmt.Errorf(
-			"invalid database URL: %q. Expected format: postgresql://user:password@host:port/database",
-			databaseURL)
+		return nil, errors.New(
+			"invalid database URL: must start with postgresql:// or postgres://")
 	}
 
 	db, err := sql.Open("pgx", databaseURL)


### PR DESCRIPTION
## Summary
Remove database connection URL (containing `user:password@`) from error messages. When `DB_CONNECTION_URL` lacked the `postgresql://` prefix, the full URL was included in the error via `%q` format string. Container stderr is captured by OpenShift logging and sent to centralized log stores with broader read ACLs than the `maas-db-config` Secret.

## Finding
**FIND-006** — Database Credentials in Logs (CWE-532, CVSS 5.1 Medium)

## Changes
- `db_driver.go:34-37`: Replaced `fmt.Errorf("invalid database URL: %q...", databaseURL)` with `errors.New("invalid database URL: must start with postgresql:// or postgres://")` — no URL value in the error

## Test plan
- [x] `TestPostgresStoreFromURL/InvalidURL` passes (error message changed)
- [x] Build succeeds
- [ ] Verify error output does not contain credentials when DB URL has wrong prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the error shown when a database connection string uses an unsupported format, making the message shorter and clearer.
  * Invalid database URLs now return a consistent validation error without exposing the full input value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->