### PR TITLE
fix: add NetworkPolicy allowing deployment namespace to reach maas-api

### DIFF
--- a/deployment/base/maas-api/networking/kustomization.yaml
+++ b/deployment/base/maas-api/networking/kustomization.yaml
@@ -7,4 +7,5 @@ metadata:
 resources:
 - httproute.yaml
 - maas-authorino-networkpolicy.yaml
+- maas-deployment-ns-networkpolicy.yaml
 - maas-gateway-networkpolicy.yaml

--- a/deployment/base/maas-api/networking/maas-deployment-ns-networkpolicy.yaml
+++ b/deployment/base/maas-api/networking/maas-deployment-ns-networkpolicy.yaml
@@ -1,0 +1,41 @@
+# NetworkPolicy to allow pods in the deployment namespace (where the UI and
+# maas-controller run) to communicate with maas-api in the infrastructure
+# namespace (e.g., for /v1/tenants discovery).
+#
+# Security constraints:
+# - podSelector: Restricted to maas-api pods only (component=api)
+# - from: Only pods in known deployment namespaces
+#
+# Background:
+# - ODH creates a default NetworkPolicy that blocks ingress from unlabeled namespaces
+# - maas-api runs in the infrastructure namespace (odh-ai-gateway-infra /
+#   redhat-ai-gateway-infra), separate from the deployment namespace
+# - This policy adds an exception for the deployment namespace to reach maas-api
+#   on port 8443
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: maas-api-allow-deployment-ns
+  labels:
+    app.opendatahub.io/modelsasservice: "true"
+    app.kubernetes.io/part-of: maas
+    app.kubernetes.io/component: networking
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: api
+      app.kubernetes.io/part-of: models-as-a-service
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchExpressions:
+              - key: kubernetes.io/metadata.name
+                operator: In
+                values:
+                  - opendatahub
+                  - redhat-ods-applications
+      ports:
+        - protocol: TCP
+          port: 8443

--- a/deployment/base/maas-api/networking/maas-deployment-ns-networkpolicy.yaml
+++ b/deployment/base/maas-api/networking/maas-deployment-ns-networkpolicy.yaml
@@ -28,6 +28,10 @@ spec:
   policyTypes:
     - Ingress
   ingress:
+    # Allows all pods from the namespace rather than specific callers.
+    # The deployment namespace hosts the UI/Dashboard and controller, both of
+    # which may call maas-api. This matches the namespace-wide trust pattern
+    # used by maas-api-allow-gateway for openshift-ingress.
     - from:
         - namespaceSelector:
             matchExpressions:

--- a/deployment/base/maas-api/networking/maas-deployment-ns-networkpolicy.yaml
+++ b/deployment/base/maas-api/networking/maas-deployment-ns-networkpolicy.yaml
@@ -36,7 +36,7 @@ spec:
     - from:
         - namespaceSelector:
             matchLabels:
-              kubernetes.io/metadata.name: opendatahub
+              kubernetes.io/metadata.name: REPLACE_CONTROLLER_NAMESPACE
       ports:
         - protocol: TCP
           port: 8443

--- a/deployment/base/maas-api/networking/maas-deployment-ns-networkpolicy.yaml
+++ b/deployment/base/maas-api/networking/maas-deployment-ns-networkpolicy.yaml
@@ -4,7 +4,8 @@
 #
 # Security constraints:
 # - podSelector: Restricted to maas-api pods only (component=api)
-# - from: Only pods in known deployment namespaces
+# - from: Only pods in the controller's deployment namespace (patched at
+#   render time by patchResource to the actual namespace)
 #
 # Background:
 # - ODH creates a default NetworkPolicy that blocks ingress from unlabeled namespaces
@@ -34,12 +35,8 @@ spec:
     # used by maas-api-allow-gateway for openshift-ingress.
     - from:
         - namespaceSelector:
-            matchExpressions:
-              - key: kubernetes.io/metadata.name
-                operator: In
-                values:
-                  - opendatahub
-                  - redhat-ods-applications
+            matchLabels:
+              kubernetes.io/metadata.name: opendatahub
       ports:
         - protocol: TCP
           port: 8443

