### PR TITLE
docs: fix multi-tenancy documentation inaccuracies

### DIFF
--- a/docs/content/concepts/multi-tenancy.md
+++ b/docs/content/concepts/multi-tenancy.md
@@ -1,0 +1,64 @@
+# Multi-Tenancy
+
+!!! warning "Tech Preview"
+    Multi-tenancy support is in Tech Preview. API and CR schemas may change in future releases.
+
+MaaS supports multiple isolated tenants within a single cluster. Each tenant operates independently with dedicated API infrastructure, separate namespaces, and no shared state beyond the PostgreSQL database.
+
+## Tenant Model
+
+Multi-tenancy separates **platform context** from **MaaS runtime configuration** to allow independent lifecycle management:
+
+**AITenant** (platform context):
+- Lives in `ai-tenants` namespace (cluster tenant registry)
+- Defines Gateway, OIDC, tenant namespace lifecycle
+- Owned by platform administrators
+- Bootstraps the tenant environment
+
+**MaasTenantConfig** (runtime configuration):
+- Lives in tenant namespace as singleton `default-tenant`
+- Defines API key policies, telemetry settings
+- Owned by tenant administrators
+- Configures MaaS-specific operational behavior
+
+When you create an AITenant, the controller provisions the tenant namespace and creates the MaasTenantConfig automatically. When you delete an AITenant, the namespace and all tenant resources are cleaned up.
+
+## Isolation Model
+
+**Namespace isolation:**
+- Each tenant has a dedicated namespace (`ai-tenant-{name}`)
+- MaaS CRs (MaaSModelRef, MaaSAuthPolicy, MaaSSubscription) are namespace-scoped
+- No cross-tenant resource visibility
+
+**API isolation:**
+- Each tenant has a separate maas-api Deployment
+- Dedicated Gateway per tenant (Gateways cannot be shared)
+- API keys and subscriptions are tenant-scoped
+
+**Database isolation:**
+- Shared PostgreSQL database with schema-level isolation via `tenant_id` column
+- No cross-tenant API key or subscription access
+
+**Access control:**
+- Kubernetes RBAC enforces tenant namespace boundaries
+- Tenant-admin and object-admin roles grant scoped permissions
+- See [Tenant RBAC](../configuration-and-management/tenant-rbac.md)
+
+## Default Tenant
+
+Existing single-tenant deployments automatically become the **default tenant** on upgrade. The controller bootstraps `AITenant/models-as-a-service` on startup, migrates legacy `Tenant/default-tenant` to `MaasTenantConfig/default-tenant`, and preserves all existing API keys, subscriptions, and models. No user action required.
+
+## Creating Additional Tenants
+
+Each additional tenant requires a dedicated Gateway. Create the Gateway first, then reference it in the AITenant CR. The controller provisions the tenant namespace, deploys an isolated maas-api instance, and configures access control.
+
+See [Multi-Tenant Setup](../install/multi-tenant-setup.md) for procedures.
+
+## Related Documentation
+
+- [Multi-Tenant Setup](../install/multi-tenant-setup.md) - Creating and configuring tenants
+- [Multi-Tenant Validation](../install/multi-tenant-validation.md) - Verification procedures
+- [Tenant RBAC](../configuration-and-management/tenant-rbac.md) - Access control
+- [AITenant CRD](../reference/crds/ai-tenant.md) - Platform context reference
+- [MaasTenantConfig CRD](../reference/crds/tenant.md) - Runtime configuration reference
+- [Controller Architecture](../architecture-internals/controller-architecture.md) - Namespace architecture details

--- a/docs/content/configuration-and-management/infra-namespace-migration.md
+++ b/docs/content/configuration-and-management/infra-namespace-migration.md
@@ -29,12 +29,12 @@ This provides better security isolation and simpler upgrades.
 - CRDs and RBAC
 - Webhook
 
-## Disabling Namespace Separation (ROSA Only)
+## Disabling Namespace Separation
 
