### PR TITLE
fix: rhoaieng 76228 payload processing rhcl

### DIFF
--- a/deployment/base/payload-processing/manager/envoy-filter.yaml
+++ b/deployment/base/payload-processing/manager/envoy-filter.yaml
@@ -64,8 +64,8 @@ spec:
             grpc_service:
               envoy_grpc:
                 cluster_name: outbound|9004||payload-processing.openshift-ingress.svc.cluster.local
-    # RHCL injects auth via envoy.filters.http.wasm (no WasmPlugin CR). Only one anchor
-    # pair matches per cluster: WasmPlugin on ODH/community Kuadrant, wasm filter on RHCL.
+    # RHCL 1.4 injects auth via envoy.filters.http.wasm (no WasmPlugin CR). Only one anchor
+    # pair matches per cluster: WasmPlugin on ODH/community Kuadrant, wasm filter on RHCL 1.4.
     - applyTo: HTTP_FILTER
       match:
         context: GATEWAY

--- a/deployment/base/payload-processing/manager/envoy-filter.yaml
+++ b/deployment/base/payload-processing/manager/envoy-filter.yaml
@@ -64,6 +64,61 @@ spec:
             grpc_service:
               envoy_grpc:
                 cluster_name: outbound|9004||payload-processing.openshift-ingress.svc.cluster.local
+    # RHCL injects auth via envoy.filters.http.wasm (no WasmPlugin CR). Only one anchor
+    # pair matches per cluster: WasmPlugin on ODH/community Kuadrant, wasm filter on RHCL.
+    - applyTo: HTTP_FILTER
+      match:
+        context: GATEWAY
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.filters.network.http_connection_manager"
+              subFilter:
+                name: envoy.filters.http.wasm
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: envoy.filters.http.ext_proc.ipp-pre
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
+            failure_mode_allow: true
+            allow_mode_override: true
+            processing_mode:
+              request_header_mode: "SEND"
+              response_header_mode: "SKIP"
+              request_body_mode: "FULL_DUPLEX_STREAMED"
+              response_body_mode: "NONE"
+              request_trailer_mode: "SEND"
+            grpc_service:
+              envoy_grpc:
+                cluster_name: outbound|9004||payload-pre-processing.openshift-ingress.svc.cluster.local
+    - applyTo: HTTP_FILTER
+      match:
+        context: GATEWAY
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.filters.network.http_connection_manager"
+              subFilter:
+                name: envoy.filters.http.wasm
+      patch:
+        operation: INSERT_AFTER
+        value:
+          name: envoy.filters.http.ext_proc.ipp
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
+            failure_mode_allow: false
+            allow_mode_override: true
+            processing_mode:
+              request_header_mode: "SEND"
+              response_header_mode: "SEND"
+              request_body_mode: "FULL_DUPLEX_STREAMED"
+              response_body_mode: "FULL_DUPLEX_STREAMED"
+              request_trailer_mode: "SEND"
+              response_trailer_mode: "SEND"
+            grpc_service:
+              envoy_grpc:
+                cluster_name: outbound|9004||payload-processing.openshift-ingress.svc.cluster.local
     # Disable ext_proc on all non-inference maas-api routes.
     # Route name follows Istio's Gateway API naming: <namespace>.<httproute-name>.<rule-index>
     # Rule indices correspond to httproute.yaml rules:

--- a/maas-controller/pkg/platform/tenantreconcile/params.go
+++ b/maas-controller/pkg/platform/tenantreconcile/params.go
@@ -405,7 +405,7 @@ func patchPayloadProcessingEnvoyFilter(log logr.Logger, r *unstructured.Unstruct
 		return fmt.Errorf("read EnvoyFilter configPatches: %w", err)
 	}
 	const (
-		filterPatchCount      = 4 // WasmPlugin pair + RHCL wasm pair
+		filterPatchCount      = 4 // WasmPlugin pair + RHCL 1.4 wasm pair
 		routeDisablePatchBase = filterPatchCount
 		totalConfigPatches    = routeDisablePatchBase + 4
 	)