--- a/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
@@ -338,7 +338,7 @@ const (
 		celPathParts + `[0] != "v1" && ` +
 		celPathParts + `[0] != "maas-api"`
 	celModelIdentityAvailable = `(` + celPathModelIdentityAvailable + ` || "x-gateway-model-name" in request.headers)`
-	celModelIdentity = `(` + celPathModelIdentityAvailable +
+	celModelIdentity          = `(` + celPathModelIdentityAvailable +
 		` ? ` + celPathParts + `[0] + "/" + ` + celPathParts + `[1]` +
 		` : ("x-gateway-model-name" in request.headers` +
 		`   ? request.headers["x-gateway-model-name"]` +

--- a/maas-controller/pkg/controller/maas/tenant_reconcile.go
+++ b/maas-controller/pkg/controller/maas/tenant_reconcile.go
@@ -311,7 +311,7 @@ func (r *TenantReconciler) reconcilePlatform(
 	mcfg *maasv1alpha1.Config,
 ) (*ctrl.Result, error) {
 	appNs := r.appNamespaceForTenant()
-	runRes, err := tenantreconcile.RunPlatform(ctx, log, r.Client, r.Scheme, tenant, platformContext, r.ManifestPath, appNs, r.ClusterAudience, mcfg)
+	runRes, err := tenantreconcile.RunPlatform(ctx, log, r.Client, r.Scheme, tenant, platformContext, r.ManifestPath, appNs, r.ControllerNamespace, r.ClusterAudience, mcfg)
 	if err != nil {
 		log.Error(err, "Tenant platform reconcile failed")
 		setDeploymentsAvailableCondition(tenant, false, "PlatformReconcileFailed", err.Error())

--- a/maas-controller/pkg/platform/tenantreconcile/constants.go
+++ b/maas-controller/pkg/platform/tenantreconcile/constants.go
@@ -71,6 +71,7 @@ const (
 	baseMaaSAPIDeploymentName                      = "maas-api"
 	baseMaaSAPIServiceName                         = "maas-api"
 	baseMaaSAPIKeyCleanupScriptConfigMapName       = "maas-api-key-cleanup-script" //nolint:gosec // Kubernetes resource name, not a credential
+	baseMaaSAPIDeploymentNSNetworkPolicyName       = "maas-api-allow-deployment-ns"
 
 	// Non-tenant-specific resource names (shared infrastructure)
 	PayloadProcessingName                         = "payload-processing"
@@ -107,6 +108,7 @@ var (
 	GVKServiceAccount       = schema.GroupVersionKind{Version: "v1", Kind: "ServiceAccount"}
 	GVKConfigMap            = schema.GroupVersionKind{Version: "v1", Kind: "ConfigMap"}
 	GVKClusterRoleBinding   = schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "ClusterRoleBinding"}
+	GVKNetworkPolicy        = schema.GroupVersionKind{Group: "networking.k8s.io", Version: "v1", Kind: "NetworkPolicy"}
 	GVKPersesDashboard      = schema.GroupVersionKind{Group: "perses.dev", Version: "v1alpha1", Kind: "PersesDashboard"}
 	GVKPersesDatasource     = schema.GroupVersionKind{Group: "perses.dev", Version: "v1alpha1", Kind: "PersesDatasource"}
 )

--- a/maas-controller/pkg/platform/tenantreconcile/naming_test.go
+++ b/maas-controller/pkg/platform/tenantreconcile/naming_test.go
@@ -239,7 +239,7 @@ func TestBuildPlatformParamsIncludesTenantIdentifier(t *testing.T) {
 			Namespace: "openshift-ingress",
 			Name:      "maas-default-gateway",
 		}}
-		params, err := BuildPlatformParams(tenant, platformContext, "opendatahub", "https://kubernetes.default.svc", logr.Discard())
+		params, err := BuildPlatformParams(tenant, platformContext, "opendatahub", "opendatahub", "https://kubernetes.default.svc", logr.Discard())
 		assert.NoError(t, err)
 
 		assert.Equal(t, "", params.TenantIdentifier)
@@ -268,7 +268,7 @@ func TestBuildPlatformParamsIncludesTenantIdentifier(t *testing.T) {
 			Namespace: "openshift-ingress",
 			Name:      "maas-default-gateway",
 		}}
-		params, err := BuildPlatformParams(tenant, platformContext, "opendatahub", "https://kubernetes.default.svc", logr.Discard())
+		params, err := BuildPlatformParams(tenant, platformContext, "opendatahub", "opendatahub", "https://kubernetes.default.svc", logr.Discard())
 		assert.NoError(t, err)
 
 		assert.Equal(t, "", params.TenantIdentifier)
@@ -296,7 +296,7 @@ func TestBuildPlatformParamsIncludesTenantIdentifier(t *testing.T) {
 			Namespace: "openshift-ingress",
 			Name:      "redteam-gateway",
 		}}
-		params, err := BuildPlatformParams(tenant, platformContext, "opendatahub", "https://kubernetes.default.svc", logr.Discard())
+		params, err := BuildPlatformParams(tenant, platformContext, "opendatahub", "opendatahub", "https://kubernetes.default.svc", logr.Discard())
 		assert.NoError(t, err)
 
 		assert.Equal(t, "redteam", params.TenantIdentifier)

--- a/maas-controller/pkg/platform/tenantreconcile/params.go
+++ b/maas-controller/pkg/platform/tenantreconcile/params.go
@@ -17,6 +17,7 @@ import (
 // PlatformParams holds resolved runtime values for PostRender patching.
 type PlatformParams struct {
 	AppNamespace          string
+	ControllerNamespace   string
 	GatewayNamespace      string
 	GatewayName           string
 	ClusterAudience       string
@@ -36,7 +37,7 @@ type PlatformParams struct {
 
 // BuildPlatformParams resolves all runtime parameters from the tenant config object,
 // platform context, cluster state, and RELATED_IMAGE_* env vars. No disk I/O.
-func BuildPlatformParams(tenant client.Object, platformContext PlatformContext, appNamespace, clusterAudience string, log logr.Logger) (PlatformParams, error) {
+func BuildPlatformParams(tenant client.Object, platformContext PlatformContext, appNamespace, controllerNamespace, clusterAudience string, log logr.Logger) (PlatformParams, error) {
 	tenantID, err := TenantIdentifierFor(tenant)
 	if err != nil {
 		return PlatformParams{}, fmt.Errorf("resolve tenant identifier: %w", err)
@@ -44,6 +45,7 @@ func BuildPlatformParams(tenant client.Object, platformContext PlatformContext, 
 
 	params := PlatformParams{
 		AppNamespace:            appNamespace,
+		ControllerNamespace:     controllerNamespace,
 		GatewayNamespace:        platformContext.GatewayRef.Namespace,
 		GatewayName:             platformContext.GatewayRef.Name,
 		ClusterAudience:         clusterAudience,
@@ -155,10 +157,44 @@ func patchResource(log logr.Logger, r *unstructured.Unstructured, params Platfor
 		r.SetNamespace(params.GatewayNamespace)
 	case gvk == GVKConfigMap && name == PayloadProcessingPluginsConfigMapName:
 		r.SetNamespace(params.GatewayNamespace)
+	case gvk == GVKNetworkPolicy && name == baseMaaSAPIDeploymentNSNetworkPolicyName:
+		return patchDeploymentNSNetworkPolicy(r, params.ControllerNamespace)
 	case gvk == GVKClusterRoleBinding && name == PayloadProcessingReaderClusterRoleBindingName:
 		return patchClusterRoleBindingSubjectNS(r, params.GatewayNamespace)
 	}
 	return nil
+}
+
+// patchDeploymentNSNetworkPolicy rewrites the namespaceSelector in the
+// deployment-ns NetworkPolicy to use the actual controller namespace.
+func patchDeploymentNSNetworkPolicy(r *unstructured.Unstructured, controllerNamespace string) error {
+	if controllerNamespace == "" {
+		return nil
+	}
+	ingress, found, err := unstructured.NestedSlice(r.Object, "spec", "ingress")
+	if err != nil || !found || len(ingress) == 0 {
+		return err
+	}
+	rule, ok := ingress[0].(map[string]any)
+	if !ok {
+		return nil
+	}
+	from, ok := rule["from"].([]any)
+	if !ok || len(from) == 0 {
+		return nil
+	}
+	peer, ok := from[0].(map[string]any)
+	if !ok {
+		return nil
+	}
+	nsSelector, ok := peer["namespaceSelector"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	nsSelector["matchLabels"] = map[string]any{
+		"kubernetes.io/metadata.name": controllerNamespace,
+	}
+	return unstructured.SetNestedSlice(r.Object, ingress, "spec", "ingress")
 }
 
 func patchMaaSAPIDeployment(log logr.Logger, r *unstructured.Unstructured, params PlatformParams) error {

--- a/maas-controller/pkg/platform/tenantreconcile/params_test.go
+++ b/maas-controller/pkg/platform/tenantreconcile/params_test.go
@@ -34,10 +34,11 @@ func TestBuildPlatformParams(t *testing.T) {
 			Namespace: "openshift-ingress",
 			Name:      "maas-default-gateway",
 		}}
-		got, err := BuildPlatformParams(tenant, platformContext, "opendatahub", "https://kubernetes.default.svc", logr.Discard())
+		got, err := BuildPlatformParams(tenant, platformContext, "opendatahub", "opendatahub", "https://kubernetes.default.svc", logr.Discard())
 		assert.NoError(t, err)
 
 		assert.Equal(t, "opendatahub", got.AppNamespace)
+		assert.Equal(t, "opendatahub", got.ControllerNamespace)
 		assert.Equal(t, "openshift-ingress", got.GatewayNamespace)
 		assert.Equal(t, "maas-default-gateway", got.GatewayName)
 		assert.Equal(t, "https://kubernetes.default.svc", got.ClusterAudience)
@@ -69,7 +70,7 @@ func TestBuildPlatformParams(t *testing.T) {
 			Namespace: "gateway-ns",
 			Name:      "gateway-name",
 		}}
-		got, err := BuildPlatformParams(tenant, platformContext, "tenant-ns", "cluster-audience", logr.Discard())
+		got, err := BuildPlatformParams(tenant, platformContext, "tenant-ns", "controller-ns", "cluster-audience", logr.Discard())
 		assert.NoError(t, err)
 
 		assert.Equal(t, "tenant-ns", got.AppNamespace)
@@ -87,6 +88,7 @@ func TestApplyPlatformParamsWithRenderedOverlay(t *testing.T) {
 	resources := renderOverlayResources(t, "tenant-ns")
 	params := PlatformParams{
 		AppNamespace:            "tenant-ns",
+		ControllerNamespace:     "controller-ns",
 		GatewayNamespace:        "gateway-ns",
 		GatewayName:             "custom-gateway",
 		ClusterAudience:         "openshift-custom",
@@ -241,6 +243,24 @@ func TestApplyPlatformParamsWithRenderedOverlay(t *testing.T) {
 	firstSubject, ok := subjects[0].(map[string]any)
 	require.True(t, ok)
 	assert.Equal(t, params.GatewayNamespace, firstSubject["namespace"])
+
+	deploymentNSPolicy := requireResource(t, resources, GVKNetworkPolicy, baseMaaSAPIDeploymentNSNetworkPolicyName)
+	ingress, found, err := unstructured.NestedSlice(deploymentNSPolicy.Object, "spec", "ingress")
+	require.NoError(t, err)
+	require.True(t, found)
+	require.NotEmpty(t, ingress)
+	rule, ok := ingress[0].(map[string]any)
+	require.True(t, ok)
+	from, ok := rule["from"].([]any)
+	require.True(t, ok)
+	require.NotEmpty(t, from)
+	peer, ok := from[0].(map[string]any)
+	require.True(t, ok)
+	nsSelector, ok := peer["namespaceSelector"].(map[string]any)
+	require.True(t, ok)
+	matchLabels, ok := nsSelector["matchLabels"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, params.ControllerNamespace, matchLabels["kubernetes.io/metadata.name"])
 }
 
 func renderOverlayResources(t *testing.T, appNamespace string) []unstructured.Unstructured {

--- a/maas-controller/pkg/platform/tenantreconcile/pipeline.go
+++ b/maas-controller/pkg/platform/tenantreconcile/pipeline.go
@@ -45,6 +45,7 @@ func RunPlatform(
 	platformContext PlatformContext,
 	manifestPath string,
 	appNs string,
+	controllerNs string,
 	clusterAudience string,
 	mcfg *maasv1alpha1.Config,
 ) (*RunResult, error) {
@@ -68,7 +69,7 @@ func RunPlatform(
 		return nil, fmt.Errorf("gateway lookup: %w", err)
 	}
 
-	params, err := BuildPlatformParams(tenant, platformContext, appNs, clusterAudience, log)
+	params, err := BuildPlatformParams(tenant, platformContext, appNs, controllerNs, clusterAudience, log)
 	if err != nil {
 		return nil, fmt.Errorf("build params: %w", err)
 	}
@@ -111,6 +112,7 @@ func Run(
 	tenant client.Object,
 	fallbackGatewayRef maasv1alpha1.TenantGatewayRef,
 	manifestPath string,
+	controllerNs string,
 	clusterAudience string,
 	mcfg *maasv1alpha1.Config,
 ) (*RunResult, error) {
@@ -137,7 +139,7 @@ func Run(
 		return nil, err
 	}
 
-	return RunPlatform(ctx, log, c, scheme, tenant, platformContext, manifestPath, appNs, clusterAudience, mcfg)
+	return RunPlatform(ctx, log, c, scheme, tenant, platformContext, manifestPath, appNs, controllerNs, clusterAudience, mcfg)
 }
 
 // MaasAPIDeploymentReady mirrors ODH deployments action for maas-api.

--- a/test/e2e/tests/test_helper.py
+++ b/test/e2e/tests/test_helper.py
@@ -91,9 +91,9 @@ def _resolve_maas_api_deployment_namespace() -> str:
 # Infrastructure namespace where maas-api workloads run.
 MAAS_API_DEPLOYMENT_NAMESPACE = _resolve_maas_api_deployment_namespace()
 GATEWAY_NAMESPACE = os.environ.get("GATEWAY_NAMESPACE", "openshift-ingress")
-# Ephemeral curl probes must run in a namespace allowed by maas-api NetworkPolicy
-# (openshift-ingress gateway namespace), not in the maas-api infra namespace.
-E2E_CURL_POD_NAMESPACE = os.environ.get("E2E_CURL_POD_NAMESPACE", GATEWAY_NAMESPACE)
+# Ephemeral curl probes run from the deployment namespace (where the UI runs),
+# matching the real traffic path for internal endpoints like /v1/tenants.
+E2E_CURL_POD_NAMESPACE = os.environ.get("E2E_CURL_POD_NAMESPACE", DEPLOYMENT_NAMESPACE)
 SIMULATOR_SUBSCRIPTION = os.environ.get("E2E_SIMULATOR_SUBSCRIPTION", "simulator-subscription")
 PREMIUM_MODEL_REF = os.environ.get("E2E_PREMIUM_MODEL_REF", "premium-simulated-simulated-premium")
 PREMIUM_SIMULATOR_SUBSCRIPTION = os.environ.get("E2E_PREMIUM_SIMULATOR_SUBSCRIPTION", "premium-simulator-subscription")


### PR DESCRIPTION
The UI runs in the deployment namespace (opendatahub / redhat-ods-applications) and needs to call /v1/tenants on maas-api in the infrastructure namespace. ODH's default NetworkPolicy blocks this cross-namespace ingress. Add an exception for the deployment namespace on port 8443, matching the existing pattern for gateway and authorino policies.

Also update E2E curl pod namespace default from GATEWAY_NAMESPACE to DEPLOYMENT_NAMESPACE to match the real traffic path.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a NetworkPolicy to allow the deployment namespace to securely reach MAAS API pods on TCP port 8443.
  * Enhanced tenant platform rendering so NetworkPolicy namespace selectors target the resolved controller namespace for tenant workloads.
* **Bug Fixes**
  * Updated end-to-end curl probe pods to run from the deployment namespace by default (instead of the gateway namespace) to better validate deployment-to-API connectivity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->