### PR TITLE
fix: exempt /v1/subscriptions and /v1/api-keys from gateway deny-all policies

### DIFF
--- a/deployment/base/maas-api/networking/httproute.yaml
+++ b/deployment/base/maas-api/networking/httproute.yaml
@@ -6,8 +6,13 @@ spec:
   parentRefs:
     - name: maas-default-gateway
       namespace: openshift-ingress
+  # WARNING: Rule order matters — the payload-processing EnvoyFilter
+  # (deployment/base/payload-processing/manager/envoy-filter.yaml) disables
+  # ext_proc per-route using Istio's "<namespace>.<httproute-name>.<rule-index>"
+  # naming convention. Adding, removing, or reordering rules here requires
+  # updating the EnvoyFilter route indices to match.
   rules:
-    # OpenAI-compatible /v1/models endpoint at top level
+    # Rule 0: OpenAI-compatible /v1/models endpoint at top level
     # NOTE: Using PathPrefix /v1/models (not /v1) to exclude /v1/tenants which is internal-only
     - matches:
         - path:
@@ -17,7 +22,7 @@ spec:
         - name: maas-api
           port: 8443
           weight: 100
-    # /v1/subscriptions endpoint at top level
+    # Rule 1: /v1/subscriptions endpoint at top level
     - matches:
         - path:
             type: PathPrefix
@@ -26,7 +31,7 @@ spec:
         - name: maas-api
           port: 8443
           weight: 100
-    # /v1/api-keys endpoint at top level
+    # Rule 2: /v1/api-keys endpoint at top level
     - matches:
         - path:
             type: PathPrefix
@@ -35,7 +40,7 @@ spec:
         - name: maas-api
           port: 8443
           weight: 100
-    # IMPORTANT: /v1/tenants is NOT routed through Gateway (internal-only)
+    # Rule 3: IMPORTANT: /v1/tenants is NOT routed through Gateway (internal-only)
     # It must be called via maas-api Service directly for tenant-scoped auth
     # All other maas-api endpoints remain under /maas-api prefix
     - matches:

--- a/deployment/base/maas-controller/policies/gateway-default-deny.yaml
+++ b/deployment/base/maas-controller/policies/gateway-default-deny.yaml
@@ -2,8 +2,9 @@
 # Scoped to model inference paths only — does NOT affect non-model routes
 # like /maas-api/ or /v1/models (the MaaS API management endpoints).
 #
-# The when predicate below excludes /maas-api and /v1/models so this deny
-# applies only to model inference paths (e.g. /llm/..., /production/...).
+# The when predicate below excludes /maas-api and all /v1/* management
+# endpoints so this deny applies only to model inference paths (e.g.
+# /llm/..., /production/...).
 #
 # The PRIMARY default deny is gateway-default-auth.yaml (AuthPolicy), which
 # returns 401/403 for unconfigured models. This TRLP is a defense-in-depth layer:
@@ -33,7 +34,7 @@ spec:
     limits:
       deny-all-by-default:
         when:
-          - predicate: '!request.path.startsWith("/maas-api") && !request.path.startsWith("/v1/models")'
+          - predicate: '!request.path.startsWith("/maas-api") && !request.path.startsWith("/v1/")'
         rates:
           - limit: 0
             window: 1m

--- a/deployment/base/maas-controller/policies/gateway-default-deny.yaml
+++ b/deployment/base/maas-controller/policies/gateway-default-deny.yaml
@@ -2,9 +2,10 @@
 # Scoped to model inference paths only — does NOT affect non-model routes
 # like /maas-api/ or /v1/models (the MaaS API management endpoints).
 #
-# The when predicate below excludes /maas-api and all /v1/* management
-# endpoints so this deny applies only to model inference paths (e.g.
-# /llm/..., /production/...).
+# The when predicate below excludes /maas-api and the specific /v1/*
+# management endpoints (/v1/models, /v1/subscriptions, /v1/api-keys) so
+# this deny applies to all other paths, including model inference paths
+# (e.g. /llm/..., /production/..., /v1/chat/completions via body-routing).
 #
 # The PRIMARY default deny is gateway-default-auth.yaml (AuthPolicy), which
 # returns 401/403 for unconfigured models. This TRLP is a defense-in-depth layer:
@@ -34,7 +35,7 @@ spec:
     limits:
       deny-all-by-default:
         when:
-          - predicate: '!request.path.startsWith("/maas-api") && !request.path.startsWith("/v1/")'
+          - predicate: '!request.path.startsWith("/maas-api") && !request.path.startsWith("/v1/models") && !request.path.startsWith("/v1/subscriptions") && !request.path.startsWith("/v1/api-keys")'
         rates:
           - limit: 0
             window: 1m

--- a/deployment/base/payload-processing/manager/envoy-filter.yaml
+++ b/deployment/base/payload-processing/manager/envoy-filter.yaml
@@ -64,8 +64,10 @@ spec:
             grpc_service:
               envoy_grpc:
                 cluster_name: outbound|9004||payload-processing.openshift-ingress.svc.cluster.local
