### PR TITLE
fix: deprecated flag forces insecure mode

### DIFF
--- a/maas-api/internal/config/config.go
+++ b/maas-api/internal/config/config.go
@@ -235,14 +235,22 @@ func (c *Config) Validate() error {
 }
 
 // handleDeprecatedFlags maps deprecated flags to new configuration.
-func (c *Config) handleDeprecatedFlags() {
-	// If deprecated --port flag is used, map to new model (HTTP mode)
-	if c.deprecatedHTTPPort != "" {
-		c.Secure = false
-		if c.Address == "" {
-			c.Address = ":" + c.deprecatedHTTPPort
-		}
+// Returns an error if the deprecated --port flag conflicts with TLS settings
+// (CWE-319/CWE-757 mitigation: refuse to silently downgrade to plaintext).
+func (c *Config) handleDeprecatedFlags() error {
+	if c.deprecatedHTTPPort == "" {
+		return nil
 	}
+
+	if c.Secure || c.TLS.Enabled() {
+		return fmt.Errorf("deprecated --port/PORT cannot be used with --secure or TLS configuration; "+
+			"use --address=:%s with TLS flags instead", c.deprecatedHTTPPort)
+	}
+
+	if c.Address == "" {
+		c.Address = ":" + c.deprecatedHTTPPort
+	}
+	return nil
 }
 
 // PrintDeprecationWarnings prints warnings for deprecated flags to stderr.

--- a/maas-api/internal/config/config.go
+++ b/maas-api/internal/config/config.go
@@ -174,7 +174,9 @@ func (c *Config) bindFlags(fs *flag.FlagSet) {
 // It returns an error if the configuration is invalid.
 func (c *Config) Validate() error {
 	// Handle backward compatibility for deprecated flags
-	c.handleDeprecatedFlags()
+	if err := c.handleDeprecatedFlags(); err != nil {
+		return err
+	}
 
 	// Validate required fields
 	if c.DBConnectionURL == "" {

--- a/maas-api/internal/config/config.go
+++ b/maas-api/internal/config/config.go
@@ -244,6 +244,11 @@ func (c *Config) handleDeprecatedFlags() error {
 		return nil
 	}
 
+	port, err := strconv.Atoi(c.deprecatedHTTPPort)
+	if err != nil || port < 1 || port > 65535 {
+		return fmt.Errorf("deprecated --port/PORT value %q is not a valid TCP port (1-65535)", c.deprecatedHTTPPort)
+	}
+
 	if c.Secure || c.TLS.Enabled() {
 		return fmt.Errorf("deprecated --port/PORT cannot be used with --secure or TLS configuration; "+
 			"use --address=:%s with TLS flags instead", c.deprecatedHTTPPort)

--- a/maas-api/internal/config/config_test.go
+++ b/maas-api/internal/config/config_test.go
@@ -281,15 +281,38 @@ func TestValidate(t *testing.T) {
 }
 
 func TestHandleDeprecatedFlags(t *testing.T) {
-	t.Run("deprecated port sets Address and clears Secure", func(t *testing.T) {
+	t.Run("deprecated port with Secure=true returns error", func(t *testing.T) {
 		cfg := &Config{
 			Secure:             true,
 			deprecatedHTTPPort: "9090",
 		}
-		cfg.handleDeprecatedFlags()
+		err := cfg.handleDeprecatedFlags()
 
-		if cfg.Secure {
-			t.Error("expected Secure to be false when deprecated port is used")
+		if err == nil {
+			t.Fatal("expected error when deprecated port is used with Secure=true")
+		}
+	})
+
+	t.Run("deprecated port with TLS configured returns error", func(t *testing.T) {
+		cfg := &Config{
+			deprecatedHTTPPort: "9090",
+			TLS:                TLSConfig{SelfSigned: true},
+		}
+		err := cfg.handleDeprecatedFlags()
+
+		if err == nil {
+			t.Fatal("expected error when deprecated port is used with TLS configuration")
+		}
+	})
+
+	t.Run("deprecated port without Secure or TLS sets Address", func(t *testing.T) {
+		cfg := &Config{
+			deprecatedHTTPPort: "9090",
+		}
+		err := cfg.handleDeprecatedFlags()
+
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
 		}
 		if cfg.Address != ":9090" {
 			t.Errorf("expected Address ':9090', got %q", cfg.Address)
@@ -301,8 +324,11 @@ func TestHandleDeprecatedFlags(t *testing.T) {
 			Address:            ":7777",
 			deprecatedHTTPPort: "9090",
 		}
-		cfg.handleDeprecatedFlags()
+		err := cfg.handleDeprecatedFlags()
 
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 		if cfg.Address != ":7777" {
 			t.Errorf("expected Address ':7777' to be preserved, got %q", cfg.Address)
 		}
@@ -313,8 +339,11 @@ func TestHandleDeprecatedFlags(t *testing.T) {
 			Secure:  true,
 			Address: ":8443",
 		}
-		cfg.handleDeprecatedFlags()
+		err := cfg.handleDeprecatedFlags()
 
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 		if !cfg.Secure {
 			t.Error("expected Secure to remain true")
 		}

--- a/maas-api/internal/config/config_test.go
+++ b/maas-api/internal/config/config_test.go
@@ -334,6 +334,16 @@ func TestHandleDeprecatedFlags(t *testing.T) {
 		}
 	})
 
+	t.Run("deprecated port rejects malformed values", func(t *testing.T) {
+		for _, bad := range []string{":8080", "foo", "0", "65536", "-1"} {
+			cfg := &Config{deprecatedHTTPPort: bad}
+			err := cfg.handleDeprecatedFlags()
+			if err == nil {
+				t.Errorf("expected error for port %q, got nil", bad)
+			}
+		}
+	})
+
 	t.Run("no deprecated port is a no-op", func(t *testing.T) {
 		cfg := &Config{
 			Secure:  true,


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-69242

## Description
`handleDeprecatedFlags()` in `maas-api/internal/config/config.go:237-246` unconditionally sets `c.Secure = false` whenever the deprecated PORT env var is set. This creates a dangerous scenario:

 Operator sets `SECURE=true` + `PORT=8443` (leftover) without TLS certs:
 1. `handleDeprecatedFlags()` silently clears `Secure` to `false`
 2. TLS is not configured, so `TLS.Enabled()` doesn't re-enable it
 3. The Secure && !TLS.Enabled() guard doesn't catch (Secure is already false)
 4. Server starts plaintext HTTP on :8443 — a port that conventionally implies HTTPS

The proposed **solution** is to have `handleDeprecatedFlags()` now returning an error if the deprecated `PORT/--port` flag is used alongside `SECURE=true` or any TLS configuration (TLS_CERT/TLS_KEY/TLS_SELF_SIGNED). This prevents the silent downgrade to plaintext that the CWE describes. Backward compatibility is preserved — PORT still works when neither `Secure` nor `TLS` is configured.

## How Has This Been Tested?
Unit tests updated and successfully ran.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented conflicting deprecated port and secure/TLS settings from silently downgrading connections to plaintext.
  * Configuration validation now reports errors for incompatible options instead of continuing with side effects.
  * Deprecated port settings now set the listen address only when none is already configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->