### PR TITLE
fix: add container hardening — readOnlyRootFilesystem, seccompProfile (FIND-007)

### DIFF
--- a/deployment/base/maas-api/core/cronjob-cleanup.yaml
+++ b/deployment/base/maas-api/core/cronjob-cleanup.yaml
@@ -43,3 +43,5 @@ spec:
                 - ALL
               readOnlyRootFilesystem: true
               runAsNonRoot: true
+              seccompProfile:
+                type: RuntimeDefault

--- a/deployment/base/maas-api/core/deployment.yaml
+++ b/deployment/base/maas-api/core/deployment.yaml
@@ -61,4 +61,6 @@ spec:
             - ALL
           readOnlyRootFilesystem: true
           runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
       terminationGracePeriodSeconds: 30

--- a/deployment/base/maas-controller/manager/manager.yaml
+++ b/deployment/base/maas-controller/manager/manager.yaml
@@ -91,6 +91,9 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             drop: ["ALL"]
+          readOnlyRootFilesystem: true
+          seccompProfile:
+            type: RuntimeDefault
         livenessProbe:
           httpGet:
             path: /healthz

--- a/deployment/base/payload-processing/instance/deployment.yaml
+++ b/deployment/base/payload-processing/instance/deployment.yaml
@@ -26,6 +26,8 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
           args:
             - --config-file
             - "/config/custom-ipp-config.yaml"


### PR DESCRIPTION
## Summary

Add missing container hardening fields across all deployment manifests:

| Workload | readOnlyRootFilesystem | seccompProfile: RuntimeDefault |
|---|---|---|
| **maas-controller** | **added** | **added** |
| **maas-api** | already set | **added** |
| **cleanup CronJob** | already set | **added** |
| **payload-processing** | already set | **added** |

**Finding:** FIND-007 — Missing Container Hardening (CWE-1188)  
**CVSS:** 4.0 (AV:L/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:L)

### Notes

- maas-controller's only writable path (`/tmp/k8s-webhook-server/serving-certs`) is already a `secret` volume mount — `readOnlyRootFilesystem: true` is safe
- OpenShift `restricted-v2` SCC injects seccomp in most installs, but explicit declaration satisfies CIS 5.7.2 and prevents drift on permissive SCCs
- No code changes — manifest-only

## Test plan

- [x] `kustomize build` succeeds for all bases (controller, api, payload-processing)
- [ ] Cluster validation: pods start and remain healthy with hardened security context

🤖 Generated with [Claude Code](https://claude.com/claude-code)