### PR TITLE
feat: add metadata field to API keys to aid organisational tracking and management

### DIFF
--- a/docs/content/contributing/testing-guide.md
+++ b/docs/content/contributing/testing-guide.md
@@ -72,6 +72,13 @@ Both generate a `coverage.html` report in their respective directories.
 
 Integration tests for `maas-api` verify JSONB storage, GIN index queries, and NULL handling against a real PostgreSQL database.
 
+**Integration tests skip protection:**
+
+- Build tag check (requires `-tags=integration`)
+- `testing.Short()` check (skipped in short mode)
+- Environment variable check (skips if `TEST_DATABASE_URL` not set)
+
+
 ```bash
 # Start PostgreSQL
 podman run --name maas-test -e POSTGRES_PASSWORD=postgres -p 5432:5432 -d postgres:15

--- a/docs/content/contributing/testing-guide.md
+++ b/docs/content/contributing/testing-guide.md
@@ -83,6 +83,9 @@ Integration tests for `maas-api` verify JSONB storage, GIN index queries, and NU
 # Start PostgreSQL
 podman run --name maas-test -e POSTGRES_PASSWORD=postgres -p 5432:5432 -d postgres:15
 
+# Wait for PostgreSQL readiness before creating the database.
+podman logs --follow maas-test
+
 # Create test database
 podman exec -it maas-test psql -U postgres -c "CREATE DATABASE maas_test;"
 

--- a/docs/content/contributing/testing-guide.md
+++ b/docs/content/contributing/testing-guide.md
@@ -68,6 +68,25 @@ test/e2e/
 
 Both generate a `coverage.html` report in their respective directories.
 
+### Integration Tests (PostgreSQL)
+
+Integration tests for `maas-api` verify JSONB storage, GIN index queries, and NULL handling against a real PostgreSQL database.
+
+```bash
+# Start PostgreSQL
+podman run --name maas-test -e POSTGRES_PASSWORD=postgres -p 5432:5432 -d postgres:15
+
+# Create test database
+podman exec -it maas-test psql -U postgres -c "CREATE DATABASE maas_test;"
+
+# Run integration tests
+export TEST_DATABASE_URL="postgres://postgres:postgres@localhost:5432/maas_test?sslmode=disable"
+go test -tags=integration -v -run "TestPostgres" ./internal/api_keys
+
+# Cleanup
+podman stop maas-test && podman rm maas-test
+```
+
 ### E2E Tests (Python)
 
 !!! note "Prerequisites"

--- a/docs/content/contributing/testing-guide.md
+++ b/docs/content/contributing/testing-guide.md
@@ -10,6 +10,7 @@ This guide covers what tests exist in the MaaS project, how to run them, and how
 | **Unit tests** | `maas-controller/pkg/` | Go | `make test` |
 | **E2E tests** | `test/e2e/tests/` | Python (pytest) | `run-tests-quick.sh`, `smoke.sh` |
 | **CI smoke / E2E** | `test/e2e/scripts/prow_run_smoke_test.sh` | Bash + pytest | Konflux integration |
+| **Integration tests** | `test/integration/postgres.sh` | Bash | See [Integration Tests (PostgreSQL)](#integration-tests-postgresql) |
 | **Integration tests** | [opendatahub-tests](https://github.com/opendatahub-io/opendatahub-tests) | Python (pytest) | ODH CI / Nightly |
 
 ### Repository Structure (Testing)
@@ -74,27 +75,17 @@ Integration tests for `maas-api` verify JSONB storage, GIN index queries, and NU
 
 **Integration tests skip protection:**
 
+Note: `TestPostgres` is compiled with the other unit tests. To avoid the postgresql integration tests running during unit testing with `make test` the following must be true for the postgresql tests to be included in `make test`.
+
 - Build tag check (requires `-tags=integration`)
 - `testing.Short()` check (skipped in short mode)
 - Environment variable check (skips if `TEST_DATABASE_URL` not set)
 
-
 ```bash
-# Start PostgreSQL
-podman run --name maas-test -e POSTGRES_PASSWORD=postgres -p 5432:5432 -d postgres:15
-
-# Wait for PostgreSQL readiness before creating the database.
-podman logs --follow maas-test
-
-# Create test database
-podman exec -it maas-test psql -U postgres -c "CREATE DATABASE maas_test;"
-
-# Run integration tests
-export TEST_DATABASE_URL="postgres://postgres:postgres@localhost:5432/maas_test?sslmode=disable"
-go test -tags=integration -v -run "TestPostgres" ./internal/api_keys
-
-# Cleanup
-podman stop maas-test && podman rm maas-test
+./test/integration/postgresql.sh
+if [ $? -eq 0 ]; then 
+  echo "Integration tests passed" 
+fi
 ```
 
 ### E2E Tests (Python)

--- a/docs/content/user-guide/api-key-management.md
+++ b/docs/content/user-guide/api-key-management.md
@@ -51,6 +51,28 @@ echo "API Key: ${API_KEY}"
 !!! tip "TLS certificate errors"
     If `curl` returns `curl: (60) SSL certificate problem`, see [Troubleshooting - TLS Certificate Validation](../install/troubleshooting.md#tls-certificate-validation).
 
+#### Create an API Key with Labels
+
+When creating an API key, include the `labels` field with custom key-value pairs to aid API-key management:
+
+```bash
+curl -X POST "${MAAS_API_URL}/maas-api/v1/api-keys" \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "production-pipeline",
+    "description": "Production data processing pipeline",
+    "labels": {
+      "cmdb_id": "AST123456",
+      "cost_center": "CC-DATA-001",
+      "environment": "production",
+      "acme.inc/project_code": "PROJ-ML-2024",
+      "owner_email": "ml-team@acme.inc",
+      "owner": "alice"
+    }
+  }'
+```
+
 **Request body fields:**
 
 | Field | Required | Description |
@@ -60,6 +82,7 @@ echo "API Key: ${API_KEY}"
 | `expiresIn` | No | Key expiration duration. See [Expiration Format](#expiration-format) below. Omit to use configured maximum (typically 90 days). |
 | `subscription` | No | MaaSSubscription name to bind. Omit to auto-select highest priority. |
 | `ephemeral` | No | Set to `true` for short-lived keys (max 1 hour). See [Ephemeral Keys](#ephemeral-keys). |
+| `labels` | No | A JSON-formatted key/value pair for attaching labels to API keys that assist in API-key management. See below for formatting rules. |
 
 **Response:**
 
@@ -74,6 +97,14 @@ echo "API Key: ${API_KEY}"
   "ephemeral": false
 }
 ```
+
+**Label constraints**
+
+- **Key format:** Label keys follow Kubernetes label syntax: optional DNS subdomain prefix (a-zA-Z0-9?/) plus a name of alphanumerics, dots, underscores, and hyphens (must start/end alphanumeric). Examples: environment, app.kubernetes.io/name.
+- **Label creation:** Labels are ephemeral and can only be defined during API-key creation. This ensures strong auditability.
+- **Maximum entries:** The maximum number of labels is 50.
+- **Key length:** Maximum label key length is 128 characters.
+- **Value length:** Maximum label value length is 1024 characters.
 
 ### Subscription Binding
 
@@ -112,6 +143,52 @@ curl -sS -X POST "${MAAS_API_URL}/maas-api/v1/api-keys/search" \
       "offset": 0
     }
   }' | jq .
+```
+
+### Searching API Keys using Labels
+
+Use the `labelsContain` filter to search for keys by label values:
+
+**Search by owner**
+
+```bash
+curl -X POST "${HOST}/maas-api/v1/api-keys/search" 
+  -H "Authorization: Bearer ${oc whoami -t}" 
+  -H "Content-Type: application/json" 
+  -d '{
+    "filters": {
+    "labelsContain": {"owner": "alice"}
+    }
+  }' | jq
+```
+
+**Search by cost center**
+
+```bash
+curl -X POST "${MAAS_API_URL}/maas-api/v1/api-keys/search" \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "filters": {
+      "labelsContain": {"cost_center": "CC-DATA-001"}
+    }
+  }'
+```
+
+**Search by multiple label fields (AND logic)**
+
+```bash
+curl -X POST "${MAAS_API_URL}/maas-api/v1/api-keys/search" \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "filters": {
+      "labelsContain": {
+        "environment": "production",
+        "project_code": "PROJ-ML-2024"
+      }
+    }
+  }'
 ```
 
 **Request options:**

--- a/docs/content/user-guide/api-key-management.md
+++ b/docs/content/user-guide/api-key-management.md
@@ -172,7 +172,7 @@ curl -sS -X POST "${MAAS_API_URL}/maas-api/v1/api-keys/search" \
     "filters": {
       "labelsContain": {
         "environment": "production",
-        "project_code": "PROJ-ML-2024"
+        "acme.inc/project_code": "PROJ-ML-2024"
       }
     }
   }' | jq
@@ -208,13 +208,21 @@ curl -sS "${MAAS_API_URL}/maas-api/v1/api-keys/${KEY_ID}" \
   "id": "550e8400-e29b-41d4-a716-446655440000",
   "name": "my-api-key",
   "description": "Key for model access",
-  "username": "alice",
+  "username": "admin",
+  "subscription": "simulator-subscription",
+  "tenant": "models-as-a-service",
+  "creationDate": "2026-07-12T01:27:45Z",
+  "expirationDate": "2026-10-10T01:27:45Z",
   "status": "active",
-  "subscription": "premium-subscription",
-  "creationDate": "2026-04-28T12:00:00Z",
-  "expirationDate": "2026-07-27T12:00:00Z",
-  "lastUsedAt": "2026-04-29T10:30:00Z",
-  "ephemeral": false
+  "ephemeral": false,
+  "labels": {
+    "acme.inc/project_code": "PROJ-ML-2024",
+    "cmdb_id": "AST123456",
+    "cost_center": "CC-DATA-001",
+    "environment": "production",
+    "owner": "alice",
+    "owner_email": "ml-team@acme.inc"
+  }
 }
 ```
 

--- a/docs/content/user-guide/api-key-management.md
+++ b/docs/content/user-guide/api-key-management.md
@@ -93,8 +93,8 @@ curl -sS -X POST "${MAAS_API_URL}/maas-api/v1/api-keys"   -H "Authorization: Bea
 
 ```json
 {
-  "key": "sk-oai-18Mub7kHaDLdDYX1d_FOQB6eJfBKGbM2mgv1YXOjVC7BfH1xCkjt2R1xTW9MA",
-  "keyPrefix": "sk-oai-18Mub7kHaDLd...",
+  "key": "<REDACTED_API_KEY>",
+  "keyPrefix": "<REDACTED_KEY_PREFIX>",
   "id": "c2011e55-bd97-41e6-aab7-1b8ff6713d95",
   "name": "my-api-key",
   "subscription": "simulator-subscription",

--- a/docs/content/user-guide/api-key-management.md
+++ b/docs/content/user-guide/api-key-management.md
@@ -31,15 +31,26 @@ MAAS_API_URL="https://maas.${CLUSTER_DOMAIN}"
 
 ### Create an API Key
 
-Create a new API key with a name, description, and expiration:
+Create a new API key with a name, description, expiration and labels:
 
 ```bash
-API_KEY_RESPONSE=$(curl -sS \
+API_KEY_RESPONSE=$(curl -sS -X POST "${MAAS_API_URL}/maas-api/v1/api-keys" \
   -H "Authorization: Bearer ${OC_TOKEN}" \
   -H "Content-Type: application/json" \
-  -X POST \
-  -d '{"name": "my-api-key", "description": "Key for model access", "expiresIn": "90d"}' \
-  "${MAAS_API_URL}/maas-api/v1/api-keys")
+  -d '{
+    "name": "my-api-key", 
+    "description": "Key for model access",
+    "expiresIn": "90d",
+    "labels": {
+      "cmdb_id": "AST123456",
+      "cost_center": "CC-DATA-001",
+      "environment": "production",
+      "acme.inc/project_code": "PROJ-ML-2024",
+      "owner_email": "ml-team@acme.inc",
+      "owner": "alice"
+    }
+    }' \
+  )
 
 API_KEY=$(echo $API_KEY_RESPONSE | jq -r .key)
 echo "API Key: ${API_KEY}"
@@ -50,28 +61,6 @@ echo "API Key: ${API_KEY}"
 
 !!! tip "TLS certificate errors"
     If `curl` returns `curl: (60) SSL certificate problem`, see [Troubleshooting - TLS Certificate Validation](../install/troubleshooting.md#tls-certificate-validation).
-
-#### Create an API Key with Labels
-
-When creating an API key, include the `labels` field with custom key-value pairs to aid API-key management:
-
-```bash
-curl -X POST "${MAAS_API_URL}/maas-api/v1/api-keys" \
-  -H "Authorization: Bearer ${TOKEN}" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "name": "production-pipeline",
-    "description": "Production data processing pipeline",
-    "labels": {
-      "cmdb_id": "AST123456",
-      "cost_center": "CC-DATA-001",
-      "environment": "production",
-      "acme.inc/project_code": "PROJ-ML-2024",
-      "owner_email": "ml-team@acme.inc",
-      "owner": "alice"
-    }
-  }'
-```
 
 **Request body fields:**
 
@@ -84,17 +73,42 @@ curl -X POST "${MAAS_API_URL}/maas-api/v1/api-keys" \
 | `ephemeral` | No | Set to `true` for short-lived keys (max 1 hour). See [Ephemeral Keys](#ephemeral-keys). |
 | `labels` | No | A JSON-formatted key/value pair for attaching labels to API keys that assist in API-key management. See below for formatting rules. |
 
-**Response:**
+**Full Request/Response Example:**
+
+```bash
+curl -sS -X POST "${MAAS_API_URL}/maas-api/v1/api-keys"   -H "Authorization: Bearer ${OC_TOKEN}"   -H "Content-Type: application/json"   -d '{
+    "name": "my-api-key", 
+    "description": "Key for model access",
+    "expiresIn": "90d",
+    "labels": {
+      "cmdb_id": "AST123456",
+      "cost_center": "CC-DATA-001",
+      "environment": "production",
+      "acme.inc/project_code": "PROJ-ML-2024",
+      "owner_email": "ml-team@acme.inc",
+      "owner": "alice"
+    }
+    }' | jq
+```
 
 ```json
 {
-  "id": "550e8400-e29b-41d4-a716-446655440000",
-  "key": "sk-oai-...",
+  "key": "sk-oai-18Mub7kHaDLdDYX1d_FOQB6eJfBKGbM2mgv1YXOjVC7BfH1xCkjt2R1xTW9MA",
+  "keyPrefix": "sk-oai-18Mub7kHaDLd...",
+  "id": "c2011e55-bd97-41e6-aab7-1b8ff6713d95",
   "name": "my-api-key",
-  "subscription": "premium-subscription",
-  "createdAt": "2026-04-28T12:00:00Z",
-  "expiresAt": "2026-07-27T12:00:00Z",
-  "ephemeral": false
+  "subscription": "simulator-subscription",
+  "createdAt": "2026-07-12T00:18:52Z",
+  "expiresAt": "2026-10-10T00:18:52Z",
+  "ephemeral": false,
+  "labels": {
+    "acme.inc/project_code": "PROJ-ML-2024",
+    "cmdb_id": "AST123456",
+    "cost_center": "CC-DATA-001",
+    "environment": "production",
+    "owner": "alice",
+    "owner_email": "ml-team@acme.inc"
+  }
 }
 ```
 
@@ -132,7 +146,10 @@ curl -sS -X POST "${MAAS_API_URL}/maas-api/v1/api-keys/search" \
   -H "Content-Type: application/json" \
   -d '{
     "filters": {
-      "status": ["active"]
+      "status": ["active"],
+      "labelsContain": {
+        "owner": "alice"
+      }
     },
     "sort": {
       "by": "created_at",
@@ -145,41 +162,11 @@ curl -sS -X POST "${MAAS_API_URL}/maas-api/v1/api-keys/search" \
   }' | jq .
 ```
 
-### Searching API Keys using Labels
-
-Use the `labelsContain` filter to search for keys by label values:
-
-**Search by owner**
+Search by multiple label fields (AND logic):
 
 ```bash
-curl -X POST "${HOST}/maas-api/v1/api-keys/search" 
-  -H "Authorization: Bearer ${oc whoami -t}" 
-  -H "Content-Type: application/json" 
-  -d '{
-    "filters": {
-    "labelsContain": {"owner": "alice"}
-    }
-  }' | jq
-```
-
-**Search by cost center**
-
-```bash
-curl -X POST "${MAAS_API_URL}/maas-api/v1/api-keys/search" \
-  -H "Authorization: Bearer ${TOKEN}" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "filters": {
-      "labelsContain": {"cost_center": "CC-DATA-001"}
-    }
-  }'
-```
-
-**Search by multiple label fields (AND logic)**
-
-```bash
-curl -X POST "${MAAS_API_URL}/maas-api/v1/api-keys/search" \
-  -H "Authorization: Bearer ${TOKEN}" \
+curl -sS -X POST "${MAAS_API_URL}/maas-api/v1/api-keys/search" \
+  -H "Authorization: Bearer $(oc whoami -t)" \
   -H "Content-Type: application/json" \
   -d '{
     "filters": {
@@ -188,7 +175,7 @@ curl -X POST "${MAAS_API_URL}/maas-api/v1/api-keys/search" \
         "project_code": "PROJ-ML-2024"
       }
     }
-  }'
+  }' | jq
 ```
 
 **Request options:**
@@ -198,6 +185,7 @@ curl -X POST "${MAAS_API_URL}/maas-api/v1/api-keys/search" \
 | `filters.username` | Filter by username. Admin-only; non-admin users can search only their own keys. |
 | `filters.status` | Filter by one or more statuses: `active`, `revoked`, `expired` |
 | `filters.includeEphemeral` | Include ephemeral keys (default: false) |
+| `filters.labelsContain` | Filter by one or more key/value pairs. Multiple labels are treated as an AND in the filter. |
 | `sort.by` | Sort field: `created_at` (default), `expires_at`, `last_used_at`, or `name` |
 | `sort.order` | Sort order: `desc` (default) or `asc` |
 | `pagination.limit` | Number of results per page (default: 50, max: 100) |

--- a/maas-api/db/schema/0006_add_labels_column.down.sql
+++ b/maas-api/db/schema/0006_add_labels_column.down.sql
@@ -1,0 +1,8 @@
+-- Drop constraint first
+ALTER TABLE api_keys DROP CONSTRAINT IF EXISTS api_keys_labels_is_object;
+
+-- Drop index
+DROP INDEX IF EXISTS idx_api_keys_labels_gin;
+
+-- Drop column
+ALTER TABLE api_keys DROP COLUMN IF EXISTS labels;

--- a/maas-api/db/schema/0006_add_labels_column.up.sql
+++ b/maas-api/db/schema/0006_add_labels_column.up.sql
@@ -16,6 +16,5 @@ ALTER TABLE api_keys ADD COLUMN IF NOT EXISTS labels JSONB DEFAULT NULL;
   END
   $$;
 
--- GIN index for efficient JSONB containment queries (@> operator)
--- Supports fast lookups like: WHERE labels @> '{"cmdb_id": "AST123456"}'::jsonb
-CREATE INDEX IF NOT EXISTS idx_api_keys_labels_gin ON api_keys USING GIN (labels);
+-- Note: The GIN index for efficient JSONB containment queries (@> operator) cannot be run inside a transaction block.
+-- It is applied in the runConcurrentMigrations function in the db_driver.go file.

--- a/maas-api/db/schema/0006_add_labels_column.up.sql
+++ b/maas-api/db/schema/0006_add_labels_column.up.sql
@@ -2,10 +2,20 @@
 -- NULL for existing keys (backward compatibility)
 ALTER TABLE api_keys ADD COLUMN IF NOT EXISTS labels JSONB DEFAULT NULL;
 
+-- Add check constraint for labels structure (enforce object type).
+-- PostgreSQL doesn't support ADD CONSTRAINT IF NOT EXISTS for CHECK constraints, so use a DO $$ ... $$ block that checks
+-- pg_constraint first to avoid an error if the constraint already exists from a prior run of this migration:
+  DO $$
+  BEGIN
+      IF NOT EXISTS (
+          SELECT 1 FROM pg_constraint WHERE conname = 'api_keys_labels_is_object'
+      ) THEN
+          ALTER TABLE api_keys ADD CONSTRAINT api_keys_labels_is_object
+              CHECK (labels IS NULL OR jsonb_typeof(labels) = 'object');
+      END IF;
+  END
+  $$;
+
 -- GIN index for efficient JSONB containment queries (@> operator)
 -- Supports fast lookups like: WHERE labels @> '{"cmdb_id": "AST123456"}'::jsonb
 CREATE INDEX IF NOT EXISTS idx_api_keys_labels_gin ON api_keys USING GIN (labels);
-
--- Add check constraint for labels structure (enforce object type)
-ALTER TABLE api_keys ADD CONSTRAINT api_keys_labels_is_object 
-    CHECK (labels IS NULL OR jsonb_typeof(labels) = 'object');

--- a/maas-api/db/schema/0006_add_labels_column.up.sql
+++ b/maas-api/db/schema/0006_add_labels_column.up.sql
@@ -1,0 +1,11 @@
+-- Add labels column as JSONB for structured key-value storage
+-- NULL for existing keys (backward compatibility)
+ALTER TABLE api_keys ADD COLUMN IF NOT EXISTS labels JSONB DEFAULT NULL;
+
+-- GIN index for efficient JSONB containment queries (@> operator)
+-- Supports fast lookups like: WHERE labels @> '{"cmdb_id": "AST123456"}'::jsonb
+CREATE INDEX IF NOT EXISTS idx_api_keys_labels_gin ON api_keys USING GIN (labels);
+
+-- Add check constraint for labels structure (enforce object type)
+ALTER TABLE api_keys ADD CONSTRAINT api_keys_labels_is_object 
+    CHECK (labels IS NULL OR jsonb_typeof(labels) = 'object');

--- a/maas-api/internal/api_keys/db_driver.go
+++ b/maas-api/internal/api_keys/db_driver.go
@@ -24,6 +24,23 @@ const (
 	defaultConnMaxLifetimeSecs = 300
 )
 
+// concurrentMigration defines a migration that must run outside a transaction block.
+// This is because golang-migrate wraps each migration in a transaction, which prevents statements
+// like CREATE INDEX CONCURRENTLY. These run separately after the main migration runner.
+type concurrentMigration struct {
+	name string
+	sql  string
+}
+
+// Append new concurrent migrations to this list.
+var concurrentMigrations = []concurrentMigration{
+	{
+		name: "idx_api_keys_labels_gin",
+		sql:  "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_api_keys_labels_gin ON api_keys USING GIN (labels jsonb_path_ops)",
+	},
+	// Future concurrent indexes go here.
+}
+
 // NewPostgresStoreFromURL creates a PostgreSQL store from a connection URL.
 // It automatically applies database schema migrations on startup using golang-migrate.
 // URL format: postgresql://user:password@host:port/database
@@ -52,6 +69,10 @@ func NewPostgresStoreFromURL(ctx context.Context, log *logger.Logger, databaseUR
 	if err := runMigrations(db, log); err != nil {
 		db.Close()
 		return nil, fmt.Errorf("failed to apply schema migrations: %w", err)
+	}
+	if err := runConcurrentMigrations(ctx, db, log); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("failed to apply concurrent migrations: %w", err)
 	}
 
 	log.Info("Connected to PostgreSQL database (schema applied)", "tenant", tenantName)
@@ -102,4 +123,25 @@ func configureConnectionPool(db *sql.DB) {
 	db.SetMaxOpenConns(maxOpenConns)
 	db.SetMaxIdleConns(maxIdleConns)
 	db.SetConnMaxLifetime(time.Duration(connMaxLifetimeSecs) * time.Second)
+}
+
+// Return the names of the concurrent migrations. (A convenience getter that supports better schema-migration integration testing.)
+func ConcurrentMigrationNames() []string {
+	names := make([]string, len(concurrentMigrations))
+	for i, m := range concurrentMigrations {
+		names[i] = m.name
+	}
+	return names
+}
+
+// Apply schema migrations that cannot be run inside a transaction block and must be run concurrently.
+// If they can run inside a transaction block then the correct place is in the runMigrations function.
+func runConcurrentMigrations(ctx context.Context, db *sql.DB, log *logger.Logger) error {
+	for _, m := range concurrentMigrations {
+		log.Info("Applying concurrent migration", "name", m.name)
+		if _, err := db.ExecContext(ctx, m.sql); err != nil {
+			return fmt.Errorf("concurrent migration %q failed: %w", m.name, err)
+		}
+	}
+	return nil
 }

--- a/maas-api/internal/api_keys/handler.go
+++ b/maas-api/internal/api_keys/handler.go
@@ -593,6 +593,12 @@ func (h *Handler) SearchAPIKeys(c *gin.Context) {
 		return
 	}
 
+	// Validate the labels provided as a filter in the request.
+	if err := validateLabels(req.Filters.LabelsContain); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
 	// Call service layer (tenant scoping is mandatory)
 	result, err := h.service.Search(
 		c.Request.Context(),

--- a/maas-api/internal/api_keys/handler.go
+++ b/maas-api/internal/api_keys/handler.go
@@ -26,7 +26,11 @@ const (
 	apiKeySubscriptionResolutionErrMsg  = "Unable to resolve a subscription for this API key" //nolint:gosec // G101: public JSON error text, not a credential
 )
 
+// Regular expressions to match invalid control characters in key name and label values.
 var invalidKeyNameCharsPattern = regexp.MustCompile(`[\x00-\x1F\x7F]`)
+var invalidLabelCharsPattern = regexp.MustCompile(`[\x00-\x1F\x7F]`)
+var validLabelKeyPattern = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`) // alphanumerics, dots, underscores, hyphens
+
 
 // AdminChecker is an interface for checking if a user is an admin.
 // The SARAdminChecker implementation uses Kubernetes SubjectAccessReview
@@ -179,11 +183,12 @@ func (h *Handler) GetAPIKey(c *gin.Context) {
 // If expiresIn is not provided, defaults to API_KEY_MAX_EXPIRATION_DAYS (or 1hr for ephemeral).
 // Users can only create keys for themselves - the key inherits the user's groups.
 type CreateAPIKeyRequest struct {
-	Name         string          `json:"name,omitempty"` // Required for regular keys, optional for ephemeral
-	Description  string          `json:"description,omitempty"`
-	Subscription string          `json:"subscription,omitempty"` // Optional MaaSSubscription name; when omitted, highest-priority accessible subscription is used
-	ExpiresIn    *token.Duration `json:"expiresIn,omitempty"`    // Optional - defaults to API_KEY_MAX_EXPIRATION_DAYS (1hr for ephemeral)
-	Ephemeral    bool            `json:"ephemeral,omitempty"`    // Short-lived programmatic token (default: false)
+	Name         string            `json:"name,omitempty"` // Required for regular keys, optional for ephemeral
+	Description  string            `json:"description,omitempty"`
+	Subscription string            `json:"subscription,omitempty"` // Optional MaaSSubscription name; when omitted, highest-priority accessible subscription is used
+	ExpiresIn    *token.Duration   `json:"expiresIn,omitempty"`    // Optional - defaults to API_KEY_MAX_EXPIRATION_DAYS (1hr for ephemeral)
+	Ephemeral    bool              `json:"ephemeral,omitempty"`    // Short-lived programmatic token (default: false)
+	Labels       map[string]string `json:"labels,omitempty"`       // Structured key-value pairs for API key metadata
 }
 
 // CreateAPIKey handles POST /v1/api-keys
@@ -227,6 +232,11 @@ func (h *Handler) CreateAPIKey(c *gin.Context) {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "key name contains invalid control characters"})
 			return
 		}
+		// Validate labels if provided
+		if err := validateLabels(req.Labels); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
 	}
 
 	// Parse expiration duration if provided
@@ -250,7 +260,9 @@ func (h *Handler) CreateAPIKey(c *gin.Context) {
 		expiresIn,
 		req.Ephemeral,
 		strings.TrimSpace(req.Subscription),
-		user.Tenant)
+		user.Tenant,
+		req.Labels,
+	)
 	if err != nil {
 		h.logger.Error("Failed to create API key", "error", err)
 		if errors.Is(err, ErrExpirationNotPositive) || errors.Is(err, ErrExpirationExceedsMax) {
@@ -301,6 +313,47 @@ func (h *Handler) CreateAPIKey(c *gin.Context) {
 
 	// Return the key - THIS IS THE ONLY TIME THE PLAINTEXT IS SHOWN
 	c.JSON(http.StatusCreated, result)
+}
+
+// validateLabels validates the labels map for security and size constraints.
+// Labels are user-defined key-value pairs for organizing and filtering API keys.
+func validateLabels(labels map[string]string) error {
+    if labels == nil {
+        return nil
+    }
+    
+    // Limit number of label entries (prevent abuse)
+    if len(labels) > constant.MaxLabelsEntries {
+        return fmt.Errorf("labels cannot exceed %d key-value pairs", constant.MaxLabelsEntries)
+    }
+    
+    // Validate each key-value pair
+    for key, value := range labels {
+        // Key validation
+        if len(key) == 0 {
+            return fmt.Errorf("label keys cannot be empty")
+        }
+        if len(key) > constant.MaxLabelKeyLength {
+            return fmt.Errorf("label key '%s' exceeds %d characters", key, constant.MaxLabelKeyLength)
+        }
+        // Only allow alphanumerics, underscores, hyphens, dots (similar to K8s labels). 
+		// Use a package-level variable for comparison to avoid recomputing the regex every iteration of the loop.
+        if !validLabelKeyPattern.MatchString(key) {
+            return fmt.Errorf("label key '%s' contains invalid characters (only alphanumerics, dots, underscores, hyphens allowed)", key)
+        }
+        
+        // Value validation
+        if len(value) > constant.MaxLabelValueLength {
+            return fmt.Errorf("label value for key '%s' exceeds %d characters", key, constant.MaxLabelValueLength)
+        }
+
+        // Reject control characters in values
+		if invalidLabelCharsPattern.MatchString(value) {
+            return fmt.Errorf("label value for key '%s' contains invalid control characters", key)
+        }
+    }
+    
+    return nil
 }
 
 // ValidateAPIKeyRequest is the request body for validating an API key.

--- a/maas-api/internal/api_keys/handler.go
+++ b/maas-api/internal/api_keys/handler.go
@@ -218,6 +218,12 @@ func (h *Handler) CreateAPIKey(c *gin.Context) {
 		return
 	}
 
+	// Validate labels if provided
+	if err := validateLabels(req.Labels); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
 	// Auto-generate name for ephemeral keys if not provided
 	name := req.Name
 	if req.Ephemeral && name == "" {
@@ -234,11 +240,6 @@ func (h *Handler) CreateAPIKey(c *gin.Context) {
 		}
 		if invalidKeyNameCharsPattern.MatchString(name) {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "key name contains invalid control characters"})
-			return
-		}
-		// Validate labels if provided
-		if err := validateLabels(req.Labels); err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			return
 		}
 	}

--- a/maas-api/internal/api_keys/handler.go
+++ b/maas-api/internal/api_keys/handler.go
@@ -348,6 +348,9 @@ func validateLabels(labels map[string]string) error {
         }
         
         // Value validation
+		if len(value) == 0 {
+			return fmt.Errorf("label value for key '%s' cannot be empty", key)
+		}
         if len(value) > constant.MaxLabelValueLength {
             return fmt.Errorf("label value for key '%s' exceeds %d characters", key, constant.MaxLabelValueLength)
         }

--- a/maas-api/internal/api_keys/handler.go
+++ b/maas-api/internal/api_keys/handler.go
@@ -29,8 +29,12 @@ const (
 // Regular expressions to match invalid control characters in key name and label values.
 var invalidKeyNameCharsPattern = regexp.MustCompile(`[\x00-\x1F\x7F]`)
 var invalidLabelCharsPattern = regexp.MustCompile(`[\x00-\x1F\x7F]`)
-var validLabelKeyPattern = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`) // alphanumerics, dots, underscores, hyphens
-
+// Kubernetes-style label keys: optional DNS prefix + name
+// https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
+// Prefix: DNS subdomain (alphanumeric, dots, hyphens) ending with /
+// Name: alphanumeric, dots, underscores, hyphens
+// Examples: "environment", "app.kubernetes.io/name", "company.com/project-id"
+var validLabelKeyPattern = regexp.MustCompile(`^([a-zA-Z0-9]([a-zA-Z0-9.-]*[a-zA-Z0-9])?/)?[a-zA-Z0-9]([a-zA-Z0-9._-]*[a-zA-Z0-9])?$`)
 
 // AdminChecker is an interface for checking if a user is an admin.
 // The SARAdminChecker implementation uses Kubernetes SubjectAccessReview

--- a/maas-api/internal/api_keys/handler.go
+++ b/maas-api/internal/api_keys/handler.go
@@ -33,7 +33,7 @@ var invalidLabelCharsPattern = regexp.MustCompile(`[\x00-\x1F\x7F]`)
 // https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
 // Prefix: DNS subdomain (alphanumeric, dots, hyphens) ending with /
 // Name: alphanumeric, dots, underscores, hyphens
-// Examples: "environment", "app.kubernetes.io/name", "company.com/project-id"
+// Examples: "environment", "app.kubernetes.io/name", "company.com/project-id".
 var validLabelKeyPattern = regexp.MustCompile(`^([a-zA-Z0-9]([a-zA-Z0-9.-]*[a-zA-Z0-9])?/)?[a-zA-Z0-9]([a-zA-Z0-9._-]*[a-zA-Z0-9])?$`)
 
 // AdminChecker is an interface for checking if a user is an admin.
@@ -335,7 +335,7 @@ func validateLabels(labels map[string]string) error {
     for key, value := range labels {
         // Key validation
         if len(key) == 0 {
-            return fmt.Errorf("label keys cannot be empty")
+            return errors.New("label keys cannot be empty")
         }
         if len(key) > constant.MaxLabelKeyLength {
             return fmt.Errorf("label key '%s' exceeds %d characters", key, constant.MaxLabelKeyLength)

--- a/maas-api/internal/api_keys/handler_test.go
+++ b/maas-api/internal/api_keys/handler_test.go
@@ -3151,6 +3151,11 @@ func TestSearchAPIKeys_InvalidLabelsContain(t *testing.T) {
 			wantErr:       "label keys cannot be empty",
 		},
 		{
+			name:          "empty value",
+			labelsContain: map[string]string{"key": ""},
+			wantErr:       "cannot be empty",
+		},
+		{
 			name:          "too many labels",
 			labelsContain: makeLargeLabels(constant.MaxLabelsEntries + 1),
 			wantErr:       fmt.Sprintf("cannot exceed %d", constant.MaxLabelsEntries),

--- a/maas-api/internal/api_keys/handler_test.go
+++ b/maas-api/internal/api_keys/handler_test.go
@@ -423,7 +423,8 @@ func TestSearchAPIKeys_StatusFilter(t *testing.T) {
 	// Create active and revoked keys
 	err := store.AddKey(ctx, testUser.Username, "active-key", "active-hash", "Active Key", "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false, nil)
 	require.NoError(t, err)
-	err = store.AddKey(ctx, testUser.Username, "revoked-key", "revoked-hash", "Revoked Key", "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false, nil)
+	err = store.AddKey(ctx, testUser.Username, "revoked-key", "revoked-hash", "Revoked Key", "", []string{"system:authenticated"}, testSubscriptionName, 
+		"test-tenant", nil, false, nil)
 	require.NoError(t, err)
 	err = store.Revoke(ctx, "revoked-key")
 	require.NoError(t, err)
@@ -1671,7 +1672,8 @@ func TestCleanupExpiredEphemeralKeys(t *testing.T) {
 
 	// Create expired ephemeral key within 30-minute grace period (should NOT be deleted)
 	recentExpiry := time.Now().Add(-10 * time.Minute)
-	err = store.AddKey(ctx, "alice", "recently-expired-ephemeral", "hash-5", "Recently Expired Ephemeral", "", []string{"users"}, testSubscriptionName, "test-tenant", &recentExpiry, true, nil)
+	err = store.AddKey(ctx, "alice", "recently-expired-ephemeral", "hash-5", "Recently Expired Ephemeral", "", []string{"users"}, testSubscriptionName, 
+		"test-tenant", &recentExpiry, true, nil)
 	require.NoError(t, err)
 
 	t.Run("DeletesExpiredEphemeralKeys", func(t *testing.T) {
@@ -1821,9 +1823,11 @@ func TestSearchExcludesEphemeralByDefault(t *testing.T) {
 
 	// Create ephemeral keys
 	futureExpiry := time.Now().Add(1 * time.Hour)
-	err = store.AddKey(ctx, testUser.Username, "ephemeral-key-1", "hash-3", "Ephemeral Key 1", "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", &futureExpiry, true, nil)
+	err = store.AddKey(ctx, testUser.Username, "ephemeral-key-1", "hash-3", "Ephemeral Key 1", "", []string{"system:authenticated"}, testSubscriptionName, 
+		"test-tenant", &futureExpiry, true, nil)
 	require.NoError(t, err)
-	err = store.AddKey(ctx, testUser.Username, "ephemeral-key-2", "hash-4", "Ephemeral Key 2", "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", &futureExpiry, true, nil)
+	err = store.AddKey(ctx, testUser.Username, "ephemeral-key-2", "hash-4", "Ephemeral Key 2", "", []string{"system:authenticated"}, testSubscriptionName, 
+		"test-tenant", &futureExpiry, true, nil)
 	require.NoError(t, err)
 
 	t.Run("DefaultSearchExcludesEphemeral", func(t *testing.T) {
@@ -1870,16 +1874,19 @@ func TestSearchAPIKeys_ExpiredStatusComputation(t *testing.T) {
 
 	// Create a key that expired yesterday (stored as active, but past expiration)
 	pastExpiry := time.Now().Add(-24 * time.Hour)
-	err := store.AddKey(ctx, testUser.Username, "expired-key", "expired-hash", "Expired Key", "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", &pastExpiry, false, nil)
+	err := store.AddKey(ctx, testUser.Username, "expired-key", "expired-hash", "Expired Key", "", []string{"system:authenticated"}, testSubscriptionName, 
+		"test-tenant", &pastExpiry, false, nil)
 	require.NoError(t, err)
 
 	// Create an active key with future expiration
 	futureExpiry := time.Now().Add(24 * time.Hour)
-	err = store.AddKey(ctx, testUser.Username, "active-key", "active-hash", "Active Key","", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", &futureExpiry, false, nil)
+	err = store.AddKey(ctx, testUser.Username, "active-key", "active-hash", "Active Key","", []string{"system:authenticated"}, testSubscriptionName, 
+		"test-tenant", &futureExpiry, false, nil)
 	require.NoError(t, err)
 
 	// Create an active key with no expiration
-	err = store.AddKey(ctx, testUser.Username, "permanent-key", "permanent-hash", "Permanent Key", "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false, nil)
+	err = store.AddKey(ctx, testUser.Username, "permanent-key", "permanent-hash", "Permanent Key", "", []string{"system:authenticated"}, testSubscriptionName, 
+		"test-tenant", nil, false, nil)
 	require.NoError(t, err)
 
 	t.Run("SearchReturnsExpiredStatusForPastExpirationKeys", func(t *testing.T) {
@@ -1932,12 +1939,14 @@ func TestGetAPIKey_ExpiredStatusComputation(t *testing.T) {
 
 	// Create a key that expired yesterday
 	pastExpiry := time.Now().Add(-24 * time.Hour)
-	err := store.AddKey(ctx, testUser.Username, "expired-key", "expired-hash", "Expired Key", "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", &pastExpiry, false, nil)
+	err := store.AddKey(ctx, testUser.Username, "expired-key", "expired-hash", "Expired Key", "", []string{"system:authenticated"}, testSubscriptionName, 
+		"test-tenant", &pastExpiry, false, nil)
 	require.NoError(t, err)
 
 	// Create an active key with future expiration
 	futureExpiry := time.Now().Add(24 * time.Hour)
-	err = store.AddKey(ctx, testUser.Username, "active-key", "active-hash", "Active Key", "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", &futureExpiry, false, nil)
+	err = store.AddKey(ctx, testUser.Username, "active-key", "active-hash", "Active Key", "", []string{"system:authenticated"}, testSubscriptionName, 
+		"test-tenant", &futureExpiry, false, nil)
 	require.NoError(t, err)
 
 	t.Run("GetExpiredKeyReturnsExpiredStatus", func(t *testing.T) {
@@ -2781,7 +2790,7 @@ func TestValidateLabels_Errors(t *testing.T) {
 // Helper function to create a map with a specific number of entries.
 func makeLargeLabels(count int) map[string]string {
 	labels := make(map[string]string)
-	for i := 0; i < count; i++ {
+	for i := range count {
 		labels[fmt.Sprintf("key_%d", i)] = fmt.Sprintf("value_%d", i)
 	}
 	return labels
@@ -2886,7 +2895,7 @@ func TestCreateAPIKey_InvalidLabels(t *testing.T) {
 	}{
 		{
 			name:       "too many labels",
-			labelsJSON: makeLargeLabelsJSON(51),
+			labelsJSON: makeLargeLabelsJSON(t, constant.MaxLabelsEntries+1),
 			wantStatus: http.StatusBadRequest,
 			wantErr:    "cannot exceed 50",
 		},
@@ -2898,9 +2907,9 @@ func TestCreateAPIKey_InvalidLabels(t *testing.T) {
 		},
 		{
 			name:       "key too long",
-			labelsJSON: fmt.Sprintf(`{"%s": "value"}`, strings.Repeat("a", 129)),
+			labelsJSON: fmt.Sprintf(`{"%s": "value"}`, strings.Repeat("a", constant.MaxLabelKeyLength+1)),
 			wantStatus: http.StatusBadRequest,
-			wantErr:    "exceeds 128 characters",
+			wantErr:    fmt.Sprintf("exceeds %d characters", constant.MaxLabelKeyLength),
 		},
 	}
 
@@ -2926,7 +2935,7 @@ func TestCreateAPIKey_InvalidLabels(t *testing.T) {
 
 			assert.Equal(t, tt.wantStatus, w.Code)
 			
-			var errResp map[string]interface{}
+			var errResp map[string]any
 			err := json.Unmarshal(w.Body.Bytes(), &errResp)
 			require.NoError(t, err)
 			assert.Contains(t, errResp["error"], tt.wantErr)
@@ -2935,9 +2944,11 @@ func TestCreateAPIKey_InvalidLabels(t *testing.T) {
 }
 
 // Helper to generate JSON for large labels map.
-func makeLargeLabelsJSON(count int) string {
+func makeLargeLabelsJSON(t *testing.T, count int) string {
+	t.Helper()
 	labels := makeLargeLabels(count)
-	bytes, _ := json.Marshal(labels)
+	bytes, err := json.Marshal(labels)
+	require.NoError(t, err)
 	return string(bytes)
 }
 

--- a/maas-api/internal/api_keys/handler_test.go
+++ b/maas-api/internal/api_keys/handler_test.go
@@ -189,7 +189,7 @@ func TestValidateAPIKey_RecordsValidationMetric(t *testing.T) {
 	// Create a key via service so hash and subscription are correct
 	resp, err := service.CreateAPIKey(
 		context.Background(), "alice", []string{"system:authenticated"},
-		"Val Key", "", nil, false, "", "redteam",
+		"Val Key", "", nil, false, "", "redteam", nil,
 	)
 	require.NoError(t, err)
 
@@ -1731,9 +1731,9 @@ func TestRevokeTenantAPIKeys(t *testing.T) {
 		service := NewServiceWithLogger(store, cfg, fixedSubSelector{}, logger.Development())
 		handler := NewHandler(logger.Development(), service, newMockAdminChecker(), nil)
 
-		require.NoError(t, store.AddKey(ctx, "alice", "tenant-delete-1", "tenant-delete-hash-1", "Key 1", "", []string{"users"}, testSubscriptionName, "test-tenant", nil, false))
-		require.NoError(t, store.AddKey(ctx, "bob", "tenant-delete-2", "tenant-delete-hash-2", "Key 2", "", []string{"users"}, testSubscriptionName, "test-tenant", nil, false))
-		require.NoError(t, store.AddKey(ctx, "carol", "other-tenant-key", "other-tenant-hash", "Other", "", []string{"users"}, testSubscriptionName, "other-tenant", nil, false))
+		require.NoError(t, store.AddKey(ctx, "alice", "tenant-delete-1", "tenant-delete-hash-1", "Key 1", "", []string{"users"}, testSubscriptionName, "test-tenant", nil, false, nil))
+		require.NoError(t, store.AddKey(ctx, "bob", "tenant-delete-2", "tenant-delete-hash-2", "Key 2", "", []string{"users"}, testSubscriptionName, "test-tenant", nil, false, nil))
+		require.NoError(t, store.AddKey(ctx, "carol", "other-tenant-key", "other-tenant-hash", "Other", "", []string{"users"}, testSubscriptionName, "other-tenant", nil, false, nil))
 
 		w := httptest.NewRecorder()
 		c, _ := gin.CreateTestContext(w)
@@ -2800,7 +2800,7 @@ func makeLargeLabels(count int) map[string]string {
 func TestCreateAPIKey_WithLabels(t *testing.T) {
 	store := NewMockStore()
 	svc := NewService(store, &config.Config{}, fixedSubSelector{})
-	handler := NewHandler(logger.Development(), svc, newMockAdminChecker())
+	handler := NewHandler(logger.Development(), svc, newMockAdminChecker(), nil)
 
 	labels := map[string]string{
 		"cmdb_id":      "AST123456",
@@ -2851,7 +2851,7 @@ func TestCreateAPIKey_WithLabels(t *testing.T) {
 func TestCreateAPIKey_WithoutLabels(t *testing.T) {
 	store := NewMockStore()
 	svc := NewService(store, &config.Config{}, fixedSubSelector{})
-	handler := NewHandler(logger.Development(), svc, newMockAdminChecker())
+	handler := NewHandler(logger.Development(), svc, newMockAdminChecker(), nil)
 
 	body := `{
 		"name": "legacy-key",
@@ -2917,7 +2917,7 @@ func TestCreateAPIKey_InvalidLabels(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			store := NewMockStore()
 			svc := NewService(store, &config.Config{}, fixedSubSelector{})
-			handler := NewHandler(logger.Development(), svc, newMockAdminChecker())
+			handler := NewHandler(logger.Development(), svc, newMockAdminChecker(), nil)
 
 			body := fmt.Sprintf(`{"name": "test-key", "labels": %s}`, tt.labelsJSON)
 
@@ -2943,6 +2943,34 @@ func TestCreateAPIKey_InvalidLabels(t *testing.T) {
 	}
 }
 
+// TestCreateEphemeralKey_InvalidLabels verifies that label validation
+// is enforced for ephemeral keys with auto-generated names.
+func TestCreateEphemeralKey_InvalidLabels(t *testing.T) {
+	store := NewMockStore()
+	svc := NewService(store, &config.Config{}, fixedSubSelector{})
+	handler := NewHandler(logger.Development(), svc, newMockAdminChecker(), nil)
+
+	body := fmt.Sprintf(`{"ephemeral": true, "labels": {"%s": "value"}}`, strings.Repeat("a", constant.MaxLabelKeyLength+1))
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/api-keys", strings.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Set("user", &token.UserContext{
+		Username: "alice",
+		Groups:   []string{"data-science"},
+		Tenant:   "test-tenant",
+	})
+
+	handler.CreateAPIKey(c)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	var errResp map[string]any
+	err := json.Unmarshal(w.Body.Bytes(), &errResp)
+	require.NoError(t, err)
+	assert.Contains(t, errResp["error"], fmt.Sprintf("exceeds %d characters", constant.MaxLabelKeyLength))
+}
+
 // Helper to generate JSON for large labels map.
 func makeLargeLabelsJSON(t *testing.T, count int) string {
 	t.Helper()
@@ -2957,7 +2985,7 @@ func TestSearchAPIKeys_ByLabels(t *testing.T) {
 	ctx := context.Background()
 	store := NewMockStore()
 	svc := NewService(store, &config.Config{}, fixedSubSelector{})
-	handler := NewHandler(logger.Development(), svc, newMockAdminChecker())
+	handler := NewHandler(logger.Development(), svc, newMockAdminChecker(), nil)
 
 	testUser := &token.UserContext{Username: "alice", Tenant: "test-tenant"}
 
@@ -3056,7 +3084,7 @@ func TestGetAPIKey_WithLabels(t *testing.T) {
 	ctx := context.Background()
 	store := NewMockStore()
 	svc := NewService(store, &config.Config{}, fixedSubSelector{})
-	handler := NewHandler(logger.Development(), svc, newMockAdminChecker())
+	handler := NewHandler(logger.Development(), svc, newMockAdminChecker(), nil)
 
 	testUser := &token.UserContext{Username: "alice", Tenant: "test-tenant"}
 

--- a/maas-api/internal/api_keys/handler_test.go
+++ b/maas-api/internal/api_keys/handler_test.go
@@ -2894,6 +2894,12 @@ func TestCreateAPIKey_InvalidLabels(t *testing.T) {
 		wantErr    string
 	}{
 		{
+			name:       "empty key",
+			labelsJSON: `{"": "value"}`,
+			wantStatus: http.StatusBadRequest,
+			wantErr:    "label keys cannot be empty",
+		},
+		{
 			name:       "too many labels",
 			labelsJSON: makeLargeLabelsJSON(t, constant.MaxLabelsEntries+1),
 			wantStatus: http.StatusBadRequest,
@@ -2910,6 +2916,18 @@ func TestCreateAPIKey_InvalidLabels(t *testing.T) {
 			labelsJSON: fmt.Sprintf(`{"%s": "value"}`, strings.Repeat("a", constant.MaxLabelKeyLength+1)),
 			wantStatus: http.StatusBadRequest,
 			wantErr:    fmt.Sprintf("exceeds %d characters", constant.MaxLabelKeyLength),
+		},
+		{
+			name:       "value too long",
+			labelsJSON: fmt.Sprintf(`{"key": "%s"}`, strings.Repeat("a", constant.MaxLabelValueLength+1)),
+			wantStatus: http.StatusBadRequest,
+			wantErr:    fmt.Sprintf("exceeds %d characters", constant.MaxLabelValueLength),
+		},
+		{
+			name:       "control characters in value",
+			labelsJSON: `{"k": "val\u0000ue"}`,
+			wantStatus: http.StatusBadRequest,
+			wantErr:    "contains invalid control characters",
 		},
 	}
 

--- a/maas-api/internal/api_keys/handler_test.go
+++ b/maas-api/internal/api_keys/handler_test.go
@@ -2722,6 +2722,11 @@ func TestValidateLabels_Errors(t *testing.T) {
 			wantErr: fmt.Sprintf("exceeds %d characters", constant.MaxLabelKeyLength),
 		},
 		{
+			name:    "empty value",
+			labels:  map[string]string{"key": ""},
+			wantErr: "label value for key 'key' cannot be empty",
+		},
+		{
 			name:    "value too long",
 			labels:  map[string]string{"key": strings.Repeat("a", constant.MaxLabelValueLength+1)},
 			wantErr: fmt.Sprintf("exceeds %d characters", constant.MaxLabelValueLength),

--- a/maas-api/internal/api_keys/handler_test.go
+++ b/maas-api/internal/api_keys/handler_test.go
@@ -2494,7 +2494,7 @@ func TestSearchAPIKeys_NoAuthContext(t *testing.T) {
 	// Seed data so we can verify no keys leak when there is no auth context.
 	ctx := context.Background()
 	err := store.AddKey(ctx, "alice", "key-1", "hash-1", "Key 1", "",
-		[]string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false)
+		[]string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false, nil)
 	require.NoError(t, err)
 
 	t.Run("returns empty list when no auth headers at all", func(t *testing.T) {

--- a/maas-api/internal/api_keys/handler_test.go
+++ b/maas-api/internal/api_keys/handler_test.go
@@ -267,12 +267,12 @@ func TestSearchAPIKeys_EmptyRequest(t *testing.T) {
 
 	// Create test keys
 	ctx := context.Background()
-	err := store.AddKey(ctx, testUser.Username, "key-1", "hash-1", "Key 1", "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false)
+	err := store.AddKey(ctx, testUser.Username, "key-1", "hash-1", "Key 1", "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false, nil)
 	require.NoError(t, err)
-	err = store.AddKey(ctx, testUser.Username, "key-2", "hash-2", "Key 2", "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false)
+	err = store.AddKey(ctx, testUser.Username, "key-2", "hash-2", "Key 2", "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false, nil)
 	require.NoError(t, err)
 	// Create a revoked key
-	err = store.AddKey(ctx, testUser.Username, "key-3", "hash-3", "Key 3", "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false)
+	err = store.AddKey(ctx, testUser.Username, "key-3", "hash-3", "Key 3", "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false, nil)
 	require.NoError(t, err)
 	err = store.Revoke(ctx, "key-3")
 	require.NoError(t, err)
@@ -318,7 +318,7 @@ func TestSearchAPIKeys_Pagination(t *testing.T) {
 		keyID := fmt.Sprintf("key-%d", i)
 		keyHash := fmt.Sprintf("hash-%d", i)
 		name := fmt.Sprintf("Key %d", i)
-		err := store.AddKey(ctx, testUser.Username, keyID, keyHash, name, "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false)
+		err := store.AddKey(ctx, testUser.Username, keyID, keyHash, name, "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false, nil)
 		require.NoError(t, err)
 	}
 
@@ -419,9 +419,9 @@ func TestSearchAPIKeys_StatusFilter(t *testing.T) {
 	}
 
 	// Create active and revoked keys
-	err := store.AddKey(ctx, testUser.Username, "active-key", "active-hash", "Active Key", "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false)
+	err := store.AddKey(ctx, testUser.Username, "active-key", "active-hash", "Active Key", "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false, nil)
 	require.NoError(t, err)
-	err = store.AddKey(ctx, testUser.Username, "revoked-key", "revoked-hash", "Revoked Key", "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false)
+	err = store.AddKey(ctx, testUser.Username, "revoked-key", "revoked-hash", "Revoked Key", "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false, nil)
 	require.NoError(t, err)
 	err = store.Revoke(ctx, "revoked-key")
 	require.NoError(t, err)
@@ -545,9 +545,9 @@ func TestSearchAPIKeys_SubscriptionFilter(t *testing.T) {
 		Tenant:   "test-tenant",
 	}
 
-	err := store.AddKey(ctx, testUser.Username, "key-sub-a", "hash-a", "Key A", "", []string{"system:authenticated"}, "subscription-a", "test-tenant", nil, false)
+	err := store.AddKey(ctx, testUser.Username, "key-sub-a", "hash-a", "Key A", "", []string{"system:authenticated"}, "subscription-a", "test-tenant", nil, false, nil)
 	require.NoError(t, err)
-	err = store.AddKey(ctx, testUser.Username, "key-sub-b", "hash-b", "Key B", "", []string{"system:authenticated"}, "subscription-b", "test-tenant", nil, false)
+	err = store.AddKey(ctx, testUser.Username, "key-sub-b", "hash-b", "Key B", "", []string{"system:authenticated"}, "subscription-b", "test-tenant", nil, false, nil)
 	require.NoError(t, err)
 
 	t.Run("FilterBySubscription", func(t *testing.T) {
@@ -605,11 +605,11 @@ func TestSearchAPIKeys_Sorting(t *testing.T) {
 	}
 
 	// Create keys with different names
-	err := store.AddKey(ctx, testUser.Username, "key-1", "hash-1", "Charlie", "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false)
+	err := store.AddKey(ctx, testUser.Username, "key-1", "hash-1", "Charlie", "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false, nil)
 	require.NoError(t, err)
-	err = store.AddKey(ctx, testUser.Username, "key-2", "hash-2", "Alice", "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false)
+	err = store.AddKey(ctx, testUser.Username, "key-2", "hash-2", "Alice", "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false, nil)
 	require.NoError(t, err)
-	err = store.AddKey(ctx, testUser.Username, "key-3", "hash-3", "Bob", "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false)
+	err = store.AddKey(ctx, testUser.Username, "key-3", "hash-3", "Bob", "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false, nil)
 	require.NoError(t, err)
 
 	t.Run("DefaultSort_CreatedAtDesc", func(t *testing.T) {
@@ -732,7 +732,7 @@ func TestSearchAPIKeys_AdminVsRegularUser(t *testing.T) {
 			keyID := fmt.Sprintf("%s-key-%d", username, i)
 			keyHash := fmt.Sprintf("%s-hash-%d", username, i)
 			name := fmt.Sprintf("%s Key %d", username, i)
-			err := store.AddKey(ctx, username, keyID, keyHash, name, "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false)
+			err := store.AddKey(ctx, username, keyID, keyHash, name, "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false, nil)
 			require.NoError(t, err)
 		}
 	}
@@ -857,14 +857,14 @@ func TestSearchAPIKeys_AdminFiltersByUsernameAndStatus(t *testing.T) {
 			keyID := fmt.Sprintf("%s-active-%d", username, i)
 			keyHash := fmt.Sprintf("%s-hash-active-%d", username, i)
 			name := fmt.Sprintf("%s Active Key %d", username, i)
-			err := store.AddKey(ctx, username, keyID, keyHash, name, "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false)
+			err := store.AddKey(ctx, username, keyID, keyHash, name, "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false, nil)
 			require.NoError(t, err)
 		}
 		// Create 1 revoked key
 		keyID := fmt.Sprintf("%s-revoked", username)
 		keyHash := fmt.Sprintf("%s-hash-revoked", username)
 		name := fmt.Sprintf("%s Revoked Key", username)
-		err := store.AddKey(ctx, username, keyID, keyHash, name, "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false)
+		err := store.AddKey(ctx, username, keyID, keyHash, name, "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false, nil)
 		require.NoError(t, err)
 		err = store.Revoke(ctx, keyID)
 		require.NoError(t, err)
@@ -938,7 +938,7 @@ func TestBulkRevokeAPIKeys(t *testing.T) {
 		keyID := fmt.Sprintf("alice-key-%d", i)
 		keyHash := fmt.Sprintf("alice-hash-%d", i)
 		name := fmt.Sprintf("Alice Key %d", i)
-		err := store.AddKey(ctx, "alice", keyID, keyHash, name, "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false)
+		err := store.AddKey(ctx, "alice", keyID, keyHash, name, "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false, nil)
 		require.NoError(t, err)
 	}
 
@@ -946,7 +946,7 @@ func TestBulkRevokeAPIKeys(t *testing.T) {
 		keyID := fmt.Sprintf("bob-key-%d", i)
 		keyHash := fmt.Sprintf("bob-hash-%d", i)
 		name := fmt.Sprintf("Bob Key %d", i)
-		err := store.AddKey(ctx, "bob", keyID, keyHash, name, "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false)
+		err := store.AddKey(ctx, "bob", keyID, keyHash, name, "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false, nil)
 		require.NoError(t, err)
 	}
 
@@ -1003,7 +1003,7 @@ func TestBulkRevokeAPIKeys(t *testing.T) {
 			keyID := fmt.Sprintf("alice-key-%d", i)
 			keyHash := fmt.Sprintf("alice-hash-%d", i)
 			name := fmt.Sprintf("Alice Key %d", i)
-			err := store.AddKey(ctx, "alice", keyID, keyHash, name, "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false)
+			err := store.AddKey(ctx, "alice", keyID, keyHash, name, "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false, nil)
 			require.NoError(t, err)
 		}
 
@@ -1263,9 +1263,9 @@ func TestGetAPIKeyHandler(t *testing.T) {
 	}
 
 	// Add keys to store
-	err := store.AddKey(context.Background(), aliceKey.Username, aliceKey.ID, "hash1", aliceKey.Name, "", aliceKey.Groups, testSubscriptionName, "test-tenant", nil, false)
+	err := store.AddKey(context.Background(), aliceKey.Username, aliceKey.ID, "hash1", aliceKey.Name, "", aliceKey.Groups, testSubscriptionName, "test-tenant", nil, false, nil)
 	require.NoError(t, err)
-	err = store.AddKey(context.Background(), bobKey.Username, bobKey.ID, "hash2", bobKey.Name, "", bobKey.Groups, testSubscriptionName, "test-tenant", nil, false)
+	err = store.AddKey(context.Background(), bobKey.Username, bobKey.ID, "hash2", bobKey.Name, "", bobKey.Groups, testSubscriptionName, "test-tenant", nil, false, nil)
 	require.NoError(t, err)
 
 	// Helper function to test successful key retrieval
@@ -1362,7 +1362,7 @@ func testRevokeKeySuccess(t *testing.T, user *token.UserContext) {
 	handler := NewHandler(logger.Development(), service, newMockAdminChecker(), nil)
 
 	// Create alice's key
-	err := store.AddKey(context.Background(), "alice", "alice-key-1", "hash1", "Alice's Key", "", []string{"tier-free"}, testSubscriptionName, "test-tenant", nil, false)
+	err := store.AddKey(context.Background(), "alice", "alice-key-1", "hash1", "Alice's Key", "", []string{"tier-free"}, testSubscriptionName, "test-tenant", nil, false, nil)
 	require.NoError(t, err)
 
 	w := httptest.NewRecorder()
@@ -1406,7 +1406,7 @@ func TestRevokeAPIKeyHandler(t *testing.T) {
 		handler := NewHandler(logger.Development(), service, newMockAdminChecker(), nil)
 
 		// Create alice's key
-		err := store.AddKey(context.Background(), "alice", "alice-key-1", "hash1", "Alice's Key", "", []string{"tier-free"}, testSubscriptionName, "test-tenant", nil, false)
+		err := store.AddKey(context.Background(), "alice", "alice-key-1", "hash1", "Alice's Key", "", []string{"tier-free"}, testSubscriptionName, "test-tenant", nil, false, nil)
 		require.NoError(t, err)
 
 		// Bob trying to revoke Alice's key
@@ -1476,7 +1476,7 @@ func TestRevokeAPIKeyHandler(t *testing.T) {
 		handler := NewHandler(logger.Development(), service, newMockAdminChecker(), nil)
 
 		// Create and immediately revoke alice's key
-		err := store.AddKey(context.Background(), "alice", "alice-key-1", "hash1", "Alice's Key", "", []string{"tier-free"}, testSubscriptionName, "test-tenant", nil, false)
+		err := store.AddKey(context.Background(), "alice", "alice-key-1", "hash1", "Alice's Key", "", []string{"tier-free"}, testSubscriptionName, "test-tenant", nil, false, nil)
 		require.NoError(t, err)
 		err = store.Revoke(context.Background(), "alice-key-1")
 		require.NoError(t, err)
@@ -1649,28 +1649,27 @@ func TestCleanupExpiredEphemeralKeys(t *testing.T) {
 	ctx := context.Background()
 
 	// Create regular active key (should NOT be deleted)
-	err := store.AddKey(ctx, "alice", "regular-key", "hash-1", "Regular Key", "", []string{"users"}, testSubscriptionName, "test-tenant", nil, false)
+	err := store.AddKey(ctx, "alice", "regular-key", "hash-1", "Regular Key", "", []string{"users"}, testSubscriptionName, "test-tenant", nil, false, nil)
 	require.NoError(t, err)
 
 	// Create active ephemeral key with future expiration (should NOT be deleted)
 	futureExpiry := time.Now().Add(30 * time.Minute)
-	err = store.AddKey(ctx, "alice", "active-ephemeral", "hash-2", "Active Ephemeral", "", []string{"users"}, testSubscriptionName, "test-tenant", &futureExpiry, true)
+	err = store.AddKey(ctx, "alice", "active-ephemeral", "hash-2", "Active Ephemeral", "", []string{"users"}, testSubscriptionName, "test-tenant", &futureExpiry, true, nil)
 	require.NoError(t, err)
 
 	// Create expired ephemeral key (should be deleted)
 	pastExpiry := time.Now().Add(-1 * time.Hour)
-	err = store.AddKey(ctx, "alice", "expired-ephemeral", "hash-3", "Expired Ephemeral", "", []string{"users"}, testSubscriptionName, "test-tenant", &pastExpiry, true)
+	err = store.AddKey(ctx, "alice", "expired-ephemeral", "hash-3", "Expired Ephemeral", "", []string{"users"}, testSubscriptionName, "test-tenant", &pastExpiry, true, nil)
 	require.NoError(t, err)
 
 	// Create another expired ephemeral key (should be deleted)
 	pastExpiry2 := time.Now().Add(-2 * time.Hour)
-	err = store.AddKey(ctx, "bob", "expired-ephemeral-2", "hash-4", "Expired Ephemeral 2", "", []string{"users"}, testSubscriptionName, "test-tenant", &pastExpiry2, true)
+	err = store.AddKey(ctx, "bob", "expired-ephemeral-2", "hash-4", "Expired Ephemeral 2", "", []string{"users"}, testSubscriptionName, "test-tenant", &pastExpiry2, true, nil)
 	require.NoError(t, err)
 
 	// Create expired ephemeral key within 30-minute grace period (should NOT be deleted)
 	recentExpiry := time.Now().Add(-10 * time.Minute)
-	err = store.AddKey(ctx, "alice", "recently-expired-ephemeral", "hash-5", "Recently Expired Ephemeral",
-		"", []string{"users"}, testSubscriptionName, "test-tenant", &recentExpiry, true)
+	err = store.AddKey(ctx, "alice", "recently-expired-ephemeral", "hash-5", "Recently Expired Ephemeral", "", []string{"users"}, testSubscriptionName, "test-tenant", &recentExpiry, true, nil)
 	require.NoError(t, err)
 
 	t.Run("DeletesExpiredEphemeralKeys", func(t *testing.T) {
@@ -1813,18 +1812,16 @@ func TestSearchExcludesEphemeralByDefault(t *testing.T) {
 	}
 
 	// Create regular keys
-	err := store.AddKey(ctx, testUser.Username, "regular-key-1", "hash-1", "Regular Key 1", "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false)
+	err := store.AddKey(ctx, testUser.Username, "regular-key-1", "hash-1", "Regular Key 1", "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false, nil)
 	require.NoError(t, err)
-	err = store.AddKey(ctx, testUser.Username, "regular-key-2", "hash-2", "Regular Key 2", "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false)
+	err = store.AddKey(ctx, testUser.Username, "regular-key-2", "hash-2", "Regular Key 2", "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false, nil)
 	require.NoError(t, err)
 
 	// Create ephemeral keys
 	futureExpiry := time.Now().Add(1 * time.Hour)
-	err = store.AddKey(ctx, testUser.Username, "ephemeral-key-1", "hash-3", "Ephemeral Key 1",
-		"", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", &futureExpiry, true)
+	err = store.AddKey(ctx, testUser.Username, "ephemeral-key-1", "hash-3", "Ephemeral Key 1", "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", &futureExpiry, true, nil)
 	require.NoError(t, err)
-	err = store.AddKey(ctx, testUser.Username, "ephemeral-key-2", "hash-4", "Ephemeral Key 2",
-		"", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", &futureExpiry, true)
+	err = store.AddKey(ctx, testUser.Username, "ephemeral-key-2", "hash-4", "Ephemeral Key 2", "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", &futureExpiry, true, nil)
 	require.NoError(t, err)
 
 	t.Run("DefaultSearchExcludesEphemeral", func(t *testing.T) {
@@ -1871,19 +1868,16 @@ func TestSearchAPIKeys_ExpiredStatusComputation(t *testing.T) {
 
 	// Create a key that expired yesterday (stored as active, but past expiration)
 	pastExpiry := time.Now().Add(-24 * time.Hour)
-	err := store.AddKey(ctx, testUser.Username, "expired-key", "expired-hash", "Expired Key",
-		"", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", &pastExpiry, false)
+	err := store.AddKey(ctx, testUser.Username, "expired-key", "expired-hash", "Expired Key", "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", &pastExpiry, false, nil)
 	require.NoError(t, err)
 
 	// Create an active key with future expiration
 	futureExpiry := time.Now().Add(24 * time.Hour)
-	err = store.AddKey(ctx, testUser.Username, "active-key", "active-hash", "Active Key",
-		"", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", &futureExpiry, false)
+	err = store.AddKey(ctx, testUser.Username, "active-key", "active-hash", "Active Key","", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", &futureExpiry, false, nil)
 	require.NoError(t, err)
 
 	// Create an active key with no expiration
-	err = store.AddKey(ctx, testUser.Username, "permanent-key", "permanent-hash", "Permanent Key",
-		"", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false)
+	err = store.AddKey(ctx, testUser.Username, "permanent-key", "permanent-hash", "Permanent Key", "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false, nil)
 	require.NoError(t, err)
 
 	t.Run("SearchReturnsExpiredStatusForPastExpirationKeys", func(t *testing.T) {
@@ -1936,14 +1930,12 @@ func TestGetAPIKey_ExpiredStatusComputation(t *testing.T) {
 
 	// Create a key that expired yesterday
 	pastExpiry := time.Now().Add(-24 * time.Hour)
-	err := store.AddKey(ctx, testUser.Username, "expired-key", "expired-hash", "Expired Key",
-		"", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", &pastExpiry, false)
+	err := store.AddKey(ctx, testUser.Username, "expired-key", "expired-hash", "Expired Key", "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", &pastExpiry, false, nil)
 	require.NoError(t, err)
 
 	// Create an active key with future expiration
 	futureExpiry := time.Now().Add(24 * time.Hour)
-	err = store.AddKey(ctx, testUser.Username, "active-key", "active-hash", "Active Key",
-		"", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", &futureExpiry, false)
+	err = store.AddKey(ctx, testUser.Username, "active-key", "active-hash", "Active Key", "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", &futureExpiry, false, nil)
 	require.NoError(t, err)
 
 	t.Run("GetExpiredKeyReturnsExpiredStatus", func(t *testing.T) {
@@ -2042,9 +2034,7 @@ func TestCrossTenantAccessRejected(t *testing.T) {
 			h := NewHandler(logger.Development(), svc, newMockAdminChecker(), nil)
 
 			ctx := context.Background()
-			err := store.AddKey(ctx, "alice", "ta-key-1", "hash-ta1", "TA Key", "",
-				[]string{"system:authenticated"}, testSubscriptionName,
-				"tenant-a", nil, false)
+			err := store.AddKey(ctx, "alice", "ta-key-1", "hash-ta1", "TA Key", "", []string{"system:authenticated"}, testSubscriptionName, "tenant-a", nil, false, nil)
 			require.NoError(t, err)
 
 			w := httptest.NewRecorder()
@@ -2078,11 +2068,11 @@ func TestSearchAPIKeys_TenantIsolation(t *testing.T) {
 	ctx := context.Background()
 
 	// Create keys for two tenants under same username
-	err := store.AddKey(ctx, "alice", "key-ta-1", "hash-ta1", "TA Key 1", "", []string{"system:authenticated"}, testSubscriptionName, "tenant-a", nil, false)
+	err := store.AddKey(ctx, "alice", "key-ta-1", "hash-ta1", "TA Key 1", "", []string{"system:authenticated"}, testSubscriptionName, "tenant-a", nil, false, nil)
 	require.NoError(t, err)
-	err = store.AddKey(ctx, "alice", "key-ta-2", "hash-ta2", "TA Key 2", "", []string{"system:authenticated"}, testSubscriptionName, "tenant-a", nil, false)
+	err = store.AddKey(ctx, "alice", "key-ta-2", "hash-ta2", "TA Key 2", "", []string{"system:authenticated"}, testSubscriptionName, "tenant-a", nil, false, nil)
 	require.NoError(t, err)
-	err = store.AddKey(ctx, "alice", "key-tb-1", "hash-tb1", "TB Key 1", "", []string{"system:authenticated"}, testSubscriptionName, "tenant-b", nil, false)
+	err = store.AddKey(ctx, "alice", "key-tb-1", "hash-tb1", "TB Key 1", "", []string{"system:authenticated"}, testSubscriptionName, "tenant-b", nil, false, nil)
 	require.NoError(t, err)
 
 	// Tenant-A user should only see tenant-A keys
@@ -2158,19 +2148,15 @@ func TestBulkRevokeAPIKeys_TenantIsolation(t *testing.T) {
 	ctx := context.Background()
 
 	// Create 2 keys for "alice" in tenant-a
-	err := store.AddKey(ctx, "alice", "ta-key-1", "hash-ta1", "TA Key 1", "",
-		[]string{"system:authenticated"}, testSubscriptionName, "tenant-a", nil, false)
+	err := store.AddKey(ctx, "alice", "ta-key-1", "hash-ta1", "TA Key 1", "", []string{"system:authenticated"}, testSubscriptionName, "tenant-a", nil, false, nil)
 	require.NoError(t, err)
-	err = store.AddKey(ctx, "alice", "ta-key-2", "hash-ta2", "TA Key 2", "",
-		[]string{"system:authenticated"}, testSubscriptionName, "tenant-a", nil, false)
+	err = store.AddKey(ctx, "alice", "ta-key-2", "hash-ta2", "TA Key 2", "", []string{"system:authenticated"}, testSubscriptionName, "tenant-a", nil, false, nil)
 	require.NoError(t, err)
 
 	// Create 2 keys for "alice" in tenant-b
-	err = store.AddKey(ctx, "alice", "tb-key-1", "hash-tb1", "TB Key 1", "",
-		[]string{"system:authenticated"}, testSubscriptionName, "tenant-b", nil, false)
+	err = store.AddKey(ctx, "alice", "tb-key-1", "hash-tb1", "TB Key 1", "", []string{"system:authenticated"}, testSubscriptionName, "tenant-b", nil, false, nil)
 	require.NoError(t, err)
-	err = store.AddKey(ctx, "alice", "tb-key-2", "hash-tb2", "TB Key 2", "",
-		[]string{"system:authenticated"}, testSubscriptionName, "tenant-b", nil, false)
+	err = store.AddKey(ctx, "alice", "tb-key-2", "hash-tb2", "TB Key 2", "", []string{"system:authenticated"}, testSubscriptionName, "tenant-b", nil, false, nil)
 	require.NoError(t, err)
 
 	// Admin from tenant-a bulk revokes "alice"
@@ -2399,11 +2385,9 @@ func TestSearchAPIKeys_AdminCrossTenantIsolation(t *testing.T) {
 	ctx := context.Background()
 
 	// Create keys for "alice" in tenant-a
-	err := store.AddKey(ctx, "alice", "ta-key-1", "hash-ta1", "TA Key 1", "",
-		[]string{"system:authenticated"}, testSubscriptionName, "tenant-a", nil, false)
+	err := store.AddKey(ctx, "alice", "ta-key-1", "hash-ta1", "TA Key 1", "", []string{"system:authenticated"}, testSubscriptionName, "tenant-a", nil, false, nil)
 	require.NoError(t, err)
-	err = store.AddKey(ctx, "alice", "ta-key-2", "hash-ta2", "TA Key 2", "",
-		[]string{"system:authenticated"}, testSubscriptionName, "tenant-a", nil, false)
+	err = store.AddKey(ctx, "alice", "ta-key-2", "hash-ta2", "TA Key 2", "", []string{"system:authenticated"}, testSubscriptionName, "tenant-a", nil, false, nil)
 	require.NoError(t, err)
 
 	t.Run("AdminFromTenantBSeesNoKeys", func(t *testing.T) {
@@ -2444,11 +2428,9 @@ func TestSearchAPIKeys_EmptyTenantNoResults(t *testing.T) {
 	ctx := context.Background()
 
 	// Create keys in tenant-a
-	err := store.AddKey(ctx, "alice", "ta-key-1", "hash-ta1", "TA Key 1", "",
-		[]string{"system:authenticated"}, testSubscriptionName, "tenant-a", nil, false)
+	err := store.AddKey(ctx, "alice", "ta-key-1", "hash-ta1", "TA Key 1", "", []string{"system:authenticated"}, testSubscriptionName, "tenant-a", nil, false, nil)
 	require.NoError(t, err)
-	err = store.AddKey(ctx, "alice", "ta-key-2", "hash-ta2", "TA Key 2", "",
-		[]string{"system:authenticated"}, testSubscriptionName, "tenant-a", nil, false)
+	err = store.AddKey(ctx, "alice", "ta-key-2", "hash-ta2", "TA Key 2", "", []string{"system:authenticated"}, testSubscriptionName, "tenant-a", nil, false, nil)
 	require.NoError(t, err)
 
 	// User from tenant-c (no keys exist) searches

--- a/maas-api/internal/api_keys/handler_test.go
+++ b/maas-api/internal/api_keys/handler_test.go
@@ -2721,6 +2721,12 @@ func TestCreateAPIKey_InvalidLabels(t *testing.T) {
 		wantErr    string
 	}{
 		{
+			name:       "empty key",
+			labelsJSON: `{"": "value"}`,
+			wantStatus: http.StatusBadRequest,
+			wantErr:    "label keys cannot be empty",
+		},
+		{
 			name:       "too many labels",
 			labelsJSON: makeLargeLabelsJSON(t, constant.MaxLabelsEntries+1),
 			wantStatus: http.StatusBadRequest,
@@ -2737,6 +2743,18 @@ func TestCreateAPIKey_InvalidLabels(t *testing.T) {
 			labelsJSON: fmt.Sprintf(`{"%s": "value"}`, strings.Repeat("a", constant.MaxLabelKeyLength+1)),
 			wantStatus: http.StatusBadRequest,
 			wantErr:    fmt.Sprintf("exceeds %d characters", constant.MaxLabelKeyLength),
+		},
+		{
+			name:       "value too long",
+			labelsJSON: fmt.Sprintf(`{"key": "%s"}`, strings.Repeat("a", constant.MaxLabelValueLength+1)),
+			wantStatus: http.StatusBadRequest,
+			wantErr:    fmt.Sprintf("exceeds %d characters", constant.MaxLabelValueLength),
+		},
+		{
+			name:       "control characters in value",
+			labelsJSON: `{"k": "val\u0000ue"}`,
+			wantStatus: http.StatusBadRequest,
+			wantErr:    "contains invalid control characters",
 		},
 	}
 

--- a/maas-api/internal/api_keys/handler_test.go
+++ b/maas-api/internal/api_keys/handler_test.go
@@ -17,6 +17,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+
+	"github.com/opendatahub-io/models-as-a-service/maas-api/internal/constant"
 	"github.com/opendatahub-io/models-as-a-service/maas-api/internal/config"
 	"github.com/opendatahub-io/models-as-a-service/maas-api/internal/logger"
 	"github.com/opendatahub-io/models-as-a-service/maas-api/internal/subscription"
@@ -2624,4 +2626,451 @@ func TestCreateAPIKey_NameValidation(t *testing.T) {
 			assert.Contains(t, response["error"], tc.errMsg, "error message should mention %s for %s", tc.errMsg, tc.reason)
 		})
 	}
+}
+
+// TestValidateLabels_Success tests valid label configurations.
+func TestValidateLabels_Success(t *testing.T) {
+	tests := []struct {
+		name   string
+		labels map[string]string
+	}{
+		{
+			name:   "nil labels",
+			labels: nil,
+		},
+		{
+			name:   "empty labels",
+			labels: map[string]string{},
+		},
+		{
+			name: "single label",
+			labels: map[string]string{
+				"environment": "production",
+			},
+		},
+		{
+			name: "multiple valid labels",
+			labels: map[string]string{
+				"cmdb_id":      "AST123456",
+				"cost_center":  "CC-DATA-001",
+				"environment":  "production",
+				"project_code": "PROJ-ML-2024",
+				"owner_email":  "ml-team@company.com",
+			},
+		},
+		{
+			name: "kubernetes-style prefixed keys",
+			labels: map[string]string{
+				"app.kubernetes.io/name":    "maas",
+				"app.kubernetes.io/version": "1.0",
+				"company.com/project-id":    "PROJ-123",
+				"example.org/owner":         "ml-team",
+			},
+		},
+		{
+			name: "simple keys with dots underscores hyphens",
+			labels: map[string]string{
+				"some_underscore_key": "value",
+				"some-hyphen-key":     "value",
+				"some.dot.key":        "value",
+				"mixed.key_with-all":  "value",
+			},
+		},
+		{
+			name: "max entries (50)",
+			labels: makeLargeLabels(constant.MaxLabelsEntries),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateLabels(tt.labels)
+			assert.NoError(t, err)
+		})
+	}
+}
+
+// TestValidateLabels_Errors tests label validation failures.
+func TestValidateLabels_Errors(t *testing.T) {
+	tests := []struct {
+		name    string
+		labels  map[string]string
+		wantErr string
+	}{
+		{
+			name:    "too many entries",
+			labels:  makeLargeLabels(constant.MaxLabelsEntries + 1),
+			wantErr: fmt.Sprintf("cannot exceed %d", constant.MaxLabelsEntries),
+		},
+		{
+			name:    "empty key",
+			labels:  map[string]string{"": "value"},
+			wantErr: "label keys cannot be empty",
+		},
+		{
+			name:    "key too long",
+			labels:  map[string]string{strings.Repeat("a", constant.MaxLabelKeyLength+1): "value"},
+			wantErr: fmt.Sprintf("exceeds %d characters", constant.MaxLabelKeyLength),
+		},
+		{
+			name:    "value too long",
+			labels:  map[string]string{"key": strings.Repeat("a", constant.MaxLabelValueLength+1)},
+			wantErr: fmt.Sprintf("exceeds %d characters", constant.MaxLabelValueLength),
+		},
+		{
+			name:    "invalid key - spaces",
+			labels:  map[string]string{"key with spaces": "value"},
+			wantErr: "contains invalid characters",
+		},
+		{
+			name:    "invalid key - special chars",
+			labels:  map[string]string{"key!@#$": "value"},
+			wantErr: "contains invalid characters",
+		},
+		{
+			name:    "invalid key - slash without prefix",
+			labels:  map[string]string{"key/slash/invalid": "value"},
+			wantErr: "contains invalid characters",
+		},
+		{
+			name:    "invalid key - prefix with underscore",
+			labels:  map[string]string{"bad_prefix.com/name": "value"},
+			wantErr: "contains invalid characters",
+		},
+		{
+			name:    "invalid key - starts with hyphen",
+			labels:  map[string]string{"-starts-with-hyphen": "value"},
+			wantErr: "contains invalid characters",
+		},
+		{
+			name:    "invalid key - ends with hyphen",
+			labels:  map[string]string{"ends-with-hyphen-": "value"},
+			wantErr: "contains invalid characters",
+		},
+		{
+			name:    "invalid key - starts with dot",
+			labels:  map[string]string{".starts.with.dot": "value"},
+			wantErr: "contains invalid characters",
+		},
+		{
+			name:    "control characters in value - null",
+			labels:  map[string]string{"key": "value\x00null"},
+			wantErr: "invalid control characters",
+		},
+		{
+			name:    "control characters in value - newline",
+			labels:  map[string]string{"key": "value\nwith\nnewlines"},
+			wantErr: "invalid control characters",
+		},
+		{
+			name:    "control characters in value - tab",
+			labels:  map[string]string{"key": "value\twith\ttabs"},
+			wantErr: "invalid control characters",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateLabels(tt.labels)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+// Helper function to create a map with a specific number of entries.
+func makeLargeLabels(count int) map[string]string {
+	labels := make(map[string]string)
+	for i := 0; i < count; i++ {
+		labels[fmt.Sprintf("key_%d", i)] = fmt.Sprintf("value_%d", i)
+	}
+	return labels
+}
+
+// TestCreateAPIKey_WithLabels tests creating an API key with labels.
+func TestCreateAPIKey_WithLabels(t *testing.T) {
+	store := NewMockStore()
+	svc := NewService(store, &config.Config{}, fixedSubSelector{})
+	handler := NewHandler(logger.Development(), svc, newMockAdminChecker())
+
+	labels := map[string]string{
+		"cmdb_id":      "AST123456",
+		"cost_center":  "CC-DATA-001",
+		"environment":  "production",
+		"project_code": "PROJ-ML-2024",
+	}
+
+	body := `{
+		"name": "prod-pipeline",
+		"description": "Production data processing",
+		"labels": {
+			"cmdb_id": "AST123456",
+			"cost_center": "CC-DATA-001",
+			"environment": "production",
+			"project_code": "PROJ-ML-2024"
+		}
+	}`
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/api-keys", strings.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Set("user", &token.UserContext{
+		Username: "alice",
+		Groups:   []string{"data-science"},
+		Tenant:   "test-tenant",
+	})
+
+	handler.CreateAPIKey(c)
+
+	assert.Equal(t, http.StatusCreated, w.Code)
+
+	var resp CreateAPIKeyResponse
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(t, err)
+
+	// Verify labels are in the response
+	assert.Equal(t, labels, resp.Labels)
+
+	// Verify labels were stored
+	storedKey, err := store.Get(context.Background(), resp.ID)
+	require.NoError(t, err)
+	assert.Equal(t, labels, storedKey.Labels)
+}
+
+// TestCreateAPIKey_WithoutLabels tests backward compatibility.
+func TestCreateAPIKey_WithoutLabels(t *testing.T) {
+	store := NewMockStore()
+	svc := NewService(store, &config.Config{}, fixedSubSelector{})
+	handler := NewHandler(logger.Development(), svc, newMockAdminChecker())
+
+	body := `{
+		"name": "legacy-key",
+		"description": "Key without labels"
+	}`
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/api-keys", strings.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Set("user", &token.UserContext{
+		Username: "alice",
+		Groups:   []string{"data-science"},
+		Tenant:   "test-tenant",
+	})
+
+	handler.CreateAPIKey(c)
+
+	assert.Equal(t, http.StatusCreated, w.Code)
+
+	var resp CreateAPIKeyResponse
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(t, err)
+
+	// Labels should be nil (not present in request)
+	assert.Nil(t, resp.Labels)
+
+	// Verify stored key also has nil labels
+	storedKey, err := store.Get(context.Background(), resp.ID)
+	require.NoError(t, err)
+	assert.Nil(t, storedKey.Labels)
+}
+
+// TestCreateAPIKey_InvalidLabels tests validation error responses.
+func TestCreateAPIKey_InvalidLabels(t *testing.T) {
+	tests := []struct {
+		name       string
+		labelsJSON string
+		wantStatus int
+		wantErr    string
+	}{
+		{
+			name:       "too many labels",
+			labelsJSON: makeLargeLabelsJSON(51),
+			wantStatus: http.StatusBadRequest,
+			wantErr:    "cannot exceed 50",
+		},
+		{
+			name:       "invalid key characters",
+			labelsJSON: `{"invalid key!": "value"}`,
+			wantStatus: http.StatusBadRequest,
+			wantErr:    "invalid characters",
+		},
+		{
+			name:       "key too long",
+			labelsJSON: fmt.Sprintf(`{"%s": "value"}`, strings.Repeat("a", 129)),
+			wantStatus: http.StatusBadRequest,
+			wantErr:    "exceeds 128 characters",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := NewMockStore()
+			svc := NewService(store, &config.Config{}, fixedSubSelector{})
+			handler := NewHandler(logger.Development(), svc, newMockAdminChecker())
+
+			body := fmt.Sprintf(`{"name": "test-key", "labels": %s}`, tt.labelsJSON)
+
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			c.Request = httptest.NewRequest(http.MethodPost, "/v1/api-keys", strings.NewReader(body))
+			c.Request.Header.Set("Content-Type", "application/json")
+			c.Set("user", &token.UserContext{
+				Username: "alice",
+				Groups:   []string{"data-science"},
+				Tenant:   "test-tenant",
+			})
+
+			handler.CreateAPIKey(c)
+
+			assert.Equal(t, tt.wantStatus, w.Code)
+			
+			var errResp map[string]interface{}
+			err := json.Unmarshal(w.Body.Bytes(), &errResp)
+			require.NoError(t, err)
+			assert.Contains(t, errResp["error"], tt.wantErr)
+		})
+	}
+}
+
+// Helper to generate JSON for large labels map.
+func makeLargeLabelsJSON(count int) string {
+	labels := makeLargeLabels(count)
+	bytes, _ := json.Marshal(labels)
+	return string(bytes)
+}
+
+// TestSearchAPIKeys_ByLabels tests searching API keys by label filters.
+func TestSearchAPIKeys_ByLabels(t *testing.T) {
+	ctx := context.Background()
+	store := NewMockStore()
+	svc := NewService(store, &config.Config{}, fixedSubSelector{})
+	handler := NewHandler(logger.Development(), svc, newMockAdminChecker())
+
+	testUser := &token.UserContext{Username: "alice", Tenant: "test-tenant"}
+
+	// Create keys with different labels
+	err := store.AddKey(ctx, testUser.Username, "key-1", "hash-1", "Key 1", "",
+		[]string{}, testSubscriptionName, "test-tenant", nil, false,
+		map[string]string{"cmdb_id": "AST123", "env": "prod"})
+	require.NoError(t, err)
+
+	err = store.AddKey(ctx, testUser.Username, "key-2", "hash-2", "Key 2", "",
+		[]string{}, testSubscriptionName, "test-tenant", nil, false,
+		map[string]string{"cmdb_id": "AST456", "env": "dev"})
+	require.NoError(t, err)
+
+	err = store.AddKey(ctx, testUser.Username, "key-3", "hash-3", "Key 3", "",
+		[]string{}, testSubscriptionName, "test-tenant", nil, false,
+		map[string]string{"cost_center": "CC-001"})
+	require.NoError(t, err)
+
+	err = store.AddKey(ctx, testUser.Username, "key-4", "hash-4", "Key 4", "",
+		[]string{}, testSubscriptionName, "test-tenant", nil, false, nil) // No labels
+	require.NoError(t, err)
+
+	tests := []struct {
+		name          string
+		labelsContain map[string]string
+		wantIDs       []string
+	}{
+		{
+			name:          "search by cmdb_id exact match",
+			labelsContain: map[string]string{"cmdb_id": "AST123"},
+			wantIDs:       []string{"key-1"},
+		},
+		{
+			name:          "search by env",
+			labelsContain: map[string]string{"env": "prod"},
+			wantIDs:       []string{"key-1"},
+		},
+		{
+			name:          "search by cost_center",
+			labelsContain: map[string]string{"cost_center": "CC-001"},
+			wantIDs:       []string{"key-3"},
+		},
+		{
+			name:          "search by multiple labels (AND logic)",
+			labelsContain: map[string]string{"cmdb_id": "AST123", "env": "prod"},
+			wantIDs:       []string{"key-1"},
+		},
+		{
+			name:          "search with no matches",
+			labelsContain: map[string]string{"cmdb_id": "NONEXISTENT"},
+			wantIDs:       []string{},
+		},
+		{
+			name:          "search with empty filter returns all",
+			labelsContain: nil,
+			wantIDs:       []string{"key-1", "key-2", "key-3", "key-4"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reqBody := SearchAPIKeysRequest{
+				Filters: &SearchFilters{
+					LabelsContain: tt.labelsContain,
+				},
+			}
+			body, _ := json.Marshal(reqBody)
+
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			c.Request = httptest.NewRequest(http.MethodPost, "/v1/api-keys/search", strings.NewReader(string(body)))
+			c.Request.Header.Set("Content-Type", "application/json")
+			c.Set("user", testUser)
+
+			handler.SearchAPIKeys(c)
+
+			assert.Equal(t, http.StatusOK, w.Code)
+
+			var resp SearchAPIKeysResponse
+			err := json.Unmarshal(w.Body.Bytes(), &resp)
+			require.NoError(t, err)
+
+			gotIDs := make([]string, len(resp.Data))
+			for i, key := range resp.Data {
+				gotIDs[i] = key.ID
+			}
+
+			assert.ElementsMatch(t, tt.wantIDs, gotIDs)
+		})
+	}
+}
+
+// TestGetAPIKey_WithLabels tests retrieving an API key that has labels.
+func TestGetAPIKey_WithLabels(t *testing.T) {
+	ctx := context.Background()
+	store := NewMockStore()
+	svc := NewService(store, &config.Config{}, fixedSubSelector{})
+	handler := NewHandler(logger.Development(), svc, newMockAdminChecker())
+
+	testUser := &token.UserContext{Username: "alice", Tenant: "test-tenant"}
+
+	labels := map[string]string{
+		"environment": "production",
+		"team":        "data-science",
+	}
+
+	err := store.AddKey(ctx, testUser.Username, "test-key-id", "hash", "Test Key", "Description",
+		[]string{}, testSubscriptionName, "test-tenant", nil, false, labels)
+	require.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/v1/api-keys/test-key-id", nil)
+	c.Params = gin.Params{{Key: "id", Value: "test-key-id"}}
+	c.Set("user", testUser)
+
+	handler.GetAPIKey(c)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var key ApiKey
+	err = json.Unmarshal(w.Body.Bytes(), &key)
+	require.NoError(t, err)
+
+	assert.Equal(t, labels, key.Labels)
 }

--- a/maas-api/internal/api_keys/handler_test.go
+++ b/maas-api/internal/api_keys/handler_test.go
@@ -17,6 +17,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+
+	"github.com/opendatahub-io/models-as-a-service/maas-api/internal/constant"
 	"github.com/opendatahub-io/models-as-a-service/maas-api/internal/config"
 	"github.com/opendatahub-io/models-as-a-service/maas-api/internal/logger"
 	"github.com/opendatahub-io/models-as-a-service/maas-api/internal/subscription"
@@ -2451,4 +2453,451 @@ func TestCreateAPIKey_NameValidation(t *testing.T) {
 			assert.Contains(t, response["error"], tc.errMsg, "error message should mention %s for %s", tc.errMsg, tc.reason)
 		})
 	}
+}
+
+// TestValidateLabels_Success tests valid label configurations.
+func TestValidateLabels_Success(t *testing.T) {
+	tests := []struct {
+		name   string
+		labels map[string]string
+	}{
+		{
+			name:   "nil labels",
+			labels: nil,
+		},
+		{
+			name:   "empty labels",
+			labels: map[string]string{},
+		},
+		{
+			name: "single label",
+			labels: map[string]string{
+				"environment": "production",
+			},
+		},
+		{
+			name: "multiple valid labels",
+			labels: map[string]string{
+				"cmdb_id":      "AST123456",
+				"cost_center":  "CC-DATA-001",
+				"environment":  "production",
+				"project_code": "PROJ-ML-2024",
+				"owner_email":  "ml-team@company.com",
+			},
+		},
+		{
+			name: "kubernetes-style prefixed keys",
+			labels: map[string]string{
+				"app.kubernetes.io/name":    "maas",
+				"app.kubernetes.io/version": "1.0",
+				"company.com/project-id":    "PROJ-123",
+				"example.org/owner":         "ml-team",
+			},
+		},
+		{
+			name: "simple keys with dots underscores hyphens",
+			labels: map[string]string{
+				"some_underscore_key": "value",
+				"some-hyphen-key":     "value",
+				"some.dot.key":        "value",
+				"mixed.key_with-all":  "value",
+			},
+		},
+		{
+			name: "max entries (50)",
+			labels: makeLargeLabels(constant.MaxLabelsEntries),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateLabels(tt.labels)
+			assert.NoError(t, err)
+		})
+	}
+}
+
+// TestValidateLabels_Errors tests label validation failures.
+func TestValidateLabels_Errors(t *testing.T) {
+	tests := []struct {
+		name    string
+		labels  map[string]string
+		wantErr string
+	}{
+		{
+			name:    "too many entries",
+			labels:  makeLargeLabels(constant.MaxLabelsEntries + 1),
+			wantErr: fmt.Sprintf("cannot exceed %d", constant.MaxLabelsEntries),
+		},
+		{
+			name:    "empty key",
+			labels:  map[string]string{"": "value"},
+			wantErr: "label keys cannot be empty",
+		},
+		{
+			name:    "key too long",
+			labels:  map[string]string{strings.Repeat("a", constant.MaxLabelKeyLength+1): "value"},
+			wantErr: fmt.Sprintf("exceeds %d characters", constant.MaxLabelKeyLength),
+		},
+		{
+			name:    "value too long",
+			labels:  map[string]string{"key": strings.Repeat("a", constant.MaxLabelValueLength+1)},
+			wantErr: fmt.Sprintf("exceeds %d characters", constant.MaxLabelValueLength),
+		},
+		{
+			name:    "invalid key - spaces",
+			labels:  map[string]string{"key with spaces": "value"},
+			wantErr: "contains invalid characters",
+		},
+		{
+			name:    "invalid key - special chars",
+			labels:  map[string]string{"key!@#$": "value"},
+			wantErr: "contains invalid characters",
+		},
+		{
+			name:    "invalid key - slash without prefix",
+			labels:  map[string]string{"key/slash/invalid": "value"},
+			wantErr: "contains invalid characters",
+		},
+		{
+			name:    "invalid key - prefix with underscore",
+			labels:  map[string]string{"bad_prefix.com/name": "value"},
+			wantErr: "contains invalid characters",
+		},
+		{
+			name:    "invalid key - starts with hyphen",
+			labels:  map[string]string{"-starts-with-hyphen": "value"},
+			wantErr: "contains invalid characters",
+		},
+		{
+			name:    "invalid key - ends with hyphen",
+			labels:  map[string]string{"ends-with-hyphen-": "value"},
+			wantErr: "contains invalid characters",
+		},
+		{
+			name:    "invalid key - starts with dot",
+			labels:  map[string]string{".starts.with.dot": "value"},
+			wantErr: "contains invalid characters",
+		},
+		{
+			name:    "control characters in value - null",
+			labels:  map[string]string{"key": "value\x00null"},
+			wantErr: "invalid control characters",
+		},
+		{
+			name:    "control characters in value - newline",
+			labels:  map[string]string{"key": "value\nwith\nnewlines"},
+			wantErr: "invalid control characters",
+		},
+		{
+			name:    "control characters in value - tab",
+			labels:  map[string]string{"key": "value\twith\ttabs"},
+			wantErr: "invalid control characters",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateLabels(tt.labels)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+// Helper function to create a map with a specific number of entries.
+func makeLargeLabels(count int) map[string]string {
+	labels := make(map[string]string)
+	for i := 0; i < count; i++ {
+		labels[fmt.Sprintf("key_%d", i)] = fmt.Sprintf("value_%d", i)
+	}
+	return labels
+}
+
+// TestCreateAPIKey_WithLabels tests creating an API key with labels.
+func TestCreateAPIKey_WithLabels(t *testing.T) {
+	store := NewMockStore()
+	svc := NewService(store, &config.Config{}, fixedSubSelector{})
+	handler := NewHandler(logger.Development(), svc, newMockAdminChecker())
+
+	labels := map[string]string{
+		"cmdb_id":      "AST123456",
+		"cost_center":  "CC-DATA-001",
+		"environment":  "production",
+		"project_code": "PROJ-ML-2024",
+	}
+
+	body := `{
+		"name": "prod-pipeline",
+		"description": "Production data processing",
+		"labels": {
+			"cmdb_id": "AST123456",
+			"cost_center": "CC-DATA-001",
+			"environment": "production",
+			"project_code": "PROJ-ML-2024"
+		}
+	}`
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/api-keys", strings.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Set("user", &token.UserContext{
+		Username: "alice",
+		Groups:   []string{"data-science"},
+		Tenant:   "test-tenant",
+	})
+
+	handler.CreateAPIKey(c)
+
+	assert.Equal(t, http.StatusCreated, w.Code)
+
+	var resp CreateAPIKeyResponse
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(t, err)
+
+	// Verify labels are in the response
+	assert.Equal(t, labels, resp.Labels)
+
+	// Verify labels were stored
+	storedKey, err := store.Get(context.Background(), resp.ID)
+	require.NoError(t, err)
+	assert.Equal(t, labels, storedKey.Labels)
+}
+
+// TestCreateAPIKey_WithoutLabels tests backward compatibility.
+func TestCreateAPIKey_WithoutLabels(t *testing.T) {
+	store := NewMockStore()
+	svc := NewService(store, &config.Config{}, fixedSubSelector{})
+	handler := NewHandler(logger.Development(), svc, newMockAdminChecker())
+
+	body := `{
+		"name": "legacy-key",
+		"description": "Key without labels"
+	}`
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/api-keys", strings.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Set("user", &token.UserContext{
+		Username: "alice",
+		Groups:   []string{"data-science"},
+		Tenant:   "test-tenant",
+	})
+
+	handler.CreateAPIKey(c)
+
+	assert.Equal(t, http.StatusCreated, w.Code)
+
+	var resp CreateAPIKeyResponse
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(t, err)
+
+	// Labels should be nil (not present in request)
+	assert.Nil(t, resp.Labels)
+
+	// Verify stored key also has nil labels
+	storedKey, err := store.Get(context.Background(), resp.ID)
+	require.NoError(t, err)
+	assert.Nil(t, storedKey.Labels)
+}
+
+// TestCreateAPIKey_InvalidLabels tests validation error responses.
+func TestCreateAPIKey_InvalidLabels(t *testing.T) {
+	tests := []struct {
+		name       string
+		labelsJSON string
+		wantStatus int
+		wantErr    string
+	}{
+		{
+			name:       "too many labels",
+			labelsJSON: makeLargeLabelsJSON(51),
+			wantStatus: http.StatusBadRequest,
+			wantErr:    "cannot exceed 50",
+		},
+		{
+			name:       "invalid key characters",
+			labelsJSON: `{"invalid key!": "value"}`,
+			wantStatus: http.StatusBadRequest,
+			wantErr:    "invalid characters",
+		},
+		{
+			name:       "key too long",
+			labelsJSON: fmt.Sprintf(`{"%s": "value"}`, strings.Repeat("a", 129)),
+			wantStatus: http.StatusBadRequest,
+			wantErr:    "exceeds 128 characters",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := NewMockStore()
+			svc := NewService(store, &config.Config{}, fixedSubSelector{})
+			handler := NewHandler(logger.Development(), svc, newMockAdminChecker())
+
+			body := fmt.Sprintf(`{"name": "test-key", "labels": %s}`, tt.labelsJSON)
+
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			c.Request = httptest.NewRequest(http.MethodPost, "/v1/api-keys", strings.NewReader(body))
+			c.Request.Header.Set("Content-Type", "application/json")
+			c.Set("user", &token.UserContext{
+				Username: "alice",
+				Groups:   []string{"data-science"},
+				Tenant:   "test-tenant",
+			})
+
+			handler.CreateAPIKey(c)
+
+			assert.Equal(t, tt.wantStatus, w.Code)
+			
+			var errResp map[string]interface{}
+			err := json.Unmarshal(w.Body.Bytes(), &errResp)
+			require.NoError(t, err)
+			assert.Contains(t, errResp["error"], tt.wantErr)
+		})
+	}
+}
+
+// Helper to generate JSON for large labels map.
+func makeLargeLabelsJSON(count int) string {
+	labels := makeLargeLabels(count)
+	bytes, _ := json.Marshal(labels)
+	return string(bytes)
+}
+
+// TestSearchAPIKeys_ByLabels tests searching API keys by label filters.
+func TestSearchAPIKeys_ByLabels(t *testing.T) {
+	ctx := context.Background()
+	store := NewMockStore()
+	svc := NewService(store, &config.Config{}, fixedSubSelector{})
+	handler := NewHandler(logger.Development(), svc, newMockAdminChecker())
+
+	testUser := &token.UserContext{Username: "alice", Tenant: "test-tenant"}
+
+	// Create keys with different labels
+	err := store.AddKey(ctx, testUser.Username, "key-1", "hash-1", "Key 1", "",
+		[]string{}, testSubscriptionName, "test-tenant", nil, false,
+		map[string]string{"cmdb_id": "AST123", "env": "prod"})
+	require.NoError(t, err)
+
+	err = store.AddKey(ctx, testUser.Username, "key-2", "hash-2", "Key 2", "",
+		[]string{}, testSubscriptionName, "test-tenant", nil, false,
+		map[string]string{"cmdb_id": "AST456", "env": "dev"})
+	require.NoError(t, err)
+
+	err = store.AddKey(ctx, testUser.Username, "key-3", "hash-3", "Key 3", "",
+		[]string{}, testSubscriptionName, "test-tenant", nil, false,
+		map[string]string{"cost_center": "CC-001"})
+	require.NoError(t, err)
+
+	err = store.AddKey(ctx, testUser.Username, "key-4", "hash-4", "Key 4", "",
+		[]string{}, testSubscriptionName, "test-tenant", nil, false, nil) // No labels
+	require.NoError(t, err)
+
+	tests := []struct {
+		name          string
+		labelsContain map[string]string
+		wantIDs       []string
+	}{
+		{
+			name:          "search by cmdb_id exact match",
+			labelsContain: map[string]string{"cmdb_id": "AST123"},
+			wantIDs:       []string{"key-1"},
+		},
+		{
+			name:          "search by env",
+			labelsContain: map[string]string{"env": "prod"},
+			wantIDs:       []string{"key-1"},
+		},
+		{
+			name:          "search by cost_center",
+			labelsContain: map[string]string{"cost_center": "CC-001"},
+			wantIDs:       []string{"key-3"},
+		},
+		{
+			name:          "search by multiple labels (AND logic)",
+			labelsContain: map[string]string{"cmdb_id": "AST123", "env": "prod"},
+			wantIDs:       []string{"key-1"},
+		},
+		{
+			name:          "search with no matches",
+			labelsContain: map[string]string{"cmdb_id": "NONEXISTENT"},
+			wantIDs:       []string{},
+		},
+		{
+			name:          "search with empty filter returns all",
+			labelsContain: nil,
+			wantIDs:       []string{"key-1", "key-2", "key-3", "key-4"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reqBody := SearchAPIKeysRequest{
+				Filters: &SearchFilters{
+					LabelsContain: tt.labelsContain,
+				},
+			}
+			body, _ := json.Marshal(reqBody)
+
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			c.Request = httptest.NewRequest(http.MethodPost, "/v1/api-keys/search", strings.NewReader(string(body)))
+			c.Request.Header.Set("Content-Type", "application/json")
+			c.Set("user", testUser)
+
+			handler.SearchAPIKeys(c)
+
+			assert.Equal(t, http.StatusOK, w.Code)
+
+			var resp SearchAPIKeysResponse
+			err := json.Unmarshal(w.Body.Bytes(), &resp)
+			require.NoError(t, err)
+
+			gotIDs := make([]string, len(resp.Data))
+			for i, key := range resp.Data {
+				gotIDs[i] = key.ID
+			}
+
+			assert.ElementsMatch(t, tt.wantIDs, gotIDs)
+		})
+	}
+}
+
+// TestGetAPIKey_WithLabels tests retrieving an API key that has labels.
+func TestGetAPIKey_WithLabels(t *testing.T) {
+	ctx := context.Background()
+	store := NewMockStore()
+	svc := NewService(store, &config.Config{}, fixedSubSelector{})
+	handler := NewHandler(logger.Development(), svc, newMockAdminChecker())
+
+	testUser := &token.UserContext{Username: "alice", Tenant: "test-tenant"}
+
+	labels := map[string]string{
+		"environment": "production",
+		"team":        "data-science",
+	}
+
+	err := store.AddKey(ctx, testUser.Username, "test-key-id", "hash", "Test Key", "Description",
+		[]string{}, testSubscriptionName, "test-tenant", nil, false, labels)
+	require.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/v1/api-keys/test-key-id", nil)
+	c.Params = gin.Params{{Key: "id", Value: "test-key-id"}}
+	c.Set("user", testUser)
+
+	handler.GetAPIKey(c)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var key ApiKey
+	err = json.Unmarshal(w.Body.Bytes(), &key)
+	require.NoError(t, err)
+
+	assert.Equal(t, labels, key.Labels)
 }

--- a/maas-api/internal/api_keys/handler_test.go
+++ b/maas-api/internal/api_keys/handler_test.go
@@ -189,7 +189,7 @@ func TestValidateAPIKey_RecordsValidationMetric(t *testing.T) {
 	// Create a key via service so hash and subscription are correct
 	resp, err := service.CreateAPIKey(
 		context.Background(), "alice", []string{"system:authenticated"},
-		"Val Key", "", nil, false, "", "redteam",
+		"Val Key", "", nil, false, "", "redteam", nil,
 	)
 	require.NoError(t, err)
 
@@ -1731,9 +1731,9 @@ func TestRevokeTenantAPIKeys(t *testing.T) {
 		service := NewServiceWithLogger(store, cfg, fixedSubSelector{}, logger.Development())
 		handler := NewHandler(logger.Development(), service, newMockAdminChecker(), nil)
 
-		require.NoError(t, store.AddKey(ctx, "alice", "tenant-delete-1", "tenant-delete-hash-1", "Key 1", "", []string{"users"}, testSubscriptionName, "test-tenant", nil, false))
-		require.NoError(t, store.AddKey(ctx, "bob", "tenant-delete-2", "tenant-delete-hash-2", "Key 2", "", []string{"users"}, testSubscriptionName, "test-tenant", nil, false))
-		require.NoError(t, store.AddKey(ctx, "carol", "other-tenant-key", "other-tenant-hash", "Other", "", []string{"users"}, testSubscriptionName, "other-tenant", nil, false))
+		require.NoError(t, store.AddKey(ctx, "alice", "tenant-delete-1", "tenant-delete-hash-1", "Key 1", "", []string{"users"}, testSubscriptionName, "test-tenant", nil, false, nil))
+		require.NoError(t, store.AddKey(ctx, "bob", "tenant-delete-2", "tenant-delete-hash-2", "Key 2", "", []string{"users"}, testSubscriptionName, "test-tenant", nil, false, nil))
+		require.NoError(t, store.AddKey(ctx, "carol", "other-tenant-key", "other-tenant-hash", "Other", "", []string{"users"}, testSubscriptionName, "other-tenant", nil, false, nil))
 
 		w := httptest.NewRecorder()
 		c, _ := gin.CreateTestContext(w)
@@ -2627,7 +2627,7 @@ func makeLargeLabels(count int) map[string]string {
 func TestCreateAPIKey_WithLabels(t *testing.T) {
 	store := NewMockStore()
 	svc := NewService(store, &config.Config{}, fixedSubSelector{})
-	handler := NewHandler(logger.Development(), svc, newMockAdminChecker())
+	handler := NewHandler(logger.Development(), svc, newMockAdminChecker(), nil)
 
 	labels := map[string]string{
 		"cmdb_id":      "AST123456",
@@ -2678,7 +2678,7 @@ func TestCreateAPIKey_WithLabels(t *testing.T) {
 func TestCreateAPIKey_WithoutLabels(t *testing.T) {
 	store := NewMockStore()
 	svc := NewService(store, &config.Config{}, fixedSubSelector{})
-	handler := NewHandler(logger.Development(), svc, newMockAdminChecker())
+	handler := NewHandler(logger.Development(), svc, newMockAdminChecker(), nil)
 
 	body := `{
 		"name": "legacy-key",
@@ -2744,7 +2744,7 @@ func TestCreateAPIKey_InvalidLabels(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			store := NewMockStore()
 			svc := NewService(store, &config.Config{}, fixedSubSelector{})
-			handler := NewHandler(logger.Development(), svc, newMockAdminChecker())
+			handler := NewHandler(logger.Development(), svc, newMockAdminChecker(), nil)
 
 			body := fmt.Sprintf(`{"name": "test-key", "labels": %s}`, tt.labelsJSON)
 
@@ -2770,6 +2770,34 @@ func TestCreateAPIKey_InvalidLabels(t *testing.T) {
 	}
 }
 
+// TestCreateEphemeralKey_InvalidLabels verifies that label validation
+// is enforced for ephemeral keys with auto-generated names.
+func TestCreateEphemeralKey_InvalidLabels(t *testing.T) {
+	store := NewMockStore()
+	svc := NewService(store, &config.Config{}, fixedSubSelector{})
+	handler := NewHandler(logger.Development(), svc, newMockAdminChecker(), nil)
+
+	body := fmt.Sprintf(`{"ephemeral": true, "labels": {"%s": "value"}}`, strings.Repeat("a", constant.MaxLabelKeyLength+1))
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/api-keys", strings.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Set("user", &token.UserContext{
+		Username: "alice",
+		Groups:   []string{"data-science"},
+		Tenant:   "test-tenant",
+	})
+
+	handler.CreateAPIKey(c)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	var errResp map[string]any
+	err := json.Unmarshal(w.Body.Bytes(), &errResp)
+	require.NoError(t, err)
+	assert.Contains(t, errResp["error"], fmt.Sprintf("exceeds %d characters", constant.MaxLabelKeyLength))
+}
+
 // Helper to generate JSON for large labels map.
 func makeLargeLabelsJSON(t *testing.T, count int) string {
 	t.Helper()
@@ -2784,7 +2812,7 @@ func TestSearchAPIKeys_ByLabels(t *testing.T) {
 	ctx := context.Background()
 	store := NewMockStore()
 	svc := NewService(store, &config.Config{}, fixedSubSelector{})
-	handler := NewHandler(logger.Development(), svc, newMockAdminChecker())
+	handler := NewHandler(logger.Development(), svc, newMockAdminChecker(), nil)
 
 	testUser := &token.UserContext{Username: "alice", Tenant: "test-tenant"}
 
@@ -2883,7 +2911,7 @@ func TestGetAPIKey_WithLabels(t *testing.T) {
 	ctx := context.Background()
 	store := NewMockStore()
 	svc := NewService(store, &config.Config{}, fixedSubSelector{})
-	handler := NewHandler(logger.Development(), svc, newMockAdminChecker())
+	handler := NewHandler(logger.Development(), svc, newMockAdminChecker(), nil)
 
 	testUser := &token.UserContext{Username: "alice", Tenant: "test-tenant"}
 

--- a/maas-api/internal/api_keys/handler_test.go
+++ b/maas-api/internal/api_keys/handler_test.go
@@ -2220,9 +2220,9 @@ func TestBulkRevokeAPIKeys_BySubscription(t *testing.T) {
 
 	ctx := context.Background()
 
-	require.NoError(t, store.AddKey(ctx, "alice", "sub-a-key-1", "h1", "Key 1", "", nil, "sub-alpha", "test-tenant", nil, false))
-	require.NoError(t, store.AddKey(ctx, "bob", "sub-a-key-2", "h2", "Key 2", "", nil, "sub-alpha", "test-tenant", nil, false))
-	require.NoError(t, store.AddKey(ctx, "alice", "sub-b-key-1", "h3", "Key 3", "", nil, "sub-beta", "test-tenant", nil, false))
+	require.NoError(t, store.AddKey(ctx, "alice", "sub-a-key-1", "h1", "Key 1", "", nil, "sub-alpha", "test-tenant", nil, false, nil))
+	require.NoError(t, store.AddKey(ctx, "bob", "sub-a-key-2", "h2", "Key 2", "", nil, "sub-alpha", "test-tenant", nil, false, nil))
+	require.NoError(t, store.AddKey(ctx, "alice", "sub-b-key-1", "h3", "Key 3", "", nil, "sub-beta", "test-tenant", nil, false, nil))
 
 	t.Run("AdminCanRevokeBySubscription", func(t *testing.T) {
 		adminUser := &token.UserContext{
@@ -2278,9 +2278,9 @@ func TestBulkRevokeAPIKeys_BySubscription(t *testing.T) {
 		service2 := NewServiceWithLogger(store2, cfg, fixedSubSelector{}, logger.Development())
 		handler2 := NewHandler(logger.Development(), service2, newMockAdminChecker(), nil)
 
-		require.NoError(t, store2.AddKey(ctx, "alice", "combo-1", "ch1", "K1", "", nil, "sub-x", "test-tenant", nil, false))
-		require.NoError(t, store2.AddKey(ctx, "alice", "combo-2", "ch2", "K2", "", nil, "sub-y", "test-tenant", nil, false))
-		require.NoError(t, store2.AddKey(ctx, "bob", "combo-3", "ch3", "K3", "", nil, "sub-x", "test-tenant", nil, false))
+		require.NoError(t, store2.AddKey(ctx, "alice", "combo-1", "ch1", "K1", "", nil, "sub-x", "test-tenant", nil, false, nil))
+		require.NoError(t, store2.AddKey(ctx, "alice", "combo-2", "ch2", "K2", "", nil, "sub-y", "test-tenant", nil, false, nil))
+		require.NoError(t, store2.AddKey(ctx, "bob", "combo-3", "ch3", "K3", "", nil, "sub-x", "test-tenant", nil, false, nil))
 
 		adminUser := &token.UserContext{
 			Username: "admin",
@@ -2321,9 +2321,9 @@ func TestBulkRevokeAPIKeys_DryRun(t *testing.T) {
 
 	ctx := context.Background()
 
-	require.NoError(t, store.AddKey(ctx, "alice", "dr-key-1", "dh1", "DK1", "", nil, "sub-a", "test-tenant", nil, false))
-	require.NoError(t, store.AddKey(ctx, "alice", "dr-key-2", "dh2", "DK2", "", nil, "sub-a", "test-tenant", nil, false))
-	require.NoError(t, store.AddKey(ctx, "alice", "dr-key-3", "dh3", "DK3", "", nil, "sub-b", "test-tenant", nil, false))
+	require.NoError(t, store.AddKey(ctx, "alice", "dr-key-1", "dh1", "DK1", "", nil, "sub-a", "test-tenant", nil, false, nil))
+	require.NoError(t, store.AddKey(ctx, "alice", "dr-key-2", "dh2", "DK2", "", nil, "sub-a", "test-tenant", nil, false, nil))
+	require.NoError(t, store.AddKey(ctx, "alice", "dr-key-3", "dh3", "DK3", "", nil, "sub-b", "test-tenant", nil, false, nil))
 
 	t.Run("DryRunDoesNotMutate", func(t *testing.T) {
 		adminUser := &token.UserContext{

--- a/maas-api/internal/api_keys/handler_test.go
+++ b/maas-api/internal/api_keys/handler_test.go
@@ -423,7 +423,8 @@ func TestSearchAPIKeys_StatusFilter(t *testing.T) {
 	// Create active and revoked keys
 	err := store.AddKey(ctx, testUser.Username, "active-key", "active-hash", "Active Key", "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false, nil)
 	require.NoError(t, err)
-	err = store.AddKey(ctx, testUser.Username, "revoked-key", "revoked-hash", "Revoked Key", "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false, nil)
+	err = store.AddKey(ctx, testUser.Username, "revoked-key", "revoked-hash", "Revoked Key", "", []string{"system:authenticated"}, testSubscriptionName, 
+		"test-tenant", nil, false, nil)
 	require.NoError(t, err)
 	err = store.Revoke(ctx, "revoked-key")
 	require.NoError(t, err)
@@ -1671,7 +1672,8 @@ func TestCleanupExpiredEphemeralKeys(t *testing.T) {
 
 	// Create expired ephemeral key within 30-minute grace period (should NOT be deleted)
 	recentExpiry := time.Now().Add(-10 * time.Minute)
-	err = store.AddKey(ctx, "alice", "recently-expired-ephemeral", "hash-5", "Recently Expired Ephemeral", "", []string{"users"}, testSubscriptionName, "test-tenant", &recentExpiry, true, nil)
+	err = store.AddKey(ctx, "alice", "recently-expired-ephemeral", "hash-5", "Recently Expired Ephemeral", "", []string{"users"}, testSubscriptionName, 
+		"test-tenant", &recentExpiry, true, nil)
 	require.NoError(t, err)
 
 	t.Run("DeletesExpiredEphemeralKeys", func(t *testing.T) {
@@ -1821,9 +1823,11 @@ func TestSearchExcludesEphemeralByDefault(t *testing.T) {
 
 	// Create ephemeral keys
 	futureExpiry := time.Now().Add(1 * time.Hour)
-	err = store.AddKey(ctx, testUser.Username, "ephemeral-key-1", "hash-3", "Ephemeral Key 1", "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", &futureExpiry, true, nil)
+	err = store.AddKey(ctx, testUser.Username, "ephemeral-key-1", "hash-3", "Ephemeral Key 1", "", []string{"system:authenticated"}, testSubscriptionName, 
+		"test-tenant", &futureExpiry, true, nil)
 	require.NoError(t, err)
-	err = store.AddKey(ctx, testUser.Username, "ephemeral-key-2", "hash-4", "Ephemeral Key 2", "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", &futureExpiry, true, nil)
+	err = store.AddKey(ctx, testUser.Username, "ephemeral-key-2", "hash-4", "Ephemeral Key 2", "", []string{"system:authenticated"}, testSubscriptionName, 
+		"test-tenant", &futureExpiry, true, nil)
 	require.NoError(t, err)
 
 	t.Run("DefaultSearchExcludesEphemeral", func(t *testing.T) {
@@ -1870,16 +1874,19 @@ func TestSearchAPIKeys_ExpiredStatusComputation(t *testing.T) {
 
 	// Create a key that expired yesterday (stored as active, but past expiration)
 	pastExpiry := time.Now().Add(-24 * time.Hour)
-	err := store.AddKey(ctx, testUser.Username, "expired-key", "expired-hash", "Expired Key", "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", &pastExpiry, false, nil)
+	err := store.AddKey(ctx, testUser.Username, "expired-key", "expired-hash", "Expired Key", "", []string{"system:authenticated"}, testSubscriptionName, 
+		"test-tenant", &pastExpiry, false, nil)
 	require.NoError(t, err)
 
 	// Create an active key with future expiration
 	futureExpiry := time.Now().Add(24 * time.Hour)
-	err = store.AddKey(ctx, testUser.Username, "active-key", "active-hash", "Active Key","", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", &futureExpiry, false, nil)
+	err = store.AddKey(ctx, testUser.Username, "active-key", "active-hash", "Active Key","", []string{"system:authenticated"}, testSubscriptionName, 
+		"test-tenant", &futureExpiry, false, nil)
 	require.NoError(t, err)
 
 	// Create an active key with no expiration
-	err = store.AddKey(ctx, testUser.Username, "permanent-key", "permanent-hash", "Permanent Key", "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false, nil)
+	err = store.AddKey(ctx, testUser.Username, "permanent-key", "permanent-hash", "Permanent Key", "", []string{"system:authenticated"}, testSubscriptionName, 
+		"test-tenant", nil, false, nil)
 	require.NoError(t, err)
 
 	t.Run("SearchReturnsExpiredStatusForPastExpirationKeys", func(t *testing.T) {
@@ -1932,12 +1939,14 @@ func TestGetAPIKey_ExpiredStatusComputation(t *testing.T) {
 
 	// Create a key that expired yesterday
 	pastExpiry := time.Now().Add(-24 * time.Hour)
-	err := store.AddKey(ctx, testUser.Username, "expired-key", "expired-hash", "Expired Key", "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", &pastExpiry, false, nil)
+	err := store.AddKey(ctx, testUser.Username, "expired-key", "expired-hash", "Expired Key", "", []string{"system:authenticated"}, testSubscriptionName, 
+		"test-tenant", &pastExpiry, false, nil)
 	require.NoError(t, err)
 
 	// Create an active key with future expiration
 	futureExpiry := time.Now().Add(24 * time.Hour)
-	err = store.AddKey(ctx, testUser.Username, "active-key", "active-hash", "Active Key", "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", &futureExpiry, false, nil)
+	err = store.AddKey(ctx, testUser.Username, "active-key", "active-hash", "Active Key", "", []string{"system:authenticated"}, testSubscriptionName, 
+		"test-tenant", &futureExpiry, false, nil)
 	require.NoError(t, err)
 
 	t.Run("GetExpiredKeyReturnsExpiredStatus", func(t *testing.T) {
@@ -2608,7 +2617,7 @@ func TestValidateLabels_Errors(t *testing.T) {
 // Helper function to create a map with a specific number of entries.
 func makeLargeLabels(count int) map[string]string {
 	labels := make(map[string]string)
-	for i := 0; i < count; i++ {
+	for i := range count {
 		labels[fmt.Sprintf("key_%d", i)] = fmt.Sprintf("value_%d", i)
 	}
 	return labels
@@ -2713,7 +2722,7 @@ func TestCreateAPIKey_InvalidLabels(t *testing.T) {
 	}{
 		{
 			name:       "too many labels",
-			labelsJSON: makeLargeLabelsJSON(51),
+			labelsJSON: makeLargeLabelsJSON(t, constant.MaxLabelsEntries+1),
 			wantStatus: http.StatusBadRequest,
 			wantErr:    "cannot exceed 50",
 		},
@@ -2725,9 +2734,9 @@ func TestCreateAPIKey_InvalidLabels(t *testing.T) {
 		},
 		{
 			name:       "key too long",
-			labelsJSON: fmt.Sprintf(`{"%s": "value"}`, strings.Repeat("a", 129)),
+			labelsJSON: fmt.Sprintf(`{"%s": "value"}`, strings.Repeat("a", constant.MaxLabelKeyLength+1)),
 			wantStatus: http.StatusBadRequest,
-			wantErr:    "exceeds 128 characters",
+			wantErr:    fmt.Sprintf("exceeds %d characters", constant.MaxLabelKeyLength),
 		},
 	}
 
@@ -2753,7 +2762,7 @@ func TestCreateAPIKey_InvalidLabels(t *testing.T) {
 
 			assert.Equal(t, tt.wantStatus, w.Code)
 			
-			var errResp map[string]interface{}
+			var errResp map[string]any
 			err := json.Unmarshal(w.Body.Bytes(), &errResp)
 			require.NoError(t, err)
 			assert.Contains(t, errResp["error"], tt.wantErr)
@@ -2762,9 +2771,11 @@ func TestCreateAPIKey_InvalidLabels(t *testing.T) {
 }
 
 // Helper to generate JSON for large labels map.
-func makeLargeLabelsJSON(count int) string {
+func makeLargeLabelsJSON(t *testing.T, count int) string {
+	t.Helper()
 	labels := makeLargeLabels(count)
-	bytes, _ := json.Marshal(labels)
+	bytes, err := json.Marshal(labels)
+	require.NoError(t, err)
 	return string(bytes)
 }
 

--- a/maas-api/internal/api_keys/handler_test.go
+++ b/maas-api/internal/api_keys/handler_test.go
@@ -3131,3 +3131,79 @@ func TestGetAPIKey_WithLabels(t *testing.T) {
 
 	assert.Equal(t, labels, key.Labels)
 }
+
+// TestSearchAPIKeys_InvalidLabelsContain verifies that labelsContain filters
+// in search requests are validated with the same rules as label creation.
+func TestSearchAPIKeys_InvalidLabelsContain(t *testing.T) {
+	tests := []struct {
+		name          string
+		labelsContain map[string]string
+		wantErr       string
+	}{
+		{
+			name:          "empty key",
+			labelsContain: map[string]string{"": "value"},
+			wantErr:       "label keys cannot be empty",
+		},
+		{
+			name:          "too many labels",
+			labelsContain: makeLargeLabels(constant.MaxLabelsEntries + 1),
+			wantErr:       fmt.Sprintf("cannot exceed %d", constant.MaxLabelsEntries),
+		},
+		{
+			name:          "invalid key characters",
+			labelsContain: map[string]string{"invalid key!": "value"},
+			wantErr:       "invalid characters",
+		},
+		{
+			name:          "key too long",
+			labelsContain: map[string]string{strings.Repeat("a", constant.MaxLabelKeyLength+1): "value"},
+			wantErr:       fmt.Sprintf("exceeds %d characters", constant.MaxLabelKeyLength),
+		},
+		{
+			name:          "value too long",
+			labelsContain: map[string]string{"key": strings.Repeat("a", constant.MaxLabelValueLength+1)},
+			wantErr:       fmt.Sprintf("exceeds %d characters", constant.MaxLabelValueLength),
+		},
+		{
+			name:          "control characters in value",
+			labelsContain: map[string]string{"k": "val\x00ue"},
+			wantErr:       "contains invalid control characters",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := NewMockStore()
+			svc := NewService(store, &config.Config{}, fixedSubSelector{})
+			handler := NewHandler(logger.Development(), svc, newMockAdminChecker(), nil)
+
+			reqBody := SearchAPIKeysRequest{
+				Filters: &SearchFilters{
+					LabelsContain: tt.labelsContain,
+				},
+			}
+			body, err := json.Marshal(reqBody)
+			require.NoError(t, err)
+
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			c.Request = httptest.NewRequest(http.MethodPost, "/v1/api-keys/search", strings.NewReader(string(body)))
+			c.Request.Header.Set("Content-Type", "application/json")
+			c.Set("user", &token.UserContext{
+				Username: "alice",
+				Groups:   []string{"data-science"},
+				Tenant:   "test-tenant",
+			})
+
+			handler.SearchAPIKeys(c)
+
+			assert.Equal(t, http.StatusBadRequest, w.Code)
+
+			var errResp map[string]any
+			err = json.Unmarshal(w.Body.Bytes(), &errResp)
+			require.NoError(t, err)
+			assert.Contains(t, errResp["error"], tt.wantErr)
+		})
+	}
+}

--- a/maas-api/internal/api_keys/handler_test.go
+++ b/maas-api/internal/api_keys/handler_test.go
@@ -2321,7 +2321,7 @@ func TestSearchAPIKeys_NoAuthContext(t *testing.T) {
 	// Seed data so we can verify no keys leak when there is no auth context.
 	ctx := context.Background()
 	err := store.AddKey(ctx, "alice", "key-1", "hash-1", "Key 1", "",
-		[]string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false)
+		[]string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false, nil)
 	require.NoError(t, err)
 
 	t.Run("returns empty list when no auth headers at all", func(t *testing.T) {

--- a/maas-api/internal/api_keys/handler_test.go
+++ b/maas-api/internal/api_keys/handler_test.go
@@ -267,12 +267,12 @@ func TestSearchAPIKeys_EmptyRequest(t *testing.T) {
 
 	// Create test keys
 	ctx := context.Background()
-	err := store.AddKey(ctx, testUser.Username, "key-1", "hash-1", "Key 1", "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false)
+	err := store.AddKey(ctx, testUser.Username, "key-1", "hash-1", "Key 1", "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false, nil)
 	require.NoError(t, err)
-	err = store.AddKey(ctx, testUser.Username, "key-2", "hash-2", "Key 2", "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false)
+	err = store.AddKey(ctx, testUser.Username, "key-2", "hash-2", "Key 2", "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false, nil)
 	require.NoError(t, err)
 	// Create a revoked key
-	err = store.AddKey(ctx, testUser.Username, "key-3", "hash-3", "Key 3", "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false)
+	err = store.AddKey(ctx, testUser.Username, "key-3", "hash-3", "Key 3", "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false, nil)
 	require.NoError(t, err)
 	err = store.Revoke(ctx, "key-3")
 	require.NoError(t, err)
@@ -318,7 +318,7 @@ func TestSearchAPIKeys_Pagination(t *testing.T) {
 		keyID := fmt.Sprintf("key-%d", i)
 		keyHash := fmt.Sprintf("hash-%d", i)
 		name := fmt.Sprintf("Key %d", i)
-		err := store.AddKey(ctx, testUser.Username, keyID, keyHash, name, "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false)
+		err := store.AddKey(ctx, testUser.Username, keyID, keyHash, name, "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false, nil)
 		require.NoError(t, err)
 	}
 
@@ -419,9 +419,9 @@ func TestSearchAPIKeys_StatusFilter(t *testing.T) {
 	}
 
 	// Create active and revoked keys
-	err := store.AddKey(ctx, testUser.Username, "active-key", "active-hash", "Active Key", "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false)
+	err := store.AddKey(ctx, testUser.Username, "active-key", "active-hash", "Active Key", "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false, nil)
 	require.NoError(t, err)
-	err = store.AddKey(ctx, testUser.Username, "revoked-key", "revoked-hash", "Revoked Key", "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false)
+	err = store.AddKey(ctx, testUser.Username, "revoked-key", "revoked-hash", "Revoked Key", "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false, nil)
 	require.NoError(t, err)
 	err = store.Revoke(ctx, "revoked-key")
 	require.NoError(t, err)
@@ -545,9 +545,9 @@ func TestSearchAPIKeys_SubscriptionFilter(t *testing.T) {
 		Tenant:   "test-tenant",
 	}
 
-	err := store.AddKey(ctx, testUser.Username, "key-sub-a", "hash-a", "Key A", "", []string{"system:authenticated"}, "subscription-a", "test-tenant", nil, false)
+	err := store.AddKey(ctx, testUser.Username, "key-sub-a", "hash-a", "Key A", "", []string{"system:authenticated"}, "subscription-a", "test-tenant", nil, false, nil)
 	require.NoError(t, err)
-	err = store.AddKey(ctx, testUser.Username, "key-sub-b", "hash-b", "Key B", "", []string{"system:authenticated"}, "subscription-b", "test-tenant", nil, false)
+	err = store.AddKey(ctx, testUser.Username, "key-sub-b", "hash-b", "Key B", "", []string{"system:authenticated"}, "subscription-b", "test-tenant", nil, false, nil)
 	require.NoError(t, err)
 
 	t.Run("FilterBySubscription", func(t *testing.T) {
@@ -605,11 +605,11 @@ func TestSearchAPIKeys_Sorting(t *testing.T) {
 	}
 
 	// Create keys with different names
-	err := store.AddKey(ctx, testUser.Username, "key-1", "hash-1", "Charlie", "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false)
+	err := store.AddKey(ctx, testUser.Username, "key-1", "hash-1", "Charlie", "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false, nil)
 	require.NoError(t, err)
-	err = store.AddKey(ctx, testUser.Username, "key-2", "hash-2", "Alice", "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false)
+	err = store.AddKey(ctx, testUser.Username, "key-2", "hash-2", "Alice", "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false, nil)
 	require.NoError(t, err)
-	err = store.AddKey(ctx, testUser.Username, "key-3", "hash-3", "Bob", "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false)
+	err = store.AddKey(ctx, testUser.Username, "key-3", "hash-3", "Bob", "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false, nil)
 	require.NoError(t, err)
 
 	t.Run("DefaultSort_CreatedAtDesc", func(t *testing.T) {
@@ -732,7 +732,7 @@ func TestSearchAPIKeys_AdminVsRegularUser(t *testing.T) {
 			keyID := fmt.Sprintf("%s-key-%d", username, i)
 			keyHash := fmt.Sprintf("%s-hash-%d", username, i)
 			name := fmt.Sprintf("%s Key %d", username, i)
-			err := store.AddKey(ctx, username, keyID, keyHash, name, "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false)
+			err := store.AddKey(ctx, username, keyID, keyHash, name, "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false, nil)
 			require.NoError(t, err)
 		}
 	}
@@ -857,14 +857,14 @@ func TestSearchAPIKeys_AdminFiltersByUsernameAndStatus(t *testing.T) {
 			keyID := fmt.Sprintf("%s-active-%d", username, i)
 			keyHash := fmt.Sprintf("%s-hash-active-%d", username, i)
 			name := fmt.Sprintf("%s Active Key %d", username, i)
-			err := store.AddKey(ctx, username, keyID, keyHash, name, "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false)
+			err := store.AddKey(ctx, username, keyID, keyHash, name, "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false, nil)
 			require.NoError(t, err)
 		}
 		// Create 1 revoked key
 		keyID := fmt.Sprintf("%s-revoked", username)
 		keyHash := fmt.Sprintf("%s-hash-revoked", username)
 		name := fmt.Sprintf("%s Revoked Key", username)
-		err := store.AddKey(ctx, username, keyID, keyHash, name, "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false)
+		err := store.AddKey(ctx, username, keyID, keyHash, name, "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false, nil)
 		require.NoError(t, err)
 		err = store.Revoke(ctx, keyID)
 		require.NoError(t, err)
@@ -938,7 +938,7 @@ func TestBulkRevokeAPIKeys(t *testing.T) {
 		keyID := fmt.Sprintf("alice-key-%d", i)
 		keyHash := fmt.Sprintf("alice-hash-%d", i)
 		name := fmt.Sprintf("Alice Key %d", i)
-		err := store.AddKey(ctx, "alice", keyID, keyHash, name, "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false)
+		err := store.AddKey(ctx, "alice", keyID, keyHash, name, "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false, nil)
 		require.NoError(t, err)
 	}
 
@@ -946,7 +946,7 @@ func TestBulkRevokeAPIKeys(t *testing.T) {
 		keyID := fmt.Sprintf("bob-key-%d", i)
 		keyHash := fmt.Sprintf("bob-hash-%d", i)
 		name := fmt.Sprintf("Bob Key %d", i)
-		err := store.AddKey(ctx, "bob", keyID, keyHash, name, "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false)
+		err := store.AddKey(ctx, "bob", keyID, keyHash, name, "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false, nil)
 		require.NoError(t, err)
 	}
 
@@ -1003,7 +1003,7 @@ func TestBulkRevokeAPIKeys(t *testing.T) {
 			keyID := fmt.Sprintf("alice-key-%d", i)
 			keyHash := fmt.Sprintf("alice-hash-%d", i)
 			name := fmt.Sprintf("Alice Key %d", i)
-			err := store.AddKey(ctx, "alice", keyID, keyHash, name, "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false)
+			err := store.AddKey(ctx, "alice", keyID, keyHash, name, "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false, nil)
 			require.NoError(t, err)
 		}
 
@@ -1263,9 +1263,9 @@ func TestGetAPIKeyHandler(t *testing.T) {
 	}
 
 	// Add keys to store
-	err := store.AddKey(context.Background(), aliceKey.Username, aliceKey.ID, "hash1", aliceKey.Name, "", aliceKey.Groups, testSubscriptionName, "test-tenant", nil, false)
+	err := store.AddKey(context.Background(), aliceKey.Username, aliceKey.ID, "hash1", aliceKey.Name, "", aliceKey.Groups, testSubscriptionName, "test-tenant", nil, false, nil)
 	require.NoError(t, err)
-	err = store.AddKey(context.Background(), bobKey.Username, bobKey.ID, "hash2", bobKey.Name, "", bobKey.Groups, testSubscriptionName, "test-tenant", nil, false)
+	err = store.AddKey(context.Background(), bobKey.Username, bobKey.ID, "hash2", bobKey.Name, "", bobKey.Groups, testSubscriptionName, "test-tenant", nil, false, nil)
 	require.NoError(t, err)
 
 	// Helper function to test successful key retrieval
@@ -1362,7 +1362,7 @@ func testRevokeKeySuccess(t *testing.T, user *token.UserContext) {
 	handler := NewHandler(logger.Development(), service, newMockAdminChecker(), nil)
 
 	// Create alice's key
-	err := store.AddKey(context.Background(), "alice", "alice-key-1", "hash1", "Alice's Key", "", []string{"tier-free"}, testSubscriptionName, "test-tenant", nil, false)
+	err := store.AddKey(context.Background(), "alice", "alice-key-1", "hash1", "Alice's Key", "", []string{"tier-free"}, testSubscriptionName, "test-tenant", nil, false, nil)
 	require.NoError(t, err)
 
 	w := httptest.NewRecorder()
@@ -1406,7 +1406,7 @@ func TestRevokeAPIKeyHandler(t *testing.T) {
 		handler := NewHandler(logger.Development(), service, newMockAdminChecker(), nil)
 
 		// Create alice's key
-		err := store.AddKey(context.Background(), "alice", "alice-key-1", "hash1", "Alice's Key", "", []string{"tier-free"}, testSubscriptionName, "test-tenant", nil, false)
+		err := store.AddKey(context.Background(), "alice", "alice-key-1", "hash1", "Alice's Key", "", []string{"tier-free"}, testSubscriptionName, "test-tenant", nil, false, nil)
 		require.NoError(t, err)
 
 		// Bob trying to revoke Alice's key
@@ -1476,7 +1476,7 @@ func TestRevokeAPIKeyHandler(t *testing.T) {
 		handler := NewHandler(logger.Development(), service, newMockAdminChecker(), nil)
 
 		// Create and immediately revoke alice's key
-		err := store.AddKey(context.Background(), "alice", "alice-key-1", "hash1", "Alice's Key", "", []string{"tier-free"}, testSubscriptionName, "test-tenant", nil, false)
+		err := store.AddKey(context.Background(), "alice", "alice-key-1", "hash1", "Alice's Key", "", []string{"tier-free"}, testSubscriptionName, "test-tenant", nil, false, nil)
 		require.NoError(t, err)
 		err = store.Revoke(context.Background(), "alice-key-1")
 		require.NoError(t, err)
@@ -1649,28 +1649,27 @@ func TestCleanupExpiredEphemeralKeys(t *testing.T) {
 	ctx := context.Background()
 
 	// Create regular active key (should NOT be deleted)
-	err := store.AddKey(ctx, "alice", "regular-key", "hash-1", "Regular Key", "", []string{"users"}, testSubscriptionName, "test-tenant", nil, false)
+	err := store.AddKey(ctx, "alice", "regular-key", "hash-1", "Regular Key", "", []string{"users"}, testSubscriptionName, "test-tenant", nil, false, nil)
 	require.NoError(t, err)
 
 	// Create active ephemeral key with future expiration (should NOT be deleted)
 	futureExpiry := time.Now().Add(30 * time.Minute)
-	err = store.AddKey(ctx, "alice", "active-ephemeral", "hash-2", "Active Ephemeral", "", []string{"users"}, testSubscriptionName, "test-tenant", &futureExpiry, true)
+	err = store.AddKey(ctx, "alice", "active-ephemeral", "hash-2", "Active Ephemeral", "", []string{"users"}, testSubscriptionName, "test-tenant", &futureExpiry, true, nil)
 	require.NoError(t, err)
 
 	// Create expired ephemeral key (should be deleted)
 	pastExpiry := time.Now().Add(-1 * time.Hour)
-	err = store.AddKey(ctx, "alice", "expired-ephemeral", "hash-3", "Expired Ephemeral", "", []string{"users"}, testSubscriptionName, "test-tenant", &pastExpiry, true)
+	err = store.AddKey(ctx, "alice", "expired-ephemeral", "hash-3", "Expired Ephemeral", "", []string{"users"}, testSubscriptionName, "test-tenant", &pastExpiry, true, nil)
 	require.NoError(t, err)
 
 	// Create another expired ephemeral key (should be deleted)
 	pastExpiry2 := time.Now().Add(-2 * time.Hour)
-	err = store.AddKey(ctx, "bob", "expired-ephemeral-2", "hash-4", "Expired Ephemeral 2", "", []string{"users"}, testSubscriptionName, "test-tenant", &pastExpiry2, true)
+	err = store.AddKey(ctx, "bob", "expired-ephemeral-2", "hash-4", "Expired Ephemeral 2", "", []string{"users"}, testSubscriptionName, "test-tenant", &pastExpiry2, true, nil)
 	require.NoError(t, err)
 
 	// Create expired ephemeral key within 30-minute grace period (should NOT be deleted)
 	recentExpiry := time.Now().Add(-10 * time.Minute)
-	err = store.AddKey(ctx, "alice", "recently-expired-ephemeral", "hash-5", "Recently Expired Ephemeral",
-		"", []string{"users"}, testSubscriptionName, "test-tenant", &recentExpiry, true)
+	err = store.AddKey(ctx, "alice", "recently-expired-ephemeral", "hash-5", "Recently Expired Ephemeral", "", []string{"users"}, testSubscriptionName, "test-tenant", &recentExpiry, true, nil)
 	require.NoError(t, err)
 
 	t.Run("DeletesExpiredEphemeralKeys", func(t *testing.T) {
@@ -1813,18 +1812,16 @@ func TestSearchExcludesEphemeralByDefault(t *testing.T) {
 	}
 
 	// Create regular keys
-	err := store.AddKey(ctx, testUser.Username, "regular-key-1", "hash-1", "Regular Key 1", "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false)
+	err := store.AddKey(ctx, testUser.Username, "regular-key-1", "hash-1", "Regular Key 1", "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false, nil)
 	require.NoError(t, err)
-	err = store.AddKey(ctx, testUser.Username, "regular-key-2", "hash-2", "Regular Key 2", "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false)
+	err = store.AddKey(ctx, testUser.Username, "regular-key-2", "hash-2", "Regular Key 2", "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false, nil)
 	require.NoError(t, err)
 
 	// Create ephemeral keys
 	futureExpiry := time.Now().Add(1 * time.Hour)
-	err = store.AddKey(ctx, testUser.Username, "ephemeral-key-1", "hash-3", "Ephemeral Key 1",
-		"", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", &futureExpiry, true)
+	err = store.AddKey(ctx, testUser.Username, "ephemeral-key-1", "hash-3", "Ephemeral Key 1", "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", &futureExpiry, true, nil)
 	require.NoError(t, err)
-	err = store.AddKey(ctx, testUser.Username, "ephemeral-key-2", "hash-4", "Ephemeral Key 2",
-		"", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", &futureExpiry, true)
+	err = store.AddKey(ctx, testUser.Username, "ephemeral-key-2", "hash-4", "Ephemeral Key 2", "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", &futureExpiry, true, nil)
 	require.NoError(t, err)
 
 	t.Run("DefaultSearchExcludesEphemeral", func(t *testing.T) {
@@ -1871,19 +1868,16 @@ func TestSearchAPIKeys_ExpiredStatusComputation(t *testing.T) {
 
 	// Create a key that expired yesterday (stored as active, but past expiration)
 	pastExpiry := time.Now().Add(-24 * time.Hour)
-	err := store.AddKey(ctx, testUser.Username, "expired-key", "expired-hash", "Expired Key",
-		"", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", &pastExpiry, false)
+	err := store.AddKey(ctx, testUser.Username, "expired-key", "expired-hash", "Expired Key", "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", &pastExpiry, false, nil)
 	require.NoError(t, err)
 
 	// Create an active key with future expiration
 	futureExpiry := time.Now().Add(24 * time.Hour)
-	err = store.AddKey(ctx, testUser.Username, "active-key", "active-hash", "Active Key",
-		"", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", &futureExpiry, false)
+	err = store.AddKey(ctx, testUser.Username, "active-key", "active-hash", "Active Key","", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", &futureExpiry, false, nil)
 	require.NoError(t, err)
 
 	// Create an active key with no expiration
-	err = store.AddKey(ctx, testUser.Username, "permanent-key", "permanent-hash", "Permanent Key",
-		"", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false)
+	err = store.AddKey(ctx, testUser.Username, "permanent-key", "permanent-hash", "Permanent Key", "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false, nil)
 	require.NoError(t, err)
 
 	t.Run("SearchReturnsExpiredStatusForPastExpirationKeys", func(t *testing.T) {
@@ -1936,14 +1930,12 @@ func TestGetAPIKey_ExpiredStatusComputation(t *testing.T) {
 
 	// Create a key that expired yesterday
 	pastExpiry := time.Now().Add(-24 * time.Hour)
-	err := store.AddKey(ctx, testUser.Username, "expired-key", "expired-hash", "Expired Key",
-		"", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", &pastExpiry, false)
+	err := store.AddKey(ctx, testUser.Username, "expired-key", "expired-hash", "Expired Key", "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", &pastExpiry, false, nil)
 	require.NoError(t, err)
 
 	// Create an active key with future expiration
 	futureExpiry := time.Now().Add(24 * time.Hour)
-	err = store.AddKey(ctx, testUser.Username, "active-key", "active-hash", "Active Key",
-		"", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", &futureExpiry, false)
+	err = store.AddKey(ctx, testUser.Username, "active-key", "active-hash", "Active Key", "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", &futureExpiry, false, nil)
 	require.NoError(t, err)
 
 	t.Run("GetExpiredKeyReturnsExpiredStatus", func(t *testing.T) {
@@ -2042,9 +2034,7 @@ func TestCrossTenantAccessRejected(t *testing.T) {
 			h := NewHandler(logger.Development(), svc, newMockAdminChecker(), nil)
 
 			ctx := context.Background()
-			err := store.AddKey(ctx, "alice", "ta-key-1", "hash-ta1", "TA Key", "",
-				[]string{"system:authenticated"}, testSubscriptionName,
-				"tenant-a", nil, false)
+			err := store.AddKey(ctx, "alice", "ta-key-1", "hash-ta1", "TA Key", "", []string{"system:authenticated"}, testSubscriptionName, "tenant-a", nil, false, nil)
 			require.NoError(t, err)
 
 			w := httptest.NewRecorder()
@@ -2078,11 +2068,11 @@ func TestSearchAPIKeys_TenantIsolation(t *testing.T) {
 	ctx := context.Background()
 
 	// Create keys for two tenants under same username
-	err := store.AddKey(ctx, "alice", "key-ta-1", "hash-ta1", "TA Key 1", "", []string{"system:authenticated"}, testSubscriptionName, "tenant-a", nil, false)
+	err := store.AddKey(ctx, "alice", "key-ta-1", "hash-ta1", "TA Key 1", "", []string{"system:authenticated"}, testSubscriptionName, "tenant-a", nil, false, nil)
 	require.NoError(t, err)
-	err = store.AddKey(ctx, "alice", "key-ta-2", "hash-ta2", "TA Key 2", "", []string{"system:authenticated"}, testSubscriptionName, "tenant-a", nil, false)
+	err = store.AddKey(ctx, "alice", "key-ta-2", "hash-ta2", "TA Key 2", "", []string{"system:authenticated"}, testSubscriptionName, "tenant-a", nil, false, nil)
 	require.NoError(t, err)
-	err = store.AddKey(ctx, "alice", "key-tb-1", "hash-tb1", "TB Key 1", "", []string{"system:authenticated"}, testSubscriptionName, "tenant-b", nil, false)
+	err = store.AddKey(ctx, "alice", "key-tb-1", "hash-tb1", "TB Key 1", "", []string{"system:authenticated"}, testSubscriptionName, "tenant-b", nil, false, nil)
 	require.NoError(t, err)
 
 	// Tenant-A user should only see tenant-A keys
@@ -2158,19 +2148,15 @@ func TestBulkRevokeAPIKeys_TenantIsolation(t *testing.T) {
 	ctx := context.Background()
 
 	// Create 2 keys for "alice" in tenant-a
-	err := store.AddKey(ctx, "alice", "ta-key-1", "hash-ta1", "TA Key 1", "",
-		[]string{"system:authenticated"}, testSubscriptionName, "tenant-a", nil, false)
+	err := store.AddKey(ctx, "alice", "ta-key-1", "hash-ta1", "TA Key 1", "", []string{"system:authenticated"}, testSubscriptionName, "tenant-a", nil, false, nil)
 	require.NoError(t, err)
-	err = store.AddKey(ctx, "alice", "ta-key-2", "hash-ta2", "TA Key 2", "",
-		[]string{"system:authenticated"}, testSubscriptionName, "tenant-a", nil, false)
+	err = store.AddKey(ctx, "alice", "ta-key-2", "hash-ta2", "TA Key 2", "", []string{"system:authenticated"}, testSubscriptionName, "tenant-a", nil, false, nil)
 	require.NoError(t, err)
 
 	// Create 2 keys for "alice" in tenant-b
-	err = store.AddKey(ctx, "alice", "tb-key-1", "hash-tb1", "TB Key 1", "",
-		[]string{"system:authenticated"}, testSubscriptionName, "tenant-b", nil, false)
+	err = store.AddKey(ctx, "alice", "tb-key-1", "hash-tb1", "TB Key 1", "", []string{"system:authenticated"}, testSubscriptionName, "tenant-b", nil, false, nil)
 	require.NoError(t, err)
-	err = store.AddKey(ctx, "alice", "tb-key-2", "hash-tb2", "TB Key 2", "",
-		[]string{"system:authenticated"}, testSubscriptionName, "tenant-b", nil, false)
+	err = store.AddKey(ctx, "alice", "tb-key-2", "hash-tb2", "TB Key 2", "", []string{"system:authenticated"}, testSubscriptionName, "tenant-b", nil, false, nil)
 	require.NoError(t, err)
 
 	// Admin from tenant-a bulk revokes "alice"
@@ -2226,11 +2212,9 @@ func TestSearchAPIKeys_AdminCrossTenantIsolation(t *testing.T) {
 	ctx := context.Background()
 
 	// Create keys for "alice" in tenant-a
-	err := store.AddKey(ctx, "alice", "ta-key-1", "hash-ta1", "TA Key 1", "",
-		[]string{"system:authenticated"}, testSubscriptionName, "tenant-a", nil, false)
+	err := store.AddKey(ctx, "alice", "ta-key-1", "hash-ta1", "TA Key 1", "", []string{"system:authenticated"}, testSubscriptionName, "tenant-a", nil, false, nil)
 	require.NoError(t, err)
-	err = store.AddKey(ctx, "alice", "ta-key-2", "hash-ta2", "TA Key 2", "",
-		[]string{"system:authenticated"}, testSubscriptionName, "tenant-a", nil, false)
+	err = store.AddKey(ctx, "alice", "ta-key-2", "hash-ta2", "TA Key 2", "", []string{"system:authenticated"}, testSubscriptionName, "tenant-a", nil, false, nil)
 	require.NoError(t, err)
 
 	t.Run("AdminFromTenantBSeesNoKeys", func(t *testing.T) {
@@ -2271,11 +2255,9 @@ func TestSearchAPIKeys_EmptyTenantNoResults(t *testing.T) {
 	ctx := context.Background()
 
 	// Create keys in tenant-a
-	err := store.AddKey(ctx, "alice", "ta-key-1", "hash-ta1", "TA Key 1", "",
-		[]string{"system:authenticated"}, testSubscriptionName, "tenant-a", nil, false)
+	err := store.AddKey(ctx, "alice", "ta-key-1", "hash-ta1", "TA Key 1", "", []string{"system:authenticated"}, testSubscriptionName, "tenant-a", nil, false, nil)
 	require.NoError(t, err)
-	err = store.AddKey(ctx, "alice", "ta-key-2", "hash-ta2", "TA Key 2", "",
-		[]string{"system:authenticated"}, testSubscriptionName, "tenant-a", nil, false)
+	err = store.AddKey(ctx, "alice", "ta-key-2", "hash-ta2", "TA Key 2", "", []string{"system:authenticated"}, testSubscriptionName, "tenant-a", nil, false, nil)
 	require.NoError(t, err)
 
 	// User from tenant-c (no keys exist) searches

--- a/maas-api/internal/api_keys/service.go
+++ b/maas-api/internal/api_keys/service.go
@@ -96,6 +96,7 @@ type CreateAPIKeyResponse struct {
 	CreatedAt    string  `json:"createdAt"`
 	ExpiresAt    *string `json:"expiresAt,omitempty"` // RFC3339 timestamp
 	Ephemeral    bool    `json:"ephemeral"`           // Short-lived programmatic key
+	Labels       map[string]string `json:"labels,omitempty"` // Structured key-value pairs for API key metadata
 }
 
 // CreateAPIKey creates a new API key (sk-oai-* format).
@@ -108,7 +109,7 @@ type CreateAPIKeyResponse struct {
 // Admins can create keys for other users by specifying a different username.
 func (s *Service) CreateAPIKey(
 	ctx context.Context, username string, userGroups []string, name, description string,
-	expiresIn *time.Duration, ephemeral bool, requestedSubscription string, tenant string,
+	expiresIn *time.Duration, ephemeral bool, requestedSubscription string, tenant string, labels map[string]string,
 ) (*CreateAPIKeyResponse, error) {
 	// Validate group names against allowlist pattern (CWE-116/CWE-74 mitigation).
 	// AuthPolicy uses CEL to build JSON arrays from groups, and CEL lacks JSON escaping
@@ -186,7 +187,7 @@ func (s *Service) CreateAPIKey(
 	// Note: prefix is NOT stored (security - reduces brute-force attack surface)
 	// userGroups stored as PostgreSQL TEXT[] array (no JSON marshaling needed)
 	// Hash is SHA-256(key_id + secret) where key_id is embedded in the API key as per-key salt
-	if err := s.store.AddKey(ctx, username, keyID, hash, name, description, userGroups, subscriptionName, tenant, &expiresAt, ephemeral); err != nil {
+	if err := s.store.AddKey(ctx, username, keyID, hash, name, description, userGroups, subscriptionName, tenant, &expiresAt, ephemeral, labels); err != nil {
 		return nil, fmt.Errorf("failed to store API key: %w", err)
 	}
 
@@ -203,6 +204,7 @@ func (s *Service) CreateAPIKey(
 		CreatedAt:    time.Now().UTC().Format(time.RFC3339),
 		ExpiresAt:    &formatted,
 		Ephemeral:    ephemeral,
+		Labels:       labels,
 	}
 
 	return response, nil

--- a/maas-api/internal/api_keys/service_test.go
+++ b/maas-api/internal/api_keys/service_test.go
@@ -436,12 +436,12 @@ func TestRevokeTenantAPIKeys(t *testing.T) {
 		tenantAIDs := []string{"tenant-revoke-a1", "tenant-revoke-a2", "tenant-revoke-a3"}
 		for _, id := range tenantAIDs {
 			_, hash := createTestAPIKey(t)
-			err := store.AddKey(ctx, "alice", id, hash, "Key "+id, "", []string{"users"}, "default-sub", "tenant-a", nil, false)
+			err := store.AddKey(ctx, "alice", id, hash, "Key "+id, "", []string{"users"}, "default-sub", "tenant-a", nil, false, nil)
 			require.NoError(t, err)
 		}
 
 		_, hash := createTestAPIKey(t)
-		require.NoError(t, store.AddKey(ctx, "bob", "tenant-revoke-b1", hash, "Tenant B", "", []string{"users"}, "default-sub", "tenant-b", nil, false))
+		require.NoError(t, store.AddKey(ctx, "bob", "tenant-revoke-b1", hash, "Tenant B", "", []string{"users"}, "default-sub", "tenant-b", nil, false, nil))
 
 		count, err := svc.RevokeTenantAPIKeys(ctx, "tenant-a")
 		require.NoError(t, err)
@@ -462,7 +462,7 @@ func TestRevokeTenantAPIKeys(t *testing.T) {
 		svc, store := createTestService(t)
 
 		_, hash := createTestAPIKey(t)
-		require.NoError(t, store.AddKey(ctx, "alice", "tenant-revoke-idem", hash, "Idempotent", "", []string{"users"}, "default-sub", "tenant-a", nil, false))
+		require.NoError(t, store.AddKey(ctx, "alice", "tenant-revoke-idem", hash, "Idempotent", "", []string{"users"}, "default-sub", "tenant-a", nil, false, nil))
 
 		count, err := svc.RevokeTenantAPIKeys(ctx, "tenant-a")
 		require.NoError(t, err)

--- a/maas-api/internal/api_keys/service_test.go
+++ b/maas-api/internal/api_keys/service_test.go
@@ -52,7 +52,7 @@ func TestValidateAPIKey_ValidKey(t *testing.T) {
 	username := "alice"
 	groups := []string{"tier-premium", "system:authenticated"}
 
-	err := store.AddKey(ctx, username, keyID, hash, "Test Key", "", groups, "default-sub", "", nil, false)
+	err := store.AddKey(ctx, username, keyID, hash, "Test Key", "", groups, "default-sub", "", nil, false, nil)
 	require.NoError(t, err)
 
 	// Validate the key
@@ -116,7 +116,7 @@ func TestValidateAPIKey_RevokedKey(t *testing.T) {
 	username := "bob"
 	groups := []string{"tier-free"}
 
-	err := store.AddKey(ctx, username, keyID, hash, "Revoked Key", "", groups, "default-sub", "", nil, false)
+	err := store.AddKey(ctx, username, keyID, hash, "Revoked Key", "", groups, "default-sub", "", nil, false, nil)
 	require.NoError(t, err)
 
 	// Revoke the key
@@ -143,7 +143,7 @@ func TestValidateAPIKey_ExpiredKey(t *testing.T) {
 	groups := []string{"tier-basic"}
 	expiresAt := time.Now().Add(-24 * time.Hour) // Expired 1 day ago
 
-	err := store.AddKey(ctx, username, keyID, hash, "Expired Key", "", groups, "default-sub", "", &expiresAt, false)
+	err := store.AddKey(ctx, username, keyID, hash, "Expired Key", "", groups, "default-sub", "", &expiresAt, false, nil)
 	require.NoError(t, err)
 
 	// Validate the expired key
@@ -164,7 +164,7 @@ func TestValidateAPIKey_EmptyGroups(t *testing.T) {
 	plainKey, hash := createTestAPIKey(t)
 	username := "dave"
 
-	err := store.AddKey(ctx, username, keyID, hash, "No Groups Key", "", nil, "default-sub", "", nil, false)
+	err := store.AddKey(ctx, username, keyID, hash, "No Groups Key", "", nil, "default-sub", "", nil, false, nil)
 	require.NoError(t, err)
 
 	// Validate the key
@@ -188,7 +188,7 @@ func TestValidateAPIKey_UpdatesLastUsed(t *testing.T) {
 	username := "eve"
 	groups := []string{"tier-enterprise"}
 
-	err := store.AddKey(ctx, username, keyID, hash, "Last Used Test", "", groups, "default-sub", "", nil, false)
+	err := store.AddKey(ctx, username, keyID, hash, "Last Used Test", "", groups, "default-sub", "", nil, false, nil)
 	require.NoError(t, err)
 
 	// Get initial metadata (last_used_at should be empty/nil)
@@ -223,7 +223,7 @@ func TestValidateAPIKey_DebounceSuppressesExtraWrites(t *testing.T) {
 
 	keyID := "550e8400-e29b-41d4-a716-446655440020"
 	plainKey, hash := createTestAPIKey(t)
-	err := store.AddKey(ctx, "frank", keyID, hash, "Debounce Test", "", []string{"tier-basic"}, "default-sub", "", nil, false)
+	err := store.AddKey(ctx, "frank", keyID, hash, "Debounce Test", "", []string{"tier-basic"}, "default-sub", "", nil, false, nil)
 	require.NoError(t, err)
 
 	const concurrentRequests = 10
@@ -255,7 +255,7 @@ func TestValidateAPIKey_DebounceDisabled_WritesEveryTime(t *testing.T) {
 
 	keyID := "550e8400-e29b-41d4-a716-446655440021"
 	plainKey, hash := createTestAPIKey(t)
-	err := store.AddKey(ctx, "grace", keyID, hash, "Debounce Disabled Test", "", []string{"tier-basic"}, "default-sub", "", nil, false)
+	err := store.AddKey(ctx, "grace", keyID, hash, "Debounce Disabled Test", "", []string{"tier-basic"}, "default-sub", "", nil, false, nil)
 	require.NoError(t, err)
 
 	const calls = 3
@@ -282,7 +282,7 @@ func TestValidateAPIKey_DebounceWritesAfterTTLExpiry(t *testing.T) {
 
 	keyID := "550e8400-e29b-41d4-a716-446655440022"
 	plainKey, hash := createTestAPIKey(t)
-	err := store.AddKey(ctx, "henry", keyID, hash, "TTL Expiry Test", "", []string{"tier-basic"}, "default-sub", "", nil, false)
+	err := store.AddKey(ctx, "henry", keyID, hash, "TTL Expiry Test", "", []string{"tier-basic"}, "default-sub", "", nil, false, nil)
 	require.NoError(t, err)
 
 	// First validation triggers a write.
@@ -321,7 +321,7 @@ func TestValidateAPIKey_ReturnsTenant(t *testing.T) {
 	keyID := "550e8400-e29b-41d4-a716-446655440010"
 	plainKey, hash := createTestAPIKey(t)
 
-	err := store.AddKey(ctx, "alice", keyID, hash, "Tenant Key", "", []string{"users"}, "default-sub", "acme-corp", nil, false)
+	err := store.AddKey(ctx, "alice", keyID, hash, "Tenant Key", "", []string{"users"}, "default-sub", "acme-corp", nil, false, nil)
 	require.NoError(t, err)
 
 	result, err := svc.ValidateAPIKey(ctx, plainKey)
@@ -340,7 +340,7 @@ func TestValidateAPIKey_EmptyTenantReturnsEmpty(t *testing.T) {
 	plainKey, hash := createTestAPIKey(t)
 
 	// Legacy key with empty tenant
-	err := store.AddKey(ctx, "alice", keyID, hash, "Legacy Key", "", []string{"users"}, "default-sub", "", nil, false)
+	err := store.AddKey(ctx, "alice", keyID, hash, "Legacy Key", "", []string{"users"}, "default-sub", "", nil, false, nil)
 	require.NoError(t, err)
 
 	result, err := svc.ValidateAPIKey(ctx, plainKey)
@@ -361,7 +361,7 @@ func TestValidateAPIKey_TenantNotExposedOnInvalid(t *testing.T) {
 		keyID := "550e8400-e29b-41d4-a716-446655440012"
 		plainKey, hash := createTestAPIKey(t)
 
-		err := store.AddKey(ctx, "alice", keyID, hash, "Tenant Revoked", "", []string{"users"}, "default-sub", "acme-corp", nil, false)
+		err := store.AddKey(ctx, "alice", keyID, hash, "Tenant Revoked", "", []string{"users"}, "default-sub", "acme-corp", nil, false, nil)
 		require.NoError(t, err)
 
 		err = store.Revoke(ctx, keyID)
@@ -400,7 +400,7 @@ func TestBulkRevokeAPIKeys_TenantScopedCount(t *testing.T) {
 	for i := range 3 {
 		_, hash := createTestAPIKey(t)
 		id := "tenant-a-key-" + string(rune('a'+i))
-		err := store.AddKey(ctx, "alice", id, hash, "Key "+id, "", []string{"users"}, "default-sub", "tenant-a", nil, false)
+		err := store.AddKey(ctx, "alice", id, hash, "Key "+id, "", []string{"users"}, "default-sub", "tenant-a", nil, false, nil)
 		require.NoError(t, err)
 	}
 
@@ -410,7 +410,7 @@ func TestBulkRevokeAPIKeys_TenantScopedCount(t *testing.T) {
 		_, hash := createTestAPIKey(t)
 		id := "tenant-b-key-" + string(rune('a'+i))
 		tenantBIDs[i] = id
-		err := store.AddKey(ctx, "alice", id, hash, "Key "+id, "", []string{"users"}, "default-sub", "tenant-b", nil, false)
+		err := store.AddKey(ctx, "alice", id, hash, "Key "+id, "", []string{"users"}, "default-sub", "tenant-b", nil, false, nil)
 		require.NoError(t, err)
 	}
 
@@ -508,7 +508,7 @@ func TestGetAPIKey(t *testing.T) {
 	username := "alice"
 	keyName := "Alice's Key"
 
-	err := store.AddKey(ctx, username, keyID, hash, keyName, "Test description", nil, "default-sub", "", nil, false)
+	err := store.AddKey(ctx, username, keyID, hash, keyName, "Test description", nil, "default-sub", "", nil, false, nil)
 	require.NoError(t, err)
 
 	// Get via service layer
@@ -540,7 +540,7 @@ func TestRevokeAPIKey(t *testing.T) {
 	_, hash := createTestAPIKey(t)
 	username := "bob"
 
-	err := store.AddKey(ctx, username, keyID, hash, "Revoke Test", "", nil, "default-sub", "", nil, false)
+	err := store.AddKey(ctx, username, keyID, hash, "Revoke Test", "", nil, "default-sub", "", nil, false, nil)
 	require.NoError(t, err)
 
 	// Verify it's active
@@ -581,7 +581,7 @@ func TestRevokeAPIKey_AlreadyRevoked(t *testing.T) {
 
 	keyID := "double-revoke-key"
 	_, hash := createTestAPIKey(t)
-	require.NoError(t, store.AddKey(ctx, "alice", keyID, hash, "Double Revoke", "", nil, "default-sub", "", nil, false))
+	require.NoError(t, store.AddKey(ctx, "alice", keyID, hash, "Double Revoke", "", nil, "default-sub", "", nil, false, nil))
 
 	// First revoke succeeds
 	require.NoError(t, svc.RevokeAPIKey(ctx, keyID))
@@ -600,7 +600,7 @@ func TestRevokeAPIKey_ThenValidate(t *testing.T) {
 
 	keyID := "revoke-validate-key"
 	plainKey, hash := createTestAPIKey(t)
-	require.NoError(t, store.AddKey(ctx, "eve", keyID, hash, "Revoke Then Validate", "", []string{"users"}, "default-sub", "", nil, false))
+	require.NoError(t, store.AddKey(ctx, "eve", keyID, hash, "Revoke Then Validate", "", []string{"users"}, "default-sub", "", nil, false, nil))
 
 	// Revoke via service
 	require.NoError(t, svc.RevokeAPIKey(ctx, keyID))
@@ -629,7 +629,7 @@ func TestBulkRevokeAPIKeys(t *testing.T) {
 		for i := range 3 {
 			_, hash := createTestAPIKey(t)
 			id := "bulk-key-" + string(rune('a'+i))
-			require.NoError(t, store.AddKey(ctx, "alice", id, hash, "Key "+id, "", nil, "default-sub", "", nil, false))
+			require.NoError(t, store.AddKey(ctx, "alice", id, hash, "Key "+id, "", nil, "default-sub", "", nil, false, nil))
 		}
 
 		count, err := svc.BulkRevokeAPIKeys(ctx, "alice", "")
@@ -662,7 +662,7 @@ func TestBulkRevokeAPIKeys(t *testing.T) {
 		svc, store := createTestService(t)
 
 		_, hash := createTestAPIKey(t)
-		require.NoError(t, store.AddKey(ctx, "bob", "idem-key", hash, "Idempotent Key", "", nil, "default-sub", "", nil, false))
+		require.NoError(t, store.AddKey(ctx, "bob", "idem-key", hash, "Idempotent Key", "", nil, "default-sub", "", nil, false, nil))
 
 		count, err := svc.BulkRevokeAPIKeys(ctx, "bob", "")
 		require.NoError(t, err)
@@ -697,7 +697,7 @@ func TestBulkRevokeAPIKeys_ThenValidateAll(t *testing.T) {
 		plain, hash := createTestAPIKey(t)
 		plainKeys[i] = plain
 		id := "bulk-validate-" + string(rune('a'+i))
-		require.NoError(t, store.AddKey(ctx, "carol", id, hash, "Key "+id, "", []string{"users"}, "default-sub", "", nil, false))
+		require.NoError(t, store.AddKey(ctx, "carol", id, hash, "Key "+id, "", []string{"users"}, "default-sub", "", nil, false, nil))
 	}
 
 	// Bulk revoke all of carol's keys
@@ -730,7 +730,7 @@ func TestCreateAPIKey_MaxExpirationLimit(t *testing.T) {
 
 		// Request 7 days - should succeed
 		expiresIn := 7 * 24 * time.Hour
-		result, err := svc.CreateAPIKey(ctx, "alice", []string{"users"}, "Test Key", "", &expiresIn, false, "", "")
+		result, err := svc.CreateAPIKey(ctx, "alice", []string{"users"}, "Test Key", "", &expiresIn, false, "", "", nil)
 
 		require.NoError(t, err)
 		require.NotNil(t, result)
@@ -746,7 +746,7 @@ func TestCreateAPIKey_MaxExpirationLimit(t *testing.T) {
 
 		// Request 60 days - should fail
 		expiresIn := 60 * 24 * time.Hour
-		result, err := svc.CreateAPIKey(ctx, "alice", []string{"users"}, "Test Key", "", &expiresIn, false, "", "")
+		result, err := svc.CreateAPIKey(ctx, "alice", []string{"users"}, "Test Key", "", &expiresIn, false, "", "", nil)
 
 		require.Error(t, err)
 		assert.Nil(t, result)
@@ -763,7 +763,7 @@ func TestCreateAPIKey_MaxExpirationLimit(t *testing.T) {
 
 		// Request exactly 30 days - should succeed
 		expiresIn := 30 * 24 * time.Hour
-		result, err := svc.CreateAPIKey(ctx, "alice", []string{"users"}, "Test Key", "", &expiresIn, false, "", "")
+		result, err := svc.CreateAPIKey(ctx, "alice", []string{"users"}, "Test Key", "", &expiresIn, false, "", "", nil)
 
 		require.NoError(t, err)
 		require.NotNil(t, result)
@@ -777,7 +777,7 @@ func TestCreateAPIKey_MaxExpirationLimit(t *testing.T) {
 		svc := api_keys.NewServiceWithLogger(store, cfg, serviceTestSubSelector{}, logger.Development())
 
 		// No expiration requested - should default to APIKeyMaxExpirationDays (30 days)
-		result, err := svc.CreateAPIKey(ctx, "alice", []string{"users"}, "Test Key", "", nil, false, "", "")
+		result, err := svc.CreateAPIKey(ctx, "alice", []string{"users"}, "Test Key", "", nil, false, "", "", nil)
 
 		require.NoError(t, err)
 		require.NotNil(t, result)
@@ -792,7 +792,7 @@ func TestCreateAPIKey_MaxExpirationLimit(t *testing.T) {
 
 		// Request 365 days - should fail because default max is 90 days
 		expiresIn := 365 * 24 * time.Hour
-		result, err := svc.CreateAPIKey(ctx, "alice", []string{"users"}, "Test Key", "", &expiresIn, false, "", "")
+		result, err := svc.CreateAPIKey(ctx, "alice", []string{"users"}, "Test Key", "", &expiresIn, false, "", "", nil)
 
 		require.Error(t, err, "should reject expiration exceeding default max (90 days)")
 		assert.Nil(t, result)
@@ -810,7 +810,7 @@ func TestCreateAPIKey_MaxExpirationLimit(t *testing.T) {
 
 		// Request 365 days - should fail because default max is 90 days
 		expiresIn := 365 * 24 * time.Hour
-		result, err := svc.CreateAPIKey(ctx, "alice", []string{"users"}, "Test Key", "", &expiresIn, false, "", "")
+		result, err := svc.CreateAPIKey(ctx, "alice", []string{"users"}, "Test Key", "", &expiresIn, false, "", "", nil)
 
 		require.Error(t, err, "should reject expiration exceeding default max (90 days)")
 		assert.Nil(t, result)
@@ -841,7 +841,7 @@ func TestEphemeralKeyExpiration(t *testing.T) {
 		svc := api_keys.NewServiceWithLogger(api_keys.NewMockStore(), &config.Config{}, serviceTestSubSelector{}, logger.Development())
 		now := time.Now().UTC()
 
-		result, err := svc.CreateAPIKey(ctx, "user", []string{"users"}, "ephemeral-test", "", nil, true, "", "")
+		result, err := svc.CreateAPIKey(ctx, "user", []string{"users"}, "ephemeral-test", "", nil, true, "", "", nil)
 
 		require.NoError(t, err)
 		require.NotNil(t, result)
@@ -855,7 +855,7 @@ func TestEphemeralKeyExpiration(t *testing.T) {
 		expiresIn := 30 * time.Minute
 		now := time.Now().UTC()
 
-		result, err := svc.CreateAPIKey(ctx, "user", []string{"users"}, "short-lived", "", &expiresIn, true, "", "")
+		result, err := svc.CreateAPIKey(ctx, "user", []string{"users"}, "short-lived", "", &expiresIn, true, "", "", nil)
 
 		require.NoError(t, err)
 		require.NotNil(t, result)
@@ -867,7 +867,7 @@ func TestEphemeralKeyExpiration(t *testing.T) {
 		svc := api_keys.NewServiceWithLogger(api_keys.NewMockStore(), &config.Config{}, serviceTestSubSelector{}, logger.Development())
 		expiresIn := 1 * time.Hour
 
-		result, err := svc.CreateAPIKey(ctx, "user", []string{"users"}, "exactly-one-hour", "", &expiresIn, true, "", "")
+		result, err := svc.CreateAPIKey(ctx, "user", []string{"users"}, "exactly-one-hour", "", &expiresIn, true, "", "", nil)
 
 		require.NoError(t, err)
 		require.NotNil(t, result)
@@ -906,7 +906,7 @@ func TestEphemeralKeyExpiration(t *testing.T) {
 			svc := api_keys.NewServiceWithLogger(api_keys.NewMockStore(), &config.Config{}, serviceTestSubSelector{}, logger.Development())
 			expiresIn := tt.expiresIn
 
-			result, err := svc.CreateAPIKey(ctx, "user", []string{"users"}, "test-key", "", &expiresIn, true, "", "")
+			result, err := svc.CreateAPIKey(ctx, "user", []string{"users"}, "test-key", "", &expiresIn, true, "", "", nil)
 
 			require.Error(t, err)
 			assert.Nil(t, result)
@@ -952,7 +952,7 @@ func TestCreateAPIKey_Subscription(t *testing.T) {
 		store := api_keys.NewMockStore()
 		svc := api_keys.NewServiceWithLogger(store, cfg, subSelectorStub{}, logger.Development())
 
-		result, err := svc.CreateAPIKey(ctx, user, groups, "key", "", nil, false, "team-a", "")
+		result, err := svc.CreateAPIKey(ctx, user, groups, "key", "", nil, false, "team-a", "", nil)
 		require.NoError(t, err)
 		require.Equal(t, "team-a", result.Subscription)
 
@@ -965,7 +965,7 @@ func TestCreateAPIKey_Subscription(t *testing.T) {
 		store := api_keys.NewMockStore()
 		svc := api_keys.NewServiceWithLogger(store, cfg, subSelectorStub{}, logger.Development())
 
-		result, err := svc.CreateAPIKey(ctx, user, groups, "key", "", nil, false, "", "")
+		result, err := svc.CreateAPIKey(ctx, user, groups, "key", "", nil, false, "", "", nil)
 		require.NoError(t, err)
 		require.Equal(t, "from-priority", result.Subscription)
 	})
@@ -1020,7 +1020,7 @@ func TestCreateAPIKey_Subscription(t *testing.T) {
 				store := api_keys.NewMockStore()
 				svc := api_keys.NewServiceWithLogger(store, cfg, tt.stub, logger.Development())
 
-				result, err := svc.CreateAPIKey(ctx, user, groups, "key", "", nil, false, tt.requested, "")
+				result, err := svc.CreateAPIKey(ctx, user, groups, "key", "", nil, false, tt.requested, "", nil)
 				require.Error(t, err)
 				require.Nil(t, result)
 				tt.assertErr(t, err)
@@ -1045,12 +1045,12 @@ func TestCleanupExpiredEphemeral(t *testing.T) {
 		svc, store := createTestService(t)
 
 		// Add active regular key
-		err := store.AddKey(ctx, "alice", "regular-1", "hash-1", "Regular", "", nil, "default-sub", "", nil, false)
+		err := store.AddKey(ctx, "alice", "regular-1", "hash-1", "Regular", "", nil, "default-sub", "", nil, false, nil)
 		require.NoError(t, err)
 
 		// Add expired ephemeral key
 		pastExpiry := time.Now().Add(-1 * time.Hour)
-		err = store.AddKey(ctx, "alice", "ephemeral-1", "hash-2", "Ephemeral", "", nil, "default-sub", "", &pastExpiry, true)
+		err = store.AddKey(ctx, "alice", "ephemeral-1", "hash-2", "Ephemeral", "", nil, "default-sub", "", &pastExpiry, true, nil)
 		require.NoError(t, err)
 
 		count, err := svc.CleanupExpiredEphemeral(ctx)
@@ -1145,7 +1145,7 @@ func TestCreateAPIKey_ValidatesSubscriptionPhase(t *testing.T) {
 			store := api_keys.NewMockStore()
 			svc := api_keys.NewServiceWithLogger(store, cfg, selector, logger.Development())
 
-			_, err := svc.CreateAPIKey(ctx, user, groups, "test-key", "", nil, false, "test-sub", "")
+			_, err := svc.CreateAPIKey(ctx, user, groups, "test-key", "", nil, false, "test-sub", "", nil)
 
 			if tt.expectError {
 				require.Error(t, err, "Expected error for %s", tt.name)
@@ -1217,14 +1217,14 @@ func TestGetMaxExpirationDays_UsedByCreateAPIKey(t *testing.T) {
 
 	// Try to create a key that exceeds the custom limit (should fail)
 	expiresIn := 20 * 24 * time.Hour // 20 days
-	_, err := svc.CreateAPIKey(ctx, "alice", []string{}, "Test Key", "", &expiresIn, false, "", "")
+	_, err := svc.CreateAPIKey(ctx, "alice", []string{}, "Test Key", "", &expiresIn, false, "", "", nil)
 
 	require.Error(t, err, "Should reject expiration exceeding custom max")
 	assert.Contains(t, err.Error(), "exceeds maximum allowed (15 days)", "Error should reference custom max from GetMaxExpirationDays")
 
 	// Create a key within the custom limit (should succeed)
 	expiresIn = 10 * 24 * time.Hour // 10 days
-	resp, err := svc.CreateAPIKey(ctx, "alice", []string{}, "Test Key", "", &expiresIn, false, "", "")
+	resp, err := svc.CreateAPIKey(ctx, "alice", []string{}, "Test Key", "", &expiresIn, false, "", "", nil)
 
 	require.NoError(t, err, "Should accept expiration within custom max")
 	assert.NotNil(t, resp)
@@ -1289,7 +1289,7 @@ func TestCreateAPIKey_GroupNameValidation(t *testing.T) {
 
 	for _, groups := range validGroups {
 		t.Run("valid_"+groups[0], func(t *testing.T) {
-			_, err := svc.CreateAPIKey(ctx, "user", groups, "test-key", "", nil, false, "", "tenant")
+			_, err := svc.CreateAPIKey(ctx, "user", groups, "test-key", "", nil, false, "", "tenant", nil)
 			require.NoError(t, err, "group %q should be valid", groups[0])
 		})
 	}
@@ -1315,7 +1315,7 @@ func TestCreateAPIKey_GroupNameValidation(t *testing.T) {
 
 	for _, tc := range invalidGroups {
 		t.Run("invalid_"+tc.reason, func(t *testing.T) {
-			_, err := svc.CreateAPIKey(ctx, "user", []string{tc.group}, "test-key", "", nil, false, "", "tenant")
+			_, err := svc.CreateAPIKey(ctx, "user", []string{tc.group}, "test-key", "", nil, false, "", "tenant", nil)
 			require.Error(t, err, "group with %s should be rejected", tc.reason)
 			assert.Contains(t, err.Error(), "invalid characters", "error should mention invalid characters")
 		})

--- a/maas-api/internal/api_keys/service_test.go
+++ b/maas-api/internal/api_keys/service_test.go
@@ -52,7 +52,7 @@ func TestValidateAPIKey_ValidKey(t *testing.T) {
 	username := "alice"
 	groups := []string{"tier-premium", "system:authenticated"}
 
-	err := store.AddKey(ctx, username, keyID, hash, "Test Key", "", groups, "default-sub", "", nil, false)
+	err := store.AddKey(ctx, username, keyID, hash, "Test Key", "", groups, "default-sub", "", nil, false, nil)
 	require.NoError(t, err)
 
 	// Validate the key
@@ -116,7 +116,7 @@ func TestValidateAPIKey_RevokedKey(t *testing.T) {
 	username := "bob"
 	groups := []string{"tier-free"}
 
-	err := store.AddKey(ctx, username, keyID, hash, "Revoked Key", "", groups, "default-sub", "", nil, false)
+	err := store.AddKey(ctx, username, keyID, hash, "Revoked Key", "", groups, "default-sub", "", nil, false, nil)
 	require.NoError(t, err)
 
 	// Revoke the key
@@ -143,7 +143,7 @@ func TestValidateAPIKey_ExpiredKey(t *testing.T) {
 	groups := []string{"tier-basic"}
 	expiresAt := time.Now().Add(-24 * time.Hour) // Expired 1 day ago
 
-	err := store.AddKey(ctx, username, keyID, hash, "Expired Key", "", groups, "default-sub", "", &expiresAt, false)
+	err := store.AddKey(ctx, username, keyID, hash, "Expired Key", "", groups, "default-sub", "", &expiresAt, false, nil)
 	require.NoError(t, err)
 
 	// Validate the expired key
@@ -164,7 +164,7 @@ func TestValidateAPIKey_EmptyGroups(t *testing.T) {
 	plainKey, hash := createTestAPIKey(t)
 	username := "dave"
 
-	err := store.AddKey(ctx, username, keyID, hash, "No Groups Key", "", nil, "default-sub", "", nil, false)
+	err := store.AddKey(ctx, username, keyID, hash, "No Groups Key", "", nil, "default-sub", "", nil, false, nil)
 	require.NoError(t, err)
 
 	// Validate the key
@@ -188,7 +188,7 @@ func TestValidateAPIKey_UpdatesLastUsed(t *testing.T) {
 	username := "eve"
 	groups := []string{"tier-enterprise"}
 
-	err := store.AddKey(ctx, username, keyID, hash, "Last Used Test", "", groups, "default-sub", "", nil, false)
+	err := store.AddKey(ctx, username, keyID, hash, "Last Used Test", "", groups, "default-sub", "", nil, false, nil)
 	require.NoError(t, err)
 
 	// Get initial metadata (last_used_at should be empty/nil)
@@ -223,7 +223,7 @@ func TestValidateAPIKey_DebounceSuppressesExtraWrites(t *testing.T) {
 
 	keyID := "550e8400-e29b-41d4-a716-446655440020"
 	plainKey, hash := createTestAPIKey(t)
-	err := store.AddKey(ctx, "frank", keyID, hash, "Debounce Test", "", []string{"tier-basic"}, "default-sub", "", nil, false)
+	err := store.AddKey(ctx, "frank", keyID, hash, "Debounce Test", "", []string{"tier-basic"}, "default-sub", "", nil, false, nil)
 	require.NoError(t, err)
 
 	const concurrentRequests = 10
@@ -255,7 +255,7 @@ func TestValidateAPIKey_DebounceDisabled_WritesEveryTime(t *testing.T) {
 
 	keyID := "550e8400-e29b-41d4-a716-446655440021"
 	plainKey, hash := createTestAPIKey(t)
-	err := store.AddKey(ctx, "grace", keyID, hash, "Debounce Disabled Test", "", []string{"tier-basic"}, "default-sub", "", nil, false)
+	err := store.AddKey(ctx, "grace", keyID, hash, "Debounce Disabled Test", "", []string{"tier-basic"}, "default-sub", "", nil, false, nil)
 	require.NoError(t, err)
 
 	const calls = 3
@@ -282,7 +282,7 @@ func TestValidateAPIKey_DebounceWritesAfterTTLExpiry(t *testing.T) {
 
 	keyID := "550e8400-e29b-41d4-a716-446655440022"
 	plainKey, hash := createTestAPIKey(t)
-	err := store.AddKey(ctx, "henry", keyID, hash, "TTL Expiry Test", "", []string{"tier-basic"}, "default-sub", "", nil, false)
+	err := store.AddKey(ctx, "henry", keyID, hash, "TTL Expiry Test", "", []string{"tier-basic"}, "default-sub", "", nil, false, nil)
 	require.NoError(t, err)
 
 	// First validation triggers a write.
@@ -321,7 +321,7 @@ func TestValidateAPIKey_ReturnsTenant(t *testing.T) {
 	keyID := "550e8400-e29b-41d4-a716-446655440010"
 	plainKey, hash := createTestAPIKey(t)
 
-	err := store.AddKey(ctx, "alice", keyID, hash, "Tenant Key", "", []string{"users"}, "default-sub", "acme-corp", nil, false)
+	err := store.AddKey(ctx, "alice", keyID, hash, "Tenant Key", "", []string{"users"}, "default-sub", "acme-corp", nil, false, nil)
 	require.NoError(t, err)
 
 	result, err := svc.ValidateAPIKey(ctx, plainKey)
@@ -340,7 +340,7 @@ func TestValidateAPIKey_EmptyTenantReturnsEmpty(t *testing.T) {
 	plainKey, hash := createTestAPIKey(t)
 
 	// Legacy key with empty tenant
-	err := store.AddKey(ctx, "alice", keyID, hash, "Legacy Key", "", []string{"users"}, "default-sub", "", nil, false)
+	err := store.AddKey(ctx, "alice", keyID, hash, "Legacy Key", "", []string{"users"}, "default-sub", "", nil, false, nil)
 	require.NoError(t, err)
 
 	result, err := svc.ValidateAPIKey(ctx, plainKey)
@@ -361,7 +361,7 @@ func TestValidateAPIKey_TenantNotExposedOnInvalid(t *testing.T) {
 		keyID := "550e8400-e29b-41d4-a716-446655440012"
 		plainKey, hash := createTestAPIKey(t)
 
-		err := store.AddKey(ctx, "alice", keyID, hash, "Tenant Revoked", "", []string{"users"}, "default-sub", "acme-corp", nil, false)
+		err := store.AddKey(ctx, "alice", keyID, hash, "Tenant Revoked", "", []string{"users"}, "default-sub", "acme-corp", nil, false, nil)
 		require.NoError(t, err)
 
 		err = store.Revoke(ctx, keyID)
@@ -400,7 +400,7 @@ func TestBulkRevokeAPIKeys_TenantScopedCount(t *testing.T) {
 	for i := range 3 {
 		_, hash := createTestAPIKey(t)
 		id := "tenant-a-key-" + string(rune('a'+i))
-		err := store.AddKey(ctx, "alice", id, hash, "Key "+id, "", []string{"users"}, "default-sub", "tenant-a", nil, false)
+		err := store.AddKey(ctx, "alice", id, hash, "Key "+id, "", []string{"users"}, "default-sub", "tenant-a", nil, false, nil)
 		require.NoError(t, err)
 	}
 
@@ -410,7 +410,7 @@ func TestBulkRevokeAPIKeys_TenantScopedCount(t *testing.T) {
 		_, hash := createTestAPIKey(t)
 		id := "tenant-b-key-" + string(rune('a'+i))
 		tenantBIDs[i] = id
-		err := store.AddKey(ctx, "alice", id, hash, "Key "+id, "", []string{"users"}, "default-sub", "tenant-b", nil, false)
+		err := store.AddKey(ctx, "alice", id, hash, "Key "+id, "", []string{"users"}, "default-sub", "tenant-b", nil, false, nil)
 		require.NoError(t, err)
 	}
 
@@ -508,7 +508,7 @@ func TestGetAPIKey(t *testing.T) {
 	username := "alice"
 	keyName := "Alice's Key"
 
-	err := store.AddKey(ctx, username, keyID, hash, keyName, "Test description", nil, "default-sub", "", nil, false)
+	err := store.AddKey(ctx, username, keyID, hash, keyName, "Test description", nil, "default-sub", "", nil, false, nil)
 	require.NoError(t, err)
 
 	// Get via service layer
@@ -540,7 +540,7 @@ func TestRevokeAPIKey(t *testing.T) {
 	_, hash := createTestAPIKey(t)
 	username := "bob"
 
-	err := store.AddKey(ctx, username, keyID, hash, "Revoke Test", "", nil, "default-sub", "", nil, false)
+	err := store.AddKey(ctx, username, keyID, hash, "Revoke Test", "", nil, "default-sub", "", nil, false, nil)
 	require.NoError(t, err)
 
 	// Verify it's active
@@ -581,7 +581,7 @@ func TestRevokeAPIKey_AlreadyRevoked(t *testing.T) {
 
 	keyID := "double-revoke-key"
 	_, hash := createTestAPIKey(t)
-	require.NoError(t, store.AddKey(ctx, "alice", keyID, hash, "Double Revoke", "", nil, "default-sub", "", nil, false))
+	require.NoError(t, store.AddKey(ctx, "alice", keyID, hash, "Double Revoke", "", nil, "default-sub", "", nil, false, nil))
 
 	// First revoke succeeds
 	require.NoError(t, svc.RevokeAPIKey(ctx, keyID))
@@ -600,7 +600,7 @@ func TestRevokeAPIKey_ThenValidate(t *testing.T) {
 
 	keyID := "revoke-validate-key"
 	plainKey, hash := createTestAPIKey(t)
-	require.NoError(t, store.AddKey(ctx, "eve", keyID, hash, "Revoke Then Validate", "", []string{"users"}, "default-sub", "", nil, false))
+	require.NoError(t, store.AddKey(ctx, "eve", keyID, hash, "Revoke Then Validate", "", []string{"users"}, "default-sub", "", nil, false, nil))
 
 	// Revoke via service
 	require.NoError(t, svc.RevokeAPIKey(ctx, keyID))
@@ -629,7 +629,7 @@ func TestBulkRevokeAPIKeys(t *testing.T) {
 		for i := range 3 {
 			_, hash := createTestAPIKey(t)
 			id := "bulk-key-" + string(rune('a'+i))
-			require.NoError(t, store.AddKey(ctx, "alice", id, hash, "Key "+id, "", nil, "default-sub", "", nil, false))
+			require.NoError(t, store.AddKey(ctx, "alice", id, hash, "Key "+id, "", nil, "default-sub", "", nil, false, nil))
 		}
 
 		count, err := svc.BulkRevokeAPIKeys(ctx, "alice", "", "", false)
@@ -662,7 +662,7 @@ func TestBulkRevokeAPIKeys(t *testing.T) {
 		svc, store := createTestService(t)
 
 		_, hash := createTestAPIKey(t)
-		require.NoError(t, store.AddKey(ctx, "bob", "idem-key", hash, "Idempotent Key", "", nil, "default-sub", "", nil, false))
+		require.NoError(t, store.AddKey(ctx, "bob", "idem-key", hash, "Idempotent Key", "", nil, "default-sub", "", nil, false, nil))
 
 		count, err := svc.BulkRevokeAPIKeys(ctx, "bob", "", "", false)
 		require.NoError(t, err)
@@ -697,7 +697,7 @@ func TestBulkRevokeAPIKeys_ThenValidateAll(t *testing.T) {
 		plain, hash := createTestAPIKey(t)
 		plainKeys[i] = plain
 		id := "bulk-validate-" + string(rune('a'+i))
-		require.NoError(t, store.AddKey(ctx, "carol", id, hash, "Key "+id, "", []string{"users"}, "default-sub", "", nil, false))
+		require.NoError(t, store.AddKey(ctx, "carol", id, hash, "Key "+id, "", []string{"users"}, "default-sub", "", nil, false, nil))
 	}
 
 	// Bulk revoke all of carol's keys
@@ -730,7 +730,7 @@ func TestCreateAPIKey_MaxExpirationLimit(t *testing.T) {
 
 		// Request 7 days - should succeed
 		expiresIn := 7 * 24 * time.Hour
-		result, err := svc.CreateAPIKey(ctx, "alice", []string{"users"}, "Test Key", "", &expiresIn, false, "", "")
+		result, err := svc.CreateAPIKey(ctx, "alice", []string{"users"}, "Test Key", "", &expiresIn, false, "", "", nil)
 
 		require.NoError(t, err)
 		require.NotNil(t, result)
@@ -746,7 +746,7 @@ func TestCreateAPIKey_MaxExpirationLimit(t *testing.T) {
 
 		// Request 60 days - should fail
 		expiresIn := 60 * 24 * time.Hour
-		result, err := svc.CreateAPIKey(ctx, "alice", []string{"users"}, "Test Key", "", &expiresIn, false, "", "")
+		result, err := svc.CreateAPIKey(ctx, "alice", []string{"users"}, "Test Key", "", &expiresIn, false, "", "", nil)
 
 		require.Error(t, err)
 		assert.Nil(t, result)
@@ -763,7 +763,7 @@ func TestCreateAPIKey_MaxExpirationLimit(t *testing.T) {
 
 		// Request exactly 30 days - should succeed
 		expiresIn := 30 * 24 * time.Hour
-		result, err := svc.CreateAPIKey(ctx, "alice", []string{"users"}, "Test Key", "", &expiresIn, false, "", "")
+		result, err := svc.CreateAPIKey(ctx, "alice", []string{"users"}, "Test Key", "", &expiresIn, false, "", "", nil)
 
 		require.NoError(t, err)
 		require.NotNil(t, result)
@@ -777,7 +777,7 @@ func TestCreateAPIKey_MaxExpirationLimit(t *testing.T) {
 		svc := api_keys.NewServiceWithLogger(store, cfg, serviceTestSubSelector{}, logger.Development())
 
 		// No expiration requested - should default to APIKeyMaxExpirationDays (30 days)
-		result, err := svc.CreateAPIKey(ctx, "alice", []string{"users"}, "Test Key", "", nil, false, "", "")
+		result, err := svc.CreateAPIKey(ctx, "alice", []string{"users"}, "Test Key", "", nil, false, "", "", nil)
 
 		require.NoError(t, err)
 		require.NotNil(t, result)
@@ -792,7 +792,7 @@ func TestCreateAPIKey_MaxExpirationLimit(t *testing.T) {
 
 		// Request 365 days - should fail because default max is 90 days
 		expiresIn := 365 * 24 * time.Hour
-		result, err := svc.CreateAPIKey(ctx, "alice", []string{"users"}, "Test Key", "", &expiresIn, false, "", "")
+		result, err := svc.CreateAPIKey(ctx, "alice", []string{"users"}, "Test Key", "", &expiresIn, false, "", "", nil)
 
 		require.Error(t, err, "should reject expiration exceeding default max (90 days)")
 		assert.Nil(t, result)
@@ -810,7 +810,7 @@ func TestCreateAPIKey_MaxExpirationLimit(t *testing.T) {
 
 		// Request 365 days - should fail because default max is 90 days
 		expiresIn := 365 * 24 * time.Hour
-		result, err := svc.CreateAPIKey(ctx, "alice", []string{"users"}, "Test Key", "", &expiresIn, false, "", "")
+		result, err := svc.CreateAPIKey(ctx, "alice", []string{"users"}, "Test Key", "", &expiresIn, false, "", "", nil)
 
 		require.Error(t, err, "should reject expiration exceeding default max (90 days)")
 		assert.Nil(t, result)
@@ -841,7 +841,7 @@ func TestEphemeralKeyExpiration(t *testing.T) {
 		svc := api_keys.NewServiceWithLogger(api_keys.NewMockStore(), &config.Config{}, serviceTestSubSelector{}, logger.Development())
 		now := time.Now().UTC()
 
-		result, err := svc.CreateAPIKey(ctx, "user", []string{"users"}, "ephemeral-test", "", nil, true, "", "")
+		result, err := svc.CreateAPIKey(ctx, "user", []string{"users"}, "ephemeral-test", "", nil, true, "", "", nil)
 
 		require.NoError(t, err)
 		require.NotNil(t, result)
@@ -855,7 +855,7 @@ func TestEphemeralKeyExpiration(t *testing.T) {
 		expiresIn := 30 * time.Minute
 		now := time.Now().UTC()
 
-		result, err := svc.CreateAPIKey(ctx, "user", []string{"users"}, "short-lived", "", &expiresIn, true, "", "")
+		result, err := svc.CreateAPIKey(ctx, "user", []string{"users"}, "short-lived", "", &expiresIn, true, "", "", nil)
 
 		require.NoError(t, err)
 		require.NotNil(t, result)
@@ -867,7 +867,7 @@ func TestEphemeralKeyExpiration(t *testing.T) {
 		svc := api_keys.NewServiceWithLogger(api_keys.NewMockStore(), &config.Config{}, serviceTestSubSelector{}, logger.Development())
 		expiresIn := 1 * time.Hour
 
-		result, err := svc.CreateAPIKey(ctx, "user", []string{"users"}, "exactly-one-hour", "", &expiresIn, true, "", "")
+		result, err := svc.CreateAPIKey(ctx, "user", []string{"users"}, "exactly-one-hour", "", &expiresIn, true, "", "", nil)
 
 		require.NoError(t, err)
 		require.NotNil(t, result)
@@ -906,7 +906,7 @@ func TestEphemeralKeyExpiration(t *testing.T) {
 			svc := api_keys.NewServiceWithLogger(api_keys.NewMockStore(), &config.Config{}, serviceTestSubSelector{}, logger.Development())
 			expiresIn := tt.expiresIn
 
-			result, err := svc.CreateAPIKey(ctx, "user", []string{"users"}, "test-key", "", &expiresIn, true, "", "")
+			result, err := svc.CreateAPIKey(ctx, "user", []string{"users"}, "test-key", "", &expiresIn, true, "", "", nil)
 
 			require.Error(t, err)
 			assert.Nil(t, result)
@@ -952,7 +952,7 @@ func TestCreateAPIKey_Subscription(t *testing.T) {
 		store := api_keys.NewMockStore()
 		svc := api_keys.NewServiceWithLogger(store, cfg, subSelectorStub{}, logger.Development())
 
-		result, err := svc.CreateAPIKey(ctx, user, groups, "key", "", nil, false, "team-a", "")
+		result, err := svc.CreateAPIKey(ctx, user, groups, "key", "", nil, false, "team-a", "", nil)
 		require.NoError(t, err)
 		require.Equal(t, "team-a", result.Subscription)
 
@@ -965,7 +965,7 @@ func TestCreateAPIKey_Subscription(t *testing.T) {
 		store := api_keys.NewMockStore()
 		svc := api_keys.NewServiceWithLogger(store, cfg, subSelectorStub{}, logger.Development())
 
-		result, err := svc.CreateAPIKey(ctx, user, groups, "key", "", nil, false, "", "")
+		result, err := svc.CreateAPIKey(ctx, user, groups, "key", "", nil, false, "", "", nil)
 		require.NoError(t, err)
 		require.Equal(t, "from-priority", result.Subscription)
 	})
@@ -1020,7 +1020,7 @@ func TestCreateAPIKey_Subscription(t *testing.T) {
 				store := api_keys.NewMockStore()
 				svc := api_keys.NewServiceWithLogger(store, cfg, tt.stub, logger.Development())
 
-				result, err := svc.CreateAPIKey(ctx, user, groups, "key", "", nil, false, tt.requested, "")
+				result, err := svc.CreateAPIKey(ctx, user, groups, "key", "", nil, false, tt.requested, "", nil)
 				require.Error(t, err)
 				require.Nil(t, result)
 				tt.assertErr(t, err)
@@ -1045,12 +1045,12 @@ func TestCleanupExpiredEphemeral(t *testing.T) {
 		svc, store := createTestService(t)
 
 		// Add active regular key
-		err := store.AddKey(ctx, "alice", "regular-1", "hash-1", "Regular", "", nil, "default-sub", "", nil, false)
+		err := store.AddKey(ctx, "alice", "regular-1", "hash-1", "Regular", "", nil, "default-sub", "", nil, false, nil)
 		require.NoError(t, err)
 
 		// Add expired ephemeral key
 		pastExpiry := time.Now().Add(-1 * time.Hour)
-		err = store.AddKey(ctx, "alice", "ephemeral-1", "hash-2", "Ephemeral", "", nil, "default-sub", "", &pastExpiry, true)
+		err = store.AddKey(ctx, "alice", "ephemeral-1", "hash-2", "Ephemeral", "", nil, "default-sub", "", &pastExpiry, true, nil)
 		require.NoError(t, err)
 
 		count, err := svc.CleanupExpiredEphemeral(ctx)
@@ -1145,7 +1145,7 @@ func TestCreateAPIKey_ValidatesSubscriptionPhase(t *testing.T) {
 			store := api_keys.NewMockStore()
 			svc := api_keys.NewServiceWithLogger(store, cfg, selector, logger.Development())
 
-			_, err := svc.CreateAPIKey(ctx, user, groups, "test-key", "", nil, false, "test-sub", "")
+			_, err := svc.CreateAPIKey(ctx, user, groups, "test-key", "", nil, false, "test-sub", "", nil)
 
 			if tt.expectError {
 				require.Error(t, err, "Expected error for %s", tt.name)
@@ -1217,14 +1217,14 @@ func TestGetMaxExpirationDays_UsedByCreateAPIKey(t *testing.T) {
 
 	// Try to create a key that exceeds the custom limit (should fail)
 	expiresIn := 20 * 24 * time.Hour // 20 days
-	_, err := svc.CreateAPIKey(ctx, "alice", []string{}, "Test Key", "", &expiresIn, false, "", "")
+	_, err := svc.CreateAPIKey(ctx, "alice", []string{}, "Test Key", "", &expiresIn, false, "", "", nil)
 
 	require.Error(t, err, "Should reject expiration exceeding custom max")
 	assert.Contains(t, err.Error(), "exceeds maximum allowed (15 days)", "Error should reference custom max from GetMaxExpirationDays")
 
 	// Create a key within the custom limit (should succeed)
 	expiresIn = 10 * 24 * time.Hour // 10 days
-	resp, err := svc.CreateAPIKey(ctx, "alice", []string{}, "Test Key", "", &expiresIn, false, "", "")
+	resp, err := svc.CreateAPIKey(ctx, "alice", []string{}, "Test Key", "", &expiresIn, false, "", "", nil)
 
 	require.NoError(t, err, "Should accept expiration within custom max")
 	assert.NotNil(t, resp)
@@ -1289,7 +1289,7 @@ func TestCreateAPIKey_GroupNameValidation(t *testing.T) {
 
 	for _, groups := range validGroups {
 		t.Run("valid_"+groups[0], func(t *testing.T) {
-			_, err := svc.CreateAPIKey(ctx, "user", groups, "test-key", "", nil, false, "", "tenant")
+			_, err := svc.CreateAPIKey(ctx, "user", groups, "test-key", "", nil, false, "", "tenant", nil)
 			require.NoError(t, err, "group %q should be valid", groups[0])
 		})
 	}
@@ -1315,7 +1315,7 @@ func TestCreateAPIKey_GroupNameValidation(t *testing.T) {
 
 	for _, tc := range invalidGroups {
 		t.Run("invalid_"+tc.reason, func(t *testing.T) {
-			_, err := svc.CreateAPIKey(ctx, "user", []string{tc.group}, "test-key", "", nil, false, "", "tenant")
+			_, err := svc.CreateAPIKey(ctx, "user", []string{tc.group}, "test-key", "", nil, false, "", "tenant", nil)
 			require.Error(t, err, "group with %s should be rejected", tc.reason)
 			assert.Contains(t, err.Error(), "invalid characters", "error should mention invalid characters")
 		})

--- a/maas-api/internal/api_keys/store_interface.go
+++ b/maas-api/internal/api_keys/store_interface.go
@@ -36,6 +36,7 @@ type MetadataStore interface {
 	//     per-key salt encoded in the API key format (sk-oai-{embedded_key_id}_{secret})
 	//   - userGroups: array of user's groups (used for authorization)
 	//   - ephemeral: marks the key as short-lived for programmatic use
+	//   - labels: caller-validated key/value metadata; this layer does not re-validate or enforce limits.
 	//
 	// Note: keyPrefix is NOT stored (security - reduces brute-force attack surface).
 	AddKey(ctx context.Context,

--- a/maas-api/internal/api_keys/store_interface.go
+++ b/maas-api/internal/api_keys/store_interface.go
@@ -48,7 +48,8 @@ type MetadataStore interface {
 		subscription,
 		tenant string,
 		expiresAt *time.Time,
-		ephemeral bool) error
+		ephemeral bool,
+		labels map[string]string) error
 
 	// Search returns API keys matching the search criteria.
 	// Supports filtering, sorting, and pagination.

--- a/maas-api/internal/api_keys/store_mock.go
+++ b/maas-api/internal/api_keys/store_mock.go
@@ -45,7 +45,18 @@ var _ MetadataStore = (*MockStore)(nil)
 // ephemeral marks the key as short-lived for programmatic use.
 // Note: keyPrefix is NOT stored (security - reduces brute-force attack surface).
 func (m *MockStore) AddKey(
-	ctx context.Context, username, keyID, keyHash, name, description string, userGroups []string, subscription string, tenant string, expiresAt *time.Time, ephemeral bool, labels map[string]string,
+	ctx context.Context, 
+	username, 
+	keyID, 
+	keyHash, 
+	name, 
+	description string, 
+	userGroups []string, 
+	subscription string, 
+	tenant string, 
+	expiresAt *time.Time, 
+	ephemeral bool, 
+	labels map[string]string,
 ) error {
 	if keyID == "" {
 		return ErrEmptyJTI

--- a/maas-api/internal/api_keys/store_mock.go
+++ b/maas-api/internal/api_keys/store_mock.go
@@ -45,7 +45,7 @@ var _ MetadataStore = (*MockStore)(nil)
 // ephemeral marks the key as short-lived for programmatic use.
 // Note: keyPrefix is NOT stored (security - reduces brute-force attack surface).
 func (m *MockStore) AddKey(
-	ctx context.Context, username, keyID, keyHash, name, description string, userGroups []string, subscription string, tenant string, expiresAt *time.Time, ephemeral bool,
+	ctx context.Context, username, keyID, keyHash, name, description string, userGroups []string, subscription string, tenant string, expiresAt *time.Time, ephemeral bool, labels map[string]string,
 ) error {
 	if keyID == "" {
 		return ErrEmptyJTI
@@ -65,6 +65,10 @@ func (m *MockStore) AddKey(
 		expiresAtTime = *expiresAt
 	}
 
+	if len(labels) == 0 {
+		labels = nil 
+	}
+
 	// userGroups is already []string - no parsing needed
 	m.keys[keyID] = &storedKey{
 		metadata: ApiKey{
@@ -77,6 +81,7 @@ func (m *MockStore) AddKey(
 			Status:       StatusActive,
 			CreationDate: time.Now().UTC().Format(time.RFC3339),
 			Ephemeral:    ephemeral,
+			Labels:       labels,
 		},
 		username:  username,
 		keyHash:   keyHash,
@@ -357,6 +362,16 @@ func (m *MockStore) Search(
 		allKeys = filtered
 	}
 
+	if len(filters.LabelsContain) > 0 {
+		filtered := allKeys[:0]
+		for _, k := range allKeys {
+			if labelsContain(k.Labels, filters.LabelsContain) {
+				filtered = append(filtered, k)
+			}
+		}
+		allKeys = filtered
+	}
+
 	// Sort keys
 	sort.Slice(allKeys, func(i, j int) bool {
 		return compareKeys(allKeys[i], allKeys[j], sortParams.By, sortParams.Order)
@@ -369,6 +384,22 @@ func (m *MockStore) Search(
 		Keys:    keys,
 		HasMore: hasMore,
 	}, nil
+}
+
+// Helper function to check if the have map contains all the keys and values in the want map.
+func labelsContain(have, want map[string]string) bool {
+	if len(want) == 0 {
+		return true
+	}
+	if have == nil {
+		return false
+	}
+	for k, v := range want {
+		if have[k] != v {
+			return false
+		}
+	}
+	return true
 }
 
 func (m *MockStore) Get(ctx context.Context, keyID string) (*ApiKey, error) {

--- a/maas-api/internal/api_keys/store_postgres.go
+++ b/maas-api/internal/api_keys/store_postgres.go
@@ -92,7 +92,7 @@ func (s *PostgresStore) AddKey(
 		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 'active', $9, $10, $11, $12)
 	`
 
-    var labelsParam interface{}
+    var labelsParam any
     if labelsJSON != nil {
         labelsParam = labelsJSON
     } else {

--- a/maas-api/internal/api_keys/store_postgres.go
+++ b/maas-api/internal/api_keys/store_postgres.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"strings"
 	"time"
+	"encoding/json"
 
 	"github.com/lib/pq"
 
@@ -48,8 +49,10 @@ func NewPostgresStore(db *sql.DB, log *logger.Logger, tenantName string) *Postgr
 // API key string (sk-oai-{embedded_key_id}_{secret}).
 //
 // Note: keyPrefix is NOT stored (security - reduces brute-force attack surface).
+// labels are stored as JSONB (NULL if empty) for efficient lookups and filtering.
 func (s *PostgresStore) AddKey(
 	ctx context.Context, username, keyID, keyHash, name, description string, userGroups []string, subscription string, tenant string, expiresAt *time.Time, ephemeral bool,
+	labels map[string]string,
 ) error {
 	if keyID == "" {
 		return ErrEmptyJTI
@@ -74,12 +77,30 @@ func (s *PostgresStore) AddKey(
 		userGroups = []string{}
 	}
 
+    // Marshal labels to JSONB (NULL if empty)
+    var labelsJSON []byte
+    var err error
+    if len(labels) > 0 {
+        labelsJSON, err = json.Marshal(labels)
+        if err != nil {
+            return fmt.Errorf("failed to marshal labels: %w", err)
+        }
+    }
+
 	query := `
-		INSERT INTO api_keys (id, username, name, description, key_hash, user_groups, subscription, tenant, status, created_at, expires_at, ephemeral)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 'active', $9, $10, $11)
+		INSERT INTO api_keys (id, username, name, description, key_hash, user_groups, subscription, tenant, status, created_at, expires_at, ephemeral, labels)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 'active', $9, $10, $11, $12)
 	`
+
+    var labelsParam interface{}
+    if labelsJSON != nil {
+        labelsParam = labelsJSON
+    } else {
+        labelsParam = nil
+    }
+
 	// Use pq.Array to handle PostgreSQL TEXT[] type
-	_, err := s.db.ExecContext(ctx, query, keyID, username, name, description, keyHash, pq.Array(userGroups), subscription, tenant, time.Now().UTC(), expiresAt, ephemeral)
+	_, err = s.db.ExecContext(ctx, query, keyID, username, name, description, keyHash, pq.Array(userGroups), subscription, tenant, time.Now().UTC(), expiresAt, ephemeral, labelsParam)
 	if err != nil {
 		return fmt.Errorf("failed to insert API key: %w", err)
 	}
@@ -259,6 +280,18 @@ func (s *PostgresStore) Search(
 		argPos++
 	}
 
+    // Add labels containment filter
+    if len(filters.LabelsContain) > 0 {
+        // Convert filter to JSONB for @> containment operator
+        filterJSON, err := json.Marshal(filters.LabelsContain)
+        if err != nil {
+            return nil, fmt.Errorf("failed to marshal labels filter: %w", err)
+        }
+        whereClauses = append(whereClauses, fmt.Sprintf("labels @> $%d::jsonb", argPos))
+        args = append(args, filterJSON)
+        argPos++
+    }
+
 	// Build final WHERE clause
 	whereClause := ""
 	if len(whereClauses) > 0 {
@@ -285,7 +318,7 @@ func (s *PostgresStore) Search(
 
 	//nolint:gosec // Dynamic ORDER BY is safe - sort.By/Order validated against allowlist in handler
 	query := fmt.Sprintf(`
-		SELECT id, name, description, subscription, tenant, username, created_at, expires_at, %s AS status, last_used_at, ephemeral
+		SELECT id, name, description, subscription, tenant, username, created_at, expires_at, %s AS status, last_used_at, ephemeral, labels
 		FROM api_keys
 		%s
 		%s
@@ -306,6 +339,7 @@ func (s *PostgresStore) Search(
 		var key ApiKey
 		var createdAt, expiresAt, lastUsedAt sql.NullTime
 		var description sql.NullString
+		var labelsJSON []byte
 
 		err := rows.Scan(
 			&key.ID,
@@ -319,6 +353,7 @@ func (s *PostgresStore) Search(
 			&key.Status,
 			&lastUsedAt,
 			&key.Ephemeral,
+			&labelsJSON,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to scan API key: %w", err)
@@ -336,6 +371,14 @@ func (s *PostgresStore) Search(
 		}
 		if lastUsedAt.Valid {
 			key.LastUsedAt = lastUsedAt.Time.Format(time.RFC3339)
+		}
+
+		// Parse labels JSONB
+		if labelsJSON != nil {
+			if err := json.Unmarshal(labelsJSON, &key.Labels); err != nil {
+				s.logger.Warn("Failed to unmarshal labels", "keyId", key.ID, "error", err)
+				key.Labels = nil // Set to nil on unmarshal error (defensive)
+			}
 		}
 
 		keys = append(keys, key)
@@ -363,7 +406,7 @@ func (s *PostgresStore) Get(ctx context.Context, keyID string) (*ApiKey, error) 
 	query := `
 		SELECT id, name, description, username, subscription, tenant, created_at, expires_at,
 			CASE WHEN status = 'active' AND expires_at IS NOT NULL AND expires_at < NOW() THEN 'expired' ELSE status END AS status,
-			last_used_at, ephemeral
+			last_used_at, ephemeral, labels
 		FROM api_keys
 		WHERE id = $1 AND tenant = $2
 	`
@@ -373,8 +416,9 @@ func (s *PostgresStore) Get(ctx context.Context, keyID string) (*ApiKey, error) 
 	var createdAt time.Time
 	var expiresAt, lastUsedAt sql.NullTime
 	var description sql.NullString
+    var labelsJSON []byte
 
-	if err := row.Scan(&k.ID, &k.Name, &description, &k.Username, &k.Subscription, &k.Tenant, &createdAt, &expiresAt, &k.Status, &lastUsedAt, &k.Ephemeral); err != nil {
+	if err := row.Scan(&k.ID, &k.Name, &description, &k.Username, &k.Subscription, &k.Tenant, &createdAt, &expiresAt, &k.Status, &lastUsedAt, &k.Ephemeral, &labelsJSON); err != nil {
 		if err == sql.ErrNoRows {
 			return nil, ErrKeyNotFound
 		}
@@ -391,6 +435,14 @@ func (s *PostgresStore) Get(ctx context.Context, keyID string) (*ApiKey, error) 
 	if lastUsedAt.Valid {
 		k.LastUsedAt = lastUsedAt.Time.UTC().Format(time.RFC3339)
 	}
+
+    // Parse labels JSONB
+    if labelsJSON != nil {
+        if err := json.Unmarshal(labelsJSON, &k.Labels); err != nil {
+            s.logger.Warn("Failed to unmarshal labels", "keyId", keyID, "error", err)
+            k.Labels = nil // Set to a safe value (empty map) on unmarshal error (defensive)
+        }
+    }
 
 	return &k, nil
 }

--- a/maas-api/internal/api_keys/store_postgres_test.go
+++ b/maas-api/internal/api_keys/store_postgres_test.go
@@ -4,6 +4,7 @@ package api_keys_test
 
 import (
 	"context"
+	"database/sql"
 	"os"
 	"testing"
 
@@ -120,6 +121,43 @@ func TestPostgresStore_BackwardCompatibility_NullLabels(t *testing.T) {
 	key, err := store.Get(ctx, keyID)
 	require.NoError(t, err)
 	assert.Nil(t, key.Labels) // Important: should be nil, not empty map
+}
+
+// TestPostgresStore_ConcurrentIndexesCreated verifies that all indexes registered
+// in concurrentMigrations are created during store initialization.
+func TestPostgresStore_ConcurrentIndexesCreated(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	if os.Getenv("TEST_DATABASE_URL") == "" {
+		t.Skip("Skipping integration test (TEST_DATABASE_URL not set)")
+	}
+
+	// Ensure migrations have run by initializing the store.
+	store := setupTestPostgresStore(t)
+	defer store.Close()
+
+	// Use a separate connection to query pg_indexes directly,
+	// avoiding the need to expose *sql.DB on PostgresStore.
+	db, err := sql.Open("pgx", os.Getenv("TEST_DATABASE_URL"))
+	require.NoError(t, err)
+	defer db.Close()
+
+	// The db_driver.go file contains a list of concurrent migrations that are applied to the database.
+	// This test verifies that all of these indexes are created in the database.
+	for _, name := range api_keys.ConcurrentMigrationNames() {
+		t.Run(name, func(t *testing.T) {
+			var indexName string
+			err := db.QueryRow(
+				"SELECT indexname FROM pg_indexes WHERE tablename = 'api_keys' AND indexname = $1",
+				name,
+			).Scan(&indexName)
+
+			require.NoError(t, err, "expected index %q to exist", name)
+			assert.Equal(t, name, indexName)
+		})
+	}
 }
 
 // setupTestPostgresStore creates a PostgreSQL store for testing.

--- a/maas-api/internal/api_keys/store_postgres_test.go
+++ b/maas-api/internal/api_keys/store_postgres_test.go
@@ -67,9 +67,9 @@ func TestPostgresStore_SearchByLabels(t *testing.T) {
 	labels3 := map[string]string{"cost_center": "CC-001"}
 
 	require.NoError(t, store.AddKey(ctx, "alice", uuid.New().String(), "hash1",
-		"key1", "", []string{}, "sub1", "test-tenant", nil, false, labels1)
+		"key1", "", []string{}, "sub1", "test-tenant", nil, false, labels1))
 	require.NoError(t, store.AddKey(ctx, "alice", uuid.New().String(), "hash2",
-		"key2", "", []string{}, "sub1", "test-tenant", nil, false, labels2)
+		"key2", "", []string{}, "sub1", "test-tenant", nil, false, labels2))
 	require.NoError(t, store.AddKey(ctx, "alice", uuid.New().String(), "hash3",
 		"key3", "", []string{}, "sub1", "test-tenant", nil, false, labels3))
 

--- a/maas-api/internal/api_keys/store_postgres_test.go
+++ b/maas-api/internal/api_keys/store_postgres_test.go
@@ -1,0 +1,143 @@
+//go:build integration
+// +build integration
+
+package api_keys_test
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/opendatahub-io/models-as-a-service/maas-api/internal/api_keys"
+	"github.com/opendatahub-io/models-as-a-service/maas-api/internal/logger"
+)
+
+// TestPostgresStore_LabelsRoundTrip tests storing and retrieving labels.
+func TestPostgresStore_LabelsRoundTrip(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	
+	if os.Getenv("TEST_DATABASE_URL") == "" {
+		t.Skip("Skipping integration test (TEST_DATABASE_URL not set)")
+	}
+
+	ctx := context.Background()
+	store := setupTestPostgresStore(t)
+	defer store.Close()
+
+	labels := map[string]string{
+		"cmdb_id":     "AST123456",
+		"cost_center": "CC-DATA-001",
+		"environment": "production",
+	}
+
+	keyID := uuid.New().String()
+	err := store.AddKey(ctx, "alice", keyID, "hash123",
+		"test-key", "test description", []string{"group1"},
+		"subscription1", "test-tenant", nil, false, labels)
+	require.NoError(t, err)
+
+	// Retrieve and verify labels
+	key, err := store.Get(ctx, keyID)
+	require.NoError(t, err)
+	assert.Equal(t, labels, key.Labels)
+}
+
+// TestPostgresStore_SearchByLabels tests JSONB containment queries.
+func TestPostgresStore_SearchByLabels(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	
+	if os.Getenv("TEST_DATABASE_URL") == "" {
+		t.Skip("Skipping integration test (TEST_DATABASE_URL not set)")
+	}
+
+	ctx := context.Background()
+	store := setupTestPostgresStore(t)
+	defer store.Close()
+
+	// Insert keys with different labels
+	labels1 := map[string]string{"cmdb_id": "AST123", "env": "prod"}
+	labels2 := map[string]string{"cmdb_id": "AST456", "env": "dev"}
+	labels3 := map[string]string{"cost_center": "CC-001"}
+
+	store.AddKey(ctx, "alice", uuid.New().String(), "hash1",
+		"key1", "", []string{}, "sub1", "test-tenant", nil, false, labels1)
+	store.AddKey(ctx, "alice", uuid.New().String(), "hash2",
+		"key2", "", []string{}, "sub1", "test-tenant", nil, false, labels2)
+	store.AddKey(ctx, "alice", uuid.New().String(), "hash3",
+		"key3", "", []string{}, "sub1", "test-tenant", nil, false, labels3)
+
+	// Search by exact match
+	result, err := store.Search(ctx, "alice", "test-tenant",
+		&api_keys.SearchFilters{LabelsContain: map[string]string{"cmdb_id": "AST123"}},
+		&api_keys.SortParams{By: "created_at", Order: "desc"},
+		&api_keys.PaginationParams{Limit: 10, Offset: 0})
+
+	require.NoError(t, err)
+	assert.Len(t, result.Keys, 1)
+	assert.Equal(t, "AST123", result.Keys[0].Labels["cmdb_id"])
+
+	// Search by partial match (JSONB @> supports subset matching)
+	result, err = store.Search(ctx, "alice", "test-tenant",
+		&api_keys.SearchFilters{LabelsContain: map[string]string{"env": "prod"}},
+		&api_keys.SortParams{By: "created_at", Order: "desc"},
+		&api_keys.PaginationParams{Limit: 10, Offset: 0})
+
+	require.NoError(t, err)
+	assert.Len(t, result.Keys, 1)
+	assert.Equal(t, "prod", result.Keys[0].Labels["env"])
+}
+
+// TestPostgresStore_BackwardCompatibility_NullLabels tests NULL handling.
+func TestPostgresStore_BackwardCompatibility_NullLabels(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	
+	if os.Getenv("TEST_DATABASE_URL") == "" {
+		t.Skip("Skipping integration test (TEST_DATABASE_URL not set)")
+	}
+
+	ctx := context.Background()
+	store := setupTestPostgresStore(t)
+	defer store.Close()
+
+	// Create key without labels (nil/NULL)
+	keyID := uuid.New().String()
+	keyHash := uuid.New().String()  // Unique hash to allow multiple runs without dropping table.
+	err := store.AddKey(ctx, "alice", keyID, keyHash,
+		"legacy-key", "no labels", []string{"group1"},
+		"subscription1", "test-tenant", nil, false, nil)
+	require.NoError(t, err)
+
+	// Retrieve and verify labels is nil (not empty map)
+	key, err := store.Get(ctx, keyID)
+	require.NoError(t, err)
+	assert.Nil(t, key.Labels) // Important: should be nil, not empty map
+}
+
+// setupTestPostgresStore creates a PostgreSQL store for testing.
+// Requires TEST_DATABASE_URL environment variable (e.g., "postgres://user:pass@localhost:5432/testdb").
+func setupTestPostgresStore(t *testing.T) *api_keys.PostgresStore {
+	t.Helper()
+	
+	dbURL := os.Getenv("TEST_DATABASE_URL")
+	if dbURL == "" {
+		t.Fatal("TEST_DATABASE_URL environment variable not set")
+	}
+	
+	testLogger := logger.Development()
+	store, err := api_keys.NewPostgresStoreFromURL(context.Background(), testLogger, dbURL, "test-tenant")
+	if err != nil {
+		t.Fatalf("Failed to create PostgreSQL store: %v", err)
+	}
+	
+	return store
+}

--- a/maas-api/internal/api_keys/store_postgres_test.go
+++ b/maas-api/internal/api_keys/store_postgres_test.go
@@ -66,12 +66,12 @@ func TestPostgresStore_SearchByLabels(t *testing.T) {
 	labels2 := map[string]string{"cmdb_id": "AST456", "env": "dev"}
 	labels3 := map[string]string{"cost_center": "CC-001"}
 
-	store.AddKey(ctx, "alice", uuid.New().String(), "hash1",
+	require.NoError(t, store.AddKey(ctx, "alice", uuid.New().String(), "hash1",
 		"key1", "", []string{}, "sub1", "test-tenant", nil, false, labels1)
-	store.AddKey(ctx, "alice", uuid.New().String(), "hash2",
+	require.NoError(t, store.AddKey(ctx, "alice", uuid.New().String(), "hash2",
 		"key2", "", []string{}, "sub1", "test-tenant", nil, false, labels2)
-	store.AddKey(ctx, "alice", uuid.New().String(), "hash3",
-		"key3", "", []string{}, "sub1", "test-tenant", nil, false, labels3)
+	require.NoError(t, store.AddKey(ctx, "alice", uuid.New().String(), "hash3",
+		"key3", "", []string{}, "sub1", "test-tenant", nil, false, labels3))
 
 	// Search by exact match
 	result, err := store.Search(ctx, "alice", "test-tenant",

--- a/maas-api/internal/api_keys/store_postgres_test.go
+++ b/maas-api/internal/api_keys/store_postgres_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 package api_keys_test
 

--- a/maas-api/internal/api_keys/store_test.go
+++ b/maas-api/internal/api_keys/store_test.go
@@ -381,9 +381,9 @@ func TestInvalidateTenant(t *testing.T) {
 	store := createTestStore(t)
 	defer store.Close()
 
-	require.NoError(t, store.AddKey(ctx, "alice", "tenant-a-1", "tenant-ah1", "key-ta1", "", nil, "sub-1", "tenant-a", nil, false))
-	require.NoError(t, store.AddKey(ctx, "bob", "tenant-a-2", "tenant-ah2", "key-ta2", "", nil, "sub-1", "tenant-a", nil, false))
-	require.NoError(t, store.AddKey(ctx, "alice", "tenant-b-1", "tenant-bh1", "key-tb1", "", nil, "sub-1", "tenant-b", nil, false))
+	require.NoError(t, store.AddKey(ctx, "alice", "tenant-a-1", "tenant-ah1", "key-ta1", "", nil, "sub-1", "tenant-a", nil, false, nil))
+	require.NoError(t, store.AddKey(ctx, "bob", "tenant-a-2", "tenant-ah2", "key-ta2", "", nil, "sub-1", "tenant-a", nil, false, nil))
+	require.NoError(t, store.AddKey(ctx, "alice", "tenant-b-1", "tenant-bh1", "key-tb1", "", nil, "sub-1", "tenant-b", nil, false, nil))
 
 	count, err := store.InvalidateTenant(ctx, "tenant-a")
 	require.NoError(t, err)

--- a/maas-api/internal/api_keys/store_test.go
+++ b/maas-api/internal/api_keys/store_test.go
@@ -326,9 +326,9 @@ func TestInvalidateTenant(t *testing.T) {
 	store := createTestStore(t)
 	defer store.Close()
 
-	require.NoError(t, store.AddKey(ctx, "alice", "tenant-a-1", "tenant-ah1", "key-ta1", "", nil, "sub-1", "tenant-a", nil, false))
-	require.NoError(t, store.AddKey(ctx, "bob", "tenant-a-2", "tenant-ah2", "key-ta2", "", nil, "sub-1", "tenant-a", nil, false))
-	require.NoError(t, store.AddKey(ctx, "alice", "tenant-b-1", "tenant-bh1", "key-tb1", "", nil, "sub-1", "tenant-b", nil, false))
+	require.NoError(t, store.AddKey(ctx, "alice", "tenant-a-1", "tenant-ah1", "key-ta1", "", nil, "sub-1", "tenant-a", nil, false, nil))
+	require.NoError(t, store.AddKey(ctx, "bob", "tenant-a-2", "tenant-ah2", "key-ta2", "", nil, "sub-1", "tenant-a", nil, false, nil))
+	require.NoError(t, store.AddKey(ctx, "alice", "tenant-b-1", "tenant-bh1", "key-tb1", "", nil, "sub-1", "tenant-b", nil, false, nil))
 
 	count, err := store.InvalidateTenant(ctx, "tenant-a")
 	require.NoError(t, err)

--- a/maas-api/internal/api_keys/store_test.go
+++ b/maas-api/internal/api_keys/store_test.go
@@ -65,7 +65,7 @@ func TestAPIKeyOperations(t *testing.T) {
 	defer store.Close()
 
 	t.Run("AddKey", func(t *testing.T) {
-		err := store.AddKey(ctx, "user1", "key-id-1", "hash123", "my-key", "test key", []string{"system:authenticated", "premium-user"}, "sub-1", "", nil, false)
+		err := store.AddKey(ctx, "user1", "key-id-1", "hash123", "my-key", "test key", []string{"system:authenticated", "premium-user"}, "sub-1", "", nil, false, nil)
 		require.NoError(t, err)
 
 		// Verify key was added by fetching it
@@ -106,7 +106,7 @@ func TestAPIKeyOperations(t *testing.T) {
 	// matching PostgreSQL behavior: only keys with status='active' can be revoked.
 	t.Run("RevokeAlreadyRevokedKey", func(t *testing.T) {
 		// Create a fresh key, revoke it, then try revoking again
-		err := store.AddKey(ctx, "user3", "key-revoke-twice", "hash-revoke-twice", "revoke-twice", "", nil, "sub-1", "", nil, false)
+		err := store.AddKey(ctx, "user3", "key-revoke-twice", "hash-revoke-twice", "revoke-twice", "", nil, "sub-1", "", nil, false, nil)
 		require.NoError(t, err)
 
 		err = store.Revoke(ctx, "key-revoke-twice")
@@ -119,7 +119,7 @@ func TestAPIKeyOperations(t *testing.T) {
 
 	t.Run("UpdateLastUsed", func(t *testing.T) {
 		// Add another key for this test
-		err := store.AddKey(ctx, "user2", "key-id-2", "hash456", "key2", "", []string{"system:authenticated", "free-user"}, "sub-2", "", nil, false)
+		err := store.AddKey(ctx, "user2", "key-id-2", "hash456", "key2", "", []string{"system:authenticated", "free-user"}, "sub-2", "", nil, false, nil)
 		require.NoError(t, err)
 
 		err = store.UpdateLastUsed(ctx, "key-id-2")
@@ -142,11 +142,11 @@ func TestBulkRevoke(t *testing.T) {
 	t.Run("BasicHappyPath", func(t *testing.T) {
 		for i := range 3 {
 			id := "alice-key-" + string(rune('a'+i))
-			require.NoError(t, store.AddKey(ctx, "alice", id, "ahash"+id, "key-"+id, "", nil, "sub-1", "", nil, false))
+			require.NoError(t, store.AddKey(ctx, "alice", id, "ahash"+id, "key-"+id, "", nil, "sub-1", "", nil, false, nil))
 		}
 		for i := range 2 {
 			id := "bob-key-" + string(rune('a'+i))
-			require.NoError(t, store.AddKey(ctx, "bob", id, "bhash"+id, "key-"+id, "", nil, "sub-1", "", nil, false))
+			require.NoError(t, store.AddKey(ctx, "bob", id, "bhash"+id, "key-"+id, "", nil, "sub-1", "", nil, false, nil))
 		}
 
 		count, err := store.BulkRevoke(ctx, "alice", "", "", false)
@@ -178,9 +178,9 @@ func TestBulkRevoke(t *testing.T) {
 		s := createTestStore(t)
 		defer s.Close()
 
-		require.NoError(t, s.AddKey(ctx, "carol", "c1", "ch1", "k1", "", nil, "sub-1", "", nil, false))
-		require.NoError(t, s.AddKey(ctx, "carol", "c2", "ch2", "k2", "", nil, "sub-1", "", nil, false))
-		require.NoError(t, s.AddKey(ctx, "carol", "c3", "ch3", "k3", "", nil, "sub-1", "", nil, false))
+		require.NoError(t, s.AddKey(ctx, "carol", "c1", "ch1", "k1", "", nil, "sub-1", "", nil, false, nil))
+		require.NoError(t, s.AddKey(ctx, "carol", "c2", "ch2", "k2", "", nil, "sub-1", "", nil, false, nil))
+		require.NoError(t, s.AddKey(ctx, "carol", "c3", "ch3", "k3", "", nil, "sub-1", "", nil, false, nil))
 
 		require.NoError(t, s.Revoke(ctx, "c3"))
 
@@ -193,7 +193,7 @@ func TestBulkRevoke(t *testing.T) {
 		s := createTestStore(t)
 		defer s.Close()
 
-		require.NoError(t, s.AddKey(ctx, "dan", "d1", "dh1", "k1", "", nil, "sub-1", "", nil, false))
+		require.NoError(t, s.AddKey(ctx, "dan", "d1", "dh1", "k1", "", nil, "sub-1", "", nil, false, nil))
 
 		count, err := s.BulkRevoke(ctx, "dan", "", "", false)
 		require.NoError(t, err)
@@ -245,7 +245,7 @@ func TestAddKeyWithTenant(t *testing.T) {
 	defer store.Close()
 
 	t.Run("TenantRoundTripsViaGet", func(t *testing.T) {
-		err := store.AddKey(ctx, "user1", "tenant-key-1", "thash1", "tenant-key", "", nil, "sub-1", "acme-corp", nil, false)
+		err := store.AddKey(ctx, "user1", "tenant-key-1", "thash1", "tenant-key", "", nil, "sub-1", "acme-corp", nil, false, nil)
 		require.NoError(t, err)
 
 		key, err := store.Get(ctx, "tenant-key-1")
@@ -254,7 +254,7 @@ func TestAddKeyWithTenant(t *testing.T) {
 	})
 
 	t.Run("EmptyTenantSentinel", func(t *testing.T) {
-		err := store.AddKey(ctx, "user1", "tenant-key-2", "thash2", "no-tenant-key", "", nil, "sub-1", "", nil, false)
+		err := store.AddKey(ctx, "user1", "tenant-key-2", "thash2", "no-tenant-key", "", nil, "sub-1", "", nil, false, nil)
 		require.NoError(t, err)
 
 		key, err := store.Get(ctx, "tenant-key-2")
@@ -263,7 +263,7 @@ func TestAddKeyWithTenant(t *testing.T) {
 	})
 
 	t.Run("TenantRoundTripsViaGetByHash", func(t *testing.T) {
-		err := store.AddKey(ctx, "user1", "tenant-key-3", "thash3", "hash-tenant-key", "", nil, "sub-1", "tenant-xyz", nil, false)
+		err := store.AddKey(ctx, "user1", "tenant-key-3", "thash3", "hash-tenant-key", "", nil, "sub-1", "tenant-xyz", nil, false, nil)
 		require.NoError(t, err)
 
 		key, err := store.GetByHash(ctx, "thash3")
@@ -280,12 +280,12 @@ func TestSearchByTenant(t *testing.T) {
 	defer store.Close()
 
 	// Add 2 keys for tenant-a
-	require.NoError(t, store.AddKey(ctx, "user1", "sa-1", "shah1", "key-a1", "", nil, "sub-1", "tenant-a", nil, false))
-	require.NoError(t, store.AddKey(ctx, "user1", "sa-2", "shah2", "key-a2", "", nil, "sub-1", "tenant-a", nil, false))
+	require.NoError(t, store.AddKey(ctx, "user1", "sa-1", "shah1", "key-a1", "", nil, "sub-1", "tenant-a", nil, false, nil))
+	require.NoError(t, store.AddKey(ctx, "user1", "sa-2", "shah2", "key-a2", "", nil, "sub-1", "tenant-a", nil, false, nil))
 	// Add 1 key for tenant-b
-	require.NoError(t, store.AddKey(ctx, "user1", "sb-1", "shbh1", "key-b1", "", nil, "sub-1", "tenant-b", nil, false))
+	require.NoError(t, store.AddKey(ctx, "user1", "sb-1", "shbh1", "key-b1", "", nil, "sub-1", "tenant-b", nil, false, nil))
 	// Add 1 key for tenant-c
-	require.NoError(t, store.AddKey(ctx, "user1", "sc-1", "shch1", "key-c1", "", nil, "sub-1", "tenant-c", nil, false))
+	require.NoError(t, store.AddKey(ctx, "user1", "sc-1", "shch1", "key-c1", "", nil, "sub-1", "tenant-c", nil, false, nil))
 
 	filters := api_keys.SearchFilters{}
 	sortP := api_keys.SortParams{By: api_keys.DefaultSortBy, Order: api_keys.DefaultSortOrder}
@@ -317,10 +317,12 @@ func TestBulkRevoke_TenantScoped(t *testing.T) {
 	store := createTestStore(t)
 	defer store.Close()
 
-	require.NoError(t, store.AddKey(ctx, "alice", "ta-1", "tah1", "key-ta1", "", nil, "sub-1", "tenant-a", nil, false))
-	require.NoError(t, store.AddKey(ctx, "alice", "ta-2", "tah2", "key-ta2", "", nil, "sub-1", "tenant-a", nil, false))
-	require.NoError(t, store.AddKey(ctx, "alice", "tb-1", "tbh1", "key-tb1", "", nil, "sub-1", "tenant-b", nil, false))
-	require.NoError(t, store.AddKey(ctx, "alice", "tb-2", "tbh2", "key-tb2", "", nil, "sub-1", "tenant-b", nil, false))
+	// Add 2 keys for alice in tenant-a
+	require.NoError(t, store.AddKey(ctx, "alice", "ta-1", "tah1", "key-ta1", "", nil, "sub-1", "tenant-a", nil, false, nil))
+	require.NoError(t, store.AddKey(ctx, "alice", "ta-2", "tah2", "key-ta2", "", nil, "sub-1", "tenant-a", nil, false, nil))
+	// Add 2 keys for alice in tenant-b
+	require.NoError(t, store.AddKey(ctx, "alice", "tb-1", "tbh1", "key-tb1", "", nil, "sub-1", "tenant-b", nil, false, nil))
+	require.NoError(t, store.AddKey(ctx, "alice", "tb-2", "tbh2", "key-tb2", "", nil, "sub-1", "tenant-b", nil, false, nil))
 
 	count, err := store.BulkRevoke(ctx, "alice", "", "tenant-a", false)
 	require.NoError(t, err)

--- a/maas-api/internal/api_keys/store_test.go
+++ b/maas-api/internal/api_keys/store_test.go
@@ -208,9 +208,9 @@ func TestBulkRevoke(t *testing.T) {
 		s := createTestStore(t)
 		defer s.Close()
 
-		require.NoError(t, s.AddKey(ctx, "alice", "sa-1", "sah1", "k1", "", nil, "sub-alpha", "", nil, false))
-		require.NoError(t, s.AddKey(ctx, "bob", "sa-2", "sah2", "k2", "", nil, "sub-alpha", "", nil, false))
-		require.NoError(t, s.AddKey(ctx, "alice", "sb-1", "sbh1", "k3", "", nil, "sub-beta", "", nil, false))
+		require.NoError(t, s.AddKey(ctx, "alice", "sa-1", "sah1", "k1", "", nil, "sub-alpha", "", nil, false, nil))
+		require.NoError(t, s.AddKey(ctx, "bob", "sa-2", "sah2", "k2", "", nil, "sub-alpha", "", nil, false, nil))
+		require.NoError(t, s.AddKey(ctx, "alice", "sb-1", "sbh1", "k3", "", nil, "sub-beta", "", nil, false, nil))
 
 		count, err := s.BulkRevoke(ctx, "", "sub-alpha", "", false)
 		require.NoError(t, err)
@@ -224,9 +224,9 @@ func TestBulkRevoke(t *testing.T) {
 		s := createTestStore(t)
 		defer s.Close()
 
-		require.NoError(t, s.AddKey(ctx, "alice", "us-1", "ush1", "k1", "", nil, "sub-x", "", nil, false))
-		require.NoError(t, s.AddKey(ctx, "alice", "us-2", "ush2", "k2", "", nil, "sub-y", "", nil, false))
-		require.NoError(t, s.AddKey(ctx, "bob", "us-3", "ush3", "k3", "", nil, "sub-x", "", nil, false))
+		require.NoError(t, s.AddKey(ctx, "alice", "us-1", "ush1", "k1", "", nil, "sub-x", "", nil, false, nil))
+		require.NoError(t, s.AddKey(ctx, "alice", "us-2", "ush2", "k2", "", nil, "sub-y", "", nil, false, nil))
+		require.NoError(t, s.AddKey(ctx, "bob", "us-3", "ush3", "k3", "", nil, "sub-x", "", nil, false, nil))
 
 		count, err := s.BulkRevoke(ctx, "alice", "sub-x", "", false)
 		require.NoError(t, err)
@@ -349,9 +349,9 @@ func TestBulkRevoke_ExcludesExpiredKeys(t *testing.T) {
 	pastExpiry := time.Now().Add(-time.Hour)
 	futureExpiry := time.Now().Add(24 * time.Hour)
 
-	require.NoError(t, store.AddKey(ctx, "alice", "active-1", "ah1", "key-a1", "", nil, "sub-1", "tenant-a", &futureExpiry, false))
-	require.NoError(t, store.AddKey(ctx, "alice", "expired-1", "ah2", "key-a2", "", nil, "sub-1", "tenant-a", &pastExpiry, false))
-	require.NoError(t, store.AddKey(ctx, "alice", "permanent-1", "ah3", "key-a3", "", nil, "sub-1", "tenant-a", nil, false))
+	require.NoError(t, store.AddKey(ctx, "alice", "active-1", "ah1", "key-a1", "", nil, "sub-1", "tenant-a", &futureExpiry, false, nil))
+	require.NoError(t, store.AddKey(ctx, "alice", "expired-1", "ah2", "key-a2", "", nil, "sub-1", "tenant-a", &pastExpiry, false, nil))
+	require.NoError(t, store.AddKey(ctx, "alice", "permanent-1", "ah3", "key-a3", "", nil, "sub-1", "tenant-a", nil, false, nil))
 
 	count, err := store.BulkRevoke(ctx, "alice", "", "tenant-a", true)
 	require.NoError(t, err)

--- a/maas-api/internal/api_keys/store_test.go
+++ b/maas-api/internal/api_keys/store_test.go
@@ -64,7 +64,7 @@ func TestAPIKeyOperations(t *testing.T) {
 	defer store.Close()
 
 	t.Run("AddKey", func(t *testing.T) {
-		err := store.AddKey(ctx, "user1", "key-id-1", "hash123", "my-key", "test key", []string{"system:authenticated", "premium-user"}, "sub-1", "", nil, false)
+		err := store.AddKey(ctx, "user1", "key-id-1", "hash123", "my-key", "test key", []string{"system:authenticated", "premium-user"}, "sub-1", "", nil, false, nil)
 		require.NoError(t, err)
 
 		// Verify key was added by fetching it
@@ -105,7 +105,7 @@ func TestAPIKeyOperations(t *testing.T) {
 	// matching PostgreSQL behavior: only keys with status='active' can be revoked.
 	t.Run("RevokeAlreadyRevokedKey", func(t *testing.T) {
 		// Create a fresh key, revoke it, then try revoking again
-		err := store.AddKey(ctx, "user3", "key-revoke-twice", "hash-revoke-twice", "revoke-twice", "", nil, "sub-1", "", nil, false)
+		err := store.AddKey(ctx, "user3", "key-revoke-twice", "hash-revoke-twice", "revoke-twice", "", nil, "sub-1", "", nil, false, nil)
 		require.NoError(t, err)
 
 		err = store.Revoke(ctx, "key-revoke-twice")
@@ -118,7 +118,7 @@ func TestAPIKeyOperations(t *testing.T) {
 
 	t.Run("UpdateLastUsed", func(t *testing.T) {
 		// Add another key for this test
-		err := store.AddKey(ctx, "user2", "key-id-2", "hash456", "key2", "", []string{"system:authenticated", "free-user"}, "sub-2", "", nil, false)
+		err := store.AddKey(ctx, "user2", "key-id-2", "hash456", "key2", "", []string{"system:authenticated", "free-user"}, "sub-2", "", nil, false, nil)
 		require.NoError(t, err)
 
 		err = store.UpdateLastUsed(ctx, "key-id-2")
@@ -143,11 +143,11 @@ func TestInvalidateAll(t *testing.T) {
 		// Add 3 keys for alice, 2 for bob
 		for i := range 3 {
 			id := "alice-key-" + string(rune('a'+i))
-			require.NoError(t, store.AddKey(ctx, "alice", id, "ahash"+id, "key-"+id, "", nil, "sub-1", "", nil, false))
+			require.NoError(t, store.AddKey(ctx, "alice", id, "ahash"+id, "key-"+id, "", nil, "sub-1", "", nil, false, nil))
 		}
 		for i := range 2 {
 			id := "bob-key-" + string(rune('a'+i))
-			require.NoError(t, store.AddKey(ctx, "bob", id, "bhash"+id, "key-"+id, "", nil, "sub-1", "", nil, false))
+			require.NoError(t, store.AddKey(ctx, "bob", id, "bhash"+id, "key-"+id, "", nil, "sub-1", "", nil, false, nil))
 		}
 
 		count, err := store.InvalidateAll(ctx, "alice", "")
@@ -184,9 +184,9 @@ func TestInvalidateAll(t *testing.T) {
 		s := createTestStore(t)
 		defer s.Close()
 
-		require.NoError(t, s.AddKey(ctx, "carol", "c1", "ch1", "k1", "", nil, "sub-1", "", nil, false))
-		require.NoError(t, s.AddKey(ctx, "carol", "c2", "ch2", "k2", "", nil, "sub-1", "", nil, false))
-		require.NoError(t, s.AddKey(ctx, "carol", "c3", "ch3", "k3", "", nil, "sub-1", "", nil, false))
+		require.NoError(t, s.AddKey(ctx, "carol", "c1", "ch1", "k1", "", nil, "sub-1", "", nil, false, nil))
+		require.NoError(t, s.AddKey(ctx, "carol", "c2", "ch2", "k2", "", nil, "sub-1", "", nil, false, nil))
+		require.NoError(t, s.AddKey(ctx, "carol", "c3", "ch3", "k3", "", nil, "sub-1", "", nil, false, nil))
 
 		// Revoke one key manually first
 		require.NoError(t, s.Revoke(ctx, "c3"))
@@ -203,7 +203,7 @@ func TestInvalidateAll(t *testing.T) {
 		s := createTestStore(t)
 		defer s.Close()
 
-		require.NoError(t, s.AddKey(ctx, "dan", "d1", "dh1", "k1", "", nil, "sub-1", "", nil, false))
+		require.NoError(t, s.AddKey(ctx, "dan", "d1", "dh1", "k1", "", nil, "sub-1", "", nil, false, nil))
 
 		count, err := s.InvalidateAll(ctx, "dan", "")
 		require.NoError(t, err)
@@ -222,7 +222,7 @@ func TestAddKeyWithTenant(t *testing.T) {
 	defer store.Close()
 
 	t.Run("TenantRoundTripsViaGet", func(t *testing.T) {
-		err := store.AddKey(ctx, "user1", "tenant-key-1", "thash1", "tenant-key", "", nil, "sub-1", "acme-corp", nil, false)
+		err := store.AddKey(ctx, "user1", "tenant-key-1", "thash1", "tenant-key", "", nil, "sub-1", "acme-corp", nil, false, nil)
 		require.NoError(t, err)
 
 		key, err := store.Get(ctx, "tenant-key-1")
@@ -231,7 +231,7 @@ func TestAddKeyWithTenant(t *testing.T) {
 	})
 
 	t.Run("EmptyTenantSentinel", func(t *testing.T) {
-		err := store.AddKey(ctx, "user1", "tenant-key-2", "thash2", "no-tenant-key", "", nil, "sub-1", "", nil, false)
+		err := store.AddKey(ctx, "user1", "tenant-key-2", "thash2", "no-tenant-key", "", nil, "sub-1", "", nil, false, nil)
 		require.NoError(t, err)
 
 		key, err := store.Get(ctx, "tenant-key-2")
@@ -240,7 +240,7 @@ func TestAddKeyWithTenant(t *testing.T) {
 	})
 
 	t.Run("TenantRoundTripsViaGetByHash", func(t *testing.T) {
-		err := store.AddKey(ctx, "user1", "tenant-key-3", "thash3", "hash-tenant-key", "", nil, "sub-1", "tenant-xyz", nil, false)
+		err := store.AddKey(ctx, "user1", "tenant-key-3", "thash3", "hash-tenant-key", "", nil, "sub-1", "tenant-xyz", nil, false, nil)
 		require.NoError(t, err)
 
 		key, err := store.GetByHash(ctx, "thash3")
@@ -257,12 +257,12 @@ func TestSearchByTenant(t *testing.T) {
 	defer store.Close()
 
 	// Add 2 keys for tenant-a
-	require.NoError(t, store.AddKey(ctx, "user1", "sa-1", "shah1", "key-a1", "", nil, "sub-1", "tenant-a", nil, false))
-	require.NoError(t, store.AddKey(ctx, "user1", "sa-2", "shah2", "key-a2", "", nil, "sub-1", "tenant-a", nil, false))
+	require.NoError(t, store.AddKey(ctx, "user1", "sa-1", "shah1", "key-a1", "", nil, "sub-1", "tenant-a", nil, false, nil))
+	require.NoError(t, store.AddKey(ctx, "user1", "sa-2", "shah2", "key-a2", "", nil, "sub-1", "tenant-a", nil, false, nil))
 	// Add 1 key for tenant-b
-	require.NoError(t, store.AddKey(ctx, "user1", "sb-1", "shbh1", "key-b1", "", nil, "sub-1", "tenant-b", nil, false))
+	require.NoError(t, store.AddKey(ctx, "user1", "sb-1", "shbh1", "key-b1", "", nil, "sub-1", "tenant-b", nil, false, nil))
 	// Add 1 key for tenant-c
-	require.NoError(t, store.AddKey(ctx, "user1", "sc-1", "shch1", "key-c1", "", nil, "sub-1", "tenant-c", nil, false))
+	require.NoError(t, store.AddKey(ctx, "user1", "sc-1", "shch1", "key-c1", "", nil, "sub-1", "tenant-c", nil, false, nil))
 
 	filters := api_keys.SearchFilters{}
 	sortP := api_keys.SortParams{By: api_keys.DefaultSortBy, Order: api_keys.DefaultSortOrder}
@@ -295,11 +295,11 @@ func TestInvalidateAll_TenantScoped(t *testing.T) {
 	defer store.Close()
 
 	// Add 2 keys for alice in tenant-a
-	require.NoError(t, store.AddKey(ctx, "alice", "ta-1", "tah1", "key-ta1", "", nil, "sub-1", "tenant-a", nil, false))
-	require.NoError(t, store.AddKey(ctx, "alice", "ta-2", "tah2", "key-ta2", "", nil, "sub-1", "tenant-a", nil, false))
+	require.NoError(t, store.AddKey(ctx, "alice", "ta-1", "tah1", "key-ta1", "", nil, "sub-1", "tenant-a", nil, false, nil))
+	require.NoError(t, store.AddKey(ctx, "alice", "ta-2", "tah2", "key-ta2", "", nil, "sub-1", "tenant-a", nil, false, nil))
 	// Add 2 keys for alice in tenant-b
-	require.NoError(t, store.AddKey(ctx, "alice", "tb-1", "tbh1", "key-tb1", "", nil, "sub-1", "tenant-b", nil, false))
-	require.NoError(t, store.AddKey(ctx, "alice", "tb-2", "tbh2", "key-tb2", "", nil, "sub-1", "tenant-b", nil, false))
+	require.NoError(t, store.AddKey(ctx, "alice", "tb-1", "tbh1", "key-tb1", "", nil, "sub-1", "tenant-b", nil, false, nil))
+	require.NoError(t, store.AddKey(ctx, "alice", "tb-2", "tbh2", "key-tb2", "", nil, "sub-1", "tenant-b", nil, false, nil))
 
 	// Invalidate only tenant-a keys
 	count, err := store.InvalidateAll(ctx, "alice", "tenant-a")

--- a/maas-api/internal/api_keys/types.go
+++ b/maas-api/internal/api_keys/types.go
@@ -32,6 +32,7 @@ type ApiKey struct {
 	Status         Status   `json:"status"`                   // "active", "expired", "revoked"
 	LastUsedAt     string   `json:"lastUsedAt,omitempty"`     // Tracks when key was last used for validation
 	Ephemeral      bool     `json:"ephemeral"`                // Short-lived programmatic key
+	Labels         map[string]string `json:"labels,omitempty"`   // Structured key-value pairs for API key metadata
 }
 
 // ValidationResult holds the result of API key validation (for Authorino HTTP callback).
@@ -96,6 +97,9 @@ type SearchFilters struct {
 
 	// Ephemeral key filter
 	IncludeEphemeral *bool `json:"includeEphemeral,omitempty"` // Include ephemeral keys in results (default: false)
+
+	// Labels filter
+	LabelsContain  map[string]string `json:"labelsContain,omitempty"` // Filter by structured key-value pairs for API key metadata
 }
 
 // SortParams specifies sorting criteria.

--- a/maas-api/internal/constant/const.go
+++ b/maas-api/internal/constant/const.go
@@ -34,7 +34,7 @@ const (
 	AnnotationModelCapabilities = "opendatahub.io/model-capabilities"
 
 	// MaxLabelsEntries is the maximum number of label key-value pairs per API key (prevent abuse).
-	MaxLabelsEntries = 50
-	MaxLabelKeyLength = 128
+	MaxLabelsEntries    = 50
+	MaxLabelKeyLength   = 128
 	MaxLabelValueLength = 1024
 )

--- a/maas-api/internal/constant/const.go
+++ b/maas-api/internal/constant/const.go
@@ -32,4 +32,9 @@ const (
 	AnnotationDisplayName       = "openshift.io/display-name"
 	AnnotationContextWindow     = "opendatahub.io/context-window"
 	AnnotationModelCapabilities = "opendatahub.io/model-capabilities"
+
+	// MaxLabelsEntries is the maximum number of label key-value pairs per API key (prevent abuse).
+	MaxLabelsEntries = 50
+	MaxLabelKeyLength = 128
+	MaxLabelValueLength = 1024
 )

--- a/test/e2e/tests/test_api_keys.py
+++ b/test/e2e/tests/test_api_keys.py
@@ -1841,3 +1841,132 @@ class TestAPIKeySubscriptionFilter:
         finally:
             for kid in key_ids:
                 requests.delete(f"{api_keys_base_url}/{kid}", headers=headers, timeout=TIMEOUT, verify=TLS_VERIFY)
+
+
+class TestAPIKeyLabels:
+    """Tests for API key label creation, search, validation, and backward compatibility."""
+
+    def test_create_api_key_with_labels(self, api_keys_base_url: str, headers: dict):
+        """Create an API key with labels and verify they're returned and persisted."""
+        labels = {
+            "cmdb_id": "AST123456",
+            "cost_center": "CC-DATA-001",
+            "environment": "production",
+            "project_code": "PROJ-ML-2024",
+        }
+
+        r = requests.post(
+            api_keys_base_url,
+            headers=headers,
+            json={
+                "name": "e2e-label-create",
+                "description": "E2E label round-trip test",
+                "labels": labels,
+            },
+            timeout=30,
+            verify=TLS_VERIFY,
+        )
+        assert r.status_code in (200, 201), f"Expected 200/201, got {r.status_code}: {r.text}"
+        data = r.json()
+        assert "key" in data and "id" in data
+        assert data.get("labels") == labels, "Labels in create response don't match request"
+
+        r_get = requests.get(
+            f"{api_keys_base_url}/{data['id']}",
+            headers=headers,
+            timeout=30,
+            verify=TLS_VERIFY,
+        )
+        assert r_get.status_code == 200
+        assert r_get.json().get("labels") == labels, "Labels from GET don't match original"
+
+    def test_search_api_keys_by_labels(self, api_keys_base_url: str, headers: dict):
+        """Create keys with different labels and verify search filtering."""
+        labels1 = {"cmdb_id": "AST111", "env": "prod"}
+        labels2 = {"cmdb_id": "AST222", "env": "dev"}
+        labels3 = {"cost_center": "CC-999"}
+
+        r1 = requests.post(api_keys_base_url, headers=headers,
+                           json={"name": "e2e-label-search-1", "labels": labels1},
+                           timeout=30, verify=TLS_VERIFY)
+        assert r1.status_code in (200, 201)
+        key1_id = r1.json()["id"]
+
+        r2 = requests.post(api_keys_base_url, headers=headers,
+                           json={"name": "e2e-label-search-2", "labels": labels2},
+                           timeout=30, verify=TLS_VERIFY)
+        assert r2.status_code in (200, 201)
+        key2_id = r2.json()["id"]
+
+        r3 = requests.post(api_keys_base_url, headers=headers,
+                           json={"name": "e2e-label-search-3", "labels": labels3},
+                           timeout=30, verify=TLS_VERIFY)
+        assert r3.status_code in (200, 201)
+
+        # Search by CMDB ID — should find key1 only
+        r_search = requests.post(
+            f"{api_keys_base_url}/search",
+            headers=headers,
+            json={"filters": {"labelsContain": {"cmdb_id": "AST111"}}},
+            timeout=30,
+            verify=TLS_VERIFY,
+        )
+        assert r_search.status_code == 200
+        items = r_search.json().get("items") or r_search.json().get("data") or []
+        found_ids = [k["id"] for k in items]
+        assert key1_id in found_ids, "Should find key with cmdb_id AST111"
+
+        found_key = next(k for k in items if k["id"] == key1_id)
+        assert found_key["labels"]["cmdb_id"] == "AST111"
+
+        # Search by env=prod — should find key1, not key2
+        r_search = requests.post(
+            f"{api_keys_base_url}/search",
+            headers=headers,
+            json={"filters": {"labelsContain": {"env": "prod"}}},
+            timeout=30,
+            verify=TLS_VERIFY,
+        )
+        assert r_search.status_code == 200
+        items = r_search.json().get("items") or r_search.json().get("data") or []
+        found_ids = [k["id"] for k in items]
+        assert key1_id in found_ids
+        assert key2_id not in found_ids, "Should not find dev key when searching for prod"
+
+    def test_labels_validation_errors(self, api_keys_base_url: str, headers: dict):
+        """Verify invalid labels are rejected with 400 and clear error messages."""
+        # Too many labels (>50)
+        large_labels = {f"key{i}": f"value{i}" for i in range(51)}
+        r = requests.post(api_keys_base_url, headers=headers,
+                          json={"name": "e2e-label-too-many", "labels": large_labels},
+                          timeout=30, verify=TLS_VERIFY)
+        assert r.status_code == 400
+        assert "50" in r.json().get("error", "")
+
+        # Key too long (>128 chars)
+        r = requests.post(api_keys_base_url, headers=headers,
+                          json={"name": "e2e-label-long-key", "labels": {"a" * 129: "value"}},
+                          timeout=30, verify=TLS_VERIFY)
+        assert r.status_code == 400
+        assert "128" in r.json().get("error", "")
+
+        # Invalid characters in key
+        r = requests.post(api_keys_base_url, headers=headers,
+                          json={"name": "e2e-label-bad-chars", "labels": {"invalid key!": "value"}},
+                          timeout=30, verify=TLS_VERIFY)
+        assert r.status_code == 400
+
+    def test_backward_compatibility_no_labels(self, api_keys_base_url: str, headers: dict):
+        """Keys created without labels still work (backward compatibility)."""
+        r = requests.post(api_keys_base_url, headers=headers,
+                          json={"name": "e2e-label-none", "description": "No labels"},
+                          timeout=30, verify=TLS_VERIFY)
+        assert r.status_code in (200, 201)
+        data = r.json()
+        key_id = data["id"]
+        assert data.get("labels") is None or data.get("labels") == {}
+
+        r_get = requests.get(f"{api_keys_base_url}/{key_id}", headers=headers,
+                             timeout=30, verify=TLS_VERIFY)
+        assert r_get.status_code == 200
+        assert r_get.json().get("labels") is None or r_get.json().get("labels") == {}

--- a/test/e2e/tests/test_api_keys.py
+++ b/test/e2e/tests/test_api_keys.py
@@ -1584,3 +1584,132 @@ class TestAPIKeySubscriptionFilter:
         finally:
             for kid in key_ids:
                 requests.delete(f"{api_keys_base_url}/{kid}", headers=headers, timeout=TIMEOUT, verify=TLS_VERIFY)
+
+
+class TestAPIKeyLabels:
+    """Tests for API key label creation, search, validation, and backward compatibility."""
+
+    def test_create_api_key_with_labels(self, api_keys_base_url: str, headers: dict):
+        """Create an API key with labels and verify they're returned and persisted."""
+        labels = {
+            "cmdb_id": "AST123456",
+            "cost_center": "CC-DATA-001",
+            "environment": "production",
+            "project_code": "PROJ-ML-2024",
+        }
+
+        r = requests.post(
+            api_keys_base_url,
+            headers=headers,
+            json={
+                "name": "e2e-label-create",
+                "description": "E2E label round-trip test",
+                "labels": labels,
+            },
+            timeout=30,
+            verify=TLS_VERIFY,
+        )
+        assert r.status_code in (200, 201), f"Expected 200/201, got {r.status_code}: {r.text}"
+        data = r.json()
+        assert "key" in data and "id" in data
+        assert data.get("labels") == labels, "Labels in create response don't match request"
+
+        r_get = requests.get(
+            f"{api_keys_base_url}/{data['id']}",
+            headers=headers,
+            timeout=30,
+            verify=TLS_VERIFY,
+        )
+        assert r_get.status_code == 200
+        assert r_get.json().get("labels") == labels, "Labels from GET don't match original"
+
+    def test_search_api_keys_by_labels(self, api_keys_base_url: str, headers: dict):
+        """Create keys with different labels and verify search filtering."""
+        labels1 = {"cmdb_id": "AST111", "env": "prod"}
+        labels2 = {"cmdb_id": "AST222", "env": "dev"}
+        labels3 = {"cost_center": "CC-999"}
+
+        r1 = requests.post(api_keys_base_url, headers=headers,
+                           json={"name": "e2e-label-search-1", "labels": labels1},
+                           timeout=30, verify=TLS_VERIFY)
+        assert r1.status_code in (200, 201)
+        key1_id = r1.json()["id"]
+
+        r2 = requests.post(api_keys_base_url, headers=headers,
+                           json={"name": "e2e-label-search-2", "labels": labels2},
+                           timeout=30, verify=TLS_VERIFY)
+        assert r2.status_code in (200, 201)
+        key2_id = r2.json()["id"]
+
+        r3 = requests.post(api_keys_base_url, headers=headers,
+                           json={"name": "e2e-label-search-3", "labels": labels3},
+                           timeout=30, verify=TLS_VERIFY)
+        assert r3.status_code in (200, 201)
+
+        # Search by CMDB ID — should find key1 only
+        r_search = requests.post(
+            f"{api_keys_base_url}/search",
+            headers=headers,
+            json={"filters": {"labelsContain": {"cmdb_id": "AST111"}}},
+            timeout=30,
+            verify=TLS_VERIFY,
+        )
+        assert r_search.status_code == 200
+        items = r_search.json().get("items") or r_search.json().get("data") or []
+        found_ids = [k["id"] for k in items]
+        assert key1_id in found_ids, "Should find key with cmdb_id AST111"
+
+        found_key = next(k for k in items if k["id"] == key1_id)
+        assert found_key["labels"]["cmdb_id"] == "AST111"
+
+        # Search by env=prod — should find key1, not key2
+        r_search = requests.post(
+            f"{api_keys_base_url}/search",
+            headers=headers,
+            json={"filters": {"labelsContain": {"env": "prod"}}},
+            timeout=30,
+            verify=TLS_VERIFY,
+        )
+        assert r_search.status_code == 200
+        items = r_search.json().get("items") or r_search.json().get("data") or []
+        found_ids = [k["id"] for k in items]
+        assert key1_id in found_ids
+        assert key2_id not in found_ids, "Should not find dev key when searching for prod"
+
+    def test_labels_validation_errors(self, api_keys_base_url: str, headers: dict):
+        """Verify invalid labels are rejected with 400 and clear error messages."""
+        # Too many labels (>50)
+        large_labels = {f"key{i}": f"value{i}" for i in range(51)}
+        r = requests.post(api_keys_base_url, headers=headers,
+                          json={"name": "e2e-label-too-many", "labels": large_labels},
+                          timeout=30, verify=TLS_VERIFY)
+        assert r.status_code == 400
+        assert "50" in r.json().get("error", "")
+
+        # Key too long (>128 chars)
+        r = requests.post(api_keys_base_url, headers=headers,
+                          json={"name": "e2e-label-long-key", "labels": {"a" * 129: "value"}},
+                          timeout=30, verify=TLS_VERIFY)
+        assert r.status_code == 400
+        assert "128" in r.json().get("error", "")
+
+        # Invalid characters in key
+        r = requests.post(api_keys_base_url, headers=headers,
+                          json={"name": "e2e-label-bad-chars", "labels": {"invalid key!": "value"}},
+                          timeout=30, verify=TLS_VERIFY)
+        assert r.status_code == 400
+
+    def test_backward_compatibility_no_labels(self, api_keys_base_url: str, headers: dict):
+        """Keys created without labels still work (backward compatibility)."""
+        r = requests.post(api_keys_base_url, headers=headers,
+                          json={"name": "e2e-label-none", "description": "No labels"},
+                          timeout=30, verify=TLS_VERIFY)
+        assert r.status_code in (200, 201)
+        data = r.json()
+        key_id = data["id"]
+        assert data.get("labels") is None or data.get("labels") == {}
+
+        r_get = requests.get(f"{api_keys_base_url}/{key_id}", headers=headers,
+                             timeout=30, verify=TLS_VERIFY)
+        assert r_get.status_code == 200
+        assert r_get.json().get("labels") is None or r_get.json().get("labels") == {}

--- a/test/integration/postgresql.sh
+++ b/test/integration/postgresql.sh
@@ -1,0 +1,47 @@
+ #!/usr/bin/env bash
+  set -euo pipefail
+
+  CONTAINER_NAME="maas-test"
+  DB_NAME="maas_test"
+  PG_USER="postgres"
+  PG_PASS="postgres"
+  PG_PORT="5432"
+  PG_IMAGE="postgres:15"
+  MAX_RETRIES=30
+
+  cleanup() {
+      echo "Cleaning up..."
+      podman stop "$CONTAINER_NAME" 2>/dev/null || true
+      podman rm "$CONTAINER_NAME" 2>/dev/null || true
+  }
+  trap cleanup EXIT
+
+  # Remove any leftover container from a prior run
+  podman rm -f "$CONTAINER_NAME" 2>/dev/null || true
+
+  echo "Starting PostgreSQL container..."
+  podman run --name "$CONTAINER_NAME" \
+      -e POSTGRES_PASSWORD="$PG_PASS" \
+      -p "${PG_PORT}:5432" \
+      -d "$PG_IMAGE"
+
+  echo "Waiting for PostgreSQL readiness..."
+  for i in $(seq 1 "$MAX_RETRIES"); do
+      if podman exec "$CONTAINER_NAME" pg_isready -U "$PG_USER" -q 2>/dev/null; then
+          echo "PostgreSQL ready after ${i}s"
+          break
+      fi
+      if [ "$i" -eq "$MAX_RETRIES" ]; then
+          echo "PostgreSQL failed to start after ${MAX_RETRIES}s"
+          exit 1
+      fi
+      sleep 1
+  done
+
+  echo "Creating test database..."
+  podman exec "$CONTAINER_NAME" psql -U "$PG_USER" -c "CREATE DATABASE ${DB_NAME};"
+
+  echo "Running integration tests..."
+  export TEST_DATABASE_URL="postgres://${PG_USER}:${PG_PASS}@localhost:${PG_PORT}/${DB_NAME}?sslmode=disable"
+  cd "$(git rev-parse --show-toplevel)/maas-api"
+  go test -tags=integration -v -run "TestPostgres" ./internal/api_keys/


### PR DESCRIPTION
## Description

Closes: #1058 

Added optional `labels` field to API keys, enabling organizations to attach custom key-value metadata for enterprise integration (CMDB tracking, cost center allocation, compliance, etc.).

**Storage**: PostgreSQL JSONB with GIN index for efficient queries  
**Backward Compatible**: NULL for existing keys, optional for new keys  

---

## Files Changed

- `maas-api/internal/api_keys/types.go`
  - `ApiKey` - Added `Labels map[string]string` field
  - `CreateAPIKeyRequest` - Added `Labels map[string]string` field
  - `SearchFilters` - Added `LabelsContain map[string]string` field
- `maas-api/internal/api_keys/handler.go`
  - `validateLabels()` function for label validation.
- `maas-api/internal/api_keys/service.go`
  - `CreateAPIKeyResponse` - Added `Labels map[string]string` field
  - `CreateAPIKey()` signature: added `labels map[string]string` parameter
  - `CreateAPIKeyResponse` struct: added `Labels` field
  - Response population: includes labels for user confirmation
  - Logging: added `"hasLabels", len(labels) > 0` for observability
- `maas-api/internal/api_keys/store_interface.go`
  - Updated persistence interface with labels parm.
- `maas-api/internal/api_keys/store_postgres.go`
  - Updated INSERT query to include `labels` column
  - Added `labels` to SELECT query
- `maas-api/internal/api_keys/store_mock.go`
  - `AddKey()`: added `labels` parameter, normalizes empty map to `nil`
  - `Search()`: added labels filtering logic
  - `labelsContain()` helper: mirrors PostgreSQL JSONB `@>` semantics
 
- Included regression updates plus new tests in the following test files:.
  - `test/e2e/test_api_keys.py` (4 new e2e tests)
  - `maas-api/internal/api_keys/handler_test.go`
  - `maas-api/internal/api_keys/service_test.go`
  - `maas-api/internal/api_keys/store_test.go`
  - `maas-api/internal/api_keys/store_postgres_test.go`

- Documentation changes:
  - `docs/content/user-guide/api-key-management.md` - guides and examples
  - `docs/content/contributing/testing-guide.md` - new integration test

---

## How Has This Been Tested?

Updated existing unit tests to include `nil` label to ensure no regressions were introduced.

**Verification:** All 59 existing tests pass - no regressions introduced.

Added new tests for labels: `maas-api/internal/api_keys/handler_test.go`

**Implemented tests:**

1. `TestValidateLabels_Success` - Valid label configurations (6 cases)
2. `TestValidateLabels_Errors` - Validation failures (10 cases)
3. `TestCreateAPIKey_WithLabels` - Creation with labels
4. `TestCreateAPIKey_WithoutLabels` - Backward compatibility
5. `TestCreateAPIKey_InvalidLabels` - Error handling (6 cases)
6. `TestSearchAPIKeys_ByLabels` - Search filtering (6 scenarios)
7. `TestGetAPIKey_WithLabels` - Retrieval with labels
8. `TestCreateEphemeralKey_InvalidLabels` - Error handling

**Result:** All 7 new tests passing.

---

### New Integration Tests

MockStore cannot calidate JSONB encoding and GIN index perforemance and NULL vs. empty object semantics so a three new integration tests were created. Test coverage: Validation scenarios, CRUD operations, search filtering, edge cases, and database-specific behaviour.

**File:** `maas-api/internal/api_keys/store_postgres_test.go`

1. `TestPostgresStore_LabelsRoundTrip` - JSONB marshaling/unmarshaling verification
2. `TestPostgresStore_SearchByLabels` - GIN index and `@>` containment operator
3. `TestPostgresStore_BackwardCompatibility_NullLabels` - NULL handling for legacy keys

Note: The process for running these tests is documented in the `./docs/content/contributing/testing-guide.md` document.

**Result:** All 3 integration tests passing.

---

### New E2E Tests

Added new E2E tests to `test/e2e/tests/test_api_keys.py` (new `TestAPIKeyLabels` class)

**Tests:**

1. `test_create_api_key_with_labels` - Create with labels, verify in response and GET
2. `test_search_api_keys_by_labels` - Search by `labelsContain` filter, verify JSONB containment
3. `test_labels_validation_errors` - Reject >50 labels, key >128 chars, invalid key characters
4. `test_backward_compatibility_no_labels` - Keys without labels return `null`/absent labels

**Run command:**

```bash
pytest ./test/e2e/tests/test_api_keys.py::TestAPIKeyLabels -v
```

### Test Coverage Summary

**Unit Tests:** 76 tests total

- 69 regression tests (existing functionality)
- 7 new tests (labels functionality)
- All passing 

**Integration Tests:** 3 tests (optional, requires PostgreSQL)

- All passing

**e2e Tests:** 4 tests total

```bash
test/e2e/tests/test_api_keys.py::TestAPIKeyLabels::test_create_api_key_with_labels PASSED          [25%]
test/e2e/tests/test_api_keys.py::TestAPIKeyLabels::test_search_api_keys_by_labels PASSED           [50%]
test/e2e/tests/test_api_keys.py::TestAPIKeyLabels::test_labels_validation_errors PASSED            [75%]
test/e2e/tests/test_api_keys.py::TestAPIKeyLabels::test_backward_compatibility_no_labels PASSED    [100%]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Added optional structured `labels` on API key creation; labels are validated, persisted, and returned in create and key details responses.
  * Added API key search filtering with `filters.labelsContain` (including AND behavior across multiple label pairs).
* **Bug Fixes**
  * Improved backward compatibility: keys created without labels return `labels` consistently as `null`/empty.
* **Documentation**
  * Updated API key management guide with label request/response examples, constraints, and label-based filtering examples.
  * Expanded the testing guide with PostgreSQL integration test instructions.
* **Database**
  * Added JSONB `labels` storage with indexing to support efficient label containment queries.
* **Tests**
  * Added unit, PostgreSQL integration, and end-to-end tests covering label persistence, validation errors, and label-based search.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->