### PR TITLE
feat: add body-based routing (BBR) support for LLMInferenceService

### DIFF
--- a/.github/workflows/maas-api-ci.yml
+++ b/.github/workflows/maas-api-ci.yml
@@ -53,7 +53,7 @@ jobs:
           cache-dependency-path: ${{ env.PROJECT_DIR }}/go.sum
 
       - name: Run govulncheck (non-blocking until go-toolset ships >= 1.25.12)
-        run: go run golang.org/x/vuln/cmd/govulncheck@v1.4.0 ./... || true
+        run: go run golang.org/x/vuln/cmd/govulncheck@v1.6.0 ./... || true
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/maas-controller-ci.yml
+++ b/.github/workflows/maas-controller-ci.yml
@@ -54,7 +54,7 @@ jobs:
           cache-dependency-path: ${{ env.PROJECT_DIR }}/go.sum
 
       - name: Run govulncheck (non-blocking until go-toolset ships >= 1.25.12)
-        run: go run golang.org/x/vuln/cmd/govulncheck@v1.4.0 ./... || true
+        run: go run golang.org/x/vuln/cmd/govulncheck@v1.6.0 ./... || true
 
   test:
     runs-on: ubuntu-latest

--- a/deployment/base/maas-controller/crd/bases/maas.opendatahub.io_maasmodelrefs.yaml
+++ b/deployment/base/maas-controller/crd/bases/maas.opendatahub.io_maasmodelrefs.yaml
@@ -213,6 +213,13 @@ spec:
                 - Failed
                 - Invalid
                 type: string
+              resolvedModelAlias:
+                description: |-
+                  ResolvedModelAlias is the model identity used in body-based routing headers.
+                  For LLMInferenceService: publishers/{namespace}/models/{spec.model.name}.
+                  For ExternalModel: the targetModel from spec.externalProviderRefs[0].targetModel.
+                  The maas-api uses this for reverse-lookup when matching subscription model refs.
+                type: string
             type: object
         required:
         - spec

--- a/deployment/base/payload-processing/manager/envoy-filter.yaml
+++ b/deployment/base/payload-processing/manager/envoy-filter.yaml
@@ -37,8 +37,6 @@ spec:
               envoy_grpc:
                 cluster_name: outbound|9004||payload-pre-processing.openshift-ingress.svc.cluster.local
     # Stage 2: must run AFTER the WasmPlugin (needs auth to have completed).
-    # request_body_mode BUFFERED: Envoy holds the full request body until ext_proc responds,
-    # allowing model-provider-resolver to rewrite the body model field before vLLM receives it.
     - applyTo: HTTP_FILTER
       match:
         context: GATEWAY
@@ -59,7 +57,7 @@ spec:
             processing_mode:
               request_header_mode: "SEND"
               response_header_mode: "SEND"
-              request_body_mode: "BUFFERED"
+              request_body_mode: "FULL_DUPLEX_STREAMED"
               response_body_mode: "FULL_DUPLEX_STREAMED"
               request_trailer_mode: "SEND"
               response_trailer_mode: "SEND"
@@ -114,7 +112,7 @@ spec:
             processing_mode:
               request_header_mode: "SEND"
               response_header_mode: "SEND"
-              request_body_mode: "BUFFERED"
+              request_body_mode: "FULL_DUPLEX_STREAMED"
               response_body_mode: "FULL_DUPLEX_STREAMED"
               request_trailer_mode: "SEND"
               response_trailer_mode: "SEND"

--- a/deployment/base/payload-processing/manager/envoy-filter.yaml
+++ b/deployment/base/payload-processing/manager/envoy-filter.yaml
@@ -37,6 +37,8 @@ spec:
               envoy_grpc:
                 cluster_name: outbound|9004||payload-pre-processing.openshift-ingress.svc.cluster.local
     # Stage 2: must run AFTER the WasmPlugin (needs auth to have completed).
+    # request_body_mode BUFFERED: Envoy holds the full request body until ext_proc responds,
+    # allowing model-provider-resolver to rewrite the body model field before vLLM receives it.
     - applyTo: HTTP_FILTER
       match:
         context: GATEWAY
@@ -57,7 +59,7 @@ spec:
             processing_mode:
               request_header_mode: "SEND"
               response_header_mode: "SEND"
-              request_body_mode: "FULL_DUPLEX_STREAMED"
+              request_body_mode: "BUFFERED"
               response_body_mode: "FULL_DUPLEX_STREAMED"
               request_trailer_mode: "SEND"
               response_trailer_mode: "SEND"
@@ -112,7 +114,7 @@ spec:
             processing_mode:
               request_header_mode: "SEND"
               response_header_mode: "SEND"
-              request_body_mode: "FULL_DUPLEX_STREAMED"
+              request_body_mode: "BUFFERED"
               response_body_mode: "FULL_DUPLEX_STREAMED"
               request_trailer_mode: "SEND"
               response_trailer_mode: "SEND"

--- a/maas-api/internal/subscription/selector.go
+++ b/maas-api/internal/subscription/selector.go
@@ -76,6 +76,26 @@ func (s *Selector) buildModelIndex() map[string]*unstructured.Unstructured {
 	return index
 }
 
+// resolveModelAlias maps a body-based-routing model identity (e.g. publisher ID
+// or targetModel) back to canonical "namespace/name" using MaaSModelRef
+// status.resolvedModelAlias. Returns the input unchanged when no alias matches.
+func (s *Selector) resolveModelAlias(requestedModel string) string {
+	if s.modelLister == nil || requestedModel == "" {
+		return requestedModel
+	}
+	items, err := s.modelLister.List()
+	if err != nil {
+		return requestedModel
+	}
+	for _, u := range items {
+		alias, found, _ := unstructured.NestedString(u.Object, "status", "resolvedModelAlias")
+		if found && alias == requestedModel {
+			return u.GetNamespace() + "/" + u.GetName()
+		}
+	}
+	return requestedModel
+}
+
 // subscription represents a parsed MaaSSubscription for selection.
 type subscription struct {
 	Name                   string
@@ -165,6 +185,8 @@ func (s *Selector) Select(groups []string, username string, requestedSubscriptio
 	if len(groups) == 0 && username == "" {
 		return nil, errors.New("either groups or username must be provided")
 	}
+
+	requestedModel = s.resolveModelAlias(requestedModel)
 
 	subscriptions, err := s.loadSubscriptions()
 	if err != nil {

--- a/maas-controller/api/maas/v1alpha1/maasmodelref_types.go
+++ b/maas-controller/api/maas/v1alpha1/maasmodelref_types.go
@@ -119,6 +119,13 @@ type MaaSModelStatus struct {
 	// +optional
 	HTTPRouteHostnames []string `json:"httpRouteHostnames,omitempty"`
 
+	// ResolvedModelAlias is the model identity used in body-based routing headers.
+	// For LLMInferenceService: publishers/{namespace}/models/{spec.model.name}.
+	// For ExternalModel: the targetModel from spec.externalProviderRefs[0].targetModel.
+	// The maas-api uses this for reverse-lookup when matching subscription model refs.
+	// +optional
+	ResolvedModelAlias string `json:"resolvedModelAlias,omitempty"`
+
 	// Conditions represent the latest available observations of the model's state.
 	// Condition types include:
 	//   - Ready: overall readiness (governance + runtime).

--- a/maas-controller/go.mod
+++ b/maas-controller/go.mod
@@ -82,7 +82,7 @@ require (
 	github.com/googleapis/google-cloud-go-testing v0.0.0-20210719221736-1c9a4c676720 // indirect
 	github.com/jmespath/go-jmespath v0.4.1-0.20220621161143-b0104c826a24 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
-	github.com/kedacore/keda/v2 v2.18.0 // indirect
+	github.com/kedacore/keda/v2 v2.18.3 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect

--- a/maas-controller/go.sum
+++ b/maas-controller/go.sum
@@ -203,8 +203,8 @@ github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfC
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
-github.com/kedacore/keda/v2 v2.18.0 h1:ttR223fii/4QJ0YvtrhcWHaEoezByb/t5CeFopjl6EI=
-github.com/kedacore/keda/v2 v2.18.0/go.mod h1:pw+qlQwMzj3T8LMayUnOtT15Gt1yRPF3lS1r5rt9F5k=
+github.com/kedacore/keda/v2 v2.18.3 h1:PY3o80tzBAzCffS8J6eBZctT4B+g/r26zErNSMleC50=
+github.com/kedacore/keda/v2 v2.18.3/go.mod h1:gaFzDtqtXg6KPmMcwzeCjv7aoK8Z1I2NaUkqHkREbDk=
 github.com/keybase/go-keychain v0.0.1 h1:way+bWYa6lDppZoZcgMbYsvC7GxljxrskdNInRtuthU=
 github.com/keybase/go-keychain v0.0.1/go.mod h1:PdEILRW3i9D8JcdM+FmY6RwkHGnhHxXwkPPMeUgOK1k=
 github.com/klauspost/compress v1.18.2 h1:iiPHWW0YrcFgpBYhsA6D1+fqHssJscY/Tm/y2Uqnapk=

--- a/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
@@ -338,12 +338,10 @@ const (
 		celPathParts + `[0] != "v1" && ` +
 		celPathParts + `[0] != "maas-api"`
 	celModelIdentityAvailable = `(` + celPathModelIdentityAvailable + ` || "x-gateway-model-name" in request.headers)`
-	celModelIdentity          = `(` + celPathModelIdentityAvailable +
+	celModelIdentity = `(` + celPathModelIdentityAvailable +
 		` ? ` + celPathParts + `[0] + "/" + ` + celPathParts + `[1]` +
 		` : ("x-gateway-model-name" in request.headers` +
-		`   ? (request.headers["x-gateway-model-name"].startsWith("publishers/")` +
-		`     ? request.headers["x-gateway-model-name"].split("/")[1] + "/" + request.headers["x-gateway-model-name"].split("/")[3]` +
-		`     : request.headers["x-gateway-model-name"])` +
+		`   ? request.headers["x-gateway-model-name"]` +
 		`   : ""))`
 )
 
@@ -733,11 +731,7 @@ path_model_identity := sprintf("%%s/%%s", [path_parts[0], path_parts[1]]) {
 	path_parts[0] != "maas-api"
 }
 
-raw_header_model_identity := object.get(request_headers, "x-gateway-model-name", "")
-
-header_model_identity := sprintf("%%s/%%s", [split(raw_header_model_identity, "/")[1], split(raw_header_model_identity, "/")[3]]) {
-	startswith(raw_header_model_identity, "publishers/")
-} else := raw_header_model_identity
+header_model_identity := object.get(request_headers, "x-gateway-model-name", "")
 
 model_identity := path_model_identity {
 	path_model_identity != ""
@@ -1300,10 +1294,29 @@ func (r *MaaSAuthPolicyReconciler) aggregateModelSubjectAllowlists(ctx context.C
 			entry.Groups = deduplicateAndSort(entry.Groups)
 			entry.Users = deduplicateAndSort(entry.Users)
 			aggregate[key] = entry
+
+			for _, altKey := range r.resolveHeaderModelKeys(ctx, ref) {
+				aggregate[altKey] = entry
+			}
 		}
 	}
 
 	return aggregate, nil
+}
+
+// resolveHeaderModelKeys returns alternate model_access keys that match the value
+// ipp-pre sets in the X-Gateway-Model-Name header for body-based routing.
+// Reads MaaSModelRef.status.resolvedModelAlias, which the modelref controller
+// populates from the backing CRD (publisher ID for LLMISvc, targetModel for ExternalModel).
+func (r *MaaSAuthPolicyReconciler) resolveHeaderModelKeys(ctx context.Context, ref maasv1alpha1.ModelRef) []string {
+	modelRef := &maasv1alpha1.MaaSModelRef{}
+	if err := r.Get(ctx, client.ObjectKey{Name: ref.Name, Namespace: ref.Namespace}, modelRef); err != nil {
+		return nil
+	}
+	if modelRef.Status.ResolvedModelAlias == "" {
+		return nil
+	}
+	return []string{modelRef.Status.ResolvedModelAlias}
 }
 
 func (r *MaaSAuthPolicyReconciler) modelAuthPolicyExists(ctx context.Context, modelNamespace, modelName string) (bool, error) {

--- a/maas-controller/pkg/controller/maas/maasauthpolicy_controller_test.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_controller_test.go
@@ -2000,58 +2000,168 @@ func TestMaaSAuthPolicyReconciler_CanonicalModelIDNormalization(t *testing.T) {
 		t.Fatalf("Get gateway AuthPolicy: %v", err)
 	}
 
-	t.Run("CEL normalizes canonical publishers/ prefix", func(t *testing.T) {
-		// The CEL celModelIdentity is embedded in auth-valid authorization block.
-		// Check that the gateway AuthPolicy's auth-valid rego or CEL-based expressions
-		// contain the normalization for publishers/ prefix.
-		// celModelIdentity is used in the response and cache-key sections.
-		// It should handle: publishers/{ns}/models/{name} -> {ns}/{name}
-		if !strings.Contains(celModelIdentity, `startsWith("publishers/")`) {
-			t.Errorf("celModelIdentity should normalize canonical model IDs with publishers/ prefix, got: %s", celModelIdentity)
+	t.Run("CEL uses header value as-is for model identity", func(t *testing.T) {
+		if !strings.Contains(celModelIdentity, `request.headers["x-gateway-model-name"]`) {
+			t.Errorf("celModelIdentity should use raw header value as model identity, got: %s", celModelIdentity)
 		}
-		if !strings.Contains(celModelIdentity, `split("/")[1]`) || !strings.Contains(celModelIdentity, `split("/")[3]`) {
-			t.Errorf("celModelIdentity should extract ns (index 1) and name (index 3) from canonical format, got: %s", celModelIdentity)
-		}
-		if !strings.Contains(celModelIdentity, `x-gateway-model-name`) {
-			t.Errorf("celModelIdentity should read from x-gateway-model-name header, got: %s", celModelIdentity)
+		if strings.Contains(celModelIdentity, `request.headers["x-gateway-model-name"].split`) {
+			t.Errorf("celModelIdentity should not split the header value, got: %s", celModelIdentity)
 		}
 	})
 
-	t.Run("OPA Rego normalizes canonical publishers/ prefix", func(t *testing.T) {
+	t.Run("OPA Rego uses header value as-is for model identity", func(t *testing.T) {
 		rego, found, err := unstructured.NestedString(gwPolicy.Object, "spec", "defaults", "rules", "authorization", "require-group-membership", "opa", "rego")
 		if err != nil || !found {
 			t.Fatalf("require-group-membership rego missing: found=%v err=%v", found, err)
 		}
 
-		if !strings.Contains(rego, "raw_header_model_identity") {
-			t.Errorf("rego should extract raw header value before normalization, got: %s", rego)
+		if !strings.Contains(rego, `header_model_identity := object.get(request_headers, "x-gateway-model-name", "")`) {
+			t.Errorf("rego should use raw header value directly as model identity, got: %s", rego)
 		}
-		if !strings.Contains(rego, `startswith(raw_header_model_identity, "publishers/")`) {
-			t.Errorf("rego should check for publishers/ prefix, got: %s", rego)
+		if strings.Contains(rego, `startswith(raw_header_model_identity`) {
+			t.Errorf("rego should not split or parse publisher ID format, got: %s", rego)
 		}
-		if !strings.Contains(rego, `split(raw_header_model_identity, "/")[1]`) {
-			t.Errorf("rego should extract namespace at index 1 from canonical format, got: %s", rego)
-		}
-		if !strings.Contains(rego, `split(raw_header_model_identity, "/")[3]`) {
-			t.Errorf("rego should extract model name at index 3 from canonical format, got: %s", rego)
+	})
+}
+
+// TestMaaSAuthPolicyReconciler_PublisherIDModelAccess verifies that the gateway AuthPolicy's
+// model_access map contains publisher-ID-keyed entries for LLMInferenceService-backed models,
+// allowing BBR requests with publisher ID format to pass auth.
+func TestMaaSAuthPolicyReconciler_PublisherIDModelAccess(t *testing.T) {
+	const (
+		modelRefName   = "facebook-opt-125m-simulated"
+		llmisvcName    = "facebook-opt-125m"
+		namespace      = "llm"
+		gatewayNS      = "gateway-ns"
+		maasPolicyName = "policy-bbr"
+	)
+	publisherID := "publishers/" + namespace + "/models/facebook/opt-125m"
+
+	modelRef := newMaaSModelRef(modelRefName, namespace, "LLMInferenceService", llmisvcName)
+	modelRef.Status.ResolvedModelAlias = publisherID
+	route := newHTTPRoute(modelRefName, namespace)
+	maasPolicy := newMaaSAuthPolicy(maasPolicyName, namespace, "system:authenticated",
+		maasv1alpha1.ModelRef{Name: modelRefName, Namespace: namespace},
+	)
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithRESTMapper(testRESTMapper()).
+		WithObjects(modelRef, route, maasPolicy).
+		WithStatusSubresource(&maasv1alpha1.MaaSAuthPolicy{}).
+		Build()
+
+	r := &MaaSAuthPolicyReconciler{
+		Client:           c,
+		Scheme:           scheme,
+		InfraNamespace:   "maas-system",
+		GatewayName:      "maas-default-gateway",
+		GatewayNamespace: gatewayNS,
+		MetadataCacheTTL: 60,
+		AuthzCacheTTL:    60,
+	}
+
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: maasPolicyName, Namespace: namespace}}
+	if _, err := r.Reconcile(context.Background(), req); err != nil {
+		t.Fatalf("Reconcile: unexpected error: %v", err)
+	}
+
+	gwPolicy := &unstructured.Unstructured{}
+	gwPolicy.SetGroupVersionKind(schema.GroupVersionKind{Group: "kuadrant.io", Version: "v1", Kind: "AuthPolicy"})
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "maas-gateway-auth", Namespace: gatewayNS}, gwPolicy); err != nil {
+		t.Fatalf("Get gateway AuthPolicy: %v", err)
+	}
+
+	rego, found, err := unstructured.NestedString(gwPolicy.Object, "spec", "defaults", "rules", "authorization", "require-group-membership", "opa", "rego")
+	if err != nil || !found {
+		t.Fatalf("require-group-membership rego missing: found=%v err=%v", found, err)
+	}
+
+	standardKey := namespace + "/" + modelRefName
+
+	t.Run("model_access contains standard namespace/name key", func(t *testing.T) {
+		if !strings.Contains(rego, standardKey) {
+			t.Errorf("model_access should contain standard key %q, rego:\n%s", standardKey, rego)
 		}
 	})
 
-	t.Run("CEL passes through short model names unchanged", func(t *testing.T) {
-		// When the header doesn't start with "publishers/", the raw value should be used as-is
-		if !strings.Contains(celModelIdentity, `: request.headers["x-gateway-model-name"])`) {
-			t.Errorf("celModelIdentity should pass through non-canonical model names as-is, got: %s", celModelIdentity)
+	t.Run("model_access contains publisher ID key for LLMInferenceService", func(t *testing.T) {
+		if !strings.Contains(rego, publisherID) {
+			t.Errorf("model_access should contain publisher ID key %q, rego:\n%s", publisherID, rego)
+		}
+	})
+}
+
+// TestMaaSAuthPolicyReconciler_TargetModelAccess_ExternalModel verifies that the gateway
+// AuthPolicy's model_access map contains a targetModel-keyed entry for ExternalModel-backed
+// models, allowing BBR requests with the upstream model name to pass auth.
+func TestMaaSAuthPolicyReconciler_TargetModelAccess_ExternalModel(t *testing.T) {
+	const (
+		modelRefName   = "my-gpt4o"
+		emName         = "my-gpt4o"
+		targetModel    = "gpt-4o"
+		namespace      = "default"
+		gatewayNS      = "gateway-ns"
+		maasPolicyName = "policy-ext"
+	)
+
+	modelRef := newMaaSModelRef(modelRefName, namespace, "ExternalModel", emName)
+	modelRef.Status.ResolvedModelAlias = targetModel
+	route := newHTTPRoute(modelRefName, namespace)
+	maasPolicy := newMaaSAuthPolicy(maasPolicyName, namespace, "team-a",
+		maasv1alpha1.ModelRef{Name: modelRefName, Namespace: namespace},
+	)
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithRESTMapper(testRESTMapper()).
+		WithObjects(modelRef, route, maasPolicy).
+		WithStatusSubresource(&maasv1alpha1.MaaSAuthPolicy{}).
+		Build()
+
+	r := &MaaSAuthPolicyReconciler{
+		Client:           c,
+		Scheme:           scheme,
+		InfraNamespace:   "maas-system",
+		GatewayName:      "maas-default-gateway",
+		GatewayNamespace: gatewayNS,
+		MetadataCacheTTL: 60,
+		AuthzCacheTTL:    60,
+	}
+
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: maasPolicyName, Namespace: namespace}}
+	if _, err := r.Reconcile(context.Background(), req); err != nil {
+		t.Fatalf("Reconcile: unexpected error: %v", err)
+	}
+
+	gwPolicy := &unstructured.Unstructured{}
+	gwPolicy.SetGroupVersionKind(schema.GroupVersionKind{Group: "kuadrant.io", Version: "v1", Kind: "AuthPolicy"})
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "maas-gateway-auth", Namespace: gatewayNS}, gwPolicy); err != nil {
+		t.Fatalf("Get gateway AuthPolicy: %v", err)
+	}
+
+	rego, found, err := unstructured.NestedString(gwPolicy.Object, "spec", "defaults", "rules", "authorization", "require-group-membership", "opa", "rego")
+	if err != nil || !found {
+		t.Fatalf("require-group-membership rego missing: found=%v err=%v", found, err)
+	}
+
+	standardKey := namespace + "/" + modelRefName
+
+	t.Run("model_access contains standard namespace/name key", func(t *testing.T) {
+		if !strings.Contains(rego, standardKey) {
+			t.Errorf("model_access should contain standard key %q, rego:\n%s", standardKey, rego)
 		}
 	})
 
-	t.Run("OPA Rego passes through short model names unchanged", func(t *testing.T) {
-		rego, found, err := unstructured.NestedString(gwPolicy.Object, "spec", "defaults", "rules", "authorization", "require-group-membership", "opa", "rego")
-		if err != nil || !found {
-			t.Fatalf("require-group-membership rego missing: found=%v err=%v", found, err)
+	t.Run("model_access contains targetModel key for ExternalModel", func(t *testing.T) {
+		if !strings.Contains(rego, `"`+targetModel+`"`) {
+			t.Errorf("model_access should contain targetModel key %q, rego:\n%s", targetModel, rego)
 		}
-		// The else clause should assign the raw value when not canonical
-		if !strings.Contains(rego, "else := raw_header_model_identity") {
-			t.Errorf("rego should fall back to raw header value for non-canonical names, got: %s", rego)
+	})
+
+	t.Run("model_access does NOT contain publishers/ for ExternalModel", func(t *testing.T) {
+		if strings.Contains(rego, "publishers/") {
+			t.Errorf("model_access should not contain publisher ID for ExternalModel, rego:\n%s", rego)
 		}
 	})
 }

--- a/maas-controller/pkg/controller/maas/maasmodelref_controller.go
+++ b/maas-controller/pkg/controller/maas/maasmodelref_controller.go
@@ -174,6 +174,8 @@ func (r *MaaSModelRefReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		model.Status.Endpoint = endpoint
 	}
 
+	model.Status.ResolvedModelAlias = handler.ResolveModelAlias(ctx, log, model)
+
 	governed := r.checkGovernanceAttached(ctx, model)
 	r.setGovernanceCondition(model, governed)
 	r.setRuntimeReadyCondition(model, runtimeReady)

--- a/maas-controller/pkg/controller/maas/maasmodelref_controller_test.go
+++ b/maas-controller/pkg/controller/maas/maasmodelref_controller_test.go
@@ -62,6 +62,9 @@ func (f *fakeHandler) Status(_ context.Context, _ logr.Logger, _ *maasv1alpha1.M
 func (f *fakeHandler) GetModelEndpoint(_ context.Context, _ logr.Logger, _ *maasv1alpha1.MaaSModelRef) (string, error) {
 	return f.endpoint, nil
 }
+func (f *fakeHandler) ResolveModelAlias(_ context.Context, _ logr.Logger, _ *maasv1alpha1.MaaSModelRef) string {
+	return ""
+}
 func (f *fakeHandler) CleanupOnDelete(_ context.Context, _ logr.Logger, _ *maasv1alpha1.MaaSModelRef) error {
 	return nil
 }

--- a/maas-controller/pkg/controller/maas/providers.go
+++ b/maas-controller/pkg/controller/maas/providers.go
@@ -53,6 +53,11 @@ type BackendHandler interface {
 	// GetModelEndpoint returns the endpoint URL for the model. Kind-specific: e.g. llmisvc uses gateway/HTTPRoute
 	// hostname + path; ExternalModel (when implemented) would use its own logic and need not follow the same path assumptions.
 	GetModelEndpoint(ctx context.Context, log logr.Logger, model *maasv1alpha1.MaaSModelRef) (string, error)
+	// ResolveModelAlias returns the model identity used in body-based routing headers.
+	// LLMInferenceService: publishers/{namespace}/models/{spec.model.name}.
+	// ExternalModel: spec.externalProviderRefs[0].targetModel.
+	// Returns "" if the alias cannot be resolved (backing resource missing or field unset).
+	ResolveModelAlias(ctx context.Context, log logr.Logger, model *maasv1alpha1.MaaSModelRef) string
 	// CleanupOnDelete is called when the MaaSModelRef is deleted (e.g. delete HTTPRoute for ExternalModel).
 	CleanupOnDelete(ctx context.Context, log logr.Logger, model *maasv1alpha1.MaaSModelRef) error
 }

--- a/maas-controller/pkg/controller/maas/providers_external.go
+++ b/maas-controller/pkg/controller/maas/providers_external.go
@@ -266,6 +266,30 @@ func (h *externalModelHandler) GetModelEndpoint(ctx context.Context, log logr.Lo
 	return "", fmt.Errorf("unable to determine endpoint: gateway %s/%s has no hostname or addresses", gatewayNS, gatewayName)
 }
 
+// ResolveModelAlias returns the targetModel from the first externalProviderRef, which is the
+// value the client sends in the body model field for BBR requests.
+// Note: assumes at most one ExternalModel per targetModel value per tenant. If multiple
+// ExternalModels share the same targetModel, the subscription reverse-lookup returns the
+// first match non-deterministically.
+func (h *externalModelHandler) ResolveModelAlias(ctx context.Context, log logr.Logger, model *maasv1alpha1.MaaSModelRef) string {
+	em := &unstructured.Unstructured{}
+	em.SetGroupVersionKind(inferenceExternalModelGVK)
+	key := client.ObjectKey{Name: model.Spec.ModelRef.Name, Namespace: model.Namespace}
+	if err := h.r.Get(ctx, key, em); err != nil {
+		return ""
+	}
+	refs, found, _ := unstructured.NestedSlice(em.Object, "spec", "externalProviderRefs")
+	if !found || len(refs) == 0 {
+		return ""
+	}
+	ref0, ok := refs[0].(map[string]any)
+	if !ok {
+		return ""
+	}
+	targetModel, _ := ref0["targetModel"].(string)
+	return targetModel
+}
+
 // CleanupOnDelete is called when the MaaSModelRef is deleted.
 // ExternalModel: the ExternalModel reconciler handles cleanup of all resources via finalizer.
 func (h *externalModelHandler) CleanupOnDelete(ctx context.Context, log logr.Logger, model *maasv1alpha1.MaaSModelRef) error {

--- a/maas-controller/pkg/controller/maas/providers_llmisvc.go
+++ b/maas-controller/pkg/controller/maas/providers_llmisvc.go
@@ -288,6 +288,19 @@ func (h *llmisvcHandler) selectAddress(llmisvc *kservev1alpha1.LLMInferenceServi
 	return ""
 }
 
+func (h *llmisvcHandler) ResolveModelAlias(ctx context.Context, log logr.Logger, model *maasv1alpha1.MaaSModelRef) string {
+	llmisvc := &kservev1alpha1.LLMInferenceService{}
+	key := client.ObjectKey{Name: model.Spec.ModelRef.Name, Namespace: model.Namespace}
+	if err := h.r.Get(ctx, key, llmisvc); err != nil {
+		return ""
+	}
+	modelName := llmisvc.Name
+	if llmisvc.Spec.Model.Name != nil && *llmisvc.Spec.Model.Name != "" {
+		modelName = *llmisvc.Spec.Model.Name
+	}
+	return fmt.Sprintf("publishers/%s/models/%s", model.Namespace, modelName)
+}
+
 func (h *llmisvcHandler) CleanupOnDelete(ctx context.Context, log logr.Logger, model *maasv1alpha1.MaaSModelRef) error {
 	// llmisvc HTTPRoutes are owned by KServe; we do not delete them.
 	return nil


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->


## Summary

- Add `resolvedModelAlias` status field to MaaSModelRef, populated by the controller from the backend handler. For LLMISvc this is the publisher ID (`publishers/{ns}/models/{name}`), for ExternalModel it's the `targetModel` from the spec.
- Update Authorino auth policy generation to pass the raw `x-gateway-model-name` header as the model identity (CEL + Rego), and add alternate keys from `resolvedModelAlias` so auth matches both path-based and BBR identities.
- Add reverse-lookup in maas-api subscription selector so BBR requests (keyed by publisher ID) resolve to the correct subscription.
- Switch ipp-post `request_body_mode` to `BUFFERED` in the EnvoyFilter so the ext_proc plugin can rewrite the request body before it reaches the backend.

https://redhat.atlassian.net/browse/RHOAIENG-78214
## Motivation

BBR sends `POST /v1/chat/completions` with the model in the request body (no path prefix). The model name in the body uses publisher ID format (`publishers/llm/models/facebook/opt-125m`), which didn't match the canonical identity used by auth, subscription lookup, or the backend. This change ensures all three layers handle the BBR identity correctly.

## Multi-tenancy

Publisher ID includes the namespace (`publishers/{namespace}/models/{name}`), so models across different tenant namespaces produce distinct identities at every layer.

## Test plan

- [x] BBR request returns 200 with correct model response
- [x] Path-based request still returns 200 (no regression)
- [x] Auth passes for BBR identity (dual-key model_access)
- [x] Subscription resolves correctly for BBR identity
- [x] Unit tests pass for auth policy controller and model ref controller

## Test evidence

**BBR (body-based routing) — 200 OK:**
```
curl -X POST "https://maas.apps.isequeir-test-1.eh5f.s1.devshift.org/v1/chat/completions" \
  -H "Authorization: Bearer sk-oai-..." \
  -H "Content-Type: application/json" \
  -d '{"model": "publishers/llm/models/facebook/opt-125m", "messages": [{"role": "user", "content": "hello"}]}'

HTTP/1.1 200 OK
{"id":"...","object":"chat.completion","model":"facebook/opt-125m","choices":[...]}
```

**Path-based routing — 200 OK (no regression):**
```
curl -X POST "https://maas.apps.isequeir-test-1.eh5f.s1.devshift.org/llm/facebook-opt-125m-simulated/v1/chat/completions" \
  -H "Authorization: Bearer sk-oai-..." \
  -H "Content-Type: application/json" \
  -d '{"model": "facebook/opt-125m", "messages": [{"role": "user", "content": "hello"}]}'

HTTP/1.1 200 OK
{"id":"...","object":"chat.completion","model":"facebook/opt-125m","choices":[...]}
```


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