--- a/maas-controller/pkg/platform/tenantreconcile/params.go
+++ b/maas-controller/pkg/platform/tenantreconcile/params.go
@@ -366,6 +366,8 @@ func patchPayloadDestinationRule(log logr.Logger, r *unstructured.Unstructured, 
 	return nil
 }
 
+const rhclWasmFilterName = "envoy.filters.http.wasm"
+
 func wasmpluginAnchorName(gatewayNamespace, gatewayName string) string {
 	return fmt.Sprintf("extensions.istio.io/wasmplugin/%s.kuadrant-%s", gatewayNamespace, gatewayName)
 }
@@ -402,41 +404,47 @@ func patchPayloadProcessingEnvoyFilter(log logr.Logger, r *unstructured.Unstruct
 	if err != nil {
 		return fmt.Errorf("read EnvoyFilter configPatches: %w", err)
 	}
-	if !found || len(configPatches) < 6 {
-		return fmt.Errorf("EnvoyFilter configPatches: expected at least 6 entries, got %d", len(configPatches))
+	const (
+		filterPatchCount      = 4 // WasmPlugin pair + RHCL wasm pair
+		routeDisablePatchBase = filterPatchCount
+		totalConfigPatches    = routeDisablePatchBase + 4
+	)
+	if !found || len(configPatches) < totalConfigPatches {
+		return fmt.Errorf("EnvoyFilter configPatches: expected at least %d entries, got %d", totalConfigPatches, len(configPatches))
 	}
 
-	clusterByIndex := []string{beforeCluster, afterCluster}
+	clusterByIndex := []string{beforeCluster, afterCluster, beforeCluster, afterCluster}
+	subFilterByIndex := []string{anchorName, anchorName, rhclWasmFilterName, rhclWasmFilterName}
 
-	for i, clusterName := range clusterByIndex {
+	for i := 0; i < filterPatchCount; i++ {
 		patch, ok := configPatches[i].(map[string]any)
 		if !ok {
 			return fmt.Errorf("EnvoyFilter configPatches[%d] is not an object", i)
 		}
 
 		subFilterPath := []string{"match", "listener", "filterChain", "filter", "subFilter", "name"}
-		if err := unstructured.SetNestedField(patch, anchorName, subFilterPath...); err != nil {
+		if err := unstructured.SetNestedField(patch, subFilterByIndex[i], subFilterPath...); err != nil {
 			return fmt.Errorf("write configPatches[%d] subFilter.name: %w", i, err)
 		}
 
 		clusterPath := []string{"patch", "value", "typed_config", "grpc_service", "envoy_grpc", "cluster_name"}
-		if err := unstructured.SetNestedField(patch, clusterName, clusterPath...); err != nil {
+		if err := unstructured.SetNestedField(patch, clusterByIndex[i], clusterPath...); err != nil {
 			return fmt.Errorf("write configPatches[%d] grpc cluster_name: %w", i, err)
 		}
 
 		configPatches[i] = patch
 	}
 
-	// Patches 2–5 disable ext_proc on all non-inference maas-api routes.
+	// Patches 4–7 disable ext_proc on all non-inference maas-api routes.
 	// Route name uses Istio's Gateway API convention: <namespace>.<httproute-name>.<rule-index>.
 	// Rule indices: 0=/v1/models, 1=/v1/subscriptions, 2=/v1/api-keys, 3=/maas-api/*
-	for i := 2; i < 6; i++ {
+	for i := routeDisablePatchBase; i < totalConfigPatches; i++ {
 		patch, ok := configPatches[i].(map[string]any)
 		if !ok {
 			return fmt.Errorf("EnvoyFilter configPatches[%d] is not an object", i)
 		}
 		if err := unstructured.SetNestedField(patch,
-			fmt.Sprintf("%s.%s.%d", params.AppNamespace, MaaSAPIRouteName(params.TenantIdentifier), i-2),
+			fmt.Sprintf("%s.%s.%d", params.AppNamespace, MaaSAPIRouteName(params.TenantIdentifier), i-routeDisablePatchBase),
 			"match", "routeConfiguration", "vhost", "route", "name"); err != nil {
 			return fmt.Errorf("write configPatches[%d] route name: %w", i, err)
 		}

--- a/maas-controller/pkg/platform/tenantreconcile/params_test.go
+++ b/maas-controller/pkg/platform/tenantreconcile/params_test.go
@@ -174,7 +174,7 @@ func TestApplyPlatformParamsWithRenderedOverlay(t *testing.T) {
 	assert.Equal(t, params.GatewayName, firstTargetRef["name"])
 
 	// Verify dual-stage filter chain with dual anchors:
-	//   [0..1] WasmPlugin (ODH/community Kuadrant), [2..3] wasm filter (RHCL),
+	//   [0..1] WasmPlugin (ODH/community Kuadrant), [2..3] wasm filter (RHCL 1.4),
 	//   [4..7] per-route disable MERGE on maas-api-route rules 0–3.
 	configPatches, found, err := unstructured.NestedSlice(payloadEnvoyFilter.Object, "spec", "configPatches")
 	require.NoError(t, err)

--- a/maas-controller/pkg/platform/tenantreconcile/params_test.go
+++ b/maas-controller/pkg/platform/tenantreconcile/params_test.go
@@ -173,20 +173,22 @@ func TestApplyPlatformParamsWithRenderedOverlay(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, params.GatewayName, firstTargetRef["name"])
 
-	// Verify dual-stage filter chain: configPatches[0]=INSERT_BEFORE, configPatches[1]=INSERT_AFTER,
-	// plus per-route disable patches: configPatches[2..5]=MERGE on maas-api-route rules 0–3.
+	// Verify dual-stage filter chain with dual anchors:
+	//   [0..1] WasmPlugin (ODH/community Kuadrant), [2..3] wasm filter (RHCL),
+	//   [4..7] per-route disable MERGE on maas-api-route rules 0–3.
 	configPatches, found, err := unstructured.NestedSlice(payloadEnvoyFilter.Object, "spec", "configPatches")
 	require.NoError(t, err)
 	require.True(t, found)
-	require.Len(t, configPatches, 6, "expected six configPatches (INSERT_BEFORE + INSERT_AFTER + 4x MERGE)")
+	require.Len(t, configPatches, 8, "expected eight configPatches (4x filter insert + 4x MERGE)")
 
-	wantAnchor := wasmpluginAnchorName(params.GatewayNamespace, params.GatewayName)
+	wantWasmPluginAnchor := wasmpluginAnchorName(params.GatewayNamespace, params.GatewayName)
 	wantBeforeCluster := grpcClusterName(PayloadPreProcessingName, params.GatewayNamespace, 9004)
 	wantAfterCluster := grpcClusterName(PayloadProcessingName, params.GatewayNamespace, 9004)
-	wantOps := []string{"INSERT_BEFORE", "INSERT_AFTER"}
-	wantClusters := []string{wantBeforeCluster, wantAfterCluster}
+	wantOps := []string{"INSERT_BEFORE", "INSERT_AFTER", "INSERT_BEFORE", "INSERT_AFTER"}
+	wantAnchors := []string{wantWasmPluginAnchor, wantWasmPluginAnchor, rhclWasmFilterName, rhclWasmFilterName}
+	wantClusters := []string{wantBeforeCluster, wantAfterCluster, wantBeforeCluster, wantAfterCluster}
 
-	for i, raw := range configPatches[:2] {
+	for i, raw := range configPatches[:4] {
 		cp, ok := raw.(map[string]any)
 		require.True(t, ok, "configPatches[%d] should be a map", i)
 
@@ -194,14 +196,14 @@ func TestApplyPlatformParamsWithRenderedOverlay(t *testing.T) {
 		assert.Equal(t, wantOps[i], op, "configPatches[%d] operation", i)
 
 		anchor, _, _ := unstructured.NestedString(cp, "match", "listener", "filterChain", "filter", "subFilter", "name")
-		assert.Equal(t, wantAnchor, anchor, "configPatches[%d] subFilter.name", i)
+		assert.Equal(t, wantAnchors[i], anchor, "configPatches[%d] subFilter.name", i)
 
 		cluster, _, _ := unstructured.NestedString(cp, "patch", "value", "typed_config", "grpc_service", "envoy_grpc", "cluster_name")
 		assert.Equal(t, wantClusters[i], cluster, "configPatches[%d] grpc cluster_name", i)
 	}
 
 	// Verify per-route ext_proc disable on maas-api-route rules 0–3.
-	for i := 2; i < 6; i++ {
+	for i := 4; i < 8; i++ {
 		cp, ok := configPatches[i].(map[string]any)
 		require.True(t, ok, "configPatches[%d] should be a map", i)
 
@@ -209,7 +211,7 @@ func TestApplyPlatformParamsWithRenderedOverlay(t *testing.T) {
 		assert.Equal(t, "MERGE", op, "configPatches[%d] operation", i)
 
 		routeName, _, _ := unstructured.NestedString(cp, "match", "routeConfiguration", "vhost", "route", "name")
-		wantRouteName := fmt.Sprintf("%s.%s.%d", params.AppNamespace, MaaSAPIRouteName(params.TenantIdentifier), i-2)
+		wantRouteName := fmt.Sprintf("%s.%s.%d", params.AppNamespace, MaaSAPIRouteName(params.TenantIdentifier), i-4)
 		assert.Equal(t, wantRouteName, routeName, "configPatches[%d] route name", i)
 
 		disabled, found, err := unstructured.NestedBool(cp, "patch", "value", "typed_per_filter_config", "envoy.filters.http.ext_proc.ipp-pre", "disabled")


### PR DESCRIPTION
## Summary

Fixes [RHOAIENG-76228](https://redhat.atlassian.net/browse/RHOAIENG-76228): body-based inference was broken on **RHCL 1.4** because the payload-processing `EnvoyFilter` only anchored ext_proc filters on the Kuadrant `WasmPlugin` sub-filter.

On RHCL 1.4, auth is injected via `envoy.filters.http.wasm` (no `WasmPlugin` CR), so the existing patches never matched and `payload-pre-processing` / `payload-processing` were never wired into the gateway filter chain.

This PR adds a second anchor pair for RHCL 1.4 and updates tenant reconcile patching so both deployment paths work:

| Platform | Auth anchor |
|----------|-------------|
| ODH / community Kuadrant | `extensions.istio.io/wasmplugin/...` |
| RHCL 1.4 | `envoy.filters.http.wasm` |

Only one pair matches per cluster, so there is no double-insertion.

## Changes

- `deployment/base/payload-processing/manager/envoy-filter.yaml` — add RHCL 1.4 ext_proc patches (8 configPatches total: 4 filter inserts + 4 route-disable MERGEs)
- `maas-controller/pkg/platform/tenantreconcile/params.go` — patch all 4 filter inserts at reconcile time
- `maas-controller/pkg/platform/tenantreconcile/params_test.go` — update expectations for dual-anchor layout

## Test plan

- [x] `go test ./pkg/platform/tenantreconcile/...`
- [x] `./scripts/ci/validate-manifests.sh`
- [x] On RHCL 1.4: confirm `ext_proc` appears in gateway config dump
- [x] On RHCL 1.4: `POST /v1/<endpoint>` with model in JSON body returns 200 (not 404)
- [ ] On ODH/Kuadrant: confirm path-based and body-based inference still work (WasmPlugin anchor unchanged)

## Risk analysis

| | |
|---|---|
| **Risk rating** | 4 |
| **Why** | This changes gateway filter-chain wiring for payload processing. The default Prow smoke path may not cover RHCL 1.4 specifically, and a bad anchor could leave ext_proc unapplied (404 on body-routed inference) or mis-ordered relative to auth. ODH/Kuadrant behavior should be unchanged since the original WasmPlugin patches are untouched, but gateway ext_proc wiring is inherently high blast radius. |

---


[RHOAIENG-76228]: https://redhat.atlassian.net/browse/RHOAIENG-76228?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for RHCL 1.4 authentication flows in payload processing.
  * Added automatic request and response payload processing around the built-in authentication filter.
  * Improved compatibility across supported authentication configurations.

* **Bug Fixes**
  * Updated route handling to consistently enable or disable payload processing as configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->