### PR TITLE
feat: maas-controller self teardown

### DIFF
--- a/deployment/base/maas-controller/rbac/clusterrole.yaml
+++ b/deployment/base/maas-controller/rbac/clusterrole.yaml
@@ -176,6 +176,7 @@ rules:
   - externalproviders
   verbs:
   - create
+  - delete
   - get
   - list
   - update
@@ -262,8 +263,16 @@ rules:
   - maas.opendatahub.io
   resources:
   - configs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - maas.opendatahub.io
+  resources:
   - externalmodels
   verbs:
+  - delete
   - get
   - list
   - watch

--- a/deployment/base/maas-controller/rbac/clusterrole.yaml
+++ b/deployment/base/maas-controller/rbac/clusterrole.yaml
@@ -176,7 +176,6 @@ rules:
   - externalproviders
   verbs:
   - create
-  - delete
   - get
   - list
   - update
@@ -263,16 +262,8 @@ rules:
   - maas.opendatahub.io
   resources:
   - configs
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - maas.opendatahub.io
-  resources:
   - externalmodels
   verbs:
-  - delete
   - get
   - list
   - watch
@@ -281,7 +272,6 @@ rules:
   resources:
   - tenants
   verbs:
-  - delete
   - get
   - list
   - patch

--- a/maas-controller/cmd/manager/main.go
+++ b/maas-controller/cmd/manager/main.go
@@ -401,6 +401,11 @@ type managedNamespaceMonitor struct {
 	purpose            string
 	interval           time.Duration
 	needLeaderElection bool
+	// pauseCondition, if set, is evaluated before each tick; returning true skips
+	// ensureManagedNamespaceWithClient for that tick (e.g. to avoid recreating a
+	// namespace that is being intentionally torn down). A returned error also skips
+	// the tick (fail-closed) and is logged; the next tick will retry.
+	pauseCondition func(ctx context.Context) (bool, error)
 }
 
 func (m *managedNamespaceMonitor) NeedLeaderElection() bool {
@@ -414,6 +419,18 @@ func (m *managedNamespaceMonitor) Start(ctx context.Context) error {
 	run := func() {
 		innerCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 		defer cancel()
+		if m.pauseCondition != nil {
+			pause, err := m.pauseCondition(innerCtx)
+			if err != nil {
+				setupLog.Error(err, "unable to evaluate pause condition before namespace maintenance", "namespace", m.namespace, "purpose", m.purpose)
+				return
+			}
+			if pause {
+				setupLog.V(1).Info("skipping namespace maintenance; pause condition active",
+					"namespace", m.namespace, "purpose", m.purpose)
+				return
+			}
+		}
 		if err := ensureManagedNamespaceWithClient(innerCtx, m.namespace, m.purpose, m.clientset); err != nil {
 			// Keep running; the next tick will retry. Alerting on sustained failure is better done via
 			// metrics (e.g. Prometheus counter) in a follow-up if product needs it.
@@ -430,6 +447,23 @@ func (m *managedNamespaceMonitor) Start(ctx context.Context) error {
 		case <-ticker.C:
 			run()
 		}
+	}
+}
+
+// aitenantTeardownPauseCondition builds a managedNamespaceMonitor pauseCondition that skips
+// AITenant namespace self-heal while the maas-controller Deployment advertises teardown
+// (or is already gone), so the monitor cannot recreate ai-tenants while cleanup is in
+// progress or the controller pod is winding down.
+func aitenantTeardownPauseCondition(reader client.Reader, deploymentKey client.ObjectKey) func(context.Context) (bool, error) {
+	return func(ctx context.Context) (bool, error) {
+		var dep appsv1.Deployment
+		if err := reader.Get(ctx, deploymentKey, &dep); err != nil {
+			if errors.IsNotFound(err) {
+				return true, nil
+			}
+			return false, err
+		}
+		return maas.TeardownRequestedOnDeployment(&dep), nil
 	}
 }
 
@@ -478,6 +512,9 @@ func ensureDefaultAITenantBootstrap(ctx context.Context, c client.Client, tenant
 		return false, fmt.Errorf("get maas-controller Deployment for bootstrap gate: %w", err)
 	}
 	if !dep.DeletionTimestamp.IsZero() {
+		return false, nil
+	}
+	if maas.TeardownRequestedOnDeployment(&dep) {
 		return false, nil
 	}
 
@@ -903,6 +940,10 @@ func main() {
 		purpose:            "aitenant",
 		interval:           subscriptionNamespaceMaintainInterval,
 		needLeaderElection: enableLeaderElection,
+		pauseCondition: aitenantTeardownPauseCondition(
+			mgr.GetAPIReader(),
+			client.ObjectKey{Name: tenantreconcile.MaaSControllerDeploymentName, Namespace: controllerNamespace},
+		),
 	}); err != nil {
 		setupLog.Error(err, "unable to add AITenant namespace monitor")
 		os.Exit(1)

--- a/maas-controller/cmd/manager/main_test.go
+++ b/maas-controller/cmd/manager/main_test.go
@@ -16,6 +16,7 @@ import (
 	controllerfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	maasv1alpha1 "github.com/opendatahub-io/models-as-a-service/maas-controller/api/maas/v1alpha1"
+	"github.com/opendatahub-io/models-as-a-service/maas-controller/pkg/controller/maas"
 	"github.com/opendatahub-io/models-as-a-service/maas-controller/pkg/platform/tenantreconcile"
 )
 
@@ -321,6 +322,120 @@ func TestEnsureDefaultAITenantBootstrapWaitsForConfigUID(t *testing.T) {
 		Namespace: tenantreconcile.DefaultAITenantNamespace,
 	}, &maasv1alpha1.AITenant{}); err == nil {
 		t.Fatalf("default AITenant was created before Config had a UID")
+	}
+}
+
+func TestEnsureDefaultAITenantBootstrapSkipsWhenTeardownRequested(t *testing.T) {
+	ctx := context.Background()
+	s := managerTestScheme(t)
+	cl := controllerfake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(
+			&appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      tenantreconcile.MaaSControllerDeploymentName,
+					Namespace: "opendatahub",
+					Annotations: map[string]string{
+						maas.TeardownRequestedAnnotation: "true",
+					},
+				},
+			},
+			&maasv1alpha1.Config{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: maasv1alpha1.ConfigInstanceName,
+					UID:  types.UID("cfg-default"),
+				},
+			},
+		).
+		Build()
+
+	created, err := ensureDefaultAITenantBootstrap(
+		ctx,
+		cl,
+		"models-as-a-service",
+		tenantreconcile.DefaultAITenantNamespace,
+		"opendatahub",
+		tenantreconcile.MaaSControllerDeploymentName,
+		"maas-default-gateway",
+		"openshift-ingress",
+	)
+	if err != nil {
+		t.Fatalf("ensure default AITenant: %v", err)
+	}
+	if created {
+		t.Fatalf("created = true, want false")
+	}
+
+	var aitenant maasv1alpha1.AITenant
+	if err := cl.Get(ctx, client.ObjectKey{
+		Name:      tenantreconcile.DefaultAITenantName,
+		Namespace: tenantreconcile.DefaultAITenantNamespace,
+	}, &aitenant); err == nil {
+		t.Fatalf("default AITenant was created during teardown: %#v", aitenant)
+	}
+}
+
+func TestAitenantTeardownPauseConditionPausesWhenDeploymentMissing(t *testing.T) {
+	ctx := context.Background()
+	s := managerTestScheme(t)
+	cl := controllerfake.NewClientBuilder().WithScheme(s).Build()
+
+	deploymentKey := client.ObjectKey{Name: tenantreconcile.MaaSControllerDeploymentName, Namespace: "opendatahub"}
+	pause, err := aitenantTeardownPauseCondition(cl, deploymentKey)(ctx)
+	if err != nil {
+		t.Fatalf("evaluate pause condition: %v", err)
+	}
+	if !pause {
+		t.Fatalf("pause = false, want true when Deployment is missing during teardown")
+	}
+}
+
+func TestAitenantTeardownPauseConditionPausesWhenTeardownRequested(t *testing.T) {
+	ctx := context.Background()
+	s := managerTestScheme(t)
+	deploymentKey := client.ObjectKey{Name: tenantreconcile.MaaSControllerDeploymentName, Namespace: "opendatahub"}
+	cl := controllerfake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      deploymentKey.Name,
+				Namespace: deploymentKey.Namespace,
+				Annotations: map[string]string{
+					maas.TeardownRequestedAnnotation: "true",
+				},
+			},
+		}).
+		Build()
+
+	pause, err := aitenantTeardownPauseCondition(cl, deploymentKey)(ctx)
+	if err != nil {
+		t.Fatalf("evaluate pause condition: %v", err)
+	}
+	if !pause {
+		t.Fatalf("pause = false, want true when Deployment advertises teardown")
+	}
+}
+
+func TestAitenantTeardownPauseConditionRunsWhenDeploymentIsHealthy(t *testing.T) {
+	ctx := context.Background()
+	s := managerTestScheme(t)
+	deploymentKey := client.ObjectKey{Name: tenantreconcile.MaaSControllerDeploymentName, Namespace: "opendatahub"}
+	cl := controllerfake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      deploymentKey.Name,
+				Namespace: deploymentKey.Namespace,
+			},
+		}).
+		Build()
+
+	pause, err := aitenantTeardownPauseCondition(cl, deploymentKey)(ctx)
+	if err != nil {
+		t.Fatalf("evaluate pause condition: %v", err)
+	}
+	if pause {
+		t.Fatalf("pause = true, want false when Deployment does not advertise teardown")
 	}
 }
 

