### PR TITLE
fix: return ExternalModel CR name as resolvedModelAlias and remove openshift-identities from gateway auth

### DIFF
--- a/maas-controller/go.mod
+++ b/maas-controller/go.mod
@@ -12,6 +12,7 @@ require (
 	k8s.io/apiextensions-apiserver v0.35.3
 	k8s.io/apimachinery v0.35.3
 	k8s.io/client-go v0.35.3
+	k8s.io/utils v0.0.0-20260319190234-28399d86e0b5
 	knative.dev/pkg v0.0.0-20260120122510-4a022ed9999a
 	sigs.k8s.io/controller-runtime v0.22.5
 	sigs.k8s.io/gateway-api v1.4.2-0.20260116062110-0d0ca872766e
@@ -133,7 +134,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260427204847-8949caaa1199 // indirect
-	k8s.io/utils v0.0.0-20260319190234-28399d86e0b5 // indirect
 	knative.dev/serving v0.48.1 // indirect
 	sigs.k8s.io/gateway-api-inference-extension v1.3.1 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect

--- a/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
@@ -656,18 +656,6 @@ func (r *MaaSAuthPolicyReconciler) buildGatewayAuthPolicySpec(modelAccessJSON st
 			"metrics":  false,
 			"priority": int64(0),
 		},
-		"openshift-identities": map[string]any{
-			"kubernetesTokenReview": map[string]any{
-				"audiences": []any{r.ClusterAudience},
-			},
-			"when": []any{
-				map[string]any{
-					"predicate": celIsNotAPIKey,
-				},
-			},
-			"metrics":  false,
-			"priority": int64(2),
-		},
 	}
 
 	if xAPIKeyEnabled {

--- a/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
@@ -656,6 +656,18 @@ func (r *MaaSAuthPolicyReconciler) buildGatewayAuthPolicySpec(modelAccessJSON st
 			"metrics":  false,
 			"priority": int64(0),
 		},
+		"openshift-identities": map[string]any{
+			"kubernetesTokenReview": map[string]any{
+				"audiences": []any{r.ClusterAudience},
+			},
+			"when": []any{
+				map[string]any{
+					"predicate": celIsNotAPIKey,
+				},
+			},
+			"metrics":  false,
+			"priority": int64(2),
+		},
 	}
 
 	if xAPIKeyEnabled {

--- a/maas-controller/pkg/controller/maas/maasauthpolicy_controller_test.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_controller_test.go
@@ -1384,8 +1384,8 @@ func TestBuildGatewayAuthPolicySpec_K8sAuth(t *testing.T) {
 	if _, exists := auth["api-keys"]; !exists {
 		t.Error("api-keys authentication should always be present")
 	}
-	if _, exists := auth["openshift-identities"]; exists {
-		t.Error("openshift-identities should NOT be present on gateway auth policy (only on maas-api-auth-policy)")
+	if _, exists := auth["openshift-identities"]; !exists {
+		t.Error("openshift-identities should always be present")
 	}
 	if _, exists := auth["oidc-identities"]; exists {
 		t.Error("oidc-identities should NOT be present when OIDC config is nil")
@@ -1527,8 +1527,13 @@ func TestBuildGatewayAuthPolicySpec_XAPIKeyEnabled(t *testing.T) {
 		t.Errorf("apiKeyValidation when predicate should include x-api-key check, got: %s", pred)
 	}
 
-	if _, exists := auth["openshift-identities"]; exists {
-		t.Error("openshift-identities should NOT be present on gateway auth policy when x-api-key is enabled")
+	osWhen, found, err := unstructured.NestedSlice(obj.Object, "spec", "defaults", "rules", "authentication", "openshift-identities", "when")
+	if err != nil || !found || len(osWhen) == 0 {
+		t.Fatalf("openshift-identities when missing")
+	}
+	osPred, _ := osWhen[0].(map[string]any)["predicate"].(string)
+	if !contains(osPred, "x-api-key") {
+		t.Errorf("openshift-identities when should exclude x-api-key requests, got: %s", osPred)
 	}
 }
 

--- a/maas-controller/pkg/controller/maas/maasauthpolicy_controller_test.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_controller_test.go
@@ -1384,8 +1384,8 @@ func TestBuildGatewayAuthPolicySpec_K8sAuth(t *testing.T) {
 	if _, exists := auth["api-keys"]; !exists {
 		t.Error("api-keys authentication should always be present")
 	}
-	if _, exists := auth["openshift-identities"]; !exists {
-		t.Error("openshift-identities should always be present")
+	if _, exists := auth["openshift-identities"]; exists {
+		t.Error("openshift-identities should NOT be present on gateway auth policy (only on maas-api-auth-policy)")
 	}
 	if _, exists := auth["oidc-identities"]; exists {
 		t.Error("oidc-identities should NOT be present when OIDC config is nil")
@@ -1527,13 +1527,8 @@ func TestBuildGatewayAuthPolicySpec_XAPIKeyEnabled(t *testing.T) {
 		t.Errorf("apiKeyValidation when predicate should include x-api-key check, got: %s", pred)
 	}
 
-	osWhen, found, err := unstructured.NestedSlice(obj.Object, "spec", "defaults", "rules", "authentication", "openshift-identities", "when")
-	if err != nil || !found || len(osWhen) == 0 {
-		t.Fatalf("openshift-identities when missing")
-	}
-	osPred, _ := osWhen[0].(map[string]any)["predicate"].(string)
-	if !contains(osPred, "x-api-key") {
-		t.Errorf("openshift-identities when should exclude x-api-key requests, got: %s", osPred)
+	if _, exists := auth["openshift-identities"]; exists {
+		t.Error("openshift-identities should NOT be present on gateway auth policy when x-api-key is enabled")
 	}
 }
 
@@ -2092,21 +2087,20 @@ func TestMaaSAuthPolicyReconciler_PublisherIDModelAccess(t *testing.T) {
 	})
 }
 
-// TestMaaSAuthPolicyReconciler_TargetModelAccess_ExternalModel verifies that the gateway
-// AuthPolicy's model_access map contains a targetModel-keyed entry for ExternalModel-backed
-// models, allowing BBR requests with the upstream model name to pass auth.
-func TestMaaSAuthPolicyReconciler_TargetModelAccess_ExternalModel(t *testing.T) {
+// TestMaaSAuthPolicyReconciler_ExternalModelAccess verifies that the gateway
+// AuthPolicy's model_access map contains an ExternalModel CR name-keyed entry,
+// allowing BBR requests with the model name from /v1/models to pass auth.
+func TestMaaSAuthPolicyReconciler_ExternalModelAccess(t *testing.T) {
 	const (
 		modelRefName   = "my-gpt4o"
 		emName         = "my-gpt4o"
-		targetModel    = "gpt-4o"
 		namespace      = "default"
 		gatewayNS      = "gateway-ns"
 		maasPolicyName = "policy-ext"
 	)
 
 	modelRef := newMaaSModelRef(modelRefName, namespace, "ExternalModel", emName)
-	modelRef.Status.ResolvedModelAlias = targetModel
+	modelRef.Status.ResolvedModelAlias = emName
 	route := newHTTPRoute(modelRefName, namespace)
 	maasPolicy := newMaaSAuthPolicy(maasPolicyName, namespace, "team-a",
 		maasv1alpha1.ModelRef{Name: modelRefName, Namespace: namespace},
@@ -2153,9 +2147,9 @@ func TestMaaSAuthPolicyReconciler_TargetModelAccess_ExternalModel(t *testing.T) 
 		}
 	})
 
-	t.Run("model_access contains targetModel key for ExternalModel", func(t *testing.T) {
-		if !strings.Contains(rego, `"`+targetModel+`"`) {
-			t.Errorf("model_access should contain targetModel key %q, rego:\n%s", targetModel, rego)
+	t.Run("model_access contains ExternalModel CR name key", func(t *testing.T) {
+		if !strings.Contains(rego, `"`+emName+`"`) {
+			t.Errorf("model_access should contain ExternalModel CR name key %q, rego:\n%s", emName, rego)
 		}
 	})
 

--- a/maas-controller/pkg/controller/maas/providers_external.go
+++ b/maas-controller/pkg/controller/maas/providers_external.go
@@ -266,28 +266,11 @@ func (h *externalModelHandler) GetModelEndpoint(ctx context.Context, log logr.Lo
 	return "", fmt.Errorf("unable to determine endpoint: gateway %s/%s has no hostname or addresses", gatewayNS, gatewayName)
 }
 
-// ResolveModelAlias returns the targetModel from the first externalProviderRef, which is the
-// value the client sends in the body model field for BBR requests.
-// Note: assumes at most one ExternalModel per targetModel value per tenant. If multiple
-// ExternalModels share the same targetModel, the subscription reverse-lookup returns the
-// first match non-deterministically.
+// ResolveModelAlias returns the ExternalModel CR name, which is the model identity
+// clients send in the body for BBR requests. This matches what /v1/models returns
+// (spec.modelRef.name for ExternalModel-backed MaaSModelRefs).
 func (h *externalModelHandler) ResolveModelAlias(ctx context.Context, log logr.Logger, model *maasv1alpha1.MaaSModelRef) string {
-	em := &unstructured.Unstructured{}
-	em.SetGroupVersionKind(inferenceExternalModelGVK)
-	key := client.ObjectKey{Name: model.Spec.ModelRef.Name, Namespace: model.Namespace}
-	if err := h.r.Get(ctx, key, em); err != nil {
-		return ""
-	}
-	refs, found, _ := unstructured.NestedSlice(em.Object, "spec", "externalProviderRefs")
-	if !found || len(refs) == 0 {
-		return ""
-	}
-	ref0, ok := refs[0].(map[string]any)
-	if !ok {
-		return ""
-	}
-	targetModel, _ := ref0["targetModel"].(string)
-	return targetModel
+	return model.Spec.ModelRef.Name
 }
 
 // CleanupOnDelete is called when the MaaSModelRef is deleted.


### PR DESCRIPTION
## Summary
- Change `ResolveModelAlias` for ExternalModel to return the CR name (`spec.modelRef.name`) instead of `targetModel`, matching what `/v1/models` returns to clients (PR #919)
- Remove `openshift-identities` authenticator from the gateway AuthPolicy so OpenShift tokens are rejected on inference routes — they remain accepted on `/v1/models` and `/v1/subscriptions` via the separate `maas-api-auth-policy`

## Context
ExternalModel BBR requests returned 403 `model_not_in_subscription` because `resolvedModelAlias` was set to `targetModel` (e.g. `facebook/opt-125m`) while clients send the CR name (e.g. `opt-external`) from `/v1/models`.

Additionally, OpenShift tokens were incorrectly accepted on inference routes because `openshift-identities` was included in the gateway auth policy. Only API keys and OIDC tokens should authenticate inference requests; OpenShift tokens are for management endpoints only.
https://redhat.atlassian.net/browse/RHOAIENG-78217
Dependent PR: https://github.com/opendatahub-io/ai-gateway-payload-processing/pull/401 

## Risk analysis
- **Risk rating**: 4
- **Why**: Changes auth policy structure on the gateway — removes an authenticator. If any workflow relies on OpenShift tokens for inference (not just management endpoints), it will break. Tested end-to-end on a live cluster confirming API keys still work for inference and OC tokens work for `/v1/models` + `/v1/subscriptions`. Not covered by default Prow smoke path.

## Test plan
- [x] `make -C maas-controller lint` — 0 issues
- [x] `make -C maas-controller test` — all unit tests pass
- [x] ExternalModel path-based: API key → 200
- [x] ExternalModel BBR: API key → 200
- [x] ExternalModel BBR: OC token → 401
- [x] `/v1/models`: OC token → 200
- [x] `/v1/subscriptions`: OC token → 200

## Test evidence

### ExternalModel path-based with API key — 200
```bash
$ curl -sk "https://maas.apps.isequeir-test-1.eh5f.s1.devshift.org/llm/opt-external/v1/chat/completions" \
  -H "Authorization: Bearer sk-oai-lgK1..." \
  -H "Content-Type: application/json" \
  -d '{"model":"opt-external","messages":[{"role":"user","content":"hello"}]}'

{"id":"chatcmpl-8fbb0ed5-c52c-53b7-92a9-ac18f0cfde20","created":1784003511,
 "model":"facebook/opt-125m",
 "usage":{"prompt_tokens":6,"completion_tokens":53,"total_tokens":59},
 "object":"chat.completion",
 "choices":[{"index":0,"finish_reason":"stop",
   "message":{"role":"assistant","content":"I am your AI assistant, how can I help you today? ..."}}]}
HTTP_CODE: 200
```

### ExternalModel BBR with API key — 200
```bash
$ curl -sk "https://maas.apps.isequeir-test-1.eh5f.s1.devshift.org/v1/chat/completions" \
  -H "Authorization: Bearer sk-oai-lgK1..." \
  -H "Content-Type: application/json" \
  -d '{"model":"opt-external","messages":[{"role":"user","content":"hello"}]}'

{"id":"chatcmpl-0de8648d-0051-5577-80dc-51300f6bd800","created":1784003512,
 "model":"facebook/opt-125m",
 "usage":{"prompt_tokens":6,"completion_tokens":11,"total_tokens":17},
 "object":"chat.completion",
 "choices":[{"index":0,"finish_reason":"stop",
   "message":{"role":"assistant","content":"Give a man a fish and you feed him for a "}}]}
HTTP_CODE: 200
```

### ExternalModel path-based with OC token — 401 (correctly rejected)
```bash
$ curl -sk "https://maas.apps.isequeir-test-1.eh5f.s1.devshift.org/llm/opt-external/v1/chat/completions" \
  -H "Authorization: Bearer sha256~..." \
  -H "Content-Type: application/json" \
  -d '{"model":"opt-external","messages":[{"role":"user","content":"hello"}]}'

HTTP_CODE: 401
```

### ExternalModel BBR with OC token — 401 (correctly rejected)
```bash
$ curl -sk "https://maas.apps.isequeir-test-1.eh5f.s1.devshift.org/v1/chat/completions" \
  -H "Authorization: Bearer sha256~..." \
  -H "Content-Type: application/json" \
  -d '{"model":"opt-external","messages":[{"role":"user","content":"hello"}]}'

HTTP_CODE: 401
```

### /v1/subscriptions with OC token — 200
```bash
$ curl -sk "https://maas.apps.isequeir-test-1.eh5f.s1.devshift.org/v1/subscriptions" \
  -H "Authorization: Bearer sha256~..."

[{"subscription_id_header":"simulator-subscription",
  "subscription_description":"Free-tier subscription with 100 tokens/min rate limit",
  "display_name":"Simulator Subscription (Free)","priority":10,
  "model_refs":[
    {"name":"facebook-opt-125m-simulated","display_name":"Facebook OPT 125M (Simulated)",
     "description":"A simulated OPT-125M model for free-tier testing","source":"internal",
     "token_rate_limits":[{"limit":100,"window":"1m"}]},
    {"name":"opt-external","source":"external",
     "token_rate_limits":[{"limit":100,"window":"1m"}]}]}]
HTTP_CODE: 200
```

### /v1/models with OC token — 200
```bash
$ curl -sk "https://maas.apps.isequeir-test-1.eh5f.s1.devshift.org/v1/models" \
  -H "Authorization: Bearer sha256~..."

{"data":[{"id":"opt-external","created":1783962960,"object":"model",
  "owned_by":"llm/opt-external","kind":"ExternalModel",
  "url":"https://maas.apps.isequeir-test-1.eh5f.s1.devshift.org/llm/opt-external",
  "ready":true,
  "subscriptions":[{"name":"simulator-subscription",
    "displayName":"Simulator Subscription (Free)",
    "description":"Free-tier subscription with 100 tokens/min rate limit"}]}],
 "object":"list"}
HTTP_CODE: 200
```


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - External model access is now resolved consistently using the configured external model name.
  - Improved reliability when external model references are missing or unavailable.
  - External model authorization checks now correctly recognize model-specific access entries.

- **Tests**
  - Updated coverage to validate external model access using the configured model name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->