### PR TITLE
fix: reduce bootstrap polling interval to unblock nightly CI (RHOAIENG-76548)

### DIFF
--- a/maas-controller/cmd/manager/main.go
+++ b/maas-controller/cmd/manager/main.go
@@ -554,13 +554,13 @@ func markDefaultAITenantBootstrapped(ctx context.Context, c client.Client, ct *m
 // owner references; LifecycleReconciler links Config to the default AITenant,
 // Deployment, and default Tenant. It does not create while the maas-controller
 // Deployment is terminating, so bootstrap does not fight teardown.
+//
+// Uses an informer watch on Config CRs so bootstrap triggers immediately when
+// Config/default is created, instead of polling on a fixed interval.
 func ensureClusterBootstrapRunnable(mgr ctrl.Manager, tenantNamespace, aitenantNamespace, controllerDeploymentNS, controllerDeploymentName, gatewayName, gatewayNamespace string) manager.RunnableFunc {
 	return func(ctx context.Context) error {
 		log := ctrl.Log.WithName("setup").WithName("ensureClusterBootstrap")
 		c := mgr.GetClient()
-
-		ticker := time.NewTicker(5 * time.Second)
-		defer ticker.Stop()
 
 		ensure := func() {
 			created, err := ensureDefaultAITenantBootstrap(ctx, c, tenantNamespace, aitenantNamespace, controllerDeploymentNS, controllerDeploymentName, gatewayName, gatewayNamespace)
@@ -578,17 +578,85 @@ func ensureClusterBootstrapRunnable(mgr ctrl.Manager, tenantNamespace, aitenantN
 			}
 		}
 
+		// Try immediately in case Config/default already exists.
 		ensure()
+
+		// Watch Config CRs via the manager's informer cache. When
+		// Config/default is created or updated, the handler sends on the
+		// channel and the bootstrap runs without delay.
+		trigger := make(chan struct{}, 1)
+		informer, err := mgr.GetCache().GetInformer(ctx, &maasv1alpha1.Config{})
+		if err != nil {
+			log.Error(err, "failed to get Config informer, falling back to polling")
+			return runBootstrapPollLoop(ctx, ensure)
+		}
+
+		handler := configEventHandler{name: maasv1alpha1.ConfigInstanceName, ch: trigger}
+		reg, err := informer.AddEventHandler(handler)
+		if err != nil {
+			log.Error(err, "failed to add Config event handler, falling back to polling")
+			return runBootstrapPollLoop(ctx, ensure)
+		}
+		defer informer.RemoveEventHandler(reg) //nolint:errcheck
+
+		// Keep a slow fallback ticker as a safety net (e.g. if the
+		// informer misses an event after a re-list).
+		fallback := time.NewTicker(60 * time.Second)
+		defer fallback.Stop()
+
 		for {
 			select {
 			case <-ctx.Done():
 				return nil
-			case <-ticker.C:
+			case <-trigger:
+				ensure()
+			case <-fallback.C:
 				ensure()
 			}
 		}
 	}
 }
+
+// runBootstrapPollLoop is the fallback when the Config informer is unavailable
+// (e.g. CRD not yet registered). Polls every 5 seconds.
+func runBootstrapPollLoop(ctx context.Context, ensure func()) error {
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			ensure()
+		}
+	}
+}
+
+// configEventHandler sends on ch when a Config CR with the given name is created or updated.
+type configEventHandler struct {
+	name string
+	ch   chan<- struct{}
+}
+
+func (h configEventHandler) OnAdd(obj interface{}, _ bool) {
+	if m, ok := obj.(metav1.ObjectMetaAccessor); ok && m.GetObjectMeta().GetName() == h.name {
+		select {
+		case h.ch <- struct{}{}:
+		default:
+		}
+	}
+}
+
+func (h configEventHandler) OnUpdate(_, newObj interface{}) {
+	if m, ok := newObj.(metav1.ObjectMetaAccessor); ok && m.GetObjectMeta().GetName() == h.name {
+		select {
+		case h.ch <- struct{}{}:
+		default:
+		}
+	}
+}
+
+func (h configEventHandler) OnDelete(_ interface{}) {}
 
 // resolveInfraNamespace determines the infrastructure namespace for maas-api and maas-db-config.
 // Note: PostgreSQL itself can be external (e.g., AWS RDS) - only maas-api and the connection secret deploy here.

--- a/maas-controller/cmd/manager/main.go
+++ b/maas-controller/cmd/manager/main.go
@@ -559,7 +559,7 @@ func ensureClusterBootstrapRunnable(mgr ctrl.Manager, tenantNamespace, aitenantN
 		log := ctrl.Log.WithName("setup").WithName("ensureClusterBootstrap")
 		c := mgr.GetClient()
 
-		ticker := time.NewTicker(30 * time.Second)
+		ticker := time.NewTicker(5 * time.Second)
 		defer ticker.Stop()
 
 		ensure := func() {


### PR DESCRIPTION
## Summary

Reduce `ensureClusterBootstrapRunnable` polling interval from 30s to 5s to prevent DSC health check timeout after nightly cleanup deletes MaaS CRDs.

**Problem:** The nightly cleanup script deletes MaaS CRDs (not just CR instances). After operator reinstall, the bootstrap chain must complete:

1. Operator re-registers `configs.maas.opendatahub.io` CRD
2. `LifecycleReconciler` creates `Config/default` (waits for CRD to be established)
3. `ensureClusterBootstrapRunnable` polls for `Config/default` → creates AITenant
4. AITenant reconciler creates MaasTenantConfig
5. Operator health check looks for Tenant CR ready

Step 3 polls every **30 seconds**, which combined with CRD re-registration and informer sync, easily exceeds the 120s DSC health check timeout. Result: `ModelsAsServiceReady: False` with message "Tenant CR not available yet" → build fails before any tests run.

**Fix:** Reduce polling to 5s. The bootstrap function is cheap (two cached API GETs) and stops running once the AITenant exists.

**Longer-term:** The nightly cleanup should delete CR instances, not CRDs — that avoids the full bootstrap chain entirely.

## Test plan

- [x] `go build ./cmd/manager/` succeeds
- [ ] Nightly CI passes with this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cluster bootstrap reliability by triggering an immediate bootstrap attempt and then reacting faster when the default configuration is created or updated.
  * Reduced the time clusters may wait before bootstrap runs, with a resilient fallback that retries periodically if event-based monitoring isn’t available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->