--- a/maas-controller/pkg/controller/maas/aitenant_controller.go
+++ b/maas-controller/pkg/controller/maas/aitenant_controller.go
@@ -422,6 +422,7 @@ func (r *AITenantReconciler) markLegacyTenantDeprecated(ctx context.Context, ten
 	annotations["maas.opendatahub.io/deprecated-by"] = maasv1alpha1.MaasTenantConfigKind
 	annotations["maas.opendatahub.io/migrated-to"] = maasv1alpha1.MaasTenantConfigInstanceName
 	legacy.SetAnnotations(annotations)
+	controllerutil.RemoveFinalizer(&legacy, tenantFinalizer)
 	if equality.Semantic.DeepEqual(base, &legacy) {
 		return nil
 	}

--- a/maas-controller/pkg/controller/maas/aitenant_controller.go
+++ b/maas-controller/pkg/controller/maas/aitenant_controller.go
@@ -116,16 +116,14 @@ func (r *AITenantReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return r.reconcileAITenantDelete(ctx, &aitenant)
 	}
 
-	// Unblocking UI
-	// TODO: Include adding the finalizer back as part of https://github.com/opendatahub-io/models-as-a-service/pull/1159
-	// if !controllerutil.ContainsFinalizer(&aitenant, aitenantFinalizer) {
-	// 	base := aitenant.DeepCopy()
-	// 	controllerutil.AddFinalizer(&aitenant, aitenantFinalizer)
-	// 	if err := r.Patch(ctx, &aitenant, client.MergeFrom(base)); err != nil {
-	// 		return ctrl.Result{}, err
-	// 	}
-	// 	return ctrl.Result{RequeueAfter: time.Second}, nil
-	// }
+	if !controllerutil.ContainsFinalizer(&aitenant, aitenantFinalizer) {
+		base := aitenant.DeepCopy()
+		controllerutil.AddFinalizer(&aitenant, aitenantFinalizer)
+		if err := r.Patch(ctx, &aitenant, client.MergeFrom(base)); err != nil {
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{RequeueAfter: time.Second}, nil
+	}
 
 	statusSnapshot := aitenant.Status.DeepCopy()
 
@@ -504,11 +502,9 @@ func (r *AITenantReconciler) ensureAITenantObjectRole(ctx context.Context, aiten
 }
 
 func (r *AITenantReconciler) reconcileAITenantDelete(ctx context.Context, aitenant *maasv1alpha1.AITenant) (ctrl.Result, error) {
-	// Unblocking UI
-	// TODO: Include adding the finalizer back as part of https://github.com/opendatahub-io/models-as-a-service/pull/1159
-	// if !controllerutil.ContainsFinalizer(aitenant, aitenantFinalizer) {
-	// 	return ctrl.Result{}, nil
-	// }
+	if !controllerutil.ContainsFinalizer(aitenant, aitenantFinalizer) {
+		return ctrl.Result{}, nil
+	}
 
 	tenantNamespace := r.tenantNamespaceName(aitenant)
 	statusSnapshot := aitenant.Status.DeepCopy()
@@ -572,13 +568,11 @@ func (r *AITenantReconciler) reconcileAITenantDelete(ctx context.Context, aitena
 		return ctrl.Result{}, err
 	}
 
-	// Unblocking UI
-	// TODO: Include adding the finalizer back as part of https://github.com/opendatahub-io/models-as-a-service/pull/1159
-	// base := aitenant.DeepCopy()
-	// controllerutil.RemoveFinalizer(aitenant, aitenantFinalizer)
-	// if err := r.Patch(ctx, aitenant, client.MergeFrom(base)); err != nil {
-	// 	return ctrl.Result{}, err
-	// }
+	base := aitenant.DeepCopy()
+	controllerutil.RemoveFinalizer(aitenant, aitenantFinalizer)
+	if err := r.Patch(ctx, aitenant, client.MergeFrom(base)); err != nil {
+		return ctrl.Result{}, err
+	}
 	return ctrl.Result{}, nil
 }
 
@@ -599,16 +593,14 @@ func (r *AITenantReconciler) deleteTenantConfig(ctx context.Context, aitenant *m
 	if !tenant.DeletionTimestamp.IsZero() {
 		return false, nil
 	}
-	// Unblocking UI / Config GC teardown
-	// TODO: Include adding the finalizer back as part of https://github.com/opendatahub-io/models-as-a-service/pull/1159
-	// if !controllerutil.ContainsFinalizer(&tenant, tenantFinalizer) {
-	// 	base := tenant.DeepCopy()
-	// 	controllerutil.AddFinalizer(&tenant, tenantFinalizer)
-	// 	if err := r.Patch(ctx, &tenant, client.MergeFrom(base)); err != nil {
-	// 		return false, fmt.Errorf("add cleanup finalizer to MaasTenantConfig %s/%s: %w", key.Namespace, key.Name, err)
-	// 	}
-	// 	return false, nil
-	// }
+	if !controllerutil.ContainsFinalizer(&tenant, tenantFinalizer) {
+		base := tenant.DeepCopy()
+		controllerutil.AddFinalizer(&tenant, tenantFinalizer)
+		if err := r.Patch(ctx, &tenant, client.MergeFrom(base)); err != nil {
+			return false, fmt.Errorf("add cleanup finalizer to MaasTenantConfig %s/%s: %w", key.Namespace, key.Name, err)
+		}
+		return false, nil
+	}
 	if err := r.Delete(ctx, &tenant); client.IgnoreNotFound(err) != nil {
 		return false, fmt.Errorf("delete MaasTenantConfig %s/%s: %w", key.Namespace, key.Name, err)
 	}

--- a/maas-controller/pkg/controller/maas/aitenant_controller.go
+++ b/maas-controller/pkg/controller/maas/aitenant_controller.go
@@ -97,7 +97,7 @@ type AITenantReconciler struct {
 // +kubebuilder:rbac:groups=maas.opendatahub.io,resources=aitenants/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=maas.opendatahub.io,resources=aitenants/finalizers,verbs=update
 // +kubebuilder:rbac:groups=maas.opendatahub.io,resources=maastenantconfigs,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=maas.opendatahub.io,resources=tenants,verbs=get;list;watch;update;patch;delete
+// +kubebuilder:rbac:groups=maas.opendatahub.io,resources=tenants,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=gateways,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;delete

--- a/maas-controller/pkg/controller/maas/aitenant_controller_test.go
+++ b/maas-controller/pkg/controller/maas/aitenant_controller_test.go
@@ -411,6 +411,72 @@ func TestAITenantReconcile_UpdatesPreExistingTenant(t *testing.T) {
 		Name:      "old-gateway",
 	}))
 	g.Expect(tenant.Spec.ExternalOIDC).To(BeNil())
+	g.Expect(tenant.Finalizers).NotTo(ContainElement(tenantFinalizer))
+}
+
+func TestAITenantReconcile_StripsStaleFinalizerFromLegacyTenantOnMigration(t *testing.T) {
+	g := NewWithT(t)
+	s := aitenantTestScheme(t)
+
+	aitenant := &maasv1alpha1.AITenant{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "team-stalefinalizer",
+			Namespace: tenantreconcile.DefaultAITenantNamespace,
+		},
+	}
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ai-tenant-team-stalefinalizer"}}
+	// Simulates an install upgraded from a pre-MaasTenantConfig version, where a
+	// reconciler used to add tenantFinalizer directly to Tenant objects. No reconciler
+	// for the Tenant kind exists anymore, so nothing else would ever remove this.
+	preExistingTenant := &maasv1alpha1.Tenant{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       maasv1alpha1.TenantInstanceName,
+			Namespace:  "ai-tenant-team-stalefinalizer",
+			Finalizers: []string{tenantFinalizer},
+		},
+		Spec: maasv1alpha1.TenantSpec{
+			GatewayRef: maasv1alpha1.TenantGatewayRef{
+				Namespace: "openshift-ingress",
+				Name:      "old-gateway",
+			},
+		},
+	}
+	cl := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(&maasv1alpha1.AITenant{}).
+		WithObjects(aitenant, ns, preExistingTenant, existingAITenantGateway("old-gateway")).
+		Build()
+	r := &AITenantReconciler{
+		Client:           cl,
+		Scheme:           s,
+		APIReader:        cl,
+		AppNamespace:     "opendatahub",
+		TenantNamespace:  "models-as-a-service",
+		GatewayNamespace: "openshift-ingress",
+	}
+
+	key := types.NamespacedName{Name: aitenant.Name, Namespace: aitenant.Namespace}
+	for i := 0; i < 3; i++ {
+		_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
+		g.Expect(err).NotTo(HaveOccurred())
+	}
+
+	var tenant maasv1alpha1.Tenant
+	g.Expect(cl.Get(context.Background(), client.ObjectKey{
+		Name:      maasv1alpha1.TenantInstanceName,
+		Namespace: "ai-tenant-team-stalefinalizer",
+	}, &tenant)).To(Succeed())
+	g.Expect(tenant.Finalizers).NotTo(ContainElement(tenantFinalizer),
+		"stale finalizer must be stripped so the legacy Tenant can actually terminate when deleted")
+	g.Expect(tenant.Annotations).To(HaveKeyWithValue("maas.opendatahub.io/deprecated-by", maasv1alpha1.MaasTenantConfigKind))
+
+	// With the finalizer gone, deleting the legacy Tenant (e.g. via tenant namespace
+	// teardown) must actually remove it instead of hanging forever.
+	g.Expect(cl.Delete(context.Background(), &tenant)).To(Succeed())
+	g.Expect(apierrors.IsNotFound(cl.Get(context.Background(), client.ObjectKey{
+		Name:      maasv1alpha1.TenantInstanceName,
+		Namespace: "ai-tenant-team-stalefinalizer",
+	}, &maasv1alpha1.Tenant{}))).To(BeTrue())
 }
 
 func TestAITenantReconcile_IgnoresLegacyDefaultGatewayForNonDefaultTenant(t *testing.T) {

--- a/maas-controller/pkg/controller/maas/aitenant_controller_test.go
+++ b/maas-controller/pkg/controller/maas/aitenant_controller_test.go
@@ -83,10 +83,9 @@ func reconcileAITenantTwice(t *testing.T, r *AITenantReconciler, key types.Names
 	t.Helper()
 	g := NewWithT(t)
 
-	// Unblocking UI: finalizer add/requeue removed temporarily in PR #1159 follow-up.
 	res, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
 	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(res.RequeueAfter).To(Equal(time.Duration(0)))
+	g.Expect(res.RequeueAfter).To(Equal(time.Second))
 
 	res, err = r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
 	g.Expect(err).NotTo(HaveOccurred())
@@ -266,6 +265,10 @@ func TestAITenantReconcile_MissingGatewaySetsFailedStatus(t *testing.T) {
 	key := types.NamespacedName{Name: aitenant.Name, Namespace: aitenant.Namespace}
 	res, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
 	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(res.RequeueAfter).To(Equal(time.Second))
+
+	res, err = r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
+	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(res.RequeueAfter).To(Equal(30 * time.Second))
 
 	var updated maasv1alpha1.AITenant
@@ -384,7 +387,7 @@ func TestAITenantReconcile_UpdatesPreExistingTenant(t *testing.T) {
 
 	res, err = r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
 	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(res.RequeueAfter).To(Equal(time.Duration(0)))
+	g.Expect(res.RequeueAfter).To(Equal(time.Second))
 
 	res, err = r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
 	g.Expect(err).NotTo(HaveOccurred())
@@ -598,7 +601,11 @@ func TestAITenantReconcile_LegacyGatewayNamespaceMismatchFailsMigration(t *testi
 	key := types.NamespacedName{Name: aitenant.Name, Namespace: aitenant.Namespace}
 	res, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
 	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(res.RequeueAfter).To(Equal(time.Duration(0)))
+	g.Expect(res.RequeueAfter).To(Equal(time.Second))
+
+	res, err = r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(res).To(Equal(ctrl.Result{}))
 
 	var updated maasv1alpha1.AITenant
 	g.Expect(cl.Get(context.Background(), key, &updated)).To(Succeed())
@@ -927,6 +934,10 @@ func TestAITenantReconcile_RejectsNamespaceOwnedByAnotherAITenant(t *testing.T) 
 	key := types.NamespacedName{Name: aitenant.Name, Namespace: aitenant.Namespace}
 	res, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
 	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(res.RequeueAfter).To(Equal(time.Second))
+
+	res, err = r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
+	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(res.RequeueAfter).To(Equal(30 * time.Second))
 
 	var updated maasv1alpha1.AITenant
@@ -1078,9 +1089,7 @@ func TestAITenantReconcile_DeletionCleansChildrenAndRequestsNamespaceDeletionBut
 	err = cl.Get(ctx, key, &remaining)
 	if !apierrors.IsNotFound(err) {
 		g.Expect(err).NotTo(HaveOccurred())
-		// Unblocking UI
-		// TODO: Include adding the finalizer back as part of https://github.com/opendatahub-io/models-as-a-service/pull/1159
-		// g.Expect(remaining.Finalizers).NotTo(ContainElement(aitenantFinalizer))
+		g.Expect(remaining.Finalizers).NotTo(ContainElement(aitenantFinalizer))
 	}
 }
 
@@ -1357,8 +1366,13 @@ func TestAITenantReconcile_GatewayClaimBlocksDuplicateGateway(t *testing.T) {
 
 	key2 := types.NamespacedName{Name: aitenant2.Name, Namespace: aitenant2.Namespace}
 
-	// Reconcile should fail due to gateway claim conflict.
+	// First reconcile adds the finalizer.
 	res, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key2})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(res.RequeueAfter).To(Equal(time.Second))
+
+	// Second reconcile should fail due to gateway claim conflict.
+	res, err = r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key2})
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(res.RequeueAfter).To(Equal(30 * time.Second))
 
@@ -1413,8 +1427,6 @@ func TestAITenantReconcile_GatewayClaimCleanedOnDeletion(t *testing.T) {
 	var toDelete maasv1alpha1.AITenant
 	g.Expect(cl.Get(ctx, key, &toDelete)).To(Succeed())
 	setMapValue(&toDelete.Annotations, aitenantAPIKeysRevokedAnnotation, "true")
-	// Keep the object through deletion reconcile while finalizer add is disabled in controller.
-	toDelete.Finalizers = []string{aitenantFinalizer}
 	g.Expect(cl.Update(ctx, &toDelete)).To(Succeed())
 	g.Expect(cl.Delete(ctx, &maasv1alpha1.MaasTenantConfig{ObjectMeta: metav1.ObjectMeta{Name: maasv1alpha1.MaasTenantConfigInstanceName, Namespace: "ai-tenant-team-cleanup"}})).To(Succeed())
 	g.Expect(cl.Delete(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ai-tenant-team-cleanup"}})).To(Succeed())
@@ -2063,18 +2075,9 @@ func TestAITenantReconcile_DeletionAddsTenantFinalizerBeforeDelete(t *testing.T)
 	g.Expect(res.RequeueAfter).To(Equal(5 * time.Second))
 
 	var updatedTenant maasv1alpha1.MaasTenantConfig
-	err = cl.Get(ctx, client.ObjectKey{Name: maasv1alpha1.MaasTenantConfigInstanceName, Namespace: "models-as-a-service"}, &updatedTenant)
-	// Unblocking UI / Config GC teardown
-	// TODO: Include adding the finalizer back as part of https://github.com/opendatahub-io/models-as-a-service/pull/1159
-	// g.Expect(updatedTenant.Finalizers).To(ContainElement(tenantFinalizer))
-	// g.Expect(updatedTenant.DeletionTimestamp.IsZero()).To(BeTrue())
-	// Without tenant-cleanup, Delete proceeds immediately (object may already be gone in the fake client).
-	if err == nil {
-		g.Expect(updatedTenant.Finalizers).NotTo(ContainElement(tenantFinalizer))
-		g.Expect(updatedTenant.DeletionTimestamp.IsZero()).To(BeFalse(), "MaasTenantConfig delete is requested without adding tenant-cleanup")
-	} else {
-		g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
-	}
+	g.Expect(cl.Get(ctx, client.ObjectKey{Name: maasv1alpha1.MaasTenantConfigInstanceName, Namespace: "models-as-a-service"}, &updatedTenant)).To(Succeed())
+	g.Expect(updatedTenant.Finalizers).To(ContainElement(tenantFinalizer))
+	g.Expect(updatedTenant.DeletionTimestamp.IsZero()).To(BeTrue())
 }
 
 func TestAITenantReconcile_NamespaceFinalizersSetDeletionBlocked(t *testing.T) {
@@ -2214,9 +2217,7 @@ func TestAITenantReconcile_DefaultTenantDeletionCompletesInZeroTenantState(t *te
 	err = cl.Get(ctx, key, &remaining)
 	if !apierrors.IsNotFound(err) {
 		g.Expect(err).NotTo(HaveOccurred())
-		// Unblocking UI
-		// TODO: Include adding the finalizer back as part of https://github.com/opendatahub-io/models-as-a-service/pull/1159
-		// g.Expect(remaining.Finalizers).NotTo(ContainElement(aitenantFinalizer))
+		g.Expect(remaining.Finalizers).NotTo(ContainElement(aitenantFinalizer))
 	}
 }
 

--- a/maas-controller/pkg/controller/maas/self_deployment_controller.go
+++ b/maas-controller/pkg/controller/maas/self_deployment_controller.go
@@ -61,8 +61,13 @@ const envoyFilterName = "maas-model-access-logs"
 // LifecycleReconciler watches the maas-controller Deployment. It is the sole creator of the
 // cluster-scoped Config/default anchor when the Deployment exists and is not terminating (so
 // standalone installs do not race applying a Config manifest before the Config CRD is ready).
-// It links the Deployment, default AITenant, and default MaasTenantConfig to Config via non-controller
-// ownerReferences (same relationship shape for all). Legacy CleanupFinalizer entries are removed when present.
+// It links the default AITenant and default MaasTenantConfig to Config via non-controller
+// ownerReferences. The Deployment itself deliberately does NOT get an ownerReference to
+// Config: this reconciler's own workload must keep running independent of Config's lifecycle
+// (self-heal after an accidental Config deletion, and reporting TeardownCompletedAnnotation
+// once Config is deleted during teardown), so it must not be a GC dependent of the resource
+// it manages. Legacy CleanupFinalizer entries and any legacy Deployment->Config
+// ownerReference (set by older maas-controller versions) are removed when present.
 type LifecycleReconciler struct {
 	client.Client
 	Scheme                      *runtime.Scheme
@@ -81,6 +86,8 @@ type LifecycleReconciler struct {
 //+kubebuilder:rbac:groups=maas.opendatahub.io,resources=configs,verbs=get;list;watch
 //+kubebuilder:rbac:groups=maas.opendatahub.io,resources=maastenantconfigs,verbs=get;list;watch;update;patch
 //+kubebuilder:rbac:groups=maas.opendatahub.io,resources=aitenants,verbs=get;list;watch;update;patch
+//+kubebuilder:rbac:groups=maas.opendatahub.io,resources=externalmodels,verbs=get;list;watch;delete
+//+kubebuilder:rbac:groups=inference.opendatahub.io,resources=externalmodels;externalproviders,verbs=get;list;watch;delete
 //+kubebuilder:rbac:groups=perses.dev,resources=persesdashboards;persesdatasources,verbs=get;list;watch;create;patch;delete
 //+kubebuilder:rbac:groups=networking.istio.io,resources=envoyfilters,verbs=get;list;watch;create;patch;delete
 
@@ -93,15 +100,25 @@ func (r *LifecycleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 
 	if dep.DeletionTimestamp.IsZero() {
-		if res, err := r.ensureSingletonConfig(ctx, &dep); err != nil {
+		// Strip before anything else so that, if teardown is requested below, Config
+		// deletion can never cascade-delete the Deployment via a stale ownerReference
+		// from a pre-self-teardown install.
+		if err := r.stripLegacyDeploymentConfigOwnerReference(ctx, log, req.NamespacedName); err != nil {
 			return ctrl.Result{}, err
-		} else if res != nil {
+		}
+		teardownRequested := TeardownRequestedOnDeployment(&dep)
+		cfg, res, err := r.ensureSingletonConfig(ctx, &dep)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		if res != nil {
 			return *res, nil
 		}
-		if res, err := r.ensureDeploymentReferencesConfig(ctx, req.NamespacedName); err != nil {
-			return ctrl.Result{}, err
-		} else if res != nil {
-			return *res, nil
+		if teardownRequested {
+			if cfg == nil {
+				log.Info("teardown requested on maas-controller Deployment; running best-effort cleanup without Config/default")
+			}
+			return r.handleRequestedTeardown(ctx, &dep, cfg)
 		}
 		if res, err := r.ensureDefaultAITenantReferencesConfig(ctx); err != nil {
 			return ctrl.Result{}, err
@@ -199,26 +216,72 @@ func (r *LifecycleReconciler) stripLegacyCleanupFinalizer(ctx context.Context, l
 	return nil
 }
 
+// stripLegacyDeploymentConfigOwnerReference removes an ownerReference from the Deployment
+// to Config/default if present. Pre-self-teardown maas-controller versions set this
+// non-controller ownerReference (see the removed ensureDeploymentReferencesConfig); it must
+// not survive an upgrade, or deleting Config could cascade-delete the Deployment itself
+// before this reconciler can report TeardownCompletedAnnotation. New installs never set
+// this ownerReference, so this is a no-op for them.
+func (r *LifecycleReconciler) stripLegacyDeploymentConfigOwnerReference(ctx context.Context, log logr.Logger, key types.NamespacedName) error {
+	var dep appsv1.Deployment
+	if err := r.Get(ctx, key, &dep); err != nil {
+		return client.IgnoreNotFound(err)
+	}
+
+	filtered := make([]metav1.OwnerReference, 0, len(dep.OwnerReferences))
+	changed := false
+	for _, ref := range dep.OwnerReferences {
+		if isConfigOwnerReference(ref) {
+			changed = true
+			continue
+		}
+		filtered = append(filtered, ref)
+	}
+	if !changed {
+		return nil
+	}
+
+	base := dep.DeepCopy()
+	dep.OwnerReferences = filtered
+	if err := r.Patch(ctx, &dep, client.MergeFrom(base)); err != nil {
+		return fmt.Errorf("remove legacy Config owner reference from Deployment: %w", err)
+	}
+	log.Info("removed legacy Config owner reference from Deployment")
+	return nil
+}
+
+// isConfigOwnerReference reports whether ref points at the singleton Config/default
+// resource. Config is cluster-scoped and singleton, so matching by name (in addition to
+// kind and API version) is precise without needing to fetch Config to compare UIDs.
+func isConfigOwnerReference(ref metav1.OwnerReference) bool {
+	return ref.Kind == maasv1alpha1.ConfigKind &&
+		ref.APIVersion == maasv1alpha1.GroupVersion.String() &&
+		ref.Name == maasv1alpha1.ConfigInstanceName
+}
+
 // ensureSingletonConfig creates Config/default when it is missing and the watched Deployment
 // is still running. If Config is terminating, requeues until teardown completes (avoids racing
 // intentional anchor deletion). After accidental deletion while the Deployment remains, the
 // anchor is recreated on a later reconcile.
-func (r *LifecycleReconciler) ensureSingletonConfig(ctx context.Context, dep *appsv1.Deployment) (*ctrl.Result, error) {
+func (r *LifecycleReconciler) ensureSingletonConfig(ctx context.Context, dep *appsv1.Deployment) (*maasv1alpha1.Config, *ctrl.Result, error) {
 	if dep == nil || !dep.DeletionTimestamp.IsZero() {
-		return nil, nil
+		return nil, nil, nil
 	}
 	key := client.ObjectKey{Name: maasv1alpha1.ConfigInstanceName}
 	var cfg maasv1alpha1.Config
 	switch err := r.Get(ctx, key, &cfg); {
 	case err == nil:
 		if !cfg.DeletionTimestamp.IsZero() {
-			return &ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+			return &cfg, nil, nil
 		}
 		if cfg.UID == "" {
-			return &ctrl.Result{RequeueAfter: 2 * time.Second}, nil
+			return nil, &ctrl.Result{RequeueAfter: 2 * time.Second}, nil
 		}
-		return nil, nil
+		return &cfg, nil, nil
 	case apierrors.IsNotFound(err):
+		if TeardownRequestedOnDeployment(dep) {
+			return nil, nil, nil
+		}
 		toCreate := &maasv1alpha1.Config{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: maasv1alpha1.GroupVersion.String(),
@@ -227,72 +290,21 @@ func (r *LifecycleReconciler) ensureSingletonConfig(ctx context.Context, dep *ap
 			ObjectMeta: metav1.ObjectMeta{Name: maasv1alpha1.ConfigInstanceName},
 		}
 		if err := r.Create(ctx, toCreate); err != nil && !apierrors.IsAlreadyExists(err) {
-			return nil, err
+			return nil, nil, err
 		}
 		if err := r.Get(ctx, key, &cfg); err != nil {
 			if apierrors.IsNotFound(err) {
-				return &ctrl.Result{RequeueAfter: 2 * time.Second}, nil
+				return nil, &ctrl.Result{RequeueAfter: 2 * time.Second}, nil
 			}
-			return nil, err
+			return nil, nil, err
 		}
 		if cfg.UID == "" {
-			return &ctrl.Result{RequeueAfter: 2 * time.Second}, nil
+			return nil, &ctrl.Result{RequeueAfter: 2 * time.Second}, nil
 		}
-		return nil, nil
+		return &cfg, nil, nil
 	default:
-		return nil, err
+		return nil, nil, err
 	}
-}
-
-// ensureDeploymentReferencesConfig links the controller Deployment to Config/default
-// via a non-controller ownerReference so the workload participates in the same GC graph as other
-// operands without competing with the ODH operator's controller owner (when present).
-//
-// Call after ensureSingletonConfig in the same reconcile: Config should exist with a UID and
-// not be terminating. If this function still observes a missing, terminating, or UID-less anchor
-// (cache lag or races), it logs and returns a short requeue instead of succeeding with no work.
-func (r *LifecycleReconciler) ensureDeploymentReferencesConfig(ctx context.Context, key types.NamespacedName) (*ctrl.Result, error) {
-	log := ctrl.LoggerFrom(ctx).WithValues("deployment", key)
-	if r.Scheme == nil {
-		return nil, nil
-	}
-	var cfg maasv1alpha1.Config
-	if err := r.Get(ctx, client.ObjectKey{Name: maasv1alpha1.ConfigInstanceName}, &cfg); err != nil {
-		if apierrors.IsNotFound(err) {
-			log.Info("Config anchor not found when linking Deployment; requeueing (singleton reconcile should create it)")
-			res := ctrl.Result{RequeueAfter: 2 * time.Second}
-			return &res, nil
-		}
-		return nil, err
-	}
-	if !cfg.DeletionTimestamp.IsZero() {
-		log.Info("Config anchor is terminating when linking Deployment; requeueing until teardown completes")
-		res := ctrl.Result{RequeueAfter: 10 * time.Second}
-		return &res, nil
-	}
-	if cfg.UID == "" {
-		log.Info("Config anchor has no UID yet when linking Deployment; requeueing")
-		res := ctrl.Result{RequeueAfter: 2 * time.Second}
-		return &res, nil
-	}
-	var dep appsv1.Deployment
-	if err := r.Get(ctx, key, &dep); err != nil {
-		return nil, client.IgnoreNotFound(err)
-	}
-	for _, ref := range dep.OwnerReferences {
-		if ref.UID == cfg.UID && ref.Kind == maasv1alpha1.ConfigKind && ref.APIVersion == maasv1alpha1.GroupVersion.String() {
-			return nil, nil
-		}
-	}
-	base := dep.DeepCopy()
-	if err := controllerutil.SetOwnerReference(&cfg, &dep, r.Scheme); err != nil {
-		return nil, fmt.Errorf("set Config owner reference on deployment: %w", err)
-	}
-	if err := r.Patch(ctx, &dep, client.MergeFrom(base)); err != nil {
-		return nil, fmt.Errorf("patch deployment ownerReferences: %w", err)
-	}
-	log.Info("set Config owner reference on maas-controller Deployment")
-	return nil, nil
 }
 
 // ensureTenantReferencesConfig links MaasTenantConfig/default-tenant to Config/default via the same non-controller

--- a/maas-controller/pkg/controller/maas/self_deployment_controller.go
+++ b/maas-controller/pkg/controller/maas/self_deployment_controller.go
@@ -86,8 +86,6 @@ type LifecycleReconciler struct {
 //+kubebuilder:rbac:groups=maas.opendatahub.io,resources=configs,verbs=get;list;watch
 //+kubebuilder:rbac:groups=maas.opendatahub.io,resources=maastenantconfigs,verbs=get;list;watch;update;patch
 //+kubebuilder:rbac:groups=maas.opendatahub.io,resources=aitenants,verbs=get;list;watch;update;patch
-//+kubebuilder:rbac:groups=maas.opendatahub.io,resources=externalmodels,verbs=get;list;watch;delete
-//+kubebuilder:rbac:groups=inference.opendatahub.io,resources=externalmodels;externalproviders,verbs=get;list;watch;delete
 //+kubebuilder:rbac:groups=perses.dev,resources=persesdashboards;persesdatasources,verbs=get;list;watch;create;patch;delete
 //+kubebuilder:rbac:groups=networking.istio.io,resources=envoyfilters,verbs=get;list;watch;create;patch;delete
 

--- a/maas-controller/pkg/controller/maas/self_deployment_controller_test.go
+++ b/maas-controller/pkg/controller/maas/self_deployment_controller_test.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	goruntime "runtime"
 	"testing"
-	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -14,6 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -34,6 +34,17 @@ func lifecycleTestScheme(t *testing.T) *runtime.Scheme {
 	utilruntime.Must(clientgoscheme.AddToScheme(s))
 	utilruntime.Must(maasv1alpha1.AddToScheme(s))
 	return s
+}
+
+func lifecycleTestUnstructured(gvk schema.GroupVersionKind, namespace, name string, finalizers ...string) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(gvk)
+	obj.SetNamespace(namespace)
+	obj.SetName(name)
+	if len(finalizers) > 0 {
+		obj.SetFinalizers(finalizers)
+	}
+	return obj
 }
 
 func TestLifecycleReconciler_CreatesConfigWhenMissing(t *testing.T) {
@@ -87,12 +98,187 @@ func TestLifecycleReconciler_CreatesConfigWhenMissing(t *testing.T) {
 	g.Expect(cfg.Name).To(Equal(maasv1alpha1.ConfigInstanceName))
 }
 
-func TestLifecycleReconciler_ConfigTerminatingRequeues(t *testing.T) {
+func TestLifecycleReconciler_DoesNotRecreateConfigWhenTeardownRequested(t *testing.T) {
 	g := NewWithT(t)
 	s := lifecycleTestScheme(t)
 
 	const depNS = "opendatahub"
-	now := metav1.NewTime(time.Now())
+	dep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "maas-controller",
+			Namespace: depNS,
+			Annotations: map[string]string{
+				TeardownRequestedAnnotation: "true",
+			},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "maas-controller"}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "maas-controller"}},
+				Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "manager", Image: "test"}}},
+			},
+		},
+	}
+
+	cl := fake.NewClientBuilder().WithScheme(s).WithObjects(dep).Build()
+	r := &LifecycleReconciler{
+		Client:                      cl,
+		Scheme:                      s,
+		DeploymentName:              "maas-controller",
+		DeploymentNS:                depNS,
+		TenantSubscriptionNamespace: "",
+	}
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "maas-controller", Namespace: depNS},
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(res).To(Equal(ctrl.Result{}))
+
+	var cfg maasv1alpha1.Config
+	g.Expect(cl.Get(context.Background(), client.ObjectKey{Name: maasv1alpha1.ConfigInstanceName}, &cfg)).ToNot(Succeed())
+}
+
+func TestLifecycleReconciler_TeardownRequestedDeletesConfigAndMarksCompleted(t *testing.T) {
+	g := NewWithT(t)
+	s := lifecycleTestScheme(t)
+
+	const depNS = "opendatahub"
+	dep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "maas-controller",
+			Namespace: depNS,
+			Annotations: map[string]string{
+				TeardownRequestedAnnotation: "true",
+			},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "maas-controller"}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "maas-controller"}},
+				Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "manager", Image: "test"}}},
+			},
+		},
+	}
+	cfg := &maasv1alpha1.Config{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: maasv1alpha1.ConfigInstanceName,
+			UID:  types.UID("cfg-delete-request"),
+		},
+	}
+
+	cl := fake.NewClientBuilder().WithScheme(s).WithObjects(dep, cfg).Build()
+	r := &LifecycleReconciler{
+		Client:         cl,
+		Scheme:         s,
+		DeploymentName: "maas-controller",
+		DeploymentNS:   depNS,
+	}
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "maas-controller", Namespace: depNS},
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(res).To(Equal(ctrl.Result{}))
+
+	// Config/default is deleted as a plain step, no finalizer involved.
+	var updatedCfg maasv1alpha1.Config
+	g.Expect(apierrors.IsNotFound(cl.Get(context.Background(), client.ObjectKey{Name: maasv1alpha1.ConfigInstanceName}, &updatedCfg))).To(BeTrue())
+
+	// The completion signal must be observable on the Deployment regardless of Config's fate.
+	var updatedDep appsv1.Deployment
+	g.Expect(cl.Get(context.Background(), client.ObjectKey{Name: "maas-controller", Namespace: depNS}, &updatedDep)).To(Succeed())
+	g.Expect(updatedDep.Annotations[TeardownCompletedAnnotation]).To(Equal("true"))
+}
+
+func TestLifecycleReconciler_MarkTeardownCompletedIsIdempotent(t *testing.T) {
+	g := NewWithT(t)
+	s := lifecycleTestScheme(t)
+
+	const depNS = "opendatahub"
+	dep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "maas-controller",
+			Namespace: depNS,
+			Annotations: map[string]string{
+				TeardownCompletedAnnotation: "true",
+			},
+			ResourceVersion: "1",
+		},
+	}
+
+	cl := fake.NewClientBuilder().WithScheme(s).WithObjects(dep).Build()
+	r := &LifecycleReconciler{Client: cl, Scheme: s}
+
+	g.Expect(r.markTeardownCompleted(context.Background(), dep)).To(Succeed())
+
+	var updated appsv1.Deployment
+	g.Expect(cl.Get(context.Background(), client.ObjectKey{Name: "maas-controller", Namespace: depNS}, &updated)).To(Succeed())
+	g.Expect(updated.ResourceVersion).To(Equal("1"), "already-annotated Deployment should not be patched again")
+}
+
+func TestLifecycleReconciler_TeardownRequestedWithoutConfigRequestsOrphanCleanup(t *testing.T) {
+	g := NewWithT(t)
+	s := lifecycleTestScheme(t)
+
+	const depNS = "opendatahub"
+	dep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "maas-controller",
+			Namespace: depNS,
+			Annotations: map[string]string{
+				TeardownRequestedAnnotation: "true",
+			},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "maas-controller"}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "maas-controller"}},
+				Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "manager", Image: "test"}}},
+			},
+		},
+	}
+	aitenant := lifecycleTestUnstructured(
+		schema.GroupVersionKind{Group: "maas.opendatahub.io", Version: "v1alpha1", Kind: "AITenant"},
+		tenantreconcile.DefaultAITenantNamespace,
+		tenantreconcile.DefaultAITenantName,
+		aitenantFinalizer,
+	)
+
+	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(dep, aitenant).Build()
+	r := &LifecycleReconciler{
+		Client:            cl,
+		Scheme:            s,
+		DeploymentName:    "maas-controller",
+		DeploymentNS:      depNS,
+		AITenantNamespace: tenantreconcile.DefaultAITenantNamespace,
+	}
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "maas-controller", Namespace: depNS},
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(res.RequeueAfter).To(Equal(teardownRequeueAfter))
+
+	updated := &unstructured.Unstructured{}
+	updated.SetGroupVersionKind(aitenant.GroupVersionKind())
+	g.Expect(cl.Get(context.Background(), client.ObjectKey{
+		Name:      tenantreconcile.DefaultAITenantName,
+		Namespace: tenantreconcile.DefaultAITenantNamespace,
+	}, updated)).To(Succeed())
+	g.Expect(updated.GetDeletionTimestamp()).NotTo(BeNil())
+
+	// The completion annotation must not be set yet: AITenant deletion is still pending.
+	var updatedDep appsv1.Deployment
+	g.Expect(cl.Get(context.Background(), client.ObjectKey{Name: "maas-controller", Namespace: depNS}, &updatedDep)).To(Succeed())
+	g.Expect(updatedDep.Annotations[TeardownCompletedAnnotation]).To(BeEmpty())
+}
+
+func TestLifecycleReconciler_NormalReconcileDoesNotSetDeploymentOwnerReference(t *testing.T) {
+	g := NewWithT(t)
+	s := lifecycleTestScheme(t)
+
+	const depNS = "opendatahub"
 	dep := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "maas-controller",
@@ -108,10 +294,8 @@ func TestLifecycleReconciler_ConfigTerminatingRequeues(t *testing.T) {
 	}
 	cfg := &maasv1alpha1.Config{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:              maasv1alpha1.ConfigInstanceName,
-			UID:               types.UID("cfg-1"),
-			DeletionTimestamp: &now,
-			Finalizers:        []string{"test.finalizer"},
+			Name: maasv1alpha1.ConfigInstanceName,
+			UID:  types.UID("cfg-1"),
 		},
 	}
 
