### PR TITLE
Management endpoints rate limit exclusion

### DIFF
--- a/deployment/base/maas-api/networking/httproute.yaml
+++ b/deployment/base/maas-api/networking/httproute.yaml
@@ -6,8 +6,13 @@ spec:
   parentRefs:
     - name: maas-default-gateway
       namespace: openshift-ingress
+  # WARNING: Rule order matters — the payload-processing EnvoyFilter
+  # (deployment/base/payload-processing/manager/envoy-filter.yaml) disables
+  # ext_proc per-route using Istio's "<namespace>.<httproute-name>.<rule-index>"
+  # naming convention. Adding, removing, or reordering rules here requires
+  # updating the EnvoyFilter route indices to match.
   rules:
-    # OpenAI-compatible /v1/models endpoint at top level
+    # Rule 0: OpenAI-compatible /v1/models endpoint at top level
     # NOTE: Using PathPrefix /v1/models (not /v1) to exclude /v1/tenants which is internal-only
     - matches:
         - path:
@@ -17,7 +22,7 @@ spec:
         - name: maas-api
           port: 8443
           weight: 100
-    # /v1/subscriptions endpoint at top level
+    # Rule 1: /v1/subscriptions endpoint at top level
     - matches:
         - path:
             type: PathPrefix
@@ -26,7 +31,7 @@ spec:
         - name: maas-api
           port: 8443
           weight: 100
-    # /v1/api-keys endpoint at top level
+    # Rule 2: /v1/api-keys endpoint at top level
     - matches:
         - path:
             type: PathPrefix
@@ -35,7 +40,7 @@ spec:
         - name: maas-api
           port: 8443
           weight: 100
-    # IMPORTANT: /v1/tenants is NOT routed through Gateway (internal-only)
+    # Rule 3: IMPORTANT: /v1/tenants is NOT routed through Gateway (internal-only)
     # It must be called via maas-api Service directly for tenant-scoped auth
     # All other maas-api endpoints remain under /maas-api prefix
     - matches:

--- a/deployment/base/maas-controller/policies/gateway-default-deny.yaml
+++ b/deployment/base/maas-controller/policies/gateway-default-deny.yaml
@@ -2,8 +2,9 @@
 # Scoped to model inference paths only — does NOT affect non-model routes
 # like /maas-api/ or /v1/models (the MaaS API management endpoints).
 #
-# The when predicate below excludes /maas-api and /v1/models so this deny
-# applies only to model inference paths (e.g. /llm/..., /production/...).
+# The when predicate below excludes /maas-api and all /v1/* management
+# endpoints so this deny applies only to model inference paths (e.g.
+# /llm/..., /production/...).
 #
 # The PRIMARY default deny is gateway-default-auth.yaml (AuthPolicy), which
 # returns 401/403 for unconfigured models. This TRLP is a defense-in-depth layer:
@@ -33,7 +34,7 @@ spec:
     limits:
       deny-all-by-default:
         when:
-          - predicate: '!request.path.startsWith("/maas-api") && !request.path.startsWith("/v1/models")'
+          - predicate: '!request.path.startsWith("/maas-api") && !request.path.startsWith("/v1/")'
         rates:
           - limit: 0
             window: 1m

--- a/deployment/base/maas-controller/policies/gateway-default-deny.yaml
+++ b/deployment/base/maas-controller/policies/gateway-default-deny.yaml
@@ -2,9 +2,10 @@
 # Scoped to model inference paths only — does NOT affect non-model routes
 # like /maas-api/ or /v1/models (the MaaS API management endpoints).
 #
-# The when predicate below excludes /maas-api and all /v1/* management
-# endpoints so this deny applies only to model inference paths (e.g.
-# /llm/..., /production/...).
+# The when predicate below excludes /maas-api and the specific /v1/*
+# management endpoints (/v1/models, /v1/subscriptions, /v1/api-keys) so
+# this deny applies to all other paths, including model inference paths
+# (e.g. /llm/..., /production/..., /v1/chat/completions via body-routing).
 #
 # The PRIMARY default deny is gateway-default-auth.yaml (AuthPolicy), which
 # returns 401/403 for unconfigured models. This TRLP is a defense-in-depth layer:
@@ -34,7 +35,7 @@ spec:
     limits:
       deny-all-by-default:
         when:
-          - predicate: '!request.path.startsWith("/maas-api") && !request.path.startsWith("/v1/")'
+          - predicate: '!request.path.startsWith("/maas-api") && !request.path.startsWith("/v1/models") && !request.path.startsWith("/v1/subscriptions") && !request.path.startsWith("/v1/api-keys")'
         rates:
           - limit: 0
             window: 1m

--- a/deployment/base/payload-processing/manager/envoy-filter.yaml
+++ b/deployment/base/payload-processing/manager/envoy-filter.yaml
@@ -64,8 +64,10 @@ spec:
             grpc_service:
               envoy_grpc:
                 cluster_name: outbound|9004||payload-processing.openshift-ingress.svc.cluster.local
-    # Disable ext_proc on non-inference routes (maas-api /v1/models).
+    # Disable ext_proc on all non-inference maas-api routes.
     # Route name follows Istio's Gateway API naming: <namespace>.<httproute-name>.<rule-index>
+    # Rule indices correspond to httproute.yaml rules:
+    #   0 = /v1/models, 1 = /v1/subscriptions, 2 = /v1/api-keys, 3 = /maas-api/*
     - applyTo: HTTP_ROUTE
       match:
         context: GATEWAY
@@ -83,7 +85,6 @@ spec:
             envoy.filters.http.ext_proc.ipp:
               "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExtProcPerRoute
               disabled: true
-    # Disable ext_proc on non-inference routes (maas-api /maas-api/*).
     - applyTo: HTTP_ROUTE
       match:
         context: GATEWAY
@@ -91,6 +92,40 @@ spec:
           vhost:
             route:
               name: "PLACEHOLDER.maas-api-route.1"
+      patch:
+        operation: MERGE
+        value:
+          typed_per_filter_config:
+            envoy.filters.http.ext_proc.ipp-pre:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExtProcPerRoute
+              disabled: true
+            envoy.filters.http.ext_proc.ipp:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExtProcPerRoute
+              disabled: true
+    - applyTo: HTTP_ROUTE
+      match:
+        context: GATEWAY
+        routeConfiguration:
+          vhost:
+            route:
+              name: "PLACEHOLDER.maas-api-route.2"
+      patch:
+        operation: MERGE
+        value:
+          typed_per_filter_config:
+            envoy.filters.http.ext_proc.ipp-pre:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExtProcPerRoute
+              disabled: true
+            envoy.filters.http.ext_proc.ipp:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExtProcPerRoute
+              disabled: true
+    - applyTo: HTTP_ROUTE
+      match:
+        context: GATEWAY
+        routeConfiguration:
+          vhost:
+            route:
+              name: "PLACEHOLDER.maas-api-route.3"
       patch:
         operation: MERGE
         value:

--- a/maas-controller/pkg/controller/maas/maasauthpolicy_controller_test.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_controller_test.go
@@ -1542,7 +1542,7 @@ func TestBuildGatewayAuthPolicySpec_XAPIKeyEnabled(t *testing.T) {
 // gateway AuthPolicy spec.
 func TestBuildGatewayAuthPolicySpec_OIDCJWKsTTL(t *testing.T) {
 	r := &MaaSAuthPolicyReconciler{
-		MaaSAPINamespace: "maas-system",
+		InfraNamespace:   "maas-system",
 		GatewayName:      "maas-default-gateway",
 		GatewayNamespace: "gateway-ns",
 		ClusterAudience:  "https://kubernetes.default.svc",
@@ -1667,7 +1667,7 @@ func TestFetchOIDCConfig_TTLExtraction(t *testing.T) {
 				WithObjects(tenant).
 				Build()
 
-			r := &MaaSAuthPolicyReconciler{Client: c, Scheme: scheme, MaaSAPINamespace: namespace}
+			r := &MaaSAuthPolicyReconciler{Client: c, Scheme: scheme, InfraNamespace: namespace}
 			log := ctrl.Log.WithName("test")
 			got := r.fetchOIDCConfig(context.Background(), log, namespace)
 

--- a/maas-controller/pkg/platform/tenantreconcile/params.go
+++ b/maas-controller/pkg/platform/tenantreconcile/params.go
@@ -402,8 +402,8 @@ func patchPayloadProcessingEnvoyFilter(log logr.Logger, r *unstructured.Unstruct
 	if err != nil {
 		return fmt.Errorf("read EnvoyFilter configPatches: %w", err)
 	}
-	if !found || len(configPatches) < 4 {
-		return fmt.Errorf("EnvoyFilter configPatches: expected at least 4 entries, got %d", len(configPatches))
+	if !found || len(configPatches) < 6 {
+		return fmt.Errorf("EnvoyFilter configPatches: expected at least 6 entries, got %d", len(configPatches))
 	}
 
 	clusterByIndex := []string{beforeCluster, afterCluster}
@@ -427,9 +427,10 @@ func patchPayloadProcessingEnvoyFilter(log logr.Logger, r *unstructured.Unstruct
 		configPatches[i] = patch
 	}
 
-	// Patches 2 and 3 disable ext_proc on non-inference routes.
+	// Patches 2–5 disable ext_proc on all non-inference maas-api routes.
 	// Route name uses Istio's Gateway API convention: <namespace>.<httproute-name>.<rule-index>.
-	for i := 2; i < 4; i++ {
+	// Rule indices: 0=/v1/models, 1=/v1/subscriptions, 2=/v1/api-keys, 3=/maas-api/*
+	for i := 2; i < 6; i++ {
 		patch, ok := configPatches[i].(map[string]any)
 		if !ok {
 			return fmt.Errorf("EnvoyFilter configPatches[%d] is not an object", i)

--- a/maas-controller/pkg/platform/tenantreconcile/params_test.go
+++ b/maas-controller/pkg/platform/tenantreconcile/params_test.go
@@ -174,11 +174,11 @@ func TestApplyPlatformParamsWithRenderedOverlay(t *testing.T) {
 	assert.Equal(t, params.GatewayName, firstTargetRef["name"])
 
 	// Verify dual-stage filter chain: configPatches[0]=INSERT_BEFORE, configPatches[1]=INSERT_AFTER,
-	// plus per-route disable patches: configPatches[2] and [3]=MERGE on maas-api-route rules.
+	// plus per-route disable patches: configPatches[2..5]=MERGE on maas-api-route rules 0–3.
 	configPatches, found, err := unstructured.NestedSlice(payloadEnvoyFilter.Object, "spec", "configPatches")
 	require.NoError(t, err)
 	require.True(t, found)
-	require.Len(t, configPatches, 4, "expected four configPatches (INSERT_BEFORE + INSERT_AFTER + 2x MERGE)")
+	require.Len(t, configPatches, 6, "expected six configPatches (INSERT_BEFORE + INSERT_AFTER + 4x MERGE)")
 
 	wantAnchor := wasmpluginAnchorName(params.GatewayNamespace, params.GatewayName)
 	wantBeforeCluster := grpcClusterName(PayloadPreProcessingName, params.GatewayNamespace, 9004)
@@ -200,8 +200,8 @@ func TestApplyPlatformParamsWithRenderedOverlay(t *testing.T) {
 		assert.Equal(t, wantClusters[i], cluster, "configPatches[%d] grpc cluster_name", i)
 	}
 
-	// Verify per-route ext_proc disable on maas-api-route rules 0 and 1.
-	for i := 2; i < 4; i++ {
+	// Verify per-route ext_proc disable on maas-api-route rules 0–3.
+	for i := 2; i < 6; i++ {
 		cp, ok := configPatches[i].(map[string]any)
 		require.True(t, ok, "configPatches[%d] should be a map", i)
 

--- a/maas-controller/pkg/platform/tenantreconcile/params_test.go
+++ b/maas-controller/pkg/platform/tenantreconcile/params_test.go
@@ -216,6 +216,11 @@ func TestApplyPlatformParamsWithRenderedOverlay(t *testing.T) {
 		require.NoError(t, err, "configPatches[%d] ipp-pre disabled field", i)
 		require.True(t, found, "configPatches[%d] ipp-pre disabled field should exist", i)
 		assert.True(t, disabled, "configPatches[%d] ipp-pre should be disabled", i)
+
+		ippDisabled, found, err := unstructured.NestedBool(cp, "patch", "value", "typed_per_filter_config", "envoy.filters.http.ext_proc.ipp", "disabled")
+		require.NoError(t, err, "configPatches[%d] ipp disabled field", i)
+		require.True(t, found, "configPatches[%d] ipp disabled field should exist", i)
+		assert.True(t, ippDisabled, "configPatches[%d] ipp should be disabled", i)
 	}
 
 	// Verify payload-pre-processing Deployment and Service are present and namespaced correctly.


### PR DESCRIPTION
## Summary

- Fix `/v1/models` returning empty list on clusters with BBR (Body-Based Routing) enabled by swapping endpoint preference in `getEndpointFromLLMISvc` to prefer `gateway-external` (path-based) over `gateway-external-model-routing` (body-based)
- When both address types exist in LLMInferenceService status, the model-routing base URL (e.g. `https://host/`) was selected for `status.endpoint`, causing the maas-api discovery probe (`GET {endpoint}/v1/models`) to match the `maas-api-route` HTTPRoute (`PathPrefix /v1/models`) and route back to maas-api itself instead of the model backend — resulting in all LLMInferenceService models being excluded from the `/v1/models` response
- Falls back to model-routing if no path-based address exists (BBR-only deployments)

## Root cause

`getEndpointFromLLMISvc` iterated `[gateway-external-model-routing, gateway-external]`, preferring model-routing (base URL) when both were present. The base URL `https://host/` + `/v1/models` resolved to `https://host/v1/models`, which matched the maas-api management route on the same gateway rather than reaching the model backend. Path-based URLs (`https://host/llm/{model}`) probe correctly as `https://host/llm/{model}/v1/models`, which routes to the model's HTTPRoute.

## Impact

- **Only affects LLMInferenceService models** on clusters where BBR is enabled (both `gateway-external` and `gateway-external-model-routing` addresses present in LLMIS status)
- ExternalModel and InferenceService kinds have their own handlers and are unaffected
- Inference (both path-based and BBR) is unaffected — BBR routing happens at the gateway level via ext_proc, independent of `status.endpoint`
- The `url` field in `/v1/models` response changes from the base URL to the path-based URL, which is the correct and more useful value for consumers

## Why this wasn't caught earlier

**E2E/CI**: Prow smoke tests deploy without BBR enabled, so LLMInferenceService status only ever contains `gateway-external` addresses. The bug's trigger condition (both address types present) never occurs in CI.

**Manual testing**: When the BBR feature was originally developed, the requirement was to prioritize model-routing over path-based, and manual testing focused on verifying that BBR inference worked correctly. The `/v1/models` discovery probe interaction with the model-routing base URL was missed. The routing conflict is subtle — `base_url/v1/models` resolves to `https://host/v1/models`, which silently matches the `maas-api-route` HTTPRoute (`PathPrefix /v1/models`) on the same gateway and routes back to maas-api rather than the model backend. This interaction between the discovery probe path and the shared gateway's route precedence was missed during BBR validation.

## Test plan

- [x] Unit tests updated: preference, hostname filtering, fallback, and legacy mode
- [x] Validated on cluster with BBR-enabled LLMInferenceService (simulator models):
  - `status.endpoint` contains path-based URL (`/llm/{model}`)
  - `GET /v1/models` returns models with correct metadata and subscriptions
  - Path-based inference returns 200
  - Auth enforcement works (premium model returns 403 for unsubscribed users)

## Risk analysis

- **Risk rating**: 3
- **Why**: Code change is minimal (swap two constants in an iteration order), scoped to LLMInferenceService endpoint selection only. Unit tests cover all permutations. However, the affected path (`/v1/models` discovery) is not exercised by the Prow smoke test with BBR enabled, so the exact production scenario relies on manual/cluster validation.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated gateway protection rules to allow MaaS management endpoints while continuing to apply default deny behavior elsewhere.
  - Improved request processing across additional gateway routes, ensuring payload processing is disabled where appropriate.
  - Clarified route ordering requirements to help maintain consistent request handling.
  - Expanded validation and coverage for route-specific processing configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->