### PR TITLE
feat: migrate maas-db-config secret to infrastructure namespace on up…

### DIFF
--- a/deployment/base/maas-controller/base/kustomization.yaml
+++ b/deployment/base/maas-controller/base/kustomization.yaml
@@ -31,3 +31,13 @@ replacements:
           name: maas-controller
         fieldPaths:
           - spec.template.spec.containers.[name=manager].image
+  - source:
+      kind: ConfigMap
+      name: maas-parameters
+      fieldPath: data.infrastructure-namespace
+    targets:
+      - select:
+          kind: Deployment
+          name: maas-controller
+        fieldPaths:
+          - spec.template.spec.containers.[name=manager].env.[name=INFRA_NAMESPACE].value

--- a/deployment/base/maas-controller/base/params.env
+++ b/deployment/base/maas-controller/base/params.env
@@ -3,3 +3,4 @@ maas-controller-image=quay.io/opendatahub/maas-controller:odh-stable
 payload-processing-image=quay.io/opendatahub/odh-ai-gateway-payload-processing:odh-stable
 maas-api-key-cleanup-image=registry.redhat.io/ubi9/ubi-minimal:9.7
 monitoring-namespace=opendatahub
+infrastructure-namespace=AUTO

--- a/deployment/base/maas-controller/infra-rbac/kustomization.yaml
+++ b/deployment/base/maas-controller/infra-rbac/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - secret_migrate_role.yaml
+  - secret_migrate_rolebinding.yaml

--- a/deployment/base/maas-controller/infra-rbac/secret_migrate_role.yaml
+++ b/deployment/base/maas-controller/infra-rbac/secret_migrate_role.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: maas-controller-secret-migrate
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["create"]
+- apiGroups: [""]
+  resources: ["secrets"]
+  resourceNames: ["maas-db-config"]
+  verbs: ["get"]

--- a/deployment/base/maas-controller/infra-rbac/secret_migrate_rolebinding.yaml
+++ b/deployment/base/maas-controller/infra-rbac/secret_migrate_rolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: maas-controller-secret-migrate
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: maas-controller-secret-migrate
+subjects:
+- kind: ServiceAccount
+  name: maas-controller
+  namespace: opendatahub

--- a/deployment/overlays/odh/params.env
+++ b/deployment/overlays/odh/params.env
@@ -15,7 +15,7 @@ payload-processing-namespace=openshift-ingress
 # Note: PostgreSQL can be external (e.g., AWS RDS) - only maas-api and the connection secret deploy here.
 # Used for AuthPolicy URL (maas-api.<infra-namespace>.svc) and DestinationRule host.
 # Note: The operator may override this value in the maas-parameters ConfigMap.
-infra-namespace=AUTO
+infrastructure-namespace=AUTO
 api-key-max-expiration-days=90
 metadata-cache-ttl=60
 authz-cache-ttl=60