@@ -124,11 +308,134 @@ func TestLifecycleReconciler_ConfigTerminatingRequeues(t *testing.T) {
 		TenantSubscriptionNamespace: "",
 	}
 
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "maas-controller", Namespace: depNS},
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// Config must never own the Deployment: the Deployment carries the teardown
+	// annotations and must survive Config being deleted (accidentally, or during
+	// teardown), so it cannot be a GC dependent of Config.
+	var updated appsv1.Deployment
+	g.Expect(cl.Get(context.Background(), client.ObjectKey{Name: "maas-controller", Namespace: depNS}, &updated)).To(Succeed())
+	g.Expect(updated.OwnerReferences).To(BeEmpty())
+}
+
+func TestLifecycleReconciler_StripsLegacyDeploymentConfigOwnerReferenceOnNormalReconcile(t *testing.T) {
+	g := NewWithT(t)
+	s := lifecycleTestScheme(t)
+
+	const depNS = "opendatahub"
+	dep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "maas-controller",
+			Namespace: depNS,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: maasv1alpha1.GroupVersion.String(),
+					Kind:       maasv1alpha1.ConfigKind,
+					Name:       maasv1alpha1.ConfigInstanceName,
+					UID:        types.UID("cfg-1"),
+				},
+				{
+					APIVersion: "v1",
+					Kind:       "Secret",
+					Name:       "unrelated",
+					UID:        types.UID("secret-1"),
+				},
+			},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "maas-controller"}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "maas-controller"}},
+				Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "manager", Image: "test"}}},
+			},
+		},
+	}
+	cfg := &maasv1alpha1.Config{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: maasv1alpha1.ConfigInstanceName,
+			UID:  types.UID("cfg-1"),
+		},
+	}
+
+	cl := fake.NewClientBuilder().WithScheme(s).WithObjects(dep, cfg).Build()
+	r := &LifecycleReconciler{
+		Client:         cl,
+		Scheme:         s,
+		DeploymentName: "maas-controller",
+		DeploymentNS:   depNS,
+	}
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "maas-controller", Namespace: depNS},
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+
+	var updated appsv1.Deployment
+	g.Expect(cl.Get(context.Background(), client.ObjectKey{Name: "maas-controller", Namespace: depNS}, &updated)).To(Succeed())
+	g.Expect(updated.OwnerReferences).To(HaveLen(1), "only the legacy Config ownerReference should be removed")
+	g.Expect(updated.OwnerReferences[0].Name).To(Equal("unrelated"))
+}
+
+func TestLifecycleReconciler_TeardownStripsLegacyOwnerReferenceBeforeDeletingConfig(t *testing.T) {
+	g := NewWithT(t)
+	s := lifecycleTestScheme(t)
+
+	const depNS = "opendatahub"
+	dep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "maas-controller",
+			Namespace: depNS,
+			Annotations: map[string]string{
+				TeardownRequestedAnnotation: "true",
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: maasv1alpha1.GroupVersion.String(),
+					Kind:       maasv1alpha1.ConfigKind,
+					Name:       maasv1alpha1.ConfigInstanceName,
+					UID:        types.UID("cfg-legacy"),
+				},
+			},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "maas-controller"}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "maas-controller"}},
+				Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "manager", Image: "test"}}},
+			},
+		},
+	}
+	cfg := &maasv1alpha1.Config{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: maasv1alpha1.ConfigInstanceName,
+			UID:  types.UID("cfg-legacy"),
+		},
+	}
+
+	cl := fake.NewClientBuilder().WithScheme(s).WithObjects(dep, cfg).Build()
+	r := &LifecycleReconciler{
+		Client:         cl,
+		Scheme:         s,
+		DeploymentName: "maas-controller",
+		DeploymentNS:   depNS,
+	}
+
 	res, err := r.Reconcile(context.Background(), ctrl.Request{
 		NamespacedName: types.NamespacedName{Name: "maas-controller", Namespace: depNS},
 	})
 	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(res.RequeueAfter).To(Equal(10 * time.Second))