-    # Disable ext_proc on non-inference routes (maas-api /v1/models).
+    # Disable ext_proc on all non-inference maas-api routes.
     # Route name follows Istio's Gateway API naming: <namespace>.<httproute-name>.<rule-index>
+    # Rule indices correspond to httproute.yaml rules:
+    #   0 = /v1/models, 1 = /v1/subscriptions, 2 = /v1/api-keys, 3 = /maas-api/*
     - applyTo: HTTP_ROUTE
       match:
         context: GATEWAY
@@ -83,7 +85,6 @@ spec:
             envoy.filters.http.ext_proc.ipp:
               "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExtProcPerRoute
               disabled: true
-    # Disable ext_proc on non-inference routes (maas-api /maas-api/*).
     - applyTo: HTTP_ROUTE
       match:
         context: GATEWAY
@@ -91,6 +92,40 @@ spec:
           vhost:
             route:
               name: "PLACEHOLDER.maas-api-route.1"
+      patch:
+        operation: MERGE
+        value:
+          typed_per_filter_config:
+            envoy.filters.http.ext_proc.ipp-pre:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExtProcPerRoute
+              disabled: true
+            envoy.filters.http.ext_proc.ipp:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExtProcPerRoute
+              disabled: true
+    - applyTo: HTTP_ROUTE
+      match:
+        context: GATEWAY
+        routeConfiguration:
+          vhost:
+            route:
+              name: "PLACEHOLDER.maas-api-route.2"
+      patch:
+        operation: MERGE
+        value:
+          typed_per_filter_config:
+            envoy.filters.http.ext_proc.ipp-pre:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExtProcPerRoute
+              disabled: true
+            envoy.filters.http.ext_proc.ipp:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExtProcPerRoute
+              disabled: true
+    - applyTo: HTTP_ROUTE
+      match:
+        context: GATEWAY
+        routeConfiguration:
+          vhost:
+            route:
+              name: "PLACEHOLDER.maas-api-route.3"
       patch:
         operation: MERGE
         value:

--- a/maas-controller/pkg/controller/maas/maasauthpolicy_controller_test.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_controller_test.go
@@ -1542,7 +1542,7 @@ func TestBuildGatewayAuthPolicySpec_XAPIKeyEnabled(t *testing.T) {
 // gateway AuthPolicy spec.
 func TestBuildGatewayAuthPolicySpec_OIDCJWKsTTL(t *testing.T) {
 	r := &MaaSAuthPolicyReconciler{
-		MaaSAPINamespace: "maas-system",
+		InfraNamespace:   "maas-system",
 		GatewayName:      "maas-default-gateway",
 		GatewayNamespace: "gateway-ns",
 		ClusterAudience:  "https://kubernetes.default.svc",
@@ -1667,7 +1667,7 @@ func TestFetchOIDCConfig_TTLExtraction(t *testing.T) {
 				WithObjects(tenant).
 				Build()
 
-			r := &MaaSAuthPolicyReconciler{Client: c, Scheme: scheme, MaaSAPINamespace: namespace}
+			r := &MaaSAuthPolicyReconciler{Client: c, Scheme: scheme, InfraNamespace: namespace}
 			log := ctrl.Log.WithName("test")
 			got := r.fetchOIDCConfig(context.Background(), log, namespace)
 

--- a/maas-controller/pkg/platform/tenantreconcile/params.go
+++ b/maas-controller/pkg/platform/tenantreconcile/params.go
@@ -402,8 +402,8 @@ func patchPayloadProcessingEnvoyFilter(log logr.Logger, r *unstructured.Unstruct
 	if err != nil {
 		return fmt.Errorf("read EnvoyFilter configPatches: %w", err)
 	}
-	if !found || len(configPatches) < 4 {
-		return fmt.Errorf("EnvoyFilter configPatches: expected at least 4 entries, got %d", len(configPatches))
+	if !found || len(configPatches) < 6 {
+		return fmt.Errorf("EnvoyFilter configPatches: expected at least 6 entries, got %d", len(configPatches))
 	}
 
 	clusterByIndex := []string{beforeCluster, afterCluster}
@@ -427,9 +427,10 @@ func patchPayloadProcessingEnvoyFilter(log logr.Logger, r *unstructured.Unstruct
 		configPatches[i] = patch
 	}
 
-	// Patches 2 and 3 disable ext_proc on non-inference routes.
+	// Patches 2–5 disable ext_proc on all non-inference maas-api routes.
 	// Route name uses Istio's Gateway API convention: <namespace>.<httproute-name>.<rule-index>.
-	for i := 2; i < 4; i++ {
+	// Rule indices: 0=/v1/models, 1=/v1/subscriptions, 2=/v1/api-keys, 3=/maas-api/*
+	for i := 2; i < 6; i++ {
 		patch, ok := configPatches[i].(map[string]any)
 		if !ok {
 			return fmt.Errorf("EnvoyFilter configPatches[%d] is not an object", i)

--- a/maas-controller/pkg/platform/tenantreconcile/params_test.go
+++ b/maas-controller/pkg/platform/tenantreconcile/params_test.go
@@ -174,11 +174,11 @@ func TestApplyPlatformParamsWithRenderedOverlay(t *testing.T) {
 	assert.Equal(t, params.GatewayName, firstTargetRef["name"])
 
 	// Verify dual-stage filter chain: configPatches[0]=INSERT_BEFORE, configPatches[1]=INSERT_AFTER,
-	// plus per-route disable patches: configPatches[2] and [3]=MERGE on maas-api-route rules.
+	// plus per-route disable patches: configPatches[2..5]=MERGE on maas-api-route rules 0–3.
 	configPatches, found, err := unstructured.NestedSlice(payloadEnvoyFilter.Object, "spec", "configPatches")
 	require.NoError(t, err)
 	require.True(t, found)
-	require.Len(t, configPatches, 4, "expected four configPatches (INSERT_BEFORE + INSERT_AFTER + 2x MERGE)")
+	require.Len(t, configPatches, 6, "expected six configPatches (INSERT_BEFORE + INSERT_AFTER + 4x MERGE)")
 
 	wantAnchor := wasmpluginAnchorName(params.GatewayNamespace, params.GatewayName)
 	wantBeforeCluster := grpcClusterName(PayloadPreProcessingName, params.GatewayNamespace, 9004)
@@ -200,8 +200,8 @@ func TestApplyPlatformParamsWithRenderedOverlay(t *testing.T) {
 		assert.Equal(t, wantClusters[i], cluster, "configPatches[%d] grpc cluster_name", i)
 	}
 
-	// Verify per-route ext_proc disable on maas-api-route rules 0 and 1.
-	for i := 2; i < 4; i++ {
+	// Verify per-route ext_proc disable on maas-api-route rules 0–3.
+	for i := 2; i < 6; i++ {
 		cp, ok := configPatches[i].(map[string]any)
 		require.True(t, ok, "configPatches[%d] should be a map", i)
 

--- a/maas-controller/pkg/platform/tenantreconcile/params_test.go
+++ b/maas-controller/pkg/platform/tenantreconcile/params_test.go
@@ -216,6 +216,11 @@ func TestApplyPlatformParamsWithRenderedOverlay(t *testing.T) {
 		require.NoError(t, err, "configPatches[%d] ipp-pre disabled field", i)
 		require.True(t, found, "configPatches[%d] ipp-pre disabled field should exist", i)
 		assert.True(t, disabled, "configPatches[%d] ipp-pre should be disabled", i)
+
+		ippDisabled, found, err := unstructured.NestedBool(cp, "patch", "value", "typed_per_filter_config", "envoy.filters.http.ext_proc.ipp", "disabled")
+		require.NoError(t, err, "configPatches[%d] ipp disabled field", i)
+		require.True(t, found, "configPatches[%d] ipp disabled field should exist", i)
+		assert.True(t, ippDisabled, "configPatches[%d] ipp should be disabled", i)
 	}
 
 	// Verify payload-pre-processing Deployment and Service are present and namespaced correctly.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
### Problem
Requests to `/v1/subscriptions` and `/v1/api-keys` through the gateway fail with 429 or 500, making these management endpoints unusable in operator-managed deployments.                                  

Two independent issues cause this:
1. **TRLP deny-all blocks management paths** — `gateway-default-deny` exempts only `/maas-api/*` and `/v1/models` from its zero-token rate limit. Requests to `/v1/subscriptions` and `/v1/api-keys` get 0 tokens → 429 Too Many Requests.                                             

2. **ext_proc fails on unhandled routes** — The payload-processing EnvoyFilter disables ext_proc only on HTTPRoute rules 0 (`/v1/models`) and 1 (`/v1/subscriptions`), but not rules 2 (`/v1/api-keys`) and 3 (`/maas-api/*`). When the payload-processing pod is absent, `failure_mode_allow: false` causes those routes to return 500.                                 

Both issues affect any auth method (OpenShift tokens, API keys, OIDC) since the policies operate at the gateway level before authentication is evaluated.

## Changes                                                     
- Widen `gateway-default-deny` TRLP predicate from `/v1/models` to `/v1/` so all management endpoints are exempt from the zero-token deny-all rate limit                                                   
- Add ext_proc disable entries for HTTPRoute rules 2 and 3 in the payload-processing EnvoyFilter template
- Update `patchPayloadProcessingEnvoyFilter` loop and test assertions to cover all four route rules

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manual testing on the cluster

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded routing and request-processing coverage for additional MAAS API paths.
  * Added clearer routing rules so more management endpoints are handled consistently.

* **Bug Fixes**
  * Updated default-deny behavior so key management endpoints are no longer unintentionally blocked.
  * Disabled extra request-processing on more non-inference routes to reduce unwanted interference.

* **Documentation**
  * Added clearer inline guidance about route ordering and internal-only endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->