### PR TITLE
fix: prevent kustomize from blocking payload-processing ext_proc ingress

### DIFF
--- a/deployment/base/payload-processing/networking/networkpolicy.yaml
+++ b/deployment/base/payload-processing/networking/networkpolicy.yaml
@@ -29,15 +29,14 @@ spec:
     - Ingress
     - Egress
   ingress:
-    # Allow ext_proc traffic from any Istio-managed gateway pod in the
-    # ingress namespace. Uses the common label applied by the Istio gateway
-    # controller to all provisioned gateway pods, covering both
-    # data-science-gateway and maas-default-gateway.
+    # Allow ext_proc traffic from gateway pods in openshift-ingress.
+    # NOTE: Do NOT add podSelector labels here. Kustomize labels transformers
+    # with includeSelectors=true (payload-processing/default) inject
+    # app.kubernetes.io/* labels into ingress podSelectors, which gateway pods
+    # do not carry and would block all ext_proc traffic. Same pattern as
+    # maas-api-allow-gateway NetworkPolicy.
     - from:
-        - podSelector:
-            matchLabels:
-              gateway.istio.io/managed: istio.io-gateway-controller
-          namespaceSelector:
+        - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: openshift-ingress
       ports:

--- a/maas-controller/pkg/platform/tenantreconcile/params.go
+++ b/maas-controller/pkg/platform/tenantreconcile/params.go
@@ -159,6 +159,8 @@ func patchResource(log logr.Logger, r *unstructured.Unstructured, params Platfor
 		r.SetNamespace(params.GatewayNamespace)
 	case gvk == GVKNetworkPolicy && name == baseMaaSAPIDeploymentNSNetworkPolicyName:
 		return patchDeploymentNSNetworkPolicy(r, params.ControllerNamespace)
+	case gvk == GVKNetworkPolicy && name == PayloadProcessingName:
+		r.SetNamespace(params.GatewayNamespace)
 	case gvk == GVKClusterRoleBinding && name == PayloadProcessingReaderClusterRoleBindingName:
 		return patchClusterRoleBindingSubjectNS(r, params.GatewayNamespace)
 	}

--- a/test/e2e/tests/test_networkpolicy.py
+++ b/test/e2e/tests/test_networkpolicy.py
@@ -54,8 +54,8 @@ class TestPayloadProcessingNetworkPolicyExists:
                 f"podSelector must select payload-processing pods, got {pod_selector!r}"
             )
 
-    def test_ingress_uses_istio_managed_label(self):
-        """Ingress must use gateway.istio.io/managed to cover all gateways."""
+    def test_ingress_allows_gateway_namespace(self):
+        """ext_proc ingress must allow openshift-ingress without polluted pod labels."""
         np = get_json_or_none("networkpolicy", NETWORKPOLICY_NAME, GATEWAY_NAMESPACE)
         assert np is not None
         ingress_rules = np["spec"].get("ingress") or []
@@ -75,15 +75,15 @@ class TestPayloadProcessingNetworkPolicyExists:
         from_selectors = ext_proc_rule.get("from") or []
         assert len(from_selectors) > 0, "ext_proc ingress rule must have 'from' selectors"
 
-        pod_selector = from_selectors[0].get("podSelector", {})
-        match_labels = pod_selector.get("matchLabels") or {}
-        assert match_labels.get(EXPECTED_MANAGED_LABEL) == EXPECTED_MANAGED_VALUE, (
-            f"ext_proc ingress must use {EXPECTED_MANAGED_LABEL}: {EXPECTED_MANAGED_VALUE} "
-            f"to cover all Istio-managed gateways, got matchLabels: {match_labels!r}"
+        ns_selector = from_selectors[0].get("namespaceSelector", {})
+        ns_labels = ns_selector.get("matchLabels") or {}
+        assert ns_labels.get("kubernetes.io/metadata.name") == GATEWAY_NAMESPACE, (
+            f"ext_proc ingress must allow traffic from {GATEWAY_NAMESPACE}, "
+            f"got namespaceSelector: {ns_selector!r}"
         )
 
-    def test_ingress_does_not_hardcode_single_gateway(self):
-        """Ingress must NOT use gateway-name label that restricts to one gateway."""
+    def test_ingress_pod_selector_not_polluted_by_kustomize(self):
+        """Ingress podSelector must not carry maas-api/payload-processing labels."""
         np = get_json_or_none("networkpolicy", NETWORKPOLICY_NAME, GATEWAY_NAMESPACE)
         assert np is not None
         ingress_rules = np["spec"].get("ingress") or []
@@ -94,6 +94,16 @@ class TestPayloadProcessingNetworkPolicyExists:
                 continue
             for from_selector in rule.get("from") or []:
                 pod_labels = (from_selector.get("podSelector") or {}).get("matchLabels") or {}
+                assert "app.kubernetes.io/name" not in pod_labels, (
+                    "ext_proc ingress podSelector must not include app.kubernetes.io/name "
+                    "(kustomize includeSelectors pollution blocks gateway pods). "
+                    f"Found: {pod_labels!r}"
+                )
+                assert "app.kubernetes.io/component" not in pod_labels, (
+                    "ext_proc ingress podSelector must not include app.kubernetes.io/component "
+                    "(kustomize includeSelectors pollution blocks gateway pods). "
+                    f"Found: {pod_labels!r}"
+                )
                 assert "gateway.networking.k8s.io/gateway-name" not in pod_labels, (
                     "ext_proc ingress must NOT use gateway.networking.k8s.io/gateway-name "
                     "as pod selector — this restricts traffic to a single gateway. "


### PR DESCRIPTION
Patch the payload-processing NetworkPolicy to openshift-ingress and use namespaceSelector-only ingress so includeSelectors label transformers cannot inject maas-api/payload-processing labels into the gateway podSelector.

This fixes prow ext_proc 500 errors where the NP was present in the right namespace but still blocked maas-default-gateway traffic.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved payload-processing network access so traffic from the ingress gateway is reliably permitted.
  - Ensured the payload-processing network policy is applied in the correct gateway namespace during deployment.
  - Prevented deployment-generated labels from interfering with gateway traffic rules.
  - Expanded validation to confirm gateway access remains correctly scoped and does not target a single gateway instance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->