### PR TITLE
fix: prefer path-based endpoint over model-routing for LLMInferenceService discovery

### DIFF
--- a/maas-controller/pkg/controller/maas/providers_llmisvc.go
+++ b/maas-controller/pkg/controller/maas/providers_llmisvc.go
@@ -199,7 +199,9 @@ const (
 )
 
 // getEndpointFromLLMISvc returns the endpoint URL from LLMInferenceService status as-reported.
-// Prefers model-routing addresses (body-based /v1/chat/completions) over path-based addresses.
+// Prefers path-based addresses (gateway-external) over model-routing (body-based) addresses.
+// status.endpoint is used by the maas-api discovery probe (GET /v1/models); model-routing
+// base URLs lack a model path, so the probe cannot route to the correct backend.
 // When expectedHostnames is non-empty, only addresses whose hostname matches
 // (case-insensitive per RFC 4343) are considered; this prevents selecting the wrong gateway
 // when multiple gateways exist.
@@ -213,8 +215,8 @@ func (h *llmisvcHandler) getEndpointFromLLMISvc(llmisvc *kservev1alpha1.LLMInfer
 	}
 	filtering := len(hostSet) > 0
 
-	// Prefer model-routing addresses (body-based routing), fall back to path-based.
-	for _, targetName := range []string{addressNameGatewayExternalModelRouting, addressNameGatewayExternal} {
+	// Prefer path-based addresses for discovery; fall back to model-routing.
+	for _, targetName := range []string{addressNameGatewayExternal, addressNameGatewayExternalModelRouting} {
 		if u := h.selectAddress(llmisvc, targetName, hostSet, filtering); u != "" {
 			return u
 		}

--- a/maas-controller/pkg/controller/maas/providers_llmisvc_test.go
+++ b/maas-controller/pkg/controller/maas/providers_llmisvc_test.go
@@ -182,7 +182,7 @@ func TestGetEndpointFromLLMISvc_EmptyHostnameSkipped(t *testing.T) {
 	}
 }
 
-func TestGetEndpointFromLLMISvc_PrefersModelRoutingOverPathBased(t *testing.T) {
+func TestGetEndpointFromLLMISvc_PrefersPathBasedOverModelRouting(t *testing.T) {
 	llmisvc := newReadyLLMISvc("test-model", "default", []duckv1.Addressable{
 		{Name: strPtr("gateway-external"), URL: mustParseURL("https://maas.example.com/test-model")},
 		{Name: strPtr("gateway-external-model-routing"), URL: mustParseURL("https://maas.example.com/v1/chat/completions")},
@@ -190,13 +190,13 @@ func TestGetEndpointFromLLMISvc_PrefersModelRoutingOverPathBased(t *testing.T) {
 	h := &llmisvcHandler{}
 
 	got := h.getEndpointFromLLMISvc(llmisvc, []string{"maas.example.com"})
-	want := "https://maas.example.com/v1/chat/completions"
+	want := "https://maas.example.com/test-model"
 	if got != want {
-		t.Errorf("getEndpointFromLLMISvc() = %q, want %q (model-routing should be preferred)", got, want)
+		t.Errorf("getEndpointFromLLMISvc() = %q, want %q (path-based should be preferred for discovery)", got, want)
 	}
 }
 
-func TestGetEndpointFromLLMISvc_ModelRouting_HostnameFiltering(t *testing.T) {
+func TestGetEndpointFromLLMISvc_PathBased_HostnameFiltering(t *testing.T) {
 	llmisvc := newReadyLLMISvc("test-model", "default", []duckv1.Addressable{
 		{Name: strPtr("gateway-external-model-routing"), URL: mustParseURL("https://wrong-gw.example.com/v1/chat/completions")},
 		{Name: strPtr("gateway-external-model-routing"), URL: mustParseURL("https://correct-gw.example.com/v1/chat/completions")},
@@ -206,22 +206,22 @@ func TestGetEndpointFromLLMISvc_ModelRouting_HostnameFiltering(t *testing.T) {
 	h := &llmisvcHandler{}
 
 	got := h.getEndpointFromLLMISvc(llmisvc, []string{"correct-gw.example.com"})
-	want := "https://correct-gw.example.com/v1/chat/completions"
+	want := "https://correct-gw.example.com/test-model"
 	if got != want {
-		t.Errorf("getEndpointFromLLMISvc() = %q, want %q (should filter model-routing by hostname)", got, want)
+		t.Errorf("getEndpointFromLLMISvc() = %q, want %q (should select path-based filtered by hostname)", got, want)
 	}
 }
 
-func TestGetEndpointFromLLMISvc_FallsBackToPathBased_WhenNoModelRouting(t *testing.T) {
+func TestGetEndpointFromLLMISvc_FallsBackToModelRouting_WhenNoPathBased(t *testing.T) {
 	llmisvc := newReadyLLMISvc("test-model", "default", []duckv1.Addressable{
-		{Name: strPtr("gateway-external"), URL: mustParseURL("https://maas.example.com/test-model")},
+		{Name: strPtr("gateway-external-model-routing"), URL: mustParseURL("https://maas.example.com/v1/chat/completions")},
 	})
 	h := &llmisvcHandler{}
 
 	got := h.getEndpointFromLLMISvc(llmisvc, []string{"maas.example.com"})
-	want := "https://maas.example.com/test-model"
+	want := "https://maas.example.com/v1/chat/completions"
 	if got != want {
-		t.Errorf("getEndpointFromLLMISvc() = %q, want %q (should fall back to path-based)", got, want)
+		t.Errorf("getEndpointFromLLMISvc() = %q, want %q (should fall back to model-routing)", got, want)
 	}
 }
 
@@ -239,7 +239,7 @@ func TestGetEndpointFromLLMISvc_ModelRouting_PrefersHTTPS(t *testing.T) {
 	}
 }
 
-func TestGetEndpointFromLLMISvc_ModelRouting_NoHostnames_Legacy(t *testing.T) {
+func TestGetEndpointFromLLMISvc_PathBased_NoHostnames_Legacy(t *testing.T) {
 	llmisvc := newReadyLLMISvc("test-model", "default", []duckv1.Addressable{
 		{Name: strPtr("gateway-external"), URL: mustParseURL("https://maas.example.com/test-model")},
 		{Name: strPtr("gateway-external-model-routing"), URL: mustParseURL("https://maas.example.com/v1/chat/completions")},
@@ -247,9 +247,9 @@ func TestGetEndpointFromLLMISvc_ModelRouting_NoHostnames_Legacy(t *testing.T) {
 	h := &llmisvcHandler{}
 
 	got := h.getEndpointFromLLMISvc(llmisvc, nil)
-	want := "https://maas.example.com/v1/chat/completions"
+	want := "https://maas.example.com/test-model"
 	if got != want {
-		t.Errorf("getEndpointFromLLMISvc() = %q, want %q (model-routing preferred even in legacy mode)", got, want)
+		t.Errorf("getEndpointFromLLMISvc() = %q, want %q (path-based preferred even in legacy mode)", got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Fix `/v1/models` returning empty list on clusters with BBR (Body-Based Routing) enabled by swapping endpoint preference in `getEndpointFromLLMISvc` to prefer `gateway-external` (path-based) over `gateway-external-model-routing` (body-based)
- When both address types exist in LLMInferenceService status, the model-routing base URL (e.g. `https://host/`) was selected for `status.endpoint`, causing the maas-api discovery probe (`GET {endpoint}/v1/models`) to match the `maas-api-route` HTTPRoute (`PathPrefix /v1/models`) and route back to maas-api itself instead of the model backend — resulting in all LLMInferenceService models being excluded from the `/v1/models` response
- Falls back to model-routing if no path-based address exists (BBR-only deployments)

## Root cause

`getEndpointFromLLMISvc` iterated `[gateway-external-model-routing, gateway-external]`, preferring model-routing (base URL) when both were present. The base URL `https://host/` + `/v1/models` resolved to `https://host/v1/models`, which matched the maas-api management route on the same gateway rather than reaching the model backend. Path-based URLs (`https://host/llm/{model}`) probe correctly as `https://host/llm/{model}/v1/models`, which routes to the model's HTTPRoute.

## Impact

- **Only affects LLMInferenceService models** on clusters where BBR is enabled (both `gateway-external` and `gateway-external-model-routing` addresses present in LLMIS status)
- ExternalModel and InferenceService kinds have their own handlers and are unaffected
- Inference (both path-based and BBR) is unaffected — BBR routing happens at the gateway level via ext_proc, independent of `status.endpoint`
- The `url` field in `/v1/models` response changes from the base URL to the path-based URL, which is the correct and more useful value for consumers


## Test plan

- [x] Unit tests updated: preference, hostname filtering, fallback, and legacy mode
- [x] Validated on cluster with BBR-enabled LLMInferenceService (simulator models):
  - `status.endpoint` contains path-based URL (`/llm/{model}`)
  - `GET /v1/models` returns models with correct metadata and subscriptions
  - Path-based inference returns 200
  - Auth enforcement works (premium model returns 403 for unsubscribed users)

## Risk analysis

- **Risk rating**: 3
- **Why**: Code change is minimal (swap two constants in an iteration order), scoped to LLMInferenceService endpoint selection only. Unit tests cover all permutations. However, the affected path (`/v1/models` discovery) is not exercised by the Prow smoke test with BBR enabled, so the exact production scenario relies on manual/cluster validation.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved LLM inference service endpoint discovery by preferring path-based gateway addresses.
  * Preserved model-routing addresses as a fallback when path-based addresses are unavailable.
  * Updated hostname filtering and legacy discovery behavior for more reliable endpoint selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->