+	g.Expect(res).To(Equal(ctrl.Result{}))
+
+	var updatedDep appsv1.Deployment
+	g.Expect(cl.Get(context.Background(), client.ObjectKey{Name: "maas-controller", Namespace: depNS}, &updatedDep)).To(Succeed())
+	g.Expect(updatedDep.OwnerReferences).To(BeEmpty(), "legacy Config ownerReference must be gone before Config is deleted")
+	g.Expect(updatedDep.Annotations[TeardownCompletedAnnotation]).To(Equal("true"))
+
+	var updatedCfg maasv1alpha1.Config
+	g.Expect(apierrors.IsNotFound(cl.Get(context.Background(), client.ObjectKey{Name: maasv1alpha1.ConfigInstanceName}, &updatedCfg))).To(BeTrue())
 }
 
 func TestLifecycleReconciler_LinksDefaultTenantToConfig(t *testing.T) {

--- a/maas-controller/pkg/controller/maas/self_teardown.go
+++ b/maas-controller/pkg/controller/maas/self_teardown.go
@@ -18,7 +18,7 @@ import (
 )
 
 // TeardownRequestedAnnotation on the maas-controller Deployment tells LifecycleReconciler
-// to start teardown: bootstrap/self-heal behaviors stay disabled, dependent MaaS resources
+// to start teardown: bootstrap/self-heal behaviors stay disabled, the default AITenant
 // and the AITenant namespace are deleted in order, then Config/default is deleted as a
 // plain step, and finally TeardownCompletedAnnotation is set once nothing is pending.
 const TeardownRequestedAnnotation = "maas.opendatahub.io/teardown-requested"
@@ -48,16 +48,12 @@ func TeardownRequestedOnDeployment(dep *appsv1.Deployment) bool {
 	return dep.GetAnnotations()[TeardownRequestedAnnotation] == "true"
 }
 
-var configCleanupResourceTypes = []schema.GroupVersionKind{
+var resourceTypesToRemove = []schema.GroupVersionKind{
 	{Group: "maas.opendatahub.io", Version: "v1alpha1", Kind: "AITenant"},
-	{Group: "maas.opendatahub.io", Version: "v1alpha1", Kind: "MaaSModelRef"},
-	{Group: "maas.opendatahub.io", Version: "v1alpha1", Kind: "ExternalModel"},
-	{Group: "inference.opendatahub.io", Version: "v1alpha1", Kind: "ExternalModel"},
-	{Group: "inference.opendatahub.io", Version: "v1alpha1", Kind: "ExternalProvider"},
 }
 
 // handleRequestedTeardown runs on every reconcile while TeardownRequestedAnnotation is
-// present on the maas-controller Deployment. It deletes dependent MaaS resources and the
+// present on the maas-controller Deployment. It deletes the default AITenant and the
 // AITenant namespace, requeueing until nothing is pending; once clean, it deletes
 // Config/default and then marks TeardownCompletedAnnotation on the Deployment.
 //
@@ -115,25 +111,8 @@ func (r *LifecycleReconciler) markTeardownCompleted(ctx context.Context, dep *ap
 }
 
 func (r *LifecycleReconciler) cleanupTeardownResources(ctx context.Context) (bool, error) {
-	resourcesPending, err := r.requestConfigCleanupResourceDeletion(ctx)
-	if err != nil {
-		return false, err
-	}
-	if resourcesPending {
-		return true, nil
-	}
-
-	namespacePending, err := r.ensureAITenantNamespaceDeleted(ctx)
-	if err != nil {
-		return false, err
-	}
-
-	return namespacePending, nil
-}
-
-func (r *LifecycleReconciler) requestConfigCleanupResourceDeletion(ctx context.Context) (bool, error) {
-	pending := false
-	for _, resourceGVK := range configCleanupResourceTypes {
+	resourcesPending := false
+	for _, resourceGVK := range resourceTypesToRemove {
 		items, err := listUnstructuredByGVK(ctx, r.Client, resourceGVK)
 		if err != nil {
 			return false, err
@@ -141,7 +120,7 @@ func (r *LifecycleReconciler) requestConfigCleanupResourceDeletion(ctx context.C
 		if len(items) == 0 {
 			continue
 		}
-		pending = true
+		resourcesPending = true
 
 		for i := range items {
 			obj := items[i].DeepCopy()
@@ -154,8 +133,16 @@ func (r *LifecycleReconciler) requestConfigCleanupResourceDeletion(ctx context.C
 			}
 		}
 	}
+	if resourcesPending {
+		return true, nil
+	}
 
-	return pending, nil
+	namespacePending, err := r.ensureAITenantNamespaceDeleted(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	return namespacePending, nil
 }
 
 func (r *LifecycleReconciler) ensureAITenantNamespaceDeleted(ctx context.Context) (bool, error) {

--- a/maas-controller/pkg/controller/maas/self_teardown.go
+++ b/maas-controller/pkg/controller/maas/self_teardown.go
@@ -1,0 +1,220 @@
+package maas
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	maasv1alpha1 "github.com/opendatahub-io/models-as-a-service/maas-controller/api/maas/v1alpha1"
+)
+
+// TeardownRequestedAnnotation on the maas-controller Deployment tells LifecycleReconciler
+// to start teardown: bootstrap/self-heal behaviors stay disabled, dependent MaaS resources
+// and the AITenant namespace are deleted in order, then Config/default is deleted as a
+// plain step, and finally TeardownCompletedAnnotation is set once nothing is pending.
+const TeardownRequestedAnnotation = "maas.opendatahub.io/teardown-requested"
+
+// TeardownCompletedAnnotation is set on the maas-controller Deployment by LifecycleReconciler
+// once every ordered teardown step, including Config/default deletion, has finished.
+// External operators watch or poll this annotation as the "self-teardown is done" signal
+// instead of depending on Config (or anything cascade-deleted through it) to still exist.
+const TeardownCompletedAnnotation = "maas.opendatahub.io/teardown-completed"
+
+const (
+	teardownRequeueAfter        = 5 * time.Second
+	maasManagedByLabelKey       = "app.kubernetes.io/managed-by"
+	maasManagedByLabelValue     = "maas-controller"
+	maasGeneratedNamespaceLabel = "opendatahub.io/generated-namespace"
+	maasGeneratedNamespaceValue = "true"
+)
+
+// TeardownRequestedOnDeployment reports whether the maas-controller Deployment has been
+// annotated to start teardown. Callers outside this file (e.g. the Reconcile entrypoint,
+// the default AITenant bootstrap gate, and the AITenant namespace monitor in cmd/manager)
+// use this as the single source of truth for "is teardown in progress".
+func TeardownRequestedOnDeployment(dep *appsv1.Deployment) bool {
+	if dep == nil {
+		return false
+	}
+	return dep.GetAnnotations()[TeardownRequestedAnnotation] == "true"
+}
+
+var configCleanupResourceTypes = []schema.GroupVersionKind{
+	{Group: "maas.opendatahub.io", Version: "v1alpha1", Kind: "AITenant"},
+	{Group: "maas.opendatahub.io", Version: "v1alpha1", Kind: "MaaSModelRef"},
+	{Group: "maas.opendatahub.io", Version: "v1alpha1", Kind: "ExternalModel"},
+	{Group: "inference.opendatahub.io", Version: "v1alpha1", Kind: "ExternalModel"},
+	{Group: "inference.opendatahub.io", Version: "v1alpha1", Kind: "ExternalProvider"},
+}
+
+// handleRequestedTeardown runs on every reconcile while TeardownRequestedAnnotation is
+// present on the maas-controller Deployment. It deletes dependent MaaS resources and the
+// AITenant namespace, requeueing until nothing is pending; once clean, it deletes
+// Config/default and then marks TeardownCompletedAnnotation on the Deployment.
+//
+// Config deletion is a plain, unguarded step (no finalizer): this reconciler is the only
+// actor that deletes Config while teardown is requested, so ordering is enforced here in
+// Go, not by the API server. Deleting Config before writing the completion annotation is
+// safe because Reconcile strips any legacy Deployment->Config ownerReference on every pass
+// (see stripLegacyDeploymentConfigOwnerReference): the Deployment is never a GC dependent
+// of Config, so cascade-deleting Config's other dependents (ServiceMonitor, dashboards,
+// EnvoyFilter) cannot take the Deployment down with it before the annotation is written.
+// If the process crashes between the two steps, the next reconcile finds nothing pending
+// and no Config, and simply (idempotently) marks completion.
+func (r *LifecycleReconciler) handleRequestedTeardown(ctx context.Context, dep *appsv1.Deployment, cfg *maasv1alpha1.Config) (ctrl.Result, error) {
+	pending, err := r.cleanupTeardownResources(ctx)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if pending {
+		return ctrl.Result{RequeueAfter: teardownRequeueAfter}, nil
+	}
+
+	if cfg != nil {
+		if err := r.Delete(ctx, cfg); client.IgnoreNotFound(err) != nil {
+			return ctrl.Result{}, fmt.Errorf("delete Config/default during teardown: %w", err)
+		}
+	}
+
+	if err := r.markTeardownCompleted(ctx, dep); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// markTeardownCompleted sets TeardownCompletedAnnotation on the Deployment so external
+// operators have a single durable signal for "self-teardown is done" that survives
+// Config (and anything cascade-deleted through it) disappearing. Idempotent so patching
+// it does not re-trigger this reconciler indefinitely through the Deployment watch.
+func (r *LifecycleReconciler) markTeardownCompleted(ctx context.Context, dep *appsv1.Deployment) error {
+	if dep == nil {
+		return nil
+	}
+	if dep.GetAnnotations()[TeardownCompletedAnnotation] == "true" {
+		return nil
+	}
+	base := dep.DeepCopy()
+	if dep.Annotations == nil {
+		dep.Annotations = map[string]string{}
+	}
+	dep.Annotations[TeardownCompletedAnnotation] = "true"
+	if err := r.Patch(ctx, dep, client.MergeFrom(base)); err != nil {
+		return fmt.Errorf("annotate Deployment with %s: %w", TeardownCompletedAnnotation, err)
+	}
+	return nil
+}
+
+func (r *LifecycleReconciler) cleanupTeardownResources(ctx context.Context) (bool, error) {
+	resourcesPending, err := r.requestConfigCleanupResourceDeletion(ctx)
+	if err != nil {
+		return false, err
+	}
+	if resourcesPending {
+		return true, nil
+	}
+
+	namespacePending, err := r.ensureAITenantNamespaceDeleted(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	return namespacePending, nil
+}
+
+func (r *LifecycleReconciler) requestConfigCleanupResourceDeletion(ctx context.Context) (bool, error) {
+	pending := false
+	for _, resourceGVK := range configCleanupResourceTypes {
+		items, err := listUnstructuredByGVK(ctx, r.Client, resourceGVK)
+		if err != nil {
+			return false, err
+		}
+		if len(items) == 0 {
+			continue
+		}
+		pending = true
+
+		for i := range items {
+			obj := items[i].DeepCopy()
+			if !obj.GetDeletionTimestamp().IsZero() {
+				continue
+			}
+			if err := r.Delete(ctx, obj); client.IgnoreNotFound(err) != nil {
+				return false, fmt.Errorf("delete %s %s/%s during teardown: %w",
+					resourceGVK.Kind, obj.GetNamespace(), obj.GetName(), err)
+			}
+		}
+	}
+
+	return pending, nil
+}
+
+func (r *LifecycleReconciler) ensureAITenantNamespaceDeleted(ctx context.Context) (bool, error) {
+	if r.AITenantNamespace == "" {
+		return false, nil
+	}
+
+	var ns corev1.Namespace
+	err := r.Get(ctx, client.ObjectKey{Name: r.AITenantNamespace}, &ns)
+	switch {
+	case errors.IsNotFound(err):
+		return false, nil
+	case err != nil:
+		return false, fmt.Errorf("get AITenant namespace %q during teardown: %w", r.AITenantNamespace, err)
+	}
+
+	if !shouldDeleteAITenantNamespace(&ns, r.DeploymentNS) {
+		return false, nil
+	}
+
+	if ns.DeletionTimestamp.IsZero() {
+		if err := r.Delete(ctx, &ns); client.IgnoreNotFound(err) != nil {
+			return false, fmt.Errorf("delete AITenant namespace %q during teardown: %w", r.AITenantNamespace, err)
+		}
+	}
+
+	return true, nil
+}
+
+func shouldDeleteAITenantNamespace(ns *corev1.Namespace, protectedNamespace string) bool {
+	if ns == nil || ns.Name == "" || ns.Name == protectedNamespace {
+		return false
+	}
+	labels := ns.GetLabels()
+	if labels == nil {
+		return false
+	}
+	return labels[maasManagedByLabelKey] == maasManagedByLabelValue ||
+		labels[maasGeneratedNamespaceLabel] == maasGeneratedNamespaceValue
+}
+
+func listUnstructuredByGVK(ctx context.Context, cli client.Client, resourceGVK schema.GroupVersionKind) ([]unstructured.Unstructured, error) {
+	list := &unstructured.UnstructuredList{}
+	list.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   resourceGVK.Group,
+		Version: resourceGVK.Version,
+		Kind:    resourceGVK.Kind + "List",
+	})
+
+	if err := cli.List(ctx, list); err != nil {
+		if isNoMatchOrNotFound(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("list %s during teardown: %w", resourceGVK.String(), err)
+	}
+
+	return list.Items, nil
+}
+
+func isNoMatchOrNotFound(err error) bool {
+	return errors.IsNotFound(err) || apimeta.IsNoMatchError(err)
+}

--- a/maas-controller/pkg/controller/maas/tenant_reconcile.go
+++ b/maas-controller/pkg/controller/maas/tenant_reconcile.go
@@ -121,17 +121,14 @@ func (r *TenantReconciler) reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return r.handleDeletion(ctx, log, &tenant)
 	}
 
-	// Unblocking UI / Config GC teardown
-	// TODO: Include adding the finalizer back as part of https://github.com/opendatahub-io/models-as-a-service/pull/1159
-	// if usesCleanupFinalizer {
-	// 	if !controllerutil.ContainsFinalizer(&tenant, tenantFinalizer) {
-	// 		controllerutil.AddFinalizer(&tenant, tenantFinalizer)
-	// 		if err := r.Update(ctx, &tenant); err != nil {
-	// 			return ctrl.Result{}, err
-	// 		}
-	// 	}
-	// } else if controllerutil.ContainsFinalizer(&tenant, tenantFinalizer) {
-	if !usesCleanupFinalizer && controllerutil.ContainsFinalizer(&tenant, tenantFinalizer) {
+	if usesCleanupFinalizer {
+		if !controllerutil.ContainsFinalizer(&tenant, tenantFinalizer) {
+			controllerutil.AddFinalizer(&tenant, tenantFinalizer)
+			if err := r.Update(ctx, &tenant); err != nil {
+				return ctrl.Result{}, err
+			}
+		}
+	} else if controllerutil.ContainsFinalizer(&tenant, tenantFinalizer) {
 		// Converge upgraded clusters: default-tenant teardown is owned by Config GC.
 		controllerutil.RemoveFinalizer(&tenant, tenantFinalizer)
 		if err := r.Update(ctx, &tenant); err != nil {

--- a/maas-controller/pkg/controller/maas/tenant_reconcile_test.go
+++ b/maas-controller/pkg/controller/maas/tenant_reconcile_test.go
@@ -208,10 +208,7 @@ func TestTenantReconcile_AITenantManagedDefaultAddsCleanupFinalizer(t *testing.T
 
 	var updated maasv1alpha1.MaasTenantConfig
 	g.Expect(cl.Get(context.Background(), client.ObjectKey{Name: maasv1alpha1.MaasTenantConfigInstanceName, Namespace: testNS}, &updated)).To(Succeed())
-	// Unblocking UI / Config GC teardown
-	// TODO: Include adding the finalizer back as part of https://github.com/opendatahub-io/models-as-a-service/pull/1159
-	// g.Expect(updated.Finalizers).To(ContainElement(tenantFinalizer))
-	g.Expect(updated.Finalizers).To(BeEmpty(), "tenant-cleanup finalizer temporarily disabled")
+	g.Expect(updated.Finalizers).To(ContainElement(tenantFinalizer))
 }
 
 func TestTenantReconcile_DefaultTenantStripsLegacyCleanupFinalizer(t *testing.T) {
@@ -290,10 +287,7 @@ func TestTenantReconcile_AITenantManagedAddsCleanupFinalizer(t *testing.T) {
 
 	var updated maasv1alpha1.MaasTenantConfig
 	g.Expect(cl.Get(context.Background(), client.ObjectKey{Name: maasv1alpha1.MaasTenantConfigInstanceName, Namespace: testNS}, &updated)).To(Succeed())
-	// Unblocking UI / Config GC teardown
-	// TODO: Include adding the finalizer back as part of https://github.com/opendatahub-io/models-as-a-service/pull/1159
-	// g.Expect(updated.Finalizers).To(ContainElement("maas.opendatahub.io/tenant-cleanup"))
-	g.Expect(updated.Finalizers).To(BeEmpty(), "tenant-cleanup finalizer temporarily disabled")
+	g.Expect(updated.Finalizers).To(ContainElement("maas.opendatahub.io/tenant-cleanup"))
 }
 
 func TestTenantReconcile_AITenantManagedDefaultDeletionCleansPlatformResources(t *testing.T) {

--- a/test/e2e/tests/test_aitenant_lifecycle.py
+++ b/test/e2e/tests/test_aitenant_lifecycle.py
@@ -502,29 +502,27 @@ class TestAITenantLifecycle:
             _delete_best_effort("gateway", gateway_name, GATEWAY_NAMESPACE)
             _delete_best_effort("namespace", tenant_ns, timeout="90s")
 
-    # Unblocking UI
-    # TODO: Include adding the finalizer back as part of https://github.com/opendatahub-io/models-as-a-service/pull/1159
-    # def test_aitenant_delete_cleans_up_bootstrap_resources(self):
-    #     case = _new_aitenant_case()
-    #
-    #     try:
-    #         _apply_gateway_fixture(case)
-    #         _apply_aitenant(case)
-    #         _assert_aitenant_bootstrap_resources(case)
-    #
-    #         _delete_aitenant(case)
-    #         _wait_for_not_found(TENANT_CONFIG_KIND, TENANT_NAME, case["tenant_ns"])
-    #         _wait_for_not_found("role", case["tenant_admin_role"], case["tenant_ns"])
-    #         _wait_for_not_found("role", case["object_admin_role"], AITENANT_NAMESPACE)
-    #         _wait_for_not_found("namespace", case["tenant_ns"], timeout=180)
-    #
-    #         gateway = _get_json_or_none("gateway", case["gateway_name"], GATEWAY_NAMESPACE)
-    #         assert gateway is not None
-    #         assert gateway["metadata"]["labels"]["e2e.maas.opendatahub.io/fixture"] == case["aitenant_name"]
-    #     finally:
-    #         _delete_best_effort(AITENANT_KIND, case["aitenant_name"], AITENANT_NAMESPACE, timeout="180s")
-    #         _delete_best_effort("gateway", case["gateway_name"], GATEWAY_NAMESPACE)
-    #         _delete_best_effort("namespace", case["tenant_ns"], timeout="90s")
+    def test_aitenant_delete_cleans_up_bootstrap_resources(self):
+        case = _new_aitenant_case()
+
+        try:
+            _apply_gateway_fixture(case)
+            _apply_aitenant(case)
+            _assert_aitenant_bootstrap_resources(case)
+
+            _delete_aitenant(case)
+            _wait_for_not_found(TENANT_CONFIG_KIND, TENANT_NAME, case["tenant_ns"])
+            _wait_for_not_found("role", case["tenant_admin_role"], case["tenant_ns"])
+            _wait_for_not_found("role", case["object_admin_role"], AITENANT_NAMESPACE)
+            _wait_for_not_found("namespace", case["tenant_ns"], timeout=180)
+
+            gateway = _get_json_or_none("gateway", case["gateway_name"], GATEWAY_NAMESPACE)
+            assert gateway is not None
+            assert gateway["metadata"]["labels"]["e2e.maas.opendatahub.io/fixture"] == case["aitenant_name"]
+        finally:
+            _delete_best_effort(AITENANT_KIND, case["aitenant_name"], AITENANT_NAMESPACE, timeout="180s")
+            _delete_best_effort("gateway", case["gateway_name"], GATEWAY_NAMESPACE)
+            _delete_best_effort("namespace", case["tenant_ns"], timeout="90s")
 
     def test_aitenant_derives_non_default_tenant_namespace(self):
         """RHOAIENG-66836: non-default AITenant must not use models-as-a-service tenant namespace."""

--- a/test/e2e/tests/test_config_tenant.py
+++ b/test/e2e/tests/test_config_tenant.py
@@ -179,7 +179,7 @@ class TestConfigTenantOwnership:
             "(LifecycleReconciler links the anchor for GC)."
         )
 
-    def test_maas_controller_deployment_lists_config_owner_reference(self):
+    def test_maas_controller_deployment_does_not_list_config_owner_reference(self):
         result = _oc_run(
             [
                 "get",
@@ -204,7 +204,9 @@ class TestConfigTenantOwnership:
             )
         doc = json.loads(result.stdout)
         ref = _ref_to_config(doc.get("metadata", {}).get("ownerReferences"))
-        assert ref is not None, (
-            f"Deployment {CONTROLLER_DEPLOYMENT}/{CONTROLLER_DEPLOY_NS} should list an owner "
-            f"reference to Config/{CONFIG_NAME}."
+        assert ref is None, (
+            f"Deployment {CONTROLLER_DEPLOYMENT}/{CONTROLLER_DEPLOY_NS} should not reference "
+            f"Config/{CONFIG_NAME}: the controller's own workload must keep running independent "
+            "of Config's lifecycle (self-heal, TeardownCompletedAnnotation reporting), so it must "
+            "not be a GC dependent of the resource it manages."
         )

--- a/test/e2e/tests/test_multi_tenant_integration.py
+++ b/test/e2e/tests/test_multi_tenant_integration.py
@@ -67,58 +67,56 @@ def _require_multitenancy_prerequisites():
 class TestMultiTenantIntegration:
     """S27 section 7 — multi-tenant integration scenarios."""
 
-    # Unblocking UI
-    # TODO: Include adding the finalizer back as part of https://github.com/opendatahub-io/models-as-a-service/pull/1159
-    # def test_full_tenant_lifecycle_create_to_delete(self):
-    #     """7.1: Full tenant lifecycle from create through policy/subscription reconcile to delete."""
-    #     case = new_discovery_case()
-    #     role_name = f"aitenant-{case['tenant_label_name']}-tenant-admin"
-    #     try:
-    #         bootstrap_aitenant_tenant(case)
-    #
-    #         tenant = wait_for_json(TENANT_CONFIG_KIND, TENANT_CR_NAME, case["tenant_ns"], timeout=180)
-    #         tenant_labels = tenant["metadata"].get("labels") or {}
-    #         tenant_annotations = tenant["metadata"].get("annotations") or {}
-    #         assert tenant_labels[LABEL_MANAGED_BY_AITENANT] == "true"
-    #         assert tenant_labels[LABEL_TENANT_NAME] == case["tenant_label_name"]
-    #         assert tenant_labels[LABEL_TENANT_NAMESPACE] == case["tenant_ns"]
-    #         assert tenant_annotations[ANNOTATION_AITENANT_NAME] == case["tenant_label_name"]
-    #         assert tenant_annotations[ANNOTATION_AITENANT_NAMESPACE] == AITENANT_NAMESPACE
-    #         aitenant = wait_for_json(AITENANT_KIND, case["tenant_label_name"], AITENANT_NAMESPACE, timeout=180)
-    #         assert aitenant["status"]["gatewayRef"]["name"] == case["gateway_name"]
-    #         assert get_json_or_none("role", role_name, case["tenant_ns"]) is not None
-    #
-    #         model_name = f"e2e-lifecycle-model-{case['suffix']}"
-    #         provision_tenant_model(model_name, case["tenant_ns"], case["gateway_name"])
-    #
-    #         apply_maas_auth_policy(
-    #             case["policy_name"],
-    #             case["tenant_ns"],
-    #             model_ref=model_name,
-    #             model_namespace=case["tenant_ns"],
-    #         )
-    #         apply_maas_subscription(
-    #             case["subscription_name"],
-    #             case["tenant_ns"],
-    #             model_ref=model_name,
-    #             model_namespace=case["tenant_ns"],
-    #         )
-    #         wait_for_status_phase("maasauthpolicy", case["policy_name"], case["tenant_ns"], expected_phase="Active")
-    #         wait_for_status_phase(
-    #             "maassubscription",
-    #             case["subscription_name"],
-    #             case["tenant_ns"],
-    #             expected_phase="Active",
-    #         )
-    #         wait_for_aitenant_cleanup_resources(case)
-    #
-    #         delete_best_effort(AITENANT_KIND, case["tenant_label_name"], AITENANT_NAMESPACE, timeout="180s")
-    #         wait_for_not_found(TENANT_CONFIG_KIND, TENANT_CR_NAME, case["tenant_ns"], timeout=180)
-    #         wait_for_not_found("role", role_name, case["tenant_ns"], timeout=180)
-    #         wait_for_not_found("namespace", case["tenant_ns"], timeout=180)
-    #         wait_for_aitenant_cleanup_resources_deleted(case)
-    #     finally:
-    #         cleanup_discovery_case(case)
+    def test_full_tenant_lifecycle_create_to_delete(self):
+        """7.1: Full tenant lifecycle from create through policy/subscription reconcile to delete."""
+        case = new_discovery_case()
+        role_name = f"aitenant-{case['tenant_label_name']}-tenant-admin"
+        try:
+            bootstrap_aitenant_tenant(case)
+
+            tenant = wait_for_json(TENANT_CONFIG_KIND, TENANT_CR_NAME, case["tenant_ns"], timeout=180)
+            tenant_labels = tenant["metadata"].get("labels") or {}
+            tenant_annotations = tenant["metadata"].get("annotations") or {}
+            assert tenant_labels[LABEL_MANAGED_BY_AITENANT] == "true"
+            assert tenant_labels[LABEL_TENANT_NAME] == case["tenant_label_name"]
+            assert tenant_labels[LABEL_TENANT_NAMESPACE] == case["tenant_ns"]
+            assert tenant_annotations[ANNOTATION_AITENANT_NAME] == case["tenant_label_name"]
+            assert tenant_annotations[ANNOTATION_AITENANT_NAMESPACE] == AITENANT_NAMESPACE
+            aitenant = wait_for_json(AITENANT_KIND, case["tenant_label_name"], AITENANT_NAMESPACE, timeout=180)
+            assert aitenant["status"]["gatewayRef"]["name"] == case["gateway_name"]
+            assert get_json_or_none("role", role_name, case["tenant_ns"]) is not None
+
+            model_name = f"e2e-lifecycle-model-{case['suffix']}"
+            provision_tenant_model(model_name, case["tenant_ns"], case["gateway_name"])
+
+            apply_maas_auth_policy(
+                case["policy_name"],
+                case["tenant_ns"],
+                model_ref=model_name,
+                model_namespace=case["tenant_ns"],
+            )
+            apply_maas_subscription(
+                case["subscription_name"],
+                case["tenant_ns"],
+                model_ref=model_name,
+                model_namespace=case["tenant_ns"],
+            )
+            wait_for_status_phase("maasauthpolicy", case["policy_name"], case["tenant_ns"], expected_phase="Active")
+            wait_for_status_phase(
+                "maassubscription",
+                case["subscription_name"],
+                case["tenant_ns"],
+                expected_phase="Active",
+            )
+            wait_for_aitenant_cleanup_resources(case)
+
+            delete_best_effort(AITENANT_KIND, case["tenant_label_name"], AITENANT_NAMESPACE, timeout="180s")
+            wait_for_not_found(TENANT_CONFIG_KIND, TENANT_CR_NAME, case["tenant_ns"], timeout=180)
+            wait_for_not_found("role", role_name, case["tenant_ns"], timeout=180)
+            wait_for_not_found("namespace", case["tenant_ns"], timeout=180)
+            wait_for_aitenant_cleanup_resources_deleted(case)
+        finally:
+            cleanup_discovery_case(case)
 
     def test_default_tenant_unaffected_by_multitenancy_enablement(self):
         """7.2: Default tenant namespace still reconciles while discovery mode is enabled."""


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
https://redhat.atlassian.net/browse/RHOAIENG-69775

## Description
<!--- Describe your changes in detail -->
**Major**

Since maas-controller has a self deployment process, it should have a self teardown process too, instead of relying on upper operator in this matter, causing strong coupling. This PR implements a workflow for maas-controller to clean up everything it generates or reconciles. Specifically,
1. an external party (ai-gateway) annotates maas-controller with `teardown-requested` to start the teardown process.
2. maas-controller will stop ensuring namespace/ai-tenants, default tenant and Config/default.
3. maas-controller deletes MaaS CRs (including AITenants, whose finalizer will delete all tenant-specific resources), Config/default, and namespace/ai-tenants.
4. after self-teardown is done, maas-controller annotates itself with `teardown-completed` to inform the external party.

**Minor**
1. Remove legacy Tenant CRs' finalizer on migration, to present AITenant removal process from being stuck.
2. Stop Config/default from owning maas-controller. maas-controller should control the lifecycle of Config/default, not the way around.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Deployed MaaS on live cluster, manually annotated `teardown-requested`, observed expected cleanup behavior and `teardown-completed` after it's done. If annotation `teardown-requested` is taken down, maas-controller's self-heal will bring back everything.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added self-teardown support for the MAAS controller, including teardown requested/completed signals.
  - Self-teardown now cleans up remaining managed tenant resources and deletes the generated namespace when eligible.
  - Prevents AITenant namespace maintenance from recreating resources while teardown is requested.

- **Bug Fixes**
  - Improved finalizer handling and cleanup sequencing so legacy and tenant resources are removed reliably.
  - Updated controller RBAC for safer permissions (reduced delete capability).
  - Enhanced lifecycle E2E coverage by re-enabling previously skipped tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->