--- a/maas-controller/cmd/manager/main.go
+++ b/maas-controller/cmd/manager/main.go
@@ -21,6 +21,7 @@ import (
 	stderrors "errors"
 	"flag"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -250,6 +251,115 @@ func resolveNamespaceAfterTerminationWait(namespace string, finalNs *corev1.Name
 	}
 	return fmt.Errorf("namespace %q exists in unexpected state after termination wait (phase=%q)",
 		namespace, finalNs.Status.Phase), false
+}
+
+// migrateMaaSDBSecretToInfraNamespace copies the maas-db-config secret from the controller
+// namespace to the infrastructure namespace during upgrades when namespace separation is enabled.
+// This maintains backward compatibility for deployments that don't run setup-database.sh.
+func migrateMaaSDBSecretToInfraNamespace(ctx context.Context, controllerNs, infraNs string, clientset kubernetes.Interface) error {
+	secretName := tenantreconcile.MaaSDBSecretName
+	secretKey := tenantreconcile.MaaSDBSecretKey
+
+	if infraNs == controllerNs || infraNs == "" {
+		return nil
+	}
+
+	log := setupLog.WithValues("controllerNamespace", controllerNs, "infraNamespace", infraNs)
+
+	if _, err := clientset.CoreV1().Secrets(infraNs).Get(ctx, secretName, metav1.GetOptions{}); err == nil {
+		log.V(1).Info("maas-db-config secret already exists in infrastructure namespace, no migration needed")
+		return nil
+	} else if !errors.IsNotFound(err) {
+		return fmt.Errorf("failed to check for existing secret in infrastructure namespace: %w", err)
+	}
+
+	sourceSecret, err := clientset.CoreV1().Secrets(controllerNs).Get(ctx, secretName, metav1.GetOptions{})
+	if errors.IsNotFound(err) {
+		log.Info("maas-db-config secret not found in controller namespace, assuming fresh install")
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to read secret from controller namespace: %w", err)
+	}
+
+	log.Info("detected upgrade scenario: copying maas-db-config secret to infrastructure namespace with FQDN connection string")
+
+	existingURL, ok := sourceSecret.Data[secretKey]
+	if !ok || len(existingURL) == 0 {
+		return fmt.Errorf("key %q not found or empty in secret %s/%s", secretKey, controllerNs, secretName)
+	}
+
+	fqdnURL := convertToFQDNConnectionURL(string(existingURL), controllerNs)
+
+	targetSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: infraNs,
+			Labels: map[string]string{
+				"app.kubernetes.io/part-of":    "maas-controller",
+				"app.kubernetes.io/managed-by": "maas-controller",
+			},
+			Annotations: map[string]string{
+				"maas.opendatahub.io/migrated-from": controllerNs,
+			},
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			secretKey: []byte(fqdnURL),
+		},
+	}
+
+	if _, err := clientset.CoreV1().Secrets(infraNs).Create(ctx, targetSecret, metav1.CreateOptions{}); err != nil {
+		if errors.IsAlreadyExists(err) {
+			log.Info("maas-db-config secret was created concurrently in infrastructure namespace")
+			return nil
+		}
+		return fmt.Errorf("failed to create secret in infrastructure namespace: %w", err)
+	}
+
+	log.Info("successfully copied maas-db-config secret to infrastructure namespace",
+		"sourceNamespace", controllerNs,
+		"targetNamespace", infraNs,
+		"connectionURL", maskConnectionURL(fqdnURL))
+
+	return nil
+}
+
+// convertToFQDNConnectionURL updates a PostgreSQL connection URL to use FQDN for cross-namespace access.
+func convertToFQDNConnectionURL(rawURL, namespace string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		setupLog.V(1).Info("failed to parse connection URL for FQDN conversion, using as-is", "error", err)
+		return rawURL
+	}
+
+	hostname := u.Hostname()
+	if hostname == "" {
+		return rawURL
+	}
+
+	if strings.Contains(hostname, ".") {
+		return rawURL
+	}
+
+	fqdn := hostname + "." + namespace + ".svc.cluster.local"
+
+	if u.Port() != "" {
+		u.Host = fqdn + ":" + u.Port()
+	} else {
+		u.Host = fqdn
+	}
+
+	return u.String()
+}
+
+// maskConnectionURL masks the password in a connection URL for logging.
+func maskConnectionURL(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return "<invalid-url>"
+	}
+	return u.Redacted()
 }
 
 // managedNamespaceMonitor periodically re-runs ensureManagedNamespaceWithClient so a namespace
@@ -610,6 +720,22 @@ func main() {
 		if err := ensureInfraNamespaceWithClient(context.Background(), infraNamespace, clientset); err != nil {
 			setupLog.Error(err, "unable to ensure infrastructure namespace exists", "namespace", infraNamespace)
 			os.Exit(1)
+		}
+
+		// Migrate maas-db-config secret from controller namespace to infrastructure namespace
+		if err := migrateMaaSDBSecretToInfraNamespace(context.Background(), controllerNamespace, infraNamespace, clientset); err != nil {
+			if errors.IsForbidden(err) {
+				setupLog.Info("insufficient RBAC to migrate maas-db-config secret — "+
+					"ensure secret-migrate Roles and RoleBindings are applied; skipping migration for now",
+					"controllerNamespace", controllerNamespace,
+					"infraNamespace", infraNamespace,
+					"error", err)
+			} else {
+				setupLog.Error(err, "failed to migrate maas-db-config secret to infrastructure namespace",
+					"controllerNamespace", controllerNamespace,
+					"infraNamespace", infraNamespace)
+				os.Exit(1)
+			}
 		}
 	}
 

--- a/maas-controller/cmd/manager/migrate_db_secret_test.go
+++ b/maas-controller/cmd/manager/migrate_db_secret_test.go
@@ -1,0 +1,191 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestConvertToFQDNConnectionURL(t *testing.T) {
+	tests := []struct {
+		name      string
+		url       string
+		namespace string
+		want      string
+	}{
+		{
+			name:      "simple hostname with port",
+			url:       "postgresql://user:pass@postgres:5432/db",
+			namespace: "opendatahub",
+			want:      "postgresql://user:pass@postgres.opendatahub.svc.cluster.local:5432/db",
+		},
+		{
+			name:      "hostname without port",
+			url:       "postgresql://user:pass@postgres/db",
+			namespace: "redhat-ods-applications",
+			want:      "postgresql://user:pass@postgres.redhat-ods-applications.svc.cluster.local/db",
+		},
+		{
+			name:      "already FQDN - no change",
+			url:       "postgresql://user:pass@postgres.opendatahub.svc.cluster.local:5432/db",
+			namespace: "opendatahub",
+			want:      "postgresql://user:pass@postgres.opendatahub.svc.cluster.local:5432/db",
+		},
+		{
+			name:      "hostname with query params",
+			url:       "postgresql://user:pass@postgres:5432/db?sslmode=require",
+			namespace: "opendatahub",
+			want:      "postgresql://user:pass@postgres.opendatahub.svc.cluster.local:5432/db?sslmode=require",
+		},
+		{
+			name:      "external FQDN hostname",
+			url:       "postgresql://user:pass@db.example.com:5432/db",
+			namespace: "opendatahub",
+			want:      "postgresql://user:pass@db.example.com:5432/db",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := convertToFQDNConnectionURL(tt.url, tt.namespace)
+			if got != tt.want {
+				t.Errorf("convertToFQDNConnectionURL() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMaskConnectionURL(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		want string
+	}{
+		{
+			name: "with password",
+			url:  "postgresql://user:password@host:5432/db",
+			want: "postgresql://user:xxxxx@host:5432/db",
+		},
+		{
+			name: "no password",
+			url:  "postgresql://user@host:5432/db",
+			want: "postgresql://user@host:5432/db",
+		},
+		{
+			name: "no credentials",
+			url:  "postgresql://host:5432/db",
+			want: "postgresql://host:5432/db",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := maskConnectionURL(tt.url)
+			if got != tt.want {
+				t.Errorf("maskConnectionURL() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMigrateMaaSDBSecretToInfraNamespace(t *testing.T) {
+	const (
+		secretName      = "maas-db-config"
+		secretKey       = "DB_CONNECTION_URL"
+		controllerNs    = "opendatahub"
+		infraNs         = "odh-ai-gateway-infra"
+		originalConnURL = "postgresql://maas:password@postgres:5432/maas"
+		expectedFQDN    = "postgresql://maas:password@postgres.opendatahub.svc.cluster.local:5432/maas"
+	)
+
+	tests := []struct {
+		name              string
+		setupSecrets      func(*fake.Clientset)
+		controllerNs      string
+		infraNs           string
+		expectError       bool
+		expectSecretInDst bool
+		expectFQDN        bool
+	}{
+		{
+			name: "upgrade scenario - migrate secret with FQDN",
+			setupSecrets: func(cs *fake.Clientset) {
+				_, _ = cs.CoreV1().Secrets(controllerNs).Create(context.Background(), &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: secretName, Namespace: controllerNs},
+					Data:       map[string][]byte{secretKey: []byte(originalConnURL)},
+				}, metav1.CreateOptions{})
+			},
+			controllerNs:      controllerNs,
+			infraNs:           infraNs,
+			expectSecretInDst: true,
+			expectFQDN:        true,
+		},
+		{
+			name:              "fresh install - no secret anywhere",
+			setupSecrets:      func(cs *fake.Clientset) {},
+			controllerNs:      controllerNs,
+			infraNs:           infraNs,
+			expectSecretInDst: false,
+		},
+		{
+			name: "already migrated - secret exists in infra ns",
+			setupSecrets: func(cs *fake.Clientset) {
+				_, _ = cs.CoreV1().Secrets(infraNs).Create(context.Background(), &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: secretName, Namespace: infraNs},
+					Data:       map[string][]byte{secretKey: []byte(expectedFQDN)},
+				}, metav1.CreateOptions{})
+			},
+			controllerNs:      controllerNs,
+			infraNs:           infraNs,
+			expectSecretInDst: true,
+		},
+		{
+			name:              "same namespace - no separation",
+			setupSecrets:      func(cs *fake.Clientset) {},
+			controllerNs:      controllerNs,
+			infraNs:           controllerNs,
+			expectSecretInDst: false,
+		},
+		{
+			name:              "empty infra namespace - no separation",
+			setupSecrets:      func(cs *fake.Clientset) {},
+			controllerNs:      controllerNs,
+			infraNs:           "",
+			expectSecretInDst: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cs := fake.NewSimpleClientset()
+			tt.setupSecrets(cs)
+
+			err := migrateMaaSDBSecretToInfraNamespace(context.Background(), tt.controllerNs, tt.infraNs, cs)
+			if (err != nil) != tt.expectError {
+				t.Fatalf("migrateMaaSDBSecretToInfraNamespace() error = %v, expectError %v", err, tt.expectError)
+			}
+
+			if tt.expectSecretInDst && tt.infraNs != "" && tt.infraNs != tt.controllerNs {
+				secret, err := cs.CoreV1().Secrets(tt.infraNs).Get(context.Background(), secretName, metav1.GetOptions{})
+				if err != nil {
+					t.Fatalf("expected secret in infra namespace, got error: %v", err)
+				}
+				if tt.expectFQDN {
+					got := string(secret.Data[secretKey])
+					if got != expectedFQDN {
+						t.Errorf("expected FQDN URL %q, got %q", expectedFQDN, got)
+					}
+				}
+			} else if !tt.expectSecretInDst && tt.infraNs != "" && tt.infraNs != tt.controllerNs {
+				_, err := cs.CoreV1().Secrets(tt.infraNs).Get(context.Background(), secretName, metav1.GetOptions{})
+				if !errors.IsNotFound(err) {
+					t.Fatalf("expected no secret in infra namespace, got: %v", err)
+				}
+			}
+		})
+	}
+}

--- a/maas-controller/cmd/manager/migrate_db_secret_test.go
+++ b/maas-controller/cmd/manager/migrate_db_secret_test.go
@@ -94,7 +94,7 @@ func TestMaskConnectionURL(t *testing.T) {
 
 func TestMigrateMaaSDBSecretToInfraNamespace(t *testing.T) {
 	const (
-		secretName      = "maas-db-config"
+		secretName      = "maas-db-config" //nolint:gosec // Kubernetes Secret resource name, not a credential
 		secretKey       = "DB_CONNECTION_URL"
 		controllerNs    = "opendatahub"
 		infraNs         = "odh-ai-gateway-infra"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -91,6 +91,22 @@ derive_infra_namespace() {
   esac
 }
 
+apply_infra_secret_migration_rbac() {
+  local infra_ns="$1"
+  local controller_ns="$2"
+  local rbac_dir="${SCRIPT_DIR}/../deployment/base/maas-controller/infra-rbac"
+
+  if [ ! -d "$rbac_dir" ]; then
+    log_warn "Infra RBAC directory not found at $rbac_dir, skipping"
+    return 0
+  fi
+
+  log_info "Applying secret migration RBAC to namespace $infra_ns..."
+  kustomize build "$rbac_dir" \
+    | sed "s|namespace: opendatahub|namespace: $controller_ns|g" \
+    | kubectl apply -n "$infra_ns" -f -
+}
+
 # Set log level from environment variable if provided
 case "${LOG_LEVEL:-}" in
   DEBUG)
@@ -663,6 +679,12 @@ EOF
   else
     infra_namespace="$infra_namespace_raw"
   fi
+
+  # Apply infra RBAC for secret migration when namespace separation is active
+  if [ "$infra_namespace" != "$NAMESPACE" ] && [ -n "$infra_namespace" ]; then
+    apply_infra_secret_migration_rbac "$infra_namespace" "$NAMESPACE"
+  fi
+
   local maas_api_timeout="${CUSTOM_RESOURCE_TIMEOUT:-600}"
   local elapsed=0
   while [[ $elapsed -lt $maas_api_timeout ]]; do


### PR DESCRIPTION
…grade

When namespace separation is active, the maas-db-config secret must exist in the infrastructure namespace. Existing deployments have it only in the controller namespace. This adds startup migration logic that copies the secret (with FQDN-qualified connection URL) and namespace-scoped RBAC (Role + RoleBinding) so the controller can perform the copy.

Dual-path support: deploy.sh applies RBAC via kustomize with sed-based namespace substitution; the ai-gateway-operator creates it programmatically.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for separating infrastructure resources into a dedicated namespace.
  * Automatically migrates the database configuration secret during namespace upgrades.
  * Updates database connection details for cross-namespace access.
  * Adds required permissions during deployment for secure secret migration.

* **Bug Fixes**
  * Prevents duplicate secret creation and safely handles repeated migrations.

* **Tests**
  * Added coverage for connection URL conversion, password masking, and migration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->