### PR TITLE
fix: restore payload-processing NP podSelector and egress rules

### DIFF
--- a/deployment/base/payload-processing/networking/networkpolicy.yaml
+++ b/deployment/base/payload-processing/networking/networkpolicy.yaml
@@ -7,7 +7,8 @@
 # Security constraints:
 # - podSelector: covers payload-processing and payload-pre-processing pods
 # - ingress: gateway ext_proc traffic (port 9004), monitoring scrape (9005, 9090)
-# - egress: not restricted (ingress-only policy)
+# - egress: DNS + Kubernetes API server only (this container is a pure
+#   Kubernetes controller with no external HTTP/gRPC calls)
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -26,12 +27,17 @@ spec:
           - payload-pre-processing
   policyTypes:
     - Ingress
+    - Egress
   ingress:
-    # Allow ext_proc traffic from any pod in the gateway namespace.
-    # Using namespaceSelector only (no podSelector) matches the pattern in
-    # maas-api-allow-gateway and avoids label mismatches across Istio versions.
+    # Allow ext_proc traffic from any Istio-managed gateway pod in the
+    # ingress namespace. Uses the common label applied by the Istio gateway
+    # controller to all provisioned gateway pods, covering both
+    # data-science-gateway and maas-default-gateway.
     - from:
-        - namespaceSelector:
+        - podSelector:
+            matchLabels:
+              gateway.istio.io/managed: istio.io-gateway-controller
+          namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: openshift-ingress
       ports:
@@ -50,3 +56,20 @@ spec:
           port: 9005
         - protocol: TCP
           port: 9090
+  egress:
+    # Allow DNS resolution (CoreDNS on OCP uses port 5353)
+    - ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+        - protocol: UDP
+          port: 5353
+        - protocol: TCP
+          port: 5353
+    # Allow Kubernetes API server access (controller-runtime client)
+    - ports:
+        - protocol: TCP
+          port: 443
+        - protocol: TCP
+          port: 6443

--- a/maas-api/deploy/overlays/odh/kustomization.yaml
+++ b/maas-api/deploy/overlays/odh/kustomization.yaml
@@ -14,6 +14,22 @@ resources:
 
 namespace: opendatahub
 
+# Strip app.kubernetes.io labels that kustomize includeSelectors injects
+# into the NP's from[].podSelector. The inner kustomization (default/)
+# uses includeSelectors: true for Deployment/Service selectors, but this
+# also pollutes NetworkPolicy ingress selectors, making the ext_proc
+# rule unmatchable (gateway pods don't have payload-processing labels).
+patches:
+- target:
+    kind: NetworkPolicy
+    name: payload-processing
+  patch: |-
+    - op: replace
+      path: /spec/ingress/0/from/0/podSelector
+      value:
+        matchLabels:
+          gateway.istio.io/managed: istio.io-gateway-controller
+
 labels:
 - pairs:
     app.kubernetes.io/component: api

