### PR TITLE
fix: restrict debug CORS to http-only localhost (FIND-Debug-CORS)

### DIFF
--- a/maas-api/cmd/cors_test.go
+++ b/maas-api/cmd/cors_test.go
@@ -17,16 +17,14 @@ func TestIsLocalhostOrigin(t *testing.T) {
 		want   bool
 	}{
 		{name: "http localhost with port", origin: "http://localhost:3000", want: true},
-		{name: "https localhost with port", origin: "https://localhost:8443", want: true},
 		{name: "http 127.0.0.1 with port", origin: "http://127.0.0.1:8080", want: true},
-		{name: "https 127.0.0.1 with port", origin: "https://127.0.0.1:443", want: true},
 		{name: "http localhost default port", origin: "http://localhost", want: true},
-		{name: "https localhost default port", origin: "https://localhost", want: true},
 		{name: "http 127.0.0.1 default port", origin: "http://127.0.0.1", want: true},
-		{name: "https 127.0.0.1 default port", origin: "https://127.0.0.1", want: true},
 		{name: "loopback range 127.0.0.2", origin: "http://127.0.0.2:8080", want: true},
 		{name: "loopback range 127.255.255.254", origin: "http://127.255.255.254:9090", want: true},
 
+		{name: "https localhost rejected", origin: "https://localhost:8443", want: false},
+		{name: "https 127.0.0.1 rejected", origin: "https://127.0.0.1:443", want: false},
 		{name: "external origin", origin: "https://external.com", want: false},
 		{name: "external with localhost in path", origin: "https://external.com/localhost:3000", want: false},
 		{name: "localhost without scheme", origin: "localhost:3000", want: false},
@@ -59,13 +57,9 @@ func TestDebugCORS_AllowsLocalhostOrigin(t *testing.T) {
 
 	origins := []string{
 		"http://localhost:3000",
-		"https://localhost:8443",
 		"http://127.0.0.1:8080",
-		"https://127.0.0.1:443",
 		"http://localhost",
-		"https://localhost",
 		"http://127.0.0.1",
-		"https://127.0.0.1",
 	}
 
 	for _, origin := range origins {

--- a/maas-api/cmd/main.go
+++ b/maas-api/cmd/main.go
@@ -287,7 +287,7 @@ func registerHandlers(
 // http://127.0.0.1 address, used by the debug-mode CORS policy to restrict
 // cross-origin access to local development only.
 // Only plain HTTP is accepted — local dev servers do not use HTTPS.
-// (CWE-942 / FIND-Debug-CORS)
+// (CWE-942 / FIND-Debug-CORS.)
 func isLocalhostOrigin(origin string) bool {
 	u, err := url.Parse(origin)
 	if err != nil {

--- a/maas-api/cmd/main.go
+++ b/maas-api/cmd/main.go
@@ -283,31 +283,34 @@ func registerHandlers(
 	return nil
 }
 
-// isLocalhostOrigin reports whether the origin is a localhost address,
-// used by the debug-mode CORS policy to restrict cross-origin access to
-// local development only. Accepts both ported (http://localhost:3000)
-// and default-port (http://localhost) forms.
+// isLocalhostOrigin reports whether the origin is an http://localhost or
+// http://127.0.0.1 address, used by the debug-mode CORS policy to restrict
+// cross-origin access to local development only.
+// Only plain HTTP is accepted — local dev servers do not use HTTPS.
+// (CWE-942 / FIND-Debug-CORS)
 func isLocalhostOrigin(origin string) bool {
 	u, err := url.Parse(origin)
 	if err != nil {
 		return false
 	}
-	if u.Scheme != "http" && u.Scheme != "https" {
+	if u.Scheme != "http" {
 		return false
 	}
-	if u.Hostname() == "localhost" {
+	host := u.Hostname()
+	if host == "localhost" {
 		return true
 	}
-	ip := net.ParseIP(u.Hostname())
+	ip := net.ParseIP(host)
 	return ip != nil && ip.IsLoopback()
 }
 
 func debugCORSConfig() cors.Config {
 	return cors.Config{
-		AllowMethods:    []string{"GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"},
-		AllowHeaders:    []string{"Authorization", "Content-Type", "Accept"},
-		ExposeHeaders:   []string{"Content-Type"},
-		AllowOriginFunc: isLocalhostOrigin,
-		MaxAge:          12 * time.Hour,
+		AllowMethods:     []string{"GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"},
+		AllowHeaders:     []string{"Authorization", "Content-Type", "Accept"},
+		ExposeHeaders:    []string{"Content-Type"},
+		AllowOriginFunc:  isLocalhostOrigin,
+		AllowCredentials: false,
+		MaxAge:           12 * time.Hour,
 	}
 }


### PR DESCRIPTION
## Summary

- Restrict `isLocalhostOrigin` to accept only `http://` scheme — local dev servers don't use HTTPS, and accepting `https://localhost` widens the attack surface unnecessarily
- Explicitly set `AllowCredentials: false` in `debugCORSConfig()` to prevent cookie/credential forwarding on cross-origin requests (was already the default, now explicit for auditor clarity)

**Finding:** FIND-Debug-CORS — Permissive Cross-domain Policy (CWE-942)  
**CVSS:** 3.1 (AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:N/A:N)

### What changed

| Before | After |
|---|---|
| `https://localhost:8443` → allowed | `https://localhost:8443` → **rejected** |
| `http://localhost:3000` → allowed | `http://localhost:3000` → allowed (unchanged) |
| `AllowCredentials` implicit false | `AllowCredentials: false` explicit |

## Test plan

- [x] `TestIsLocalhostOrigin` — https localhost/127.0.0.1 now rejected
- [x] `TestDebugCORS_AllowsLocalhostOrigin` — http origins still allowed
- [x] `TestDebugCORS_CredentialsNotAllowed` — no `Access-Control-Allow-Credentials` header
- [x] Full `make test` passes (all 14 packages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened debug-mode cross-origin access to allow only `http://` localhost and loopback origins.
  * Rejected `https://` localhost/loopback origins that were previously permitted.
  * Disabled credential sharing for debug-mode cross-origin requests.
* **Tests**
  * Updated CORS localhost/loopback test cases and expectations to match the `http://`-only rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->