-!!! warning "ROSA Clusters Only"
-    **ODH on ROSA does not support namespace separation** due to OpenShift webhook restrictions that block namespace creation.
+!!! warning "Clusters with Namespace Creation Restrictions"
+    Some clusters (including ROSA) have webhook restrictions that block namespace creation.
     
-    On ROSA clusters, you **must disable** namespace separation by setting `INFRA_NAMESPACE=""` (empty string).
+    On such clusters, you **must disable** namespace separation by setting `INFRA_NAMESPACE=""` (empty string).
 
 ### Disable via Script
 

--- a/docs/content/install/multi-tenant-setup.md
+++ b/docs/content/install/multi-tenant-setup.md
@@ -125,7 +125,7 @@ The controller bootstraps the following resources:
 | Resource | Location | Name |
 |----------|----------|------|
 | Namespace | Cluster | `ai-tenant-${TENANT_NAME}` |
-| Tenant CR | `ai-tenant-${TENANT_NAME}` | `default-tenant` |
+| MaasTenantConfig CR | `ai-tenant-${TENANT_NAME}` | `default-tenant` |
 | maas-api Deployment | Infrastructure namespace | `maas-api-${TENANT_NAME}` |
 | AuthPolicy | Gateway namespace | `${TENANT_NAME}-maas-auth` |
 | tenant-admin Role | `ai-tenant-${TENANT_NAME}` | `aitenant-${TENANT_NAME}-tenant-admin` |
@@ -269,10 +269,11 @@ When `--enable-tenant-namespace-discovery=true` is set, the controller watches f
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--aitenant-namespace` | `ai-tenants` | Infrastructure namespace for AITenant CRs |
+| `--aitenant-namespace` | `ai-tenants` | Namespace for AITenant CRs |
 | `--enable-tenant-namespace-discovery` | `false` | Watch namespaces for tenant label changes |
 | `--gateway-namespace` | `openshift-ingress` | Namespace where Gateways are deployed |
 | `--gateway-name` | `maas-default-gateway` | Default Gateway name for the default tenant |
+| `--infra-namespace` | `AUTO` | Infrastructure namespace for maas-api and maas-db-config. See [Infrastructure Namespace Migration](../configuration-and-management/infra-namespace-migration.md) |
 
 ## Delete a Tenant
 

--- a/docs/content/reference/crds/ai-tenant.md
+++ b/docs/content/reference/crds/ai-tenant.md
@@ -28,7 +28,7 @@ The controller automatically creates `AITenant/models-as-a-service` for the defa
 
 For non-default tenants, the controller derives the tenant namespace from the `AITenant` name as `ai-tenant-<aitenant-name>`. `AITenant` names are limited to 41 characters so per-tenant platform resources stay within Kubernetes 63-character name limits. The default `AITenant/models-as-a-service` keeps the configured MaaS tenant namespace, usually `models-as-a-service`, for migration compatibility.
 
-Deleting an `AITenant` performs a hard cleanup of the tenant's MaaS state. The controller revokes active API keys through the tenant maas-api instance, deletes the bridge `Tenant/default-tenant`, deletes tenant-scoped MaaS resources such as `MaaSSubscription` and `MaaSAuthPolicy`, removes per-tenant maas-api platform resources, and deletes the tenant namespace. The shared Gateway object is never deleted or modified by `AITenant` reconciliation; tenant-scoped gateway and claim resources are cleaned up during deletion.
+Deleting an `AITenant` performs a hard cleanup of the tenant's MaaS state. The controller revokes active API keys through the tenant maas-api instance, deletes the bridge `MaasTenantConfig/default-tenant`, deletes tenant-scoped MaaS resources such as `MaaSSubscription` and `MaaSAuthPolicy`, removes per-tenant maas-api platform resources, and deletes the tenant namespace. The shared Gateway object is never deleted or modified by `AITenant` reconciliation; tenant-scoped gateway and claim resources are cleaned up during deletion.
 
 If namespace deletion is blocked by remaining content or finalizers, the `AITenant` stays in `Terminating` phase with `Ready=False` and reason `DeletionBlocked` until the namespace can finish deleting.
 

--- a/docs/content/reference/crds/tenant.md
+++ b/docs/content/reference/crds/tenant.md
@@ -8,17 +8,17 @@ Platform context such as Gateway and external OIDC belongs to [`AITenant`](ai-te
 
 In multi-tenant deployments, each tenant has one `MaasTenantConfig` in its tenant namespace:
 
-| Tenant Type | Config Namespace | Config Name | maas-api Service (in operator namespace) | Created By |
-|-------------|------------------|-------------|------------------------------------------|------------|
-| Default | `models-as-a-service` | `default-tenant` | `maas-api` | Default AITenant bootstrap |
-| Additional | `ai-tenant-{tenantID}` | `default-tenant` | `maas-api-{tenantID}` | AITenant reconciler |
+| Tenant Type | Config Namespace | Config Name | maas-api Deployment | Created By |
+|-------------|------------------|-------------|---------------------|------------|
+| Default | `models-as-a-service` | `default-tenant` | `maas-api` (infra namespace) | Default AITenant bootstrap |
+| Additional | `ai-tenant-{tenantID}` | `default-tenant` | `maas-api-{tenantID}` (infra namespace) | AITenant reconciler |
 
 Key points:
 
 - All `MaasTenantConfig` resources are named `default-tenant` within their namespace.
 - The default `MaasTenantConfig/default-tenant` is created or adopted by `AITenant/models-as-a-service`.
 - Additional tenant configs are created by the AITenant reconciler, which provisions the tenant namespace and config object.
-- All maas-api Services deploy to the operator namespace (opendatahub for ODH, redhat-ods-applications for RHOAI), not to tenant namespaces.
+- maas-api Deployments are created in the infrastructure namespace (AUTO-derived by default: `odh-ai-gateway-infra` for ODH or `redhat-ai-gateway-infra` for RHOAI). See [Infrastructure Namespace Migration](../../configuration-and-management/infra-namespace-migration.md) for details.
 - Each tenant has an isolated maas-api instance for API key and subscription management.
 - `MaasTenantConfig` resources for additional tenants have the finalizer `maas.opendatahub.io/tenant-cleanup`.
 - For AITenant-managed tenants, Gateway comes from `AITenant.status.gatewayRef`; OIDC comes from `AITenant.spec.oidc`.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -60,6 +60,7 @@ nav:
       - Upgrade to 3.5: migration/upgrade-to-3.5.md
   - Concepts:
     - Architecture: concepts/architecture.md
+    - Multi-Tenancy: concepts/multi-tenancy.md
     - Personas: concepts/personas.md
     - Access and Quota Overview: concepts/subscription-overview.md
     - Model Reference: concepts/model-reference.md
@@ -122,7 +123,7 @@ nav:
       - MaaSAuthPolicy: reference/crds/maas-auth-policy.md
       - MaaSSubscription: reference/crds/maas-subscription.md
       - AITenant: reference/crds/ai-tenant.md
-      - MaasTenantConfig: reference/crds/tenant.md
+      - MaasTenantConfig: reference/crds/tenant.md  # Legacy filename, documents MaasTenantConfig CRD
 
 extra:
   version:


### PR DESCRIPTION
- Update infrastructure namespace references to use correct names (odh-ai-gateway-infra / redhat-ai-gateway-infra)
- Fix CR terminology: use MaasTenantConfig instead of Tenant
- Clarify ROSA warning applies to all clusters with namespace creation restrictions
- Add --infra-namespace flag documentation with default value
- Add multi-tenancy concepts guide under Concepts section
- Add mkdocs.yml comment explaining legacy tenant.md filename
- Fix relative path to infra-namespace-migration.md

update for https://redhat.atlassian.net/browse/RHOAIENG-62768 

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