--- a/test/e2e/tests/test_networkpolicy.py
+++ b/test/e2e/tests/test_networkpolicy.py
@@ -6,6 +6,8 @@ Istio-managed gateway pods (not just data-science-gateway), and that
 MaaS API endpoints are reachable through maas-default-gateway.
 """
 
+import json
+
 import pytest
 import requests
 
@@ -19,6 +21,8 @@ from multitenancy_helpers import (
 )
 
 NETWORKPOLICY_NAME = "payload-processing"
+EXPECTED_MANAGED_LABEL = "gateway.istio.io/managed"
+EXPECTED_MANAGED_VALUE = "istio.io-gateway-controller"
 EXT_PROC_PORT = 9004
 
 
@@ -50,8 +54,8 @@ class TestPayloadProcessingNetworkPolicyExists:
                 f"podSelector must select payload-processing pods, got {pod_selector!r}"
             )
 
-    def test_ingress_allows_gateway_namespace(self):
-        """Ingress must allow traffic from the gateway namespace."""
+    def test_ingress_uses_istio_managed_label(self):
+        """Ingress must use gateway.istio.io/managed to cover all gateways."""
         np = get_json_or_none("networkpolicy", NETWORKPOLICY_NAME, GATEWAY_NAMESPACE)
         assert np is not None
         ingress_rules = np["spec"].get("ingress") or []
@@ -71,11 +75,11 @@ class TestPayloadProcessingNetworkPolicyExists:
         from_selectors = ext_proc_rule.get("from") or []
         assert len(from_selectors) > 0, "ext_proc ingress rule must have 'from' selectors"
 
-        ns_selector = from_selectors[0].get("namespaceSelector", {})
-        match_labels = ns_selector.get("matchLabels") or {}
-        assert match_labels.get("kubernetes.io/metadata.name") == GATEWAY_NAMESPACE, (
-            f"ext_proc ingress must allow traffic from gateway namespace "
-            f"{GATEWAY_NAMESPACE}, got namespaceSelector matchLabels: {match_labels!r}"
+        pod_selector = from_selectors[0].get("podSelector", {})
+        match_labels = pod_selector.get("matchLabels") or {}
+        assert match_labels.get(EXPECTED_MANAGED_LABEL) == EXPECTED_MANAGED_VALUE, (
+            f"ext_proc ingress must use {EXPECTED_MANAGED_LABEL}: {EXPECTED_MANAGED_VALUE} "
+            f"to cover all Istio-managed gateways, got matchLabels: {match_labels!r}"
         )
 
     def test_ingress_does_not_hardcode_single_gateway(self):
@@ -119,6 +123,21 @@ class TestPayloadProcessingConnectivity:
         ]
         assert len(ready_pods) > 0, (
             f"Gateway {DEFAULT_GATEWAY_NAME} has pods but none are ready"
+        )
+
+    def test_maas_gateway_has_istio_managed_label(self):
+        """maas-default-gateway pods must carry the Istio managed label."""
+        pods = list_json(
+            "pod",
+            GATEWAY_NAMESPACE,
+            labels=f"gateway.networking.k8s.io/gateway-name={DEFAULT_GATEWAY_NAME}",
+        )
+        assert len(pods) > 0
+        pod = pods[0]
+        labels = pod.get("metadata", {}).get("labels") or {}
+        assert labels.get(EXPECTED_MANAGED_LABEL) == EXPECTED_MANAGED_VALUE, (
+            f"Gateway pod must have label {EXPECTED_MANAGED_LABEL}={EXPECTED_MANAGED_VALUE}, "
+            f"got labels: {json.dumps({k: v for k, v in labels.items() if 'gateway' in k.lower() or 'istio' in k.lower() or 'managed' in k.lower()})}"
         )
 
     def test_payload_processing_pods_running(self):


### PR DESCRIPTION
## Description

PR #1157 weakened the payload-processing NetworkPolicy to work around kustomize `includeSelectors` injecting `app.kubernetes.io` labels into `from[].podSelector`, which made the ext_proc ingress rule unmatchable (gateway pods don't have payload-processing labels).

This PR fixes the root cause with a kustomize patch in the ODH overlay instead. The overlay runs after the inner kustomization's label transformer, so the patch resets the polluted `podSelector` back to `gateway.istio.io/managed: istio.io-gateway-controller`. The overlay's own `labels` block has no `includeSelectors`, so it won't re-pollute.

### Changes

- Restore full NP spec: `podSelector` with `gateway.istio.io/managed`, egress restrictions (DNS + k8s API), both Ingress and Egress policyTypes
- Add kustomize JSON patch in ODH overlay to strip injected labels from NP ingress `podSelector`
- Restore e2e test assertions for the `podSelector` label and gateway managed label

### Root cause

Ishita identified it in #1157: kustomize `includeSelectors: true` in `payload-processing/default/kustomization.yaml` injects `app.kubernetes.io/component`, `app.kubernetes.io/name`, and `app.kubernetes.io/part-of` into every `matchLabels` field, including the NP's `from[].podSelector`. No gateway pod has all those labels, so the ingress rule matched nothing and ext_proc traffic was blocked.

## How Has This Been Tested?

- `kustomize build maas-api/deploy/overlays/odh` produces clean NP with only `gateway.istio.io/managed` in the ingress podSelector
- `./scripts/ci/validate-manifests.sh` passes
- CodeRabbit review: 0 findings

## Risk analysis

- **Risk rating**: 3
- **Why**: Changes NetworkPolicy spec in the gateway namespace. Verified via kustomize build that the output is correct. The NP was already deployed (and working) with the broader selector in #1157, this tightens it. Risk is that the podSelector label doesn't match on some cluster variant, but we verified it on two live clusters.

## Merge criteria

- [x] The commits are squashed in a cohesive manner and have meaningful messages
- [x] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Restricted payload-processing ingress traffic to Istio-managed gateway pods.
  * Added explicit outbound network controls, permitting only DNS resolution and Kubernetes API access.
  * Preserved monitoring access for approved monitoring namespaces and scrape ports.
* **Validation**
  * Added end-to-end checks confirming gateway labels and network policy behavior match the intended traffic rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->