### PR TITLE
style: fix gci column alignment in celModelIdentity const

### DIFF
--- a/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
@@ -338,7 +338,7 @@ const (
 		celPathParts + `[0] != "v1" && ` +
 		celPathParts + `[0] != "maas-api"`
 	celModelIdentityAvailable = `(` + celPathModelIdentityAvailable + ` || "x-gateway-model-name" in request.headers)`
-	celModelIdentity = `(` + celPathModelIdentityAvailable +
+	celModelIdentity          = `(` + celPathModelIdentityAvailable +
 		` ? ` + celPathParts + `[0] + "/" + ` + celPathParts + `[1]` +
 		` : ("x-gateway-model-name" in request.headers` +
 		`   ? request.headers["x-gateway-model-name"]` +


### PR DESCRIPTION
## Summary

Fix `gci` formatter alignment error introduced in #1160, unblocking the main → stable promotion PR #1150.

## Description

- Restore `gofmt` column alignment for `celModelIdentity` in the CEL model identity `const` block in `maasauthpolicy_controller.go`.
- PR #1160 removed the padding spaces on the `=` sign, breaking alignment with the other constants (`celPathParts`, `celPathModelIdentityAvailable`, `celModelIdentityAvailable`).
- This caused `golangci-lint fmt` (`gci` formatter) to fail on the MaaS Controller lint check. The lint failure on #1160 was not a required status check, so Tide merged it despite the failure.

## Risk analysis

- **Risk rating**: 0
- **Why**: formatting-only change with zero runtime impact. No logic, types, or behavior modified.

## How it was tested

- Ran `golangci-lint fmt --diff` locally — produces no diff (clean exit).
- Ran `make -C maas-controller lint` — `fmt` step passes (the `run` step has an unrelated local Go version mismatch).

## Merge criteria

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body.
- [x] The developer has manually tested the changes and verified that the changes work.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reformatted an internal authorization policy expression without changing its behavior or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->