### PR TITLE
feat: add user-facing RBAC aggregation for inference.opendatahub.io ExternalProvider and ExternalModel resources

### DIFF
--- a/deployment/base/maas-controller/rbac/owner_role.yaml
+++ b/deployment/base/maas-controller/rbac/owner_role.yaml
@@ -20,3 +20,16 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - inference.opendatahub.io
+  resources:
+  - externalproviders
+  - externalmodels
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/deployment/base/maas-controller/rbac/viewer_role.yaml
+++ b/deployment/base/maas-controller/rbac/viewer_role.yaml
@@ -17,3 +17,12 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - inference.opendatahub.io
+  resources:
+  - externalproviders
+  - externalmodels
+  verbs:
+  - get
+  - list
+  - watch

--- a/maas-controller/pkg/controller/maas/providers_external.go
+++ b/maas-controller/pkg/controller/maas/providers_external.go
@@ -22,6 +22,8 @@ import (
 
 	"github.com/go-logr/logr"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -35,25 +37,59 @@ import (
 // but gateway controllers commonly set it on route parent status as well.
 const routeConditionProgrammed = "Programmed"
 
+var inferenceExternalModelGVK = schema.GroupVersionKind{
+	Group:   "inference.opendatahub.io",
+	Version: "v1alpha1",
+	Kind:    "ExternalModel",
+}
+
+//+kubebuilder:rbac:groups=inference.opendatahub.io,resources=externalmodels,verbs=get;list;watch
+
 // externalModelHandler implements BackendHandler for kind "ExternalModel".
 type externalModelHandler struct {
 	r *MaaSModelRefReconciler
 }
 
 // ReconcileRoute validates the HTTPRoute for an external model and populates status.
-// The ExternalModel reconciler creates the "maas-model-<model.Name>" HTTPRoute in the
-// model's namespace. This method validates that it exists and is accepted by the gateway.
+// The ExternalModel reconciler creates the HTTPRoute in the model's namespace.
+// This method validates that it exists and is accepted by the gateway.
 func (h *externalModelHandler) ReconcileRoute(ctx context.Context, log logr.Logger, model *maasv1alpha1.MaaSModelRef) error {
-	// Fetch the referenced ExternalModel CR to get provider configuration
-	externalModel := &maasv1alpha1.ExternalModel{}
 	externalModelKey := types.NamespacedName{
 		Name:      model.Spec.ModelRef.Name,
 		Namespace: model.Namespace,
 	}
-	if err := h.r.Get(ctx, externalModelKey, externalModel); err != nil {
-		if apierrors.IsNotFound(err) {
-			return fmt.Errorf("ExternalModel %s not found in namespace %s", model.Spec.ModelRef.Name, model.Namespace)
+
+	var externalModelName string
+	var providerInfo string
+
+	// Try maas.opendatahub.io/ExternalModel first, fall back to inference.opendatahub.io
+	externalModel := &maasv1alpha1.ExternalModel{}
+	err := h.r.Get(ctx, externalModelKey, externalModel)
+	if err == nil {
+		externalModelName = externalModel.Name
+		providerInfo = externalModel.Spec.Provider
+	} else if apierrors.IsNotFound(err) {
+		inferenceEM := &unstructured.Unstructured{}
+		inferenceEM.SetGroupVersionKind(inferenceExternalModelGVK)
+		if err := h.r.Get(ctx, externalModelKey, inferenceEM); err != nil {
+			if apierrors.IsNotFound(err) {
+				return fmt.Errorf("ExternalModel %s not found in namespace %s (checked maas.opendatahub.io and inference.opendatahub.io)",
+					model.Spec.ModelRef.Name, model.Namespace)
+			}
+			return fmt.Errorf("failed to get inference ExternalModel %s: %w", model.Spec.ModelRef.Name, err)
 		}
+		externalModelName = inferenceEM.GetName()
+		if refs, found, _ := unstructured.NestedSlice(inferenceEM.Object, "spec", "externalProviderRefs"); found && len(refs) > 0 {
+			if ref, ok := refs[0].(map[string]any); ok {
+				if refObj, ok := ref["ref"].(map[string]any); ok {
+					if name, ok := refObj["name"].(string); ok {
+						providerInfo = name
+					}
+				}
+			}
+		}
+		log.Info("resolved ExternalModel from inference.opendatahub.io", "name", externalModelName, "namespace", model.Namespace)
+	} else {
 		return fmt.Errorf("failed to get ExternalModel %s: %w", model.Spec.ModelRef.Name, err)
 	}
 
@@ -155,7 +191,7 @@ func (h *externalModelHandler) ReconcileRoute(ctx context.Context, log logr.Logg
 
 	log.Info("HTTPRoute validated for ExternalModel",
 		"routeName", routeName, "namespace", routeNS, "model", model.Name,
-		"externalModel", externalModel.Name, "provider", externalModel.Spec.Provider,
+		"externalModel", externalModelName, "provider", providerInfo,
 		"gateway", fmt.Sprintf("%s/%s", gatewayNamespace, gatewayName), "hostnames", hostnames)
 
 	return nil

--- a/maas-controller/pkg/controller/maas/providers_external_test.go
+++ b/maas-controller/pkg/controller/maas/providers_external_test.go
@@ -22,6 +22,9 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
@@ -294,6 +297,96 @@ func TestExternalModel_CredentialRef(t *testing.T) {
 
 	if externalModel.Spec.CredentialRef.Name != "openai-api-key" {
 		t.Errorf("CredentialRef.Name = %q, want %q", externalModel.Spec.CredentialRef.Name, "openai-api-key")
+	}
+}
+
+func newInferenceExternalModelCR(name, ns, providerRef string) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(inferenceExternalModelGVK)
+	obj.SetName(name)
+	obj.SetNamespace(ns)
+	obj.Object["spec"] = map[string]any{
+		"externalProviderRefs": []any{
+			map[string]any{
+				"ref":         map[string]any{"name": providerRef},
+				"targetModel": "gpt-4o",
+				"apiFormat":   "openai-chat",
+			},
+		},
+	}
+	return obj
+}
+
+func newTestReconcilerWithMapper(objects ...client.Object) (*MaaSModelRefReconciler, client.Client) {
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithRESTMapper(testRESTMapper()).
+		WithObjects(objects...).
+		WithStatusSubresource(&maasv1alpha1.MaaSModelRef{}).
+		Build()
+	return &MaaSModelRefReconciler{
+		Client:           c,
+		Scheme:           scheme,
+		GatewayName:      "maas-default-gateway",
+		GatewayNamespace: "openshift-ingress",
+	}, c
+}
+
+func TestExternalModel_ReconcileRoute_InferenceExternalModel(t *testing.T) {
+	model := newExternalModel("gpt-4o", "default", "", "")
+	inferenceEM := newInferenceExternalModelCR("gpt-4o", "default", "openai-provider")
+	route := newHTTPRouteWithGateway("gpt-4o", "default", "maas-default-gateway", "openshift-ingress")
+
+	r, _ := newTestReconcilerWithMapper(model, inferenceEM, route)
+	handler := &externalModelHandler{r: r}
+	log := zap.New(zap.UseDevMode(true))
+
+	err := handler.ReconcileRoute(context.Background(), log, model)
+	if err != nil {
+		t.Fatalf("ReconcileRoute: unexpected error: %v", err)
+	}
+
+	if model.Status.HTTPRouteName != "gpt-4o" {
+		t.Errorf("HTTPRouteName = %q, want %q", model.Status.HTTPRouteName, "gpt-4o")
+	}
+	if model.Status.HTTPRouteGatewayName != "maas-default-gateway" {
+		t.Errorf("HTTPRouteGatewayName = %q, want %q", model.Status.HTTPRouteGatewayName, "maas-default-gateway")
+	}
+}
+
+func TestExternalModel_ReconcileRoute_BothMissing(t *testing.T) {
+	model := newExternalModel("gpt-4o", "default", "", "")
+
+	r, _ := newTestReconcilerWithMapper(model)
+	handler := &externalModelHandler{r: r}
+	log := zap.New(zap.UseDevMode(true))
+
+	err := handler.ReconcileRoute(context.Background(), log, model)
+	if err == nil {
+		t.Fatal("ReconcileRoute: expected error when both ExternalModel types are missing")
+	}
+	if !strings.Contains(err.Error(), "maas.opendatahub.io") || !strings.Contains(err.Error(), "inference.opendatahub.io") {
+		t.Errorf("error should mention both API groups, got: %v", err)
+	}
+}
+
+func TestExternalModel_ReconcileRoute_MaasPreferred(t *testing.T) {
+	model := newExternalModel("gpt-4o", "default", "", "")
+	maasEM := newExternalModelCR("gpt-4o", "default", "openai", "api.openai.com")
+	inferenceEM := newInferenceExternalModelCR("gpt-4o", "default", "different-provider")
+	route := newHTTPRouteWithGateway("gpt-4o", "default", "maas-default-gateway", "openshift-ingress")
+
+	r, _ := newTestReconcilerWithMapper(model, maasEM, inferenceEM, route)
+	handler := &externalModelHandler{r: r}
+	log := zap.New(zap.UseDevMode(true))
+
+	err := handler.ReconcileRoute(context.Background(), log, model)
+	if err != nil {
+		t.Fatalf("ReconcileRoute: unexpected error: %v", err)
+	}
+
+	if model.Status.HTTPRouteGatewayName != "maas-default-gateway" {
+		t.Errorf("HTTPRouteGatewayName = %q, want %q", model.Status.HTTPRouteGatewayName, "maas-default-gateway")
 	}
 }
 

--- a/maas-controller/pkg/controller/maas/providers_test.go
+++ b/maas-controller/pkg/controller/maas/providers_test.go
@@ -62,6 +62,7 @@ func testRESTMapper() apimeta.RESTMapper {
 	m.Add(schema.GroupVersionKind{Group: "kuadrant.io", Version: "v1", Kind: "AuthPolicyList"}, ns)
 	m.Add(schema.GroupVersionKind{Group: "kuadrant.io", Version: "v1alpha1", Kind: "TokenRateLimitPolicy"}, ns)
 	m.Add(schema.GroupVersionKind{Group: "kuadrant.io", Version: "v1alpha1", Kind: "TokenRateLimitPolicyList"}, ns)
+	m.Add(inferenceExternalModelGVK, ns)
 	return m
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
add user-facing RBAC aggregation for inference.opendatahub.io ExternalProvider and ExternalModel resources

Fixes https://redhat.atlassian.net/browse/RHOAIENG-75906

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x]  The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * External model routing now supports models defined through either supported API.
  * Existing MAAS model definitions remain preferred when both configurations are available.
  * Authorized owners can manage external providers and models; viewers can inspect them.

* **Bug Fixes**
  * Improved error reporting when external model definitions cannot be found.

* **Tests**
  * Added coverage for inference-based models, missing configurations, and source preference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->