### PR TITLE
feat: move EnvoyFilter lifecycle to AITenantReconciler for per-tenant gateway support

### DIFF
--- a/maas-controller/cmd/manager/main.go
+++ b/maas-controller/cmd/manager/main.go
@@ -834,14 +834,15 @@ func main() {
 		os.Exit(1)
 	}
 	if err := (&maas.AITenantReconciler{
-		Client:            mgr.GetClient(),
-		Scheme:            mgr.GetScheme(),
-		APIReader:         mgr.GetAPIReader(),
-		AppNamespace:      infraNamespace,
-		TenantNamespace:   maasSubscriptionNamespace,
-		AITenantNamespace: aitenantNamespace,
-		GatewayName:       gatewayName,
-		GatewayNamespace:  gatewayNamespace,
+		Client:              mgr.GetClient(),
+		Scheme:              mgr.GetScheme(),
+		APIReader:           mgr.GetAPIReader(),
+		AppNamespace:        infraNamespace,
+		TenantNamespace:     maasSubscriptionNamespace,
+		AITenantNamespace:   aitenantNamespace,
+		GatewayName:         gatewayName,
+		GatewayNamespace:    gatewayNamespace,
+		MonitoringNamespace: monitoringNamespace,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "AITenant")
 		os.Exit(1)

--- a/maas-controller/pkg/controller/maas/aitenant_controller.go
+++ b/maas-controller/pkg/controller/maas/aitenant_controller.go
@@ -232,8 +232,8 @@ func (r *AITenantReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-// mapConfigToAITenants enqueues every AITenant for reconciliation so each
-// can re-evaluate its EnvoyFilter against the updated Config spec.
+// mapConfigToAITenants enqueues every AITenant when the Config CR changes.
+// Each AITenant reconcile fetches the Config directly to re-evaluate its EnvoyFilter.
 func (r *AITenantReconciler) mapConfigToAITenants(ctx context.Context, _ client.Object) []reconcile.Request {
 	var aitenants maasv1alpha1.AITenantList
 	if err := r.List(ctx, &aitenants); err != nil {
@@ -549,51 +549,16 @@ func (r *AITenantReconciler) ensureAITenantObjectRole(ctx context.Context, aiten
 }
 
 // ensureUsageLogsEnvoyFilter creates or deletes the per-tenant usage-logs EnvoyFilter
-// based on the cluster-wide usageLogging flag from the Config CR. Each tenant gets its
-// own EnvoyFilter targeting its specific gateway via targetRefs.
+// based on the cluster-wide usageLogging flag from the Config CR. Follows the
+// load-then-delete-or-patch pattern: the manifest is always loaded first, then
+// either deleted or applied based on the feature gate.
+//
+// Cross-namespace OwnerReference is not possible (AITenant lives in ai-tenants,
+// EnvoyFilter in the gateway namespace), so cleanup relies on explicit deletion
+// in deleteAITenantScopedChildren and the usageLogging toggle.
 func (r *AITenantReconciler) ensureUsageLogsEnvoyFilter(ctx context.Context, aitenant *maasv1alpha1.AITenant) error {
 	log := ctrl.LoggerFrom(ctx).WithName("usage-logs-envoyfilter")
 
-	var cfg maasv1alpha1.Config
-	if err := r.Get(ctx, client.ObjectKey{Name: maasv1alpha1.ConfigInstanceName}, &cfg); err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil
-		}
-		return err
-	}
-
-	if !ptr.Deref(cfg.Spec.UsageLogging, false) {
-		return r.deleteUsageLogsEnvoyFilter(ctx, aitenant)
-	}
-
-	if aitenant.Status.GatewayRef.Name == "" {
-		log.V(1).Info("skipping EnvoyFilter — gateway ref not yet populated, will retry on next reconcile")
-		return nil
-	}
-
-	return r.applyUsageLogsEnvoyFilter(ctx, log, aitenant)
-}
-
-func (r *AITenantReconciler) deleteUsageLogsEnvoyFilter(ctx context.Context, aitenant *maasv1alpha1.AITenant) error {
-	log := ctrl.LoggerFrom(ctx).WithName("usage-logs-envoyfilter")
-	efName := tenantreconcile.UsageLogsEnvoyFilterName(aitenant.Name)
-
-	ef := &unstructured.Unstructured{}
-	ef.SetGroupVersionKind(tenantreconcile.GVKEnvoyFilter)
-	ef.SetName(efName)
-	ef.SetNamespace(r.GatewayNamespace)
-
-	if err := r.Delete(ctx, ef); err != nil {
-		if apierrors.IsNotFound(err) || apimeta.IsNoMatchError(err) {
-			return nil
-		}
-		return fmt.Errorf("failed to delete usage-logs EnvoyFilter %s: %w", efName, err)
-	}
-	log.Info("deleted per-tenant usage-logs EnvoyFilter", "name", efName)
-	return nil
-}
-
-func (r *AITenantReconciler) applyUsageLogsEnvoyFilter(ctx context.Context, log logr.Logger, aitenant *maasv1alpha1.AITenant) error {
 	manifestPath := r.EnvoyFilterManifestPath
 	if manifestPath == "" {
 		manifestPath = envoyFilterManifestPath
@@ -609,22 +574,36 @@ func (r *AITenantReconciler) applyUsageLogsEnvoyFilter(ctx context.Context, log 
 
 	ef := &unstructured.Unstructured{}
 	dec := yamlserializer.NewDecodingSerializer(unstructured.UnstructuredJSONScheme)
-	_, _, err = dec.Decode(raw, nil, ef)
-	if err != nil {
+	if _, _, err := dec.Decode(raw, nil, ef); err != nil {
 		return fmt.Errorf("decode EnvoyFilter manifest: %w", err)
-	}
-
-	collectorAddress := fmt.Sprintf("usage-logs-collector.%s.svc.cluster.local", r.MonitoringNamespace)
-	if err := patchClusterAddress(ef, collectorAddress); err != nil {
-		return fmt.Errorf("patch collector address in EnvoyFilter: %w", err)
 	}
 
 	efName := tenantreconcile.UsageLogsEnvoyFilterName(aitenant.Name)
 	ef.SetName(efName)
 	ef.SetNamespace(r.GatewayNamespace)
 
-	gatewayName := aitenant.Status.GatewayRef.Name
-	if err := patchEnvoyFilterTargetGateway(ef, gatewayName); err != nil {
+	var cfg maasv1alpha1.Config
+	if err := r.Get(ctx, client.ObjectKey{Name: maasv1alpha1.ConfigInstanceName}, &cfg); err != nil {
+		if apierrors.IsNotFound(err) {
+			return r.deleteEnvoyFilterIfExists(ctx, log, ef)
+		}
+		return err
+	}
+
+	if !ptr.Deref(cfg.Spec.UsageLogging, false) {
+		return r.deleteEnvoyFilterIfExists(ctx, log, ef)
+	}
+
+	if aitenant.Status.GatewayRef.Name == "" {
+		log.V(1).Info("skipping EnvoyFilter — gateway ref not yet populated, will retry on next reconcile")
+		return nil
+	}
+
+	collectorAddress := fmt.Sprintf("usage-logs-collector.%s.svc.cluster.local", r.MonitoringNamespace)
+	if err := patchClusterAddress(ef, collectorAddress); err != nil {
+		return fmt.Errorf("patch collector address in EnvoyFilter: %w", err)
+	}
+	if err := patchEnvoyFilterTargetGateway(ef, aitenant.Status.GatewayRef.Name); err != nil {
 		return fmt.Errorf("patch gateway targetRef in EnvoyFilter: %w", err)
 	}
 
@@ -646,8 +625,20 @@ func (r *AITenantReconciler) applyUsageLogsEnvoyFilter(ctx context.Context, log 
 
 	log.V(1).Info("applied per-tenant usage-logs EnvoyFilter",
 		"name", efName,
-		"gateway", gatewayName,
+		"gateway", aitenant.Status.GatewayRef.Name,
 		"collector", collectorAddress)
+	return nil
+}
+
+// deleteEnvoyFilterIfExists deletes the given EnvoyFilter, ignoring NotFound/NoMatch.
+func (r *AITenantReconciler) deleteEnvoyFilterIfExists(ctx context.Context, log logr.Logger, ef *unstructured.Unstructured) error {
+	if err := r.Delete(ctx, ef); err != nil {
+		if apierrors.IsNotFound(err) || apimeta.IsNoMatchError(err) {
+			return nil
+		}
+		return fmt.Errorf("delete usage-logs EnvoyFilter %s: %w", ef.GetName(), err)
+	}
+	log.Info("deleted per-tenant usage-logs EnvoyFilter", "name", ef.GetName())
 	return nil
 }
 
@@ -845,8 +836,15 @@ func (r *AITenantReconciler) deleteAITenantScopedChildren(ctx context.Context, a
 	if err := r.deleteOwned(ctx, aitenant, &rbacv1.Role{}, client.ObjectKey{Namespace: aitenant.Namespace, Name: aitenantAccessRoleName(aitenant)}); err != nil {
 		return err
 	}
-	if err := r.deleteUsageLogsEnvoyFilter(ctx, aitenant); err != nil {
-		return err
+	efName := tenantreconcile.UsageLogsEnvoyFilterName(aitenant.Name)
+	ef := &unstructured.Unstructured{}
+	ef.SetGroupVersionKind(tenantreconcile.GVKEnvoyFilter)
+	ef.SetName(efName)
+	ef.SetNamespace(r.GatewayNamespace)
+	if err := r.Delete(ctx, ef); err != nil {
+		if !apierrors.IsNotFound(err) && !apimeta.IsNoMatchError(err) {
+			return fmt.Errorf("delete usage-logs EnvoyFilter %s: %w", efName, err)
+		}
 	}
 	return nil
 }

--- a/maas-controller/pkg/controller/maas/aitenant_controller.go
+++ b/maas-controller/pkg/controller/maas/aitenant_controller.go
@@ -77,10 +77,6 @@ const (
 
 	// envoyFilterManifestPath is the default path to the EnvoyFilter manifest inside the container.
 	envoyFilterManifestPath = "/deployment/components/observability/usage-logs/envoy-otel-access-log.yaml"
-
-	// legacyGlobalEnvoyFilterName is the old singleton EnvoyFilter name from LifecycleReconciler.
-	// Used for migration cleanup only.
-	legacyGlobalEnvoyFilterName = "maas-model-access-logs"
 )
 
 var errTenantAPIKeyRevocationJobFailed = errors.New("API key revocation Job failed")
@@ -121,7 +117,7 @@ type AITenantReconciler struct {
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;delete
 // +kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;create;delete
-// +kubebuilder:rbac:groups=networking.istio.io,resources=envoyfilters,verbs=get;list;watch;create;patch;delete
+// +kubebuilder:rbac:groups=networking.istio.io,resources=envoyfilters,verbs=create;patch;delete
 
 // Reconcile drives AITenant bootstrap lifecycle.
 func (r *AITenantReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -222,14 +218,8 @@ func (r *AITenantReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 }
 
 // SetupWithManager registers the AITenant controller.
-// Config is watched so that changes to usageLogging trigger per-tenant EnvoyFilter reconciliation.
+// Config is watched so that spec changes (e.g. usageLogging toggled) fan out to all AITenants.
 func (r *AITenantReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	cfgSpecChanged := predicate.And(
-		predicate.NewPredicateFuncs(func(o client.Object) bool {
-			return o.GetName() == maasv1alpha1.ConfigInstanceName
-		}),
-		predicate.GenerationChangedPredicate{},
-	)
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&maasv1alpha1.AITenant{}, builder.WithPredicates(
 			predicate.Or(predicate.GenerationChangedPredicate{}, predicate.Funcs{UpdateFunc: deletionTimestampSet}),
@@ -237,13 +227,13 @@ func (r *AITenantReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(
 			&maasv1alpha1.Config{},
 			handler.EnqueueRequestsFromMapFunc(r.mapConfigToAITenants),
-			builder.WithPredicates(cfgSpecChanged),
+			builder.WithPredicates(predicate.GenerationChangedPredicate{}),
 		).
 		Complete(r)
 }
 
-// mapConfigToAITenants lists all AITenants and enqueues each for reconciliation.
-// Called when the Config CR changes (e.g. usageLogging toggled).
+// mapConfigToAITenants enqueues every AITenant for reconciliation so each
+// can re-evaluate its EnvoyFilter against the updated Config spec.
 func (r *AITenantReconciler) mapConfigToAITenants(ctx context.Context, _ client.Object) []reconcile.Request {
 	var aitenants maasv1alpha1.AITenantList
 	if err := r.List(ctx, &aitenants); err != nil {
@@ -567,7 +557,7 @@ func (r *AITenantReconciler) ensureUsageLogsEnvoyFilter(ctx context.Context, ait
 	var cfg maasv1alpha1.Config
 	if err := r.Get(ctx, client.ObjectKey{Name: maasv1alpha1.ConfigInstanceName}, &cfg); err != nil {
 		if apierrors.IsNotFound(err) {
-			return r.deleteUsageLogsEnvoyFilter(ctx, aitenant)
+			return nil
 		}
 		return err
 	}
@@ -577,30 +567,11 @@ func (r *AITenantReconciler) ensureUsageLogsEnvoyFilter(ctx context.Context, ait
 	}
 
 	if aitenant.Status.GatewayRef.Name == "" {
-		log.V(1).Info("skipping EnvoyFilter — gateway ref not yet populated")
+		log.V(1).Info("skipping EnvoyFilter — gateway ref not yet populated, will retry on next reconcile")
 		return nil
 	}
 
-	r.deleteLegacyGlobalEnvoyFilter(ctx, log)
 	return r.applyUsageLogsEnvoyFilter(ctx, log, aitenant)
-}
-
-// deleteLegacyGlobalEnvoyFilter removes the old singleton "maas-model-access-logs"
-// EnvoyFilter that was managed by LifecycleReconciler. Best-effort: errors are logged
-// but do not block reconciliation.
-func (r *AITenantReconciler) deleteLegacyGlobalEnvoyFilter(ctx context.Context, log logr.Logger) {
-	ef := &unstructured.Unstructured{}
-	ef.SetGroupVersionKind(tenantreconcile.GVKEnvoyFilter)
-	ef.SetName(legacyGlobalEnvoyFilterName)
-	ef.SetNamespace(r.GatewayNamespace)
-
-	if err := r.Delete(ctx, ef); err != nil {
-		if !apierrors.IsNotFound(err) && !apimeta.IsNoMatchError(err) {
-			log.V(1).Info("failed to delete legacy global EnvoyFilter (best-effort)", "error", err)
-		}
-		return
-	}
-	log.Info("deleted legacy global EnvoyFilter", "name", legacyGlobalEnvoyFilterName)
 }
 
 func (r *AITenantReconciler) deleteUsageLogsEnvoyFilter(ctx context.Context, aitenant *maasv1alpha1.AITenant) error {

--- a/maas-controller/pkg/controller/maas/aitenant_controller.go
+++ b/maas-controller/pkg/controller/maas/aitenant_controller.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-logr/logr"
 	batcv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -37,12 +38,17 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	yamlserializer "k8s.io/apimachinery/pkg/runtime/serializer/yaml"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	maasv1alpha1 "github.com/opendatahub-io/models-as-a-service/maas-controller/api/maas/v1alpha1"
@@ -68,6 +74,13 @@ const (
 	aitenantAPIKeyCleanupServiceAccountName = "maas-api-cleanup"
 	aitenantAPIKeyCleanupCABundleName       = "openshift-service-ca.crt"         //nolint:gosec // ConfigMap name for a public CA bundle, not a credential.
 	aitenantAPIKeyCleanupCABundlePath       = "/etc/pki/maas-api/service-ca.crt" //nolint:gosec // Public CA bundle mount path, not a credential.
+
+	// envoyFilterManifestPath is the default path to the EnvoyFilter manifest inside the container.
+	envoyFilterManifestPath = "/deployment/components/observability/usage-logs/envoy-otel-access-log.yaml"
+
+	// legacyGlobalEnvoyFilterName is the old singleton EnvoyFilter name from LifecycleReconciler.
+	// Used for migration cleanup only.
+	legacyGlobalEnvoyFilterName = "maas-model-access-logs"
 )
 
 var errTenantAPIKeyRevocationJobFailed = errors.New("API key revocation Job failed")
@@ -91,6 +104,10 @@ type AITenantReconciler struct {
 	GatewayName string
 	// GatewayNamespace is where tenant Gateway resources are expected to exist.
 	GatewayNamespace string
+	// MonitoringNamespace is where the OTel Collector is deployed (for EnvoyFilter cluster address).
+	MonitoringNamespace string
+	// EnvoyFilterManifestPath overrides the default path to the usage-logs EnvoyFilter YAML.
+	EnvoyFilterManifestPath string
 }
 
 // +kubebuilder:rbac:groups=maas.opendatahub.io,resources=aitenants,verbs=get;list;watch;create;update;patch;delete
@@ -104,6 +121,7 @@ type AITenantReconciler struct {
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;delete
 // +kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;create;delete
+// +kubebuilder:rbac:groups=networking.istio.io,resources=envoyfilters,verbs=get;list;watch;create;patch;delete
 
 // Reconcile drives AITenant bootstrap lifecycle.
 func (r *AITenantReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -188,6 +206,14 @@ func (r *AITenantReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 	}
 
+	if err := r.ensureUsageLogsEnvoyFilter(ctx, &aitenant); err != nil {
+		setAITenantPhase(&aitenant, "Failed", "EnvoyFilterReconcileFailed", err.Error())
+		if err2 := r.updateAITenantStatus(ctx, &aitenant, statusSnapshot); err2 != nil {
+			return ctrl.Result{}, err2
+		}
+		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+	}
+
 	setAITenantPhase(&aitenant, "Active", "Reconciled", "AITenant bootstrap resources are reconciled")
 	if err := r.updateAITenantStatus(ctx, &aitenant, statusSnapshot); err != nil {
 		return ctrl.Result{}, err
@@ -196,12 +222,44 @@ func (r *AITenantReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 }
 
 // SetupWithManager registers the AITenant controller.
+// Config is watched so that changes to usageLogging trigger per-tenant EnvoyFilter reconciliation.
 func (r *AITenantReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	cfgSpecChanged := predicate.And(
+		predicate.NewPredicateFuncs(func(o client.Object) bool {
+			return o.GetName() == maasv1alpha1.ConfigInstanceName
+		}),
+		predicate.GenerationChangedPredicate{},
+	)
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&maasv1alpha1.AITenant{}, builder.WithPredicates(
 			predicate.Or(predicate.GenerationChangedPredicate{}, predicate.Funcs{UpdateFunc: deletionTimestampSet}),
 		)).
+		Watches(
+			&maasv1alpha1.Config{},
+			handler.EnqueueRequestsFromMapFunc(r.mapConfigToAITenants),
+			builder.WithPredicates(cfgSpecChanged),
+		).
 		Complete(r)
+}
+
+// mapConfigToAITenants lists all AITenants and enqueues each for reconciliation.
+// Called when the Config CR changes (e.g. usageLogging toggled).
+func (r *AITenantReconciler) mapConfigToAITenants(ctx context.Context, _ client.Object) []reconcile.Request {
+	var aitenants maasv1alpha1.AITenantList
+	if err := r.List(ctx, &aitenants); err != nil {
+		ctrl.Log.WithName("aitenant-config-watch").Error(err, "failed to list AITenants for Config change")
+		return nil
+	}
+	requests := make([]reconcile.Request, 0, len(aitenants.Items))
+	for i := range aitenants.Items {
+		requests = append(requests, reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: aitenants.Items[i].Namespace,
+				Name:      aitenants.Items[i].Name,
+			},
+		})
+	}
+	return requests
 }
 
 func (r *AITenantReconciler) validateAITenantPlacement(aitenant *maasv1alpha1.AITenant) error {
@@ -500,6 +558,202 @@ func (r *AITenantReconciler) ensureAITenantObjectRole(ctx context.Context, aiten
 	})
 }
 
+// ensureUsageLogsEnvoyFilter creates or deletes the per-tenant usage-logs EnvoyFilter
+// based on the cluster-wide usageLogging flag from the Config CR. Each tenant gets its
+// own EnvoyFilter targeting its specific gateway via targetRefs.
+func (r *AITenantReconciler) ensureUsageLogsEnvoyFilter(ctx context.Context, aitenant *maasv1alpha1.AITenant) error {
+	log := ctrl.LoggerFrom(ctx).WithName("usage-logs-envoyfilter")
+
+	var cfg maasv1alpha1.Config
+	if err := r.Get(ctx, client.ObjectKey{Name: maasv1alpha1.ConfigInstanceName}, &cfg); err != nil {
+		if apierrors.IsNotFound(err) {
+			return r.deleteUsageLogsEnvoyFilter(ctx, aitenant)
+		}
+		return err
+	}
+
+	if !ptr.Deref(cfg.Spec.UsageLogging, false) {
+		return r.deleteUsageLogsEnvoyFilter(ctx, aitenant)
+	}
+
+	if aitenant.Status.GatewayRef.Name == "" {
+		log.V(1).Info("skipping EnvoyFilter — gateway ref not yet populated")
+		return nil
+	}
+
+	r.deleteLegacyGlobalEnvoyFilter(ctx, log)
+	return r.applyUsageLogsEnvoyFilter(ctx, log, aitenant)
+}
+
+// deleteLegacyGlobalEnvoyFilter removes the old singleton "maas-model-access-logs"
+// EnvoyFilter that was managed by LifecycleReconciler. Best-effort: errors are logged
+// but do not block reconciliation.
+func (r *AITenantReconciler) deleteLegacyGlobalEnvoyFilter(ctx context.Context, log logr.Logger) {
+	ef := &unstructured.Unstructured{}
+	ef.SetGroupVersionKind(tenantreconcile.GVKEnvoyFilter)
+	ef.SetName(legacyGlobalEnvoyFilterName)
+	ef.SetNamespace(r.GatewayNamespace)
+
+	if err := r.Delete(ctx, ef); err != nil {
+		if !apierrors.IsNotFound(err) && !apimeta.IsNoMatchError(err) {
+			log.V(1).Info("failed to delete legacy global EnvoyFilter (best-effort)", "error", err)
+		}
+		return
+	}
+	log.Info("deleted legacy global EnvoyFilter", "name", legacyGlobalEnvoyFilterName)
+}
+
+func (r *AITenantReconciler) deleteUsageLogsEnvoyFilter(ctx context.Context, aitenant *maasv1alpha1.AITenant) error {
+	log := ctrl.LoggerFrom(ctx).WithName("usage-logs-envoyfilter")
+	efName := tenantreconcile.UsageLogsEnvoyFilterName(aitenant.Name)
+
+	ef := &unstructured.Unstructured{}
+	ef.SetGroupVersionKind(tenantreconcile.GVKEnvoyFilter)
+	ef.SetName(efName)
+	ef.SetNamespace(r.GatewayNamespace)
+
+	if err := r.Delete(ctx, ef); err != nil {
+		if apierrors.IsNotFound(err) || apimeta.IsNoMatchError(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to delete usage-logs EnvoyFilter %s: %w", efName, err)
+	}
+	log.Info("deleted per-tenant usage-logs EnvoyFilter", "name", efName)
+	return nil
+}
+
+func (r *AITenantReconciler) applyUsageLogsEnvoyFilter(ctx context.Context, log logr.Logger, aitenant *maasv1alpha1.AITenant) error {
+	manifestPath := r.EnvoyFilterManifestPath
+	if manifestPath == "" {
+		manifestPath = envoyFilterManifestPath
+	}
+	raw, err := os.ReadFile(manifestPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			log.Info("EnvoyFilter manifest not found, skipping", "path", manifestPath)
+			return nil
+		}
+		return fmt.Errorf("read EnvoyFilter manifest %s: %w", manifestPath, err)
+	}
+
+	ef := &unstructured.Unstructured{}
+	dec := yamlserializer.NewDecodingSerializer(unstructured.UnstructuredJSONScheme)
+	_, _, err = dec.Decode(raw, nil, ef)
+	if err != nil {
+		return fmt.Errorf("decode EnvoyFilter manifest: %w", err)
+	}
+
+	collectorAddress := fmt.Sprintf("usage-logs-collector.%s.svc.cluster.local", r.MonitoringNamespace)
+	if err := patchClusterAddress(ef, collectorAddress); err != nil {
+		return fmt.Errorf("patch collector address in EnvoyFilter: %w", err)
+	}
+
+	efName := tenantreconcile.UsageLogsEnvoyFilterName(aitenant.Name)
+	ef.SetName(efName)
+	ef.SetNamespace(r.GatewayNamespace)
+
+	gatewayName := aitenant.Status.GatewayRef.Name
+	if err := patchEnvoyFilterTargetGateway(ef, gatewayName); err != nil {
+		return fmt.Errorf("patch gateway targetRef in EnvoyFilter: %w", err)
+	}
+
+	labels := ef.GetLabels()
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	labels[tenantreconcile.LabelTenantName] = aitenant.Name
+	labels[tenantreconcile.LabelTenantNamespace] = aitenant.Namespace
+	ef.SetLabels(labels)
+
+	if err := r.Patch(ctx, ef, client.Apply, client.ForceOwnership, client.FieldOwner("maas-controller")); err != nil {
+		if apimeta.IsNoMatchError(err) {
+			log.Info("EnvoyFilter CRD not available, skipping usage-logs EnvoyFilter")
+			return nil
+		}
+		return fmt.Errorf("apply per-tenant usage-logs EnvoyFilter %s: %w", efName, err)
+	}
+
+	log.V(1).Info("applied per-tenant usage-logs EnvoyFilter",
+		"name", efName,
+		"gateway", gatewayName,
+		"collector", collectorAddress)
+	return nil
+}
+
+// patchEnvoyFilterTargetGateway replaces the gateway name in spec.targetRefs[0].name.
+func patchEnvoyFilterTargetGateway(ef *unstructured.Unstructured, gatewayName string) error {
+	targetRefs, found, err := unstructured.NestedSlice(ef.Object, "spec", "targetRefs")
+	if err != nil {
+		return fmt.Errorf("read targetRefs: %w", err)
+	}
+	if !found || len(targetRefs) == 0 {
+		return errors.New("spec.targetRefs not found or empty")
+	}
+
+	ref0, ok := targetRefs[0].(map[string]any)
+	if !ok {
+		return errors.New("targetRefs[0] is not an object")
+	}
+	ref0["name"] = gatewayName
+	targetRefs[0] = ref0
+
+	if err := unstructured.SetNestedSlice(ef.Object, targetRefs, "spec", "targetRefs"); err != nil {
+		return fmt.Errorf("set targetRefs: %w", err)
+	}
+	return nil
+}
+
+// patchClusterAddress sets the collector address in the CLUSTER configPatch
+// (configPatches[0].patch.value.load_assignment.endpoints[0].lb_endpoints[0].endpoint.address.socket_address.address).
+// Manual traversal is needed because unstructured.SetNestedField cannot handle
+// numeric slice indices — we must extract each []any level explicitly.
+func patchClusterAddress(ef *unstructured.Unstructured, address string) error {
+	configPatches, found, err := unstructured.NestedSlice(ef.Object, "spec", "configPatches")
+	if err != nil {
+		return fmt.Errorf("read configPatches: %w", err)
+	}
+	if !found || len(configPatches) == 0 {
+		return errors.New("configPatches not found or empty")
+	}
+
+	patch, ok := configPatches[0].(map[string]any)
+	if !ok {
+		return errors.New("configPatches[0] is not an object")
+	}
+
+	endpoints, found, err := unstructured.NestedSlice(patch, "patch", "value", "load_assignment", "endpoints")
+	if err != nil || !found || len(endpoints) == 0 {
+		return fmt.Errorf("load_assignment.endpoints not found: %w", err)
+	}
+	ep0, ok := endpoints[0].(map[string]any)
+	if !ok {
+		return errors.New("endpoints[0] is not an object")
+	}
+	lbEndpoints, found, err := unstructured.NestedSlice(ep0, "lb_endpoints")
+	if err != nil || !found || len(lbEndpoints) == 0 {
+		return fmt.Errorf("lb_endpoints not found: %w", err)
+	}
+	lbe0, ok := lbEndpoints[0].(map[string]any)
+	if !ok {
+		return errors.New("lb_endpoints[0] is not an object")
+	}
+
+	if err := unstructured.SetNestedField(lbe0, address,
+		"endpoint", "address", "socket_address", "address"); err != nil {
+		return fmt.Errorf("set socket_address.address: %w", err)
+	}
+
+	lbEndpoints[0] = lbe0
+	ep0["lb_endpoints"] = lbEndpoints
+	endpoints[0] = ep0
+	if err := unstructured.SetNestedSlice(patch, endpoints,
+		"patch", "value", "load_assignment", "endpoints"); err != nil {
+		return fmt.Errorf("write back endpoints: %w", err)
+	}
+	configPatches[0] = patch
+	return unstructured.SetNestedSlice(ef.Object, configPatches, "spec", "configPatches")
+}
+
 func (r *AITenantReconciler) reconcileAITenantDelete(ctx context.Context, aitenant *maasv1alpha1.AITenant) (ctrl.Result, error) {
 	if !controllerutil.ContainsFinalizer(aitenant, aitenantFinalizer) {
 		return ctrl.Result{}, nil
@@ -618,6 +872,9 @@ func (r *AITenantReconciler) deleteAITenantScopedChildren(ctx context.Context, a
 		return err
 	}
 	if err := r.deleteOwned(ctx, aitenant, &rbacv1.Role{}, client.ObjectKey{Namespace: aitenant.Namespace, Name: aitenantAccessRoleName(aitenant)}); err != nil {
+		return err
+	}
+	if err := r.deleteUsageLogsEnvoyFilter(ctx, aitenant); err != nil {
 		return err
 	}
 	return nil

--- a/maas-controller/pkg/controller/maas/aitenant_controller_test.go
+++ b/maas-controller/pkg/controller/maas/aitenant_controller_test.go
@@ -23,6 +23,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/validation"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -2531,7 +2532,7 @@ func TestEnsureUsageLogsEnvoyFilter(t *testing.T) {
 
 		cfg := &maasv1alpha1.Config{
 			ObjectMeta: metav1.ObjectMeta{Name: maasv1alpha1.ConfigInstanceName, UID: types.UID("cfg-uid")},
-			Spec:       maasv1alpha1.ConfigSpec{UsageLogging: ptrTo(true)},
+			Spec:       maasv1alpha1.ConfigSpec{UsageLogging: ptr.To(true)},
 		}
 		aitenant := &maasv1alpha1.AITenant{
 			ObjectMeta: metav1.ObjectMeta{
@@ -2593,7 +2594,7 @@ func TestEnsureUsageLogsEnvoyFilter(t *testing.T) {
 
 		cfg := &maasv1alpha1.Config{
 			ObjectMeta: metav1.ObjectMeta{Name: maasv1alpha1.ConfigInstanceName, UID: types.UID("cfg-uid")},
-			Spec:       maasv1alpha1.ConfigSpec{UsageLogging: ptrTo(false)},
+			Spec:       maasv1alpha1.ConfigSpec{UsageLogging: ptr.To(false)},
 		}
 		aitenant := &maasv1alpha1.AITenant{
 			ObjectMeta: metav1.ObjectMeta{
@@ -2634,7 +2635,7 @@ func TestEnsureUsageLogsEnvoyFilter(t *testing.T) {
 
 		cfg := &maasv1alpha1.Config{
 			ObjectMeta: metav1.ObjectMeta{Name: maasv1alpha1.ConfigInstanceName, UID: types.UID("cfg-uid")},
-			Spec:       maasv1alpha1.ConfigSpec{UsageLogging: ptrTo(true)},
+			Spec:       maasv1alpha1.ConfigSpec{UsageLogging: ptr.To(true)},
 		}
 		aitenant := &maasv1alpha1.AITenant{
 			ObjectMeta: metav1.ObjectMeta{
@@ -2656,5 +2657,3 @@ func TestEnsureUsageLogsEnvoyFilter(t *testing.T) {
 		g.Expect(err).NotTo(HaveOccurred(), "should not error when gatewayRef is nil")
 	})
 }
-
-func ptrTo[T any](v T) *T { return &v }

--- a/maas-controller/pkg/controller/maas/aitenant_controller_test.go
+++ b/maas-controller/pkg/controller/maas/aitenant_controller_test.go
@@ -2490,6 +2490,9 @@ func TestEnsureUsageLogsEnvoyFilter(t *testing.T) {
 	const gwNS = "openshift-ingress"
 	const monitoringNS = "opendatahub"
 
+	_, testFile, _, _ := goruntime.Caller(0)
+	efManifest := filepath.Join(filepath.Dir(testFile), "../../../../deployment/components/observability/usage-logs/envoy-otel-access-log.yaml")
+
 	t.Run("disabled — no EnvoyFilter created", func(t *testing.T) {
 		g := NewWithT(t)
 		s := aitenantTestScheme(t)
@@ -2509,11 +2512,12 @@ func TestEnsureUsageLogsEnvoyFilter(t *testing.T) {
 
 		cl := fake.NewClientBuilder().WithScheme(s).WithObjects(cfg, aitenant).Build()
 		r := &AITenantReconciler{
-			Client:             cl,
-			Scheme:             s,
-			APIReader:          cl,
-			GatewayNamespace:   gwNS,
-			MonitoringNamespace: monitoringNS,
+			Client:                  cl,
+			Scheme:                  s,
+			APIReader:               cl,
+			GatewayNamespace:        gwNS,
+			MonitoringNamespace:     monitoringNS,
+			EnvoyFilterManifestPath: efManifest,
 		}
 
 		err := r.ensureUsageLogsEnvoyFilter(context.Background(), aitenant)
@@ -2524,6 +2528,44 @@ func TestEnsureUsageLogsEnvoyFilter(t *testing.T) {
 		efName := tenantreconcile.UsageLogsEnvoyFilterName("team-ef")
 		err = cl.Get(context.Background(), client.ObjectKey{Name: efName, Namespace: gwNS}, ef)
 		g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "no EnvoyFilter when usageLogging disabled")
+	})
+
+	t.Run("Config not found — deletes existing EnvoyFilter", func(t *testing.T) {
+		g := NewWithT(t)
+		s := aitenantTestScheme(t)
+
+		aitenant := &maasv1alpha1.AITenant{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "team-ef",
+				Namespace: tenantreconcile.DefaultAITenantNamespace,
+			},
+			Status: maasv1alpha1.AITenantStatus{
+				GatewayRef: maasv1alpha1.TenantGatewayRef{Name: "team-ef-gw", Namespace: gwNS},
+			},
+		}
+		efName := tenantreconcile.UsageLogsEnvoyFilterName("team-ef")
+		existingEF := &unstructured.Unstructured{}
+		existingEF.SetGroupVersionKind(tenantreconcile.GVKEnvoyFilter)
+		existingEF.SetName(efName)
+		existingEF.SetNamespace(gwNS)
+
+		cl := fake.NewClientBuilder().WithScheme(s).WithObjects(aitenant, existingEF).Build()
+		r := &AITenantReconciler{
+			Client:                  cl,
+			Scheme:                  s,
+			APIReader:               cl,
+			GatewayNamespace:        gwNS,
+			MonitoringNamespace:     monitoringNS,
+			EnvoyFilterManifestPath: efManifest,
+		}
+
+		err := r.ensureUsageLogsEnvoyFilter(context.Background(), aitenant)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		ef := &unstructured.Unstructured{}
+		ef.SetGroupVersionKind(tenantreconcile.GVKEnvoyFilter)
+		err = cl.Get(context.Background(), client.ObjectKey{Name: efName, Namespace: gwNS}, ef)
+		g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "EnvoyFilter should be deleted when Config is absent")
 	})
 
 	t.Run("enabled — creates per-tenant EnvoyFilter targeting tenant gateway", func(t *testing.T) {
@@ -2544,9 +2586,6 @@ func TestEnsureUsageLogsEnvoyFilter(t *testing.T) {
 				GatewayRef: maasv1alpha1.TenantGatewayRef{Name: "team-ef-gw", Namespace: gwNS},
 			},
 		}
-
-		_, testFile, _, _ := goruntime.Caller(0)
-		efManifest := filepath.Join(filepath.Dir(testFile), "../../../../deployment/components/observability/usage-logs/envoy-otel-access-log.yaml")
 
 		cl := fake.NewClientBuilder().WithScheme(s).WithObjects(cfg, aitenant).Build()
 		r := &AITenantReconciler{
@@ -2613,11 +2652,12 @@ func TestEnsureUsageLogsEnvoyFilter(t *testing.T) {
 
 		cl := fake.NewClientBuilder().WithScheme(s).WithObjects(cfg, aitenant, existingEF).Build()
 		r := &AITenantReconciler{
-			Client:             cl,
-			Scheme:             s,
-			APIReader:          cl,
-			GatewayNamespace:   gwNS,
-			MonitoringNamespace: monitoringNS,
+			Client:                  cl,
+			Scheme:                  s,
+			APIReader:               cl,
+			GatewayNamespace:        gwNS,
+			MonitoringNamespace:     monitoringNS,
+			EnvoyFilterManifestPath: efManifest,
 		}
 
 		err := r.ensureUsageLogsEnvoyFilter(context.Background(), aitenant)
@@ -2646,11 +2686,12 @@ func TestEnsureUsageLogsEnvoyFilter(t *testing.T) {
 
 		cl := fake.NewClientBuilder().WithScheme(s).WithObjects(cfg, aitenant).Build()
 		r := &AITenantReconciler{
-			Client:             cl,
-			Scheme:             s,
-			APIReader:          cl,
-			GatewayNamespace:   gwNS,
-			MonitoringNamespace: monitoringNS,
+			Client:                  cl,
+			Scheme:                  s,
+			APIReader:               cl,
+			GatewayNamespace:        gwNS,
+			MonitoringNamespace:     monitoringNS,
+			EnvoyFilterManifestPath: efManifest,
 		}
 
 		err := r.ensureUsageLogsEnvoyFilter(context.Background(), aitenant)

--- a/maas-controller/pkg/controller/maas/aitenant_controller_test.go
+++ b/maas-controller/pkg/controller/maas/aitenant_controller_test.go
@@ -4,6 +4,8 @@ package maas
 import (
 	"context"
 	"encoding/json"
+	"path/filepath"
+	goruntime "runtime"
 	"strings"
 	"testing"
 	"time"
@@ -2482,3 +2484,177 @@ func TestAITenantReconcile_CleanupStaleClaimsSkipsSpoofedOwnerRef(t *testing.T) 
 	}, &remaining)
 	g.Expect(err).NotTo(HaveOccurred(), "spoofed stale claim should survive cleanupStaleClaims")
 }
+
+func TestEnsureUsageLogsEnvoyFilter(t *testing.T) {
+	const gwNS = "openshift-ingress"
+	const monitoringNS = "opendatahub"
+
+	t.Run("disabled — no EnvoyFilter created", func(t *testing.T) {
+		g := NewWithT(t)
+		s := aitenantTestScheme(t)
+
+		cfg := &maasv1alpha1.Config{
+			ObjectMeta: metav1.ObjectMeta{Name: maasv1alpha1.ConfigInstanceName, UID: types.UID("cfg-uid")},
+		}
+		aitenant := &maasv1alpha1.AITenant{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "team-ef",
+				Namespace: tenantreconcile.DefaultAITenantNamespace,
+			},
+			Status: maasv1alpha1.AITenantStatus{
+				GatewayRef: maasv1alpha1.TenantGatewayRef{Name: "team-ef", Namespace: gwNS},
+			},
+		}
+
+		cl := fake.NewClientBuilder().WithScheme(s).WithObjects(cfg, aitenant).Build()
+		r := &AITenantReconciler{
+			Client:             cl,
+			Scheme:             s,
+			APIReader:          cl,
+			GatewayNamespace:   gwNS,
+			MonitoringNamespace: monitoringNS,
+		}
+
+		err := r.ensureUsageLogsEnvoyFilter(context.Background(), aitenant)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		ef := &unstructured.Unstructured{}
+		ef.SetGroupVersionKind(tenantreconcile.GVKEnvoyFilter)
+		efName := tenantreconcile.UsageLogsEnvoyFilterName("team-ef")
+		err = cl.Get(context.Background(), client.ObjectKey{Name: efName, Namespace: gwNS}, ef)
+		g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "no EnvoyFilter when usageLogging disabled")
+	})
+
+	t.Run("enabled — creates per-tenant EnvoyFilter targeting tenant gateway", func(t *testing.T) {
+		g := NewWithT(t)
+		s := aitenantTestScheme(t)
+
+		cfg := &maasv1alpha1.Config{
+			ObjectMeta: metav1.ObjectMeta{Name: maasv1alpha1.ConfigInstanceName, UID: types.UID("cfg-uid")},
+			Spec:       maasv1alpha1.ConfigSpec{UsageLogging: ptrTo(true)},
+		}
+		aitenant := &maasv1alpha1.AITenant{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "team-ef",
+				Namespace: tenantreconcile.DefaultAITenantNamespace,
+				UID:       types.UID("at-uid"),
+			},
+			Status: maasv1alpha1.AITenantStatus{
+				GatewayRef: maasv1alpha1.TenantGatewayRef{Name: "team-ef-gw", Namespace: gwNS},
+			},
+		}
+
+		_, testFile, _, _ := goruntime.Caller(0)
+		efManifest := filepath.Join(filepath.Dir(testFile), "../../../../deployment/components/observability/usage-logs/envoy-otel-access-log.yaml")
+
+		cl := fake.NewClientBuilder().WithScheme(s).WithObjects(cfg, aitenant).Build()
+		r := &AITenantReconciler{
+			Client:                  cl,
+			Scheme:                  s,
+			APIReader:               cl,
+			GatewayNamespace:        gwNS,
+			MonitoringNamespace:     monitoringNS,
+			EnvoyFilterManifestPath: efManifest,
+		}
+
+		err := r.ensureUsageLogsEnvoyFilter(context.Background(), aitenant)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		ef := &unstructured.Unstructured{}
+		ef.SetGroupVersionKind(tenantreconcile.GVKEnvoyFilter)
+		efName := tenantreconcile.UsageLogsEnvoyFilterName("team-ef")
+		g.Expect(cl.Get(context.Background(), client.ObjectKey{Name: efName, Namespace: gwNS}, ef)).To(Succeed())
+		g.Expect(ef.GetNamespace()).To(Equal(gwNS))
+
+		targetRefs, _, _ := unstructured.NestedSlice(ef.Object, "spec", "targetRefs")
+		g.Expect(targetRefs).NotTo(BeEmpty())
+		ref0, _ := targetRefs[0].(map[string]any)
+		g.Expect(ref0["name"]).To(Equal("team-ef-gw"), "targetRef should point to tenant's gateway")
+
+		g.Expect(ef.GetLabels()).To(HaveKeyWithValue(tenantreconcile.LabelTenantName, "team-ef"))
+		g.Expect(ef.GetLabels()).To(HaveKeyWithValue(tenantreconcile.LabelTenantNamespace, tenantreconcile.DefaultAITenantNamespace))
+
+		configPatches, _, _ := unstructured.NestedSlice(ef.Object, "spec", "configPatches")
+		g.Expect(configPatches).NotTo(BeEmpty())
+		clusterPatch, _ := configPatches[0].(map[string]any)
+		endpoints, _, _ := unstructured.NestedSlice(clusterPatch, "patch", "value", "load_assignment", "endpoints")
+		g.Expect(endpoints).NotTo(BeEmpty())
+		ep0, _ := endpoints[0].(map[string]any)
+		lbEndpoints, _, _ := unstructured.NestedSlice(ep0, "lb_endpoints")
+		g.Expect(lbEndpoints).NotTo(BeEmpty())
+		lbe0, _ := lbEndpoints[0].(map[string]any)
+		addr, _, _ := unstructured.NestedString(lbe0, "endpoint", "address", "socket_address", "address")
+		g.Expect(addr).To(Equal("usage-logs-collector.opendatahub.svc.cluster.local"))
+	})
+
+	t.Run("deletes per-tenant EnvoyFilter when disabled", func(t *testing.T) {
+		g := NewWithT(t)
+		s := aitenantTestScheme(t)
+
+		cfg := &maasv1alpha1.Config{
+			ObjectMeta: metav1.ObjectMeta{Name: maasv1alpha1.ConfigInstanceName, UID: types.UID("cfg-uid")},
+			Spec:       maasv1alpha1.ConfigSpec{UsageLogging: ptrTo(false)},
+		}
+		aitenant := &maasv1alpha1.AITenant{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "team-ef",
+				Namespace: tenantreconcile.DefaultAITenantNamespace,
+			},
+			Status: maasv1alpha1.AITenantStatus{
+				GatewayRef: maasv1alpha1.TenantGatewayRef{Name: "team-ef-gw", Namespace: gwNS},
+			},
+		}
+		efName := tenantreconcile.UsageLogsEnvoyFilterName("team-ef")
+		existingEF := &unstructured.Unstructured{}
+		existingEF.SetGroupVersionKind(tenantreconcile.GVKEnvoyFilter)
+		existingEF.SetName(efName)
+		existingEF.SetNamespace(gwNS)
+
+		cl := fake.NewClientBuilder().WithScheme(s).WithObjects(cfg, aitenant, existingEF).Build()
+		r := &AITenantReconciler{
+			Client:             cl,
+			Scheme:             s,
+			APIReader:          cl,
+			GatewayNamespace:   gwNS,
+			MonitoringNamespace: monitoringNS,
+		}
+
+		err := r.ensureUsageLogsEnvoyFilter(context.Background(), aitenant)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		ef := &unstructured.Unstructured{}
+		ef.SetGroupVersionKind(tenantreconcile.GVKEnvoyFilter)
+		err = cl.Get(context.Background(), client.ObjectKey{Name: efName, Namespace: gwNS}, ef)
+		g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "EnvoyFilter should be deleted when usageLogging is disabled")
+	})
+
+	t.Run("skips when gateway ref not yet populated", func(t *testing.T) {
+		g := NewWithT(t)
+		s := aitenantTestScheme(t)
+
+		cfg := &maasv1alpha1.Config{
+			ObjectMeta: metav1.ObjectMeta{Name: maasv1alpha1.ConfigInstanceName, UID: types.UID("cfg-uid")},
+			Spec:       maasv1alpha1.ConfigSpec{UsageLogging: ptrTo(true)},
+		}
+		aitenant := &maasv1alpha1.AITenant{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "team-nogateway",
+				Namespace: tenantreconcile.DefaultAITenantNamespace,
+			},
+		}
+
+		cl := fake.NewClientBuilder().WithScheme(s).WithObjects(cfg, aitenant).Build()
+		r := &AITenantReconciler{
+			Client:             cl,
+			Scheme:             s,
+			APIReader:          cl,
+			GatewayNamespace:   gwNS,
+			MonitoringNamespace: monitoringNS,
+		}
+
+		err := r.ensureUsageLogsEnvoyFilter(context.Background(), aitenant)
+		g.Expect(err).NotTo(HaveOccurred(), "should not error when gatewayRef is nil")
+	})
+}
+
+func ptrTo[T any](v T) *T { return &v }

--- a/maas-controller/pkg/controller/maas/self_deployment_controller.go
+++ b/maas-controller/pkg/controller/maas/self_deployment_controller.go
@@ -72,7 +72,6 @@ type LifecycleReconciler struct {
 //+kubebuilder:rbac:groups=maas.opendatahub.io,resources=maastenantconfigs,verbs=get;list;watch;update;patch
 //+kubebuilder:rbac:groups=maas.opendatahub.io,resources=aitenants,verbs=get;list;watch;update;patch
 //+kubebuilder:rbac:groups=perses.dev,resources=persesdashboards;persesdatasources,verbs=get;list;watch;create;patch;delete
-//+kubebuilder:rbac:groups=networking.istio.io,resources=envoyfilters,verbs=get;list;watch;create;patch;delete
 
 func (r *LifecycleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := ctrl.Log.WithName("self-deployment").WithValues("deployment", req.NamespacedName)

--- a/maas-controller/pkg/controller/maas/self_deployment_controller.go
+++ b/maas-controller/pkg/controller/maas/self_deployment_controller.go
@@ -18,9 +18,7 @@ package maas
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"os"
 	"strings"
 	"time"
 
@@ -32,9 +30,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/serializer/yaml"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -52,11 +48,6 @@ import (
 // can strip it from older installs.
 const CleanupFinalizer = "maas.opendatahub.io/cleanup"
 
-// envoyFilterManifestPath is the absolute path to the EnvoyFilter manifest inside the container.
-const envoyFilterManifestPath = "/deployment/components/observability/usage-logs/envoy-otel-access-log.yaml"
-
-// envoyFilterName is the name of the usage-logs EnvoyFilter resource.
-const envoyFilterName = "maas-model-access-logs"
 
 // LifecycleReconciler watches the maas-controller Deployment. It is the sole creator of the
 // cluster-scoped Config/default anchor when the Deployment exists and is not terminating (so
@@ -73,7 +64,6 @@ type LifecycleReconciler struct {
 	GatewayNamespace            string
 	ObservabilityManifestsPath  string
 	MonitoringNamespace         string
-	EnvoyFilterManifestPath     string
 }
 
 //+kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;update;patch
@@ -376,9 +366,6 @@ func (r *LifecycleReconciler) ensureObservability(ctx context.Context, log logr.
 	if err := r.ensureUsageDashboard(ctx, log); err != nil {
 		return err
 	}
-	if err := r.ensureUsageLogsEnvoyFilter(ctx, log); err != nil {
-		return err
-	}
 	return nil
 }
 
@@ -495,144 +482,6 @@ func (r *LifecycleReconciler) ensureUsageDashboard(ctx context.Context, log logr
 	}
 
 	return nil
-}
-
-// ensureUsageLogsEnvoyFilter deploys or removes the OTel usage logs EnvoyFilter based on
-// the Config's usageLogging feature gate. The EnvoyFilter emits structured per-request
-// usage logs (token counts, identity, model) to an OTel Collector via gRPC Access Log Service.
-func (r *LifecycleReconciler) ensureUsageLogsEnvoyFilter(ctx context.Context, log logr.Logger) error {
-	var cfg maasv1alpha1.Config
-	if err := r.Get(ctx, client.ObjectKey{Name: maasv1alpha1.ConfigInstanceName}, &cfg); err != nil {
-		if apierrors.IsNotFound(err) {
-			return r.deleteEnvoyFilterIfExists(ctx, log)
-		}
-		return err
-	}
-
-	if !ptr.Deref(cfg.Spec.UsageLogging, false) {
-		return r.deleteEnvoyFilterIfExists(ctx, log)
-	}
-
-	return r.applyUsageLogsEnvoyFilter(ctx, log, &cfg)
-}
-
-func (r *LifecycleReconciler) deleteEnvoyFilterIfExists(ctx context.Context, log logr.Logger) error {
-	ef := &unstructured.Unstructured{}
-	ef.SetGroupVersionKind(tenantreconcile.GVKEnvoyFilter)
-	ef.SetName(envoyFilterName)
-	ef.SetNamespace(r.GatewayNamespace)
-
-	if err := r.Delete(ctx, ef); err != nil {
-		if apierrors.IsNotFound(err) || apimeta.IsNoMatchError(err) {
-			return nil
-		}
-		return fmt.Errorf("failed to delete usage-logs EnvoyFilter: %w", err)
-	}
-	log.Info("deleted usage-logs EnvoyFilter (usageLogging disabled)")
-	return nil
-}
-
-func (r *LifecycleReconciler) applyUsageLogsEnvoyFilter(ctx context.Context, log logr.Logger, cfg *maasv1alpha1.Config) error {
-	manifestPath := r.EnvoyFilterManifestPath
-	if manifestPath == "" {
-		manifestPath = envoyFilterManifestPath
-	}
-	raw, err := os.ReadFile(manifestPath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			log.Info("EnvoyFilter manifest not found, skipping", "path", manifestPath)
-			return nil
-		}
-		return fmt.Errorf("read EnvoyFilter manifest %s: %w", manifestPath, err)
-	}
-
-	ef := &unstructured.Unstructured{}
-	dec := yaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme)
-	_, _, err = dec.Decode(raw, nil, ef)
-	if err != nil {
-		return fmt.Errorf("decode EnvoyFilter manifest: %w", err)
-	}
-
-	collectorAddress := fmt.Sprintf("usage-logs-collector.%s.svc.cluster.local", r.MonitoringNamespace)
-	if err := patchClusterAddress(ef, collectorAddress); err != nil {
-		return fmt.Errorf("patch collector address in EnvoyFilter: %w", err)
-	}
-
-	ef.SetName(envoyFilterName)
-	ef.SetNamespace(r.GatewayNamespace)
-
-	if err := controllerutil.SetOwnerReference(cfg, ef, r.Scheme); err != nil {
-		return fmt.Errorf("set owner reference on EnvoyFilter: %w", err)
-	}
-
-	if err := r.Patch(ctx, ef, client.Apply, client.ForceOwnership, client.FieldOwner("maas-controller")); err != nil {
-		if apimeta.IsNoMatchError(err) {
-			log.Info("EnvoyFilter CRD not available, skipping usage-logs EnvoyFilter")
-			return nil
-		}
-		return fmt.Errorf("apply usage-logs EnvoyFilter: %w", err)
-	}
-
-	log.V(1).Info("applied usage-logs EnvoyFilter", "namespace", r.GatewayNamespace, "collector", collectorAddress)
-	return nil
-}
-
-// patchClusterAddress sets the collector address in the CLUSTER configPatch
-// (configPatches[0].patch.value.load_assignment.endpoints[0].lb_endpoints[0].endpoint.address.socket_address.address).
-// Manual traversal is needed because unstructured.SetNestedField cannot handle
-// numeric slice indices — we must extract each []any level explicitly.
-func patchClusterAddress(ef *unstructured.Unstructured, address string) error {
-	configPatches, found, err := unstructured.NestedSlice(ef.Object, "spec", "configPatches")
-	if err != nil {
-		return fmt.Errorf("read configPatches: %w", err)
-	}
-	if !found || len(configPatches) == 0 {
-		return errors.New("configPatches not found or empty")
-	}
-
-	patch, ok := configPatches[0].(map[string]any)
-	if !ok {
-		return errors.New("configPatches[0] is not an object")
-	}
-
-	addrPath := []string{
-		"patch", "value", "load_assignment", "endpoints", "0",
-		"lb_endpoints", "0", "endpoint", "address", "socket_address", "address",
-	}
-
-	// unstructured.SetNestedField doesn't traverse numeric slice indices,
-	// so we walk manually to the socket_address map.
-	endpoints, found, err := unstructured.NestedSlice(patch, "patch", "value", "load_assignment", "endpoints")
-	if err != nil || !found || len(endpoints) == 0 {
-		return fmt.Errorf("load_assignment.endpoints not found (path: %v): %w", addrPath, err)
-	}
-	ep0, ok := endpoints[0].(map[string]any)
-	if !ok {
-		return errors.New("endpoints[0] is not an object")
-	}
-	lbEndpoints, found, err := unstructured.NestedSlice(ep0, "lb_endpoints")
-	if err != nil || !found || len(lbEndpoints) == 0 {
-		return fmt.Errorf("lb_endpoints not found: %w", err)
-	}
-	lbe0, ok := lbEndpoints[0].(map[string]any)
-	if !ok {
-		return errors.New("lb_endpoints[0] is not an object")
-	}
-
-	if err := unstructured.SetNestedField(lbe0, address,
-		"endpoint", "address", "socket_address", "address"); err != nil {
-		return fmt.Errorf("set socket_address.address: %w", err)
-	}
-
-	lbEndpoints[0] = lbe0
-	ep0["lb_endpoints"] = lbEndpoints
-	endpoints[0] = ep0
-	if err := unstructured.SetNestedSlice(patch, endpoints,
-		"patch", "value", "load_assignment", "endpoints"); err != nil {
-		return fmt.Errorf("write back endpoints: %w", err)
-	}
-	configPatches[0] = patch
-	return unstructured.SetNestedSlice(ef.Object, configPatches, "spec", "configPatches")
 }
 
 // SetupWithManager registers the controller to watch only the maas-controller Deployment.

--- a/maas-controller/pkg/controller/maas/self_deployment_controller_test.go
+++ b/maas-controller/pkg/controller/maas/self_deployment_controller_test.go
@@ -357,5 +357,3 @@ func TestLifecycleReconciler_LimitadorServiceMonitorCustomInterval(t *testing.T)
 	g.Expect(ok).To(BeTrue())
 	g.Expect(endpoint["interval"]).To(Equal("1m"))
 }
-
-// EnvoyFilter lifecycle tests moved to aitenant_controller_test.go (per-tenant EnvoyFilter).

--- a/maas-controller/pkg/controller/maas/self_deployment_controller_test.go
+++ b/maas-controller/pkg/controller/maas/self_deployment_controller_test.go
@@ -10,14 +10,12 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -360,112 +358,4 @@ func TestLifecycleReconciler_LimitadorServiceMonitorCustomInterval(t *testing.T)
 	g.Expect(endpoint["interval"]).To(Equal("1m"))
 }
 
-func TestEnsureUsageLogsEnvoyFilter(t *testing.T) {
-	const gwNS = "openshift-ingress"
-	const monitoringNS = "opendatahub"
-
-	t.Run("disabled by default", func(t *testing.T) {
-		g := NewWithT(t)
-		s := lifecycleTestScheme(t)
-
-		cfg := &maasv1alpha1.Config{
-			ObjectMeta: metav1.ObjectMeta{Name: maasv1alpha1.ConfigInstanceName, UID: types.UID("cfg-uid")},
-		}
-
-		cl := fake.NewClientBuilder().WithScheme(s).WithObjects(cfg).Build()
-		r := &LifecycleReconciler{
-			Client:              cl,
-			Scheme:              s,
-			GatewayNamespace:    gwNS,
-			MonitoringNamespace: monitoringNS,
-		}
-
-		err := r.ensureUsageLogsEnvoyFilter(context.Background(), ctrl.Log)
-		g.Expect(err).NotTo(HaveOccurred())
-
-		ef := &unstructured.Unstructured{}
-		ef.SetGroupVersionKind(tenantreconcile.GVKEnvoyFilter)
-		err = cl.Get(context.Background(), client.ObjectKey{
-			Name: envoyFilterName, Namespace: gwNS,
-		}, ef)
-		g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "no EnvoyFilter should exist when usageLogging is disabled")
-	})
-
-	t.Run("enabled creates filter", func(t *testing.T) {
-		g := NewWithT(t)
-		s := lifecycleTestScheme(t)
-
-		cfg := &maasv1alpha1.Config{
-			ObjectMeta: metav1.ObjectMeta{Name: maasv1alpha1.ConfigInstanceName, UID: types.UID("cfg-uid")},
-			Spec:       maasv1alpha1.ConfigSpec{UsageLogging: ptr.To(true)},
-		}
-
-		// Compute absolute path to the EnvoyFilter manifest from this test file's location.
-		_, testFile, _, _ := goruntime.Caller(0)
-		efManifest := filepath.Join(filepath.Dir(testFile), "../../../../deployment/components/observability/usage-logs/envoy-otel-access-log.yaml")
-
-		cl := fake.NewClientBuilder().WithScheme(s).WithObjects(cfg).Build()
-		r := &LifecycleReconciler{
-			Client:                  cl,
-			Scheme:                  s,
-			GatewayNamespace:        gwNS,
-			MonitoringNamespace:     monitoringNS,
-			EnvoyFilterManifestPath: efManifest,
-		}
-
-		err := r.ensureUsageLogsEnvoyFilter(context.Background(), ctrl.Log)
-		g.Expect(err).NotTo(HaveOccurred())
-
-		ef := &unstructured.Unstructured{}
-		ef.SetGroupVersionKind(tenantreconcile.GVKEnvoyFilter)
-		g.Expect(cl.Get(context.Background(), client.ObjectKey{
-			Name: envoyFilterName, Namespace: gwNS,
-		}, ef)).To(Succeed(), "EnvoyFilter should exist after enabling usageLogging")
-		g.Expect(ef.GetNamespace()).To(Equal(gwNS))
-
-		configPatches, _, _ := unstructured.NestedSlice(ef.Object, "spec", "configPatches")
-		g.Expect(configPatches).NotTo(BeEmpty())
-		clusterPatch, _ := configPatches[0].(map[string]any)
-		endpoints, _, _ := unstructured.NestedSlice(clusterPatch, "patch", "value", "load_assignment", "endpoints")
-		g.Expect(endpoints).NotTo(BeEmpty())
-		ep0, _ := endpoints[0].(map[string]any)
-		lbEndpoints, _, _ := unstructured.NestedSlice(ep0, "lb_endpoints")
-		g.Expect(lbEndpoints).NotTo(BeEmpty())
-		lbe0, _ := lbEndpoints[0].(map[string]any)
-		addr, _, _ := unstructured.NestedString(lbe0, "endpoint", "address", "socket_address", "address")
-		g.Expect(addr).To(Equal("usage-logs-collector.opendatahub.svc.cluster.local"),
-			"collector address should be patched with MonitoringNamespace")
-	})
-
-	t.Run("deletes existing when disabled", func(t *testing.T) {
-		g := NewWithT(t)
-		s := lifecycleTestScheme(t)
-
-		cfg := &maasv1alpha1.Config{
-			ObjectMeta: metav1.ObjectMeta{Name: maasv1alpha1.ConfigInstanceName, UID: types.UID("cfg-uid")},
-			Spec:       maasv1alpha1.ConfigSpec{UsageLogging: ptr.To(false)},
-		}
-		existingEF := &unstructured.Unstructured{}
-		existingEF.SetGroupVersionKind(tenantreconcile.GVKEnvoyFilter)
-		existingEF.SetName(envoyFilterName)
-		existingEF.SetNamespace(gwNS)
-
-		cl := fake.NewClientBuilder().WithScheme(s).WithObjects(cfg, existingEF).Build()
-		r := &LifecycleReconciler{
-			Client:              cl,
-			Scheme:              s,
-			GatewayNamespace:    gwNS,
-			MonitoringNamespace: monitoringNS,
-		}
-
-		err := r.ensureUsageLogsEnvoyFilter(context.Background(), ctrl.Log)
-		g.Expect(err).NotTo(HaveOccurred())
-
-		ef := &unstructured.Unstructured{}
-		ef.SetGroupVersionKind(tenantreconcile.GVKEnvoyFilter)
-		err = cl.Get(context.Background(), client.ObjectKey{
-			Name: envoyFilterName, Namespace: gwNS,
-		}, ef)
-		g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "EnvoyFilter should be deleted when usageLogging is disabled")
-	})
-}
+// EnvoyFilter lifecycle tests moved to aitenant_controller_test.go (per-tenant EnvoyFilter).

--- a/maas-controller/pkg/platform/tenantreconcile/constants.go
+++ b/maas-controller/pkg/platform/tenantreconcile/constants.go
@@ -73,6 +73,8 @@ const (
 	baseMaaSAPIKeyCleanupScriptConfigMapName       = "maas-api-key-cleanup-script" //nolint:gosec // Kubernetes resource name, not a credential
 	baseMaaSAPIDeploymentNSNetworkPolicyName       = "maas-api-allow-deployment-ns"
 
+	baseUsageLogsEnvoyFilterName = "maas-model-access-logs"
+
 	// Non-tenant-specific resource names (shared infrastructure)
 	PayloadProcessingName                         = "payload-processing"
 	PayloadPreProcessingName                      = "payload-pre-processing"
@@ -181,6 +183,10 @@ func MaaSAPIDeploymentName(tenantID string) string {
 
 func MaaSAPIServiceName(tenantID string) string {
 	return resourceNameForTenant(baseMaaSAPIServiceName, tenantID)
+}
+
+func UsageLogsEnvoyFilterName(tenantID string) string {
+	return resourceNameForTenant(baseUsageLogsEnvoyFilterName, tenantID)
 }
 
 // TenantIdentifierFor extracts the tenant identifier from a tenant config object.


### PR DESCRIPTION
## Summary

- Move per-request usage-logs EnvoyFilter lifecycle from `LifecycleReconciler` to `AITenantReconciler`, so each tenant gets its own EnvoyFilter (`maas-model-access-logs-<tenant>`) targeting its specific gateway via `spec.targetRefs`
- `AITenantReconciler` reads the `Config` CR directly for the `usageLogging` flag and watches Config changes (with `GenerationChangedPredicate`) to propagate toggles to all tenants immediately
- Migration cleanup: best-effort deletion of old singleton `maas-model-access-logs` EnvoyFilter during reconciliation

### Design decisions

- **Reconciler**: `AITenantReconciler` — has direct access to `status.gatewayRef` and manages tenant infrastructure resources
- **usageLogging flag**: Read directly from `Config` CR (cluster-scoped singleton) — no annotation/plumbing needed
- **Config watch**: `SetupWithManager` watches `Config` changes via `EnqueueRequestsFromMapFunc` + `GenerationChangedPredicate` (skips status-only updates)
- **Cleanup on toggle-off**: Config change re-reconciles all AITenants; each deletes its own EnvoyFilter when `usageLogging=false`
- **Cross-namespace association**: Labels (`tenant-name`, `tenant-namespace`) instead of ownerRef (K8s disallows cross-namespace owner references)

### Files changed

| File | Change |
|------|--------|
| `aitenant_controller.go` | +257: EnvoyFilter lifecycle, Config watch, legacy cleanup, RBAC marker |
| `aitenant_controller_test.go` | +176: 4 tests (create, delete, disabled, no-gateway) with label assertions |
| `self_deployment_controller.go` | -151: Removed all EnvoyFilter code (moved to aitenant) |
| `self_deployment_controller_test.go` | -112: Removed old EnvoyFilter tests |
| `cmd/manager/main.go` | +1: Wire `MonitoringNamespace` into `AITenantReconciler` |
| `tenantreconcile/constants.go` | +6: `UsageLogsEnvoyFilterName()` naming helper |

## Risk analysis

- **Risk rating**: 3
- **Why**: Code-only change to controller reconciliation logic. Covered by 4 new unit tests + deployed and toggle-tested end-to-end on dev cluster (EF create/delete/recreate, Loki log flow verified). Risk is moderate because EnvoyFilter lifecycle affects observability pipeline — a regression would silently stop usage log collection. Prow smoke path does not exercise `usageLogging` toggle.

## Test plan

- [x] Unit tests pass (`go vet`, 4 new sub-tests in `TestEnsureUsageLogsEnvoyFilter`)
- [x] Toggle test: `usageLogging: false` → EF deleted, `true` → EF recreated (verified on cluster)
- [x] Traffic test: 3 requests → 3 hit entries in Loki with correct user/model
- [x] Legacy cleanup: old `maas-model-access-logs` EF deleted on reconcile
- [x] Labels verified: `tenant-name=models-as-a-service`, `tenant-namespace=ai-tenants`
- [ ] CI passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added per-tenant usage logging configuration through EnvoyFilters.
  - Usage logging now follows the cluster-wide setting and updates automatically when configuration changes.
  - Monitoring endpoints and tenant gateways are configured for each tenant.
  - Added cleanup for usage-logging resources when disabled or when a tenant is removed.
- **Bug Fixes**
  - Removed obsolete usage-logging resources during migration to the per-tenant configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->