### PR TITLE
docs: fix remaining modelsAsService refs and add 3.5 upgrade guide

### DIFF
--- a/docs/content/configuration-and-management/troubleshooting-external-model-rbac.md
+++ b/docs/content/configuration-and-management/troubleshooting-external-model-rbac.md
@@ -30,7 +30,7 @@ The ClusterRoleBinding `maas-controller-rolebinding` must bind this role to the 
 
 ### Fix: Add the Missing Rule
 
-If the ODH operator manages these resources (via the `modelsAsService` DSC component), upgrade or reconcile the component. Otherwise, patch the ClusterRole directly:
+If the ODH operator manages these resources (via the `aigateway.modelsAsAService` DSC component), upgrade or reconcile the component. Otherwise, patch the ClusterRole directly:
 
 ```bash
 oc patch clusterrole maas-controller-role --type=json -p='[

--- a/docs/content/install/maas-setup.md
+++ b/docs/content/install/maas-setup.md
@@ -5,7 +5,7 @@ Complete [Operator Setup](platform-setup.md) before proceeding.
 **Installation flow:**
 
 1. [Database Setup](#database-setup) — Create the PostgreSQL connection Secret
-2. [Create Gateway](#create-gateway) — Deploy maas-default-gateway (required before modelsAsService)
+2. [Create Gateway](#create-gateway) — Deploy maas-default-gateway (required before modelsAsAService)
 3. [Configure DataScienceCluster](#configure-datasciencecluster) — Enable modelsAsAService in your DataScienceCluster
 4. [Model Setup](model-setup.md) — Deploy sample models
 5. [Validation](validation.md) — Verify the deployment
@@ -54,17 +54,17 @@ postgresql://USERNAME:PASSWORD@HOSTNAME:PORT/DATABASE?sslmode=require
     ```
 
 !!! note "Restarting maas-api"
-    If you add or update the Secret after the DataScienceCluster already has modelsAsService in managed state, restart the maas-api deployment to pick up the config:
+    If you add or update the Secret after the DataScienceCluster already has modelsAsAService in managed state, restart the maas-api deployment to pick up the config:
 
     ```bash
     kubectl rollout restart deployment/maas-api -n opendatahub
     ```
 
-    This is not required when the Secret exists before enabling modelsAsService in your DataScienceCluster.
+    This is not required when the Secret exists before enabling modelsAsAService in your DataScienceCluster.
 
 ## Create Gateway
 
-Create `maas-default-gateway` in `openshift-ingress` **before** enabling `modelsAsService` in your DataScienceCluster.
+Create `maas-default-gateway` in `openshift-ingress` **before** enabling `aigateway.modelsAsAService` in your DataScienceCluster.
 
 `scripts/deploy.sh` runs this step automatically in **route** mode. Run the script yourself when installing via DataScienceCluster first, using **clusterip** mode, or on disconnected clusters.
 

--- a/docs/content/migration/upgrade-to-3.5.md
+++ b/docs/content/migration/upgrade-to-3.5.md
@@ -1,0 +1,41 @@
+# Upgrade to 3.5
+
+## What Changed
+
+MaaS moved from `kserve.modelsAsService` to `aigateway.modelsAsAService`. KServe is no longer a prerequisite for MaaS.
+
+## Backward Compatibility
+
+**No action required on upgrade.** If your DSC has `kserve.modelsAsService: Managed`, the operator continues to deploy MaaS automatically through 3.6.
+
+The old field is read-only once set (`self == oldSelf`) and will be removed in 3.7.
+
+## Migrating to the New Field
+
+When you are ready, update your DSC:
+
+```yaml
+spec:
+  components:
+    aigateway:
+      managementState: Managed
+      modelsAsAService:
+        managementState: Managed
+```
+
+GitOps users: update your manifest and sync. The old `kserve.modelsAsService` field cannot be cleared until 3.7 — leave it as-is.
+
+## Verify
+
+```bash
+oc get aigateway default-aigateway
+oc get deployment -n opendatahub ai-gateway-operator
+oc get datasciencecluster default-dsc -o jsonpath='{.spec.components.aigateway.modelsAsAService}'
+```
+
+## DSC Field Reference
+
+| 3.4 | 3.5+ |
+|-----|------|
+| `kserve.managementState: Managed` | Not required for MaaS |
+| `kserve.modelsAsService.managementState: Managed` | `aigateway.modelsAsAService.managementState: Managed` |

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -57,6 +57,7 @@ nav:
     - Migration:
       - Tier to Subscription: migration/tier-to-subscription.md
       - Upgrade to 3.4: migration/upgrade-to-3.4.md
+      - Upgrade to 3.5: migration/upgrade-to-3.5.md
   - Concepts:
     - Architecture: concepts/architecture.md
     - Personas: concepts/personas.md


### PR DESCRIPTION
## Summary

Related to - https://redhat.atlassian.net/browse/RHOAIENG-66774

Follow-up to #1118 (MaaS modularization docs). Four text references to `modelsAsService` were missed in #1118 (YAML blocks were already correct). Also adds a 3.4→3.5 upgrade guide that was missing from the migration section.

### Changes

**`docs/content/install/maas-setup.md`** — 4 missed text references:
- Step 2 in installation flow: `modelsAsService` → `modelsAsAService`
- "Restarting maas-api" note (×2): `modelsAsService` → `modelsAsAService`
- Create Gateway section: `'modelsAsService'` → `'aigateway.modelsAsAService'` (qualified with parent for clarity)

**`docs/content/configuration-and-management/troubleshooting-external-model-rbac.md`**
- `modelsAsService` DSC component → `aigateway.modelsAsAService`

**`docs/content/migration/upgrade-to-3.5.md`** *(new)*
- Brief 3.4→3.5 upgrade guide: what changed, backward compat note, migration steps, verification, DSC field reference table

**`docs/mkdocs.yml`**
- Added "Upgrade to 3.5" nav entry under Migration

## Screenshots

**maas-setup.md — Installation flow and Create Gateway (fixed references):**

<img width="1512" height="905" alt="image" src="https://github.com/user-attachments/assets/8b732a66-6447-418a-baf6-166d6455b949" />


`modelsAsAService` correctly used in step 2 and Gateway section — `aigateway.modelsAsAService` used where the full path clarifies the parent.

**upgrade-to-3.5.md — New migration guide:**

<img width="1512" height="904" alt="image" src="https://github.com/user-attachments/assets/b34acdcc-9d69-471a-af1d-1c648c221544" />

Sections: What Changed · Backward Compatibility · Migrating to the New Field · Verify · DSC Field Reference table

## Risk Analysis

**Risk rating: 0**

Documentation-only. No runtime code, no manifests. Content matches the API field names confirmed in PR #3723 and PR #1118.

## Test plan

- [x] `mkdocs serve` — all pages build and render without errors
- [x] No broken links introduced
- [x] Field names match actual CRD schema (`aigateway.modelsAsAService`)