### PR TITLE
fix: patch NetworkPolicy-required label onto pre-existing infra names…

### DIFF
--- a/maas-controller/cmd/manager/main.go
+++ b/maas-controller/cmd/manager/main.go
@@ -73,7 +73,7 @@ func init() {
 	utilruntime.Must(maasv1alpha1.AddToScheme(scheme))
 }
 
-//+kubebuilder:rbac:groups="",resources=namespaces,verbs=get;create
+//+kubebuilder:rbac:groups="",resources=namespaces,verbs=get;create;update
 
 // ensureManagedNamespaceWithClient checks whether a controller-managed namespace exists
 // and creates it if missing. It checks for existence first so that the controller can
@@ -135,7 +135,7 @@ func ensureManagedNamespaceWithClient(ctx context.Context, namespace, purpose st
 		} else {
 			setupLog.Info("managed namespace already exists",
 				"namespace", namespace, "purpose", purpose, "phase", ns.Status.Phase)
-			return nil
+			return ensureManagedNamespaceLabels(ctx, ns, namespace, purpose, clientset)
 		}
 	}
 
@@ -155,14 +155,14 @@ func ensureManagedNamespaceWithClient(ctx context.Context, namespace, purpose st
 		Duration: 1 * time.Second,
 		Factor:   2.0,
 	}, func(ctx context.Context) (bool, error) {
+		labels := make(map[string]string, len(managedNamespaceLabels))
+		for k, v := range managedNamespaceLabels {
+			labels[k] = v
+		}
 		ns := &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: namespace,
-				Labels: map[string]string{
-					"opendatahub.io/generated-namespace": "true",
-					"app.kubernetes.io/managed-by":       "maas-controller",
-					"app.kubernetes.io/part-of":          "maas-controller",
-				},
+				Name:   namespace,
+				Labels: labels,
 			},
 		}
 
@@ -181,6 +181,9 @@ func ensureManagedNamespaceWithClient(ctx context.Context, namespace, purpose st
 				return false, nil
 			}
 			if existingNs.Status.Phase == corev1.NamespaceActive || existingNs.Status.Phase == "" {
+				if labelErr := ensureManagedNamespaceLabels(ctx, existingNs, namespace, purpose, clientset); labelErr != nil {
+					return false, labelErr
+				}
 				setupLog.Info("managed namespace ready", "namespace", namespace, "purpose", purpose)
 				return true, nil
 			}
@@ -196,6 +199,37 @@ func ensureManagedNamespaceWithClient(ctx context.Context, namespace, purpose st
 		setupLog.Info("retrying namespace creation", "namespace", namespace, "purpose", purpose, "error", err)
 		return false, nil // transient error, retry
 	})
+}
+
+var managedNamespaceLabels = map[string]string{
+	"opendatahub.io/generated-namespace": "true",
+	"app.kubernetes.io/managed-by":       "maas-controller",
+	"app.kubernetes.io/part-of":          "maas-controller",
+}
+
+const networkPolicyRequiredLabel = "opendatahub.io/generated-namespace"
+
+// ensureManagedNamespaceLabels ensures the opendatahub.io/generated-namespace
+// label is present on an existing namespace. This handles the upgrade path
+// where the namespace is pre-created by the operator without the label that
+// the DSCI NetworkPolicy requires for ingress. Only the NetworkPolicy-required
+// label is patched; ownership labels (managed-by, part-of) are left as-is
+// since the namespace may be legitimately managed by another component.
+func ensureManagedNamespaceLabels(ctx context.Context, ns *corev1.Namespace, namespace, purpose string, clientset kubernetes.Interface) error {
+	if ns.Labels != nil && ns.Labels[networkPolicyRequiredLabel] == "true" {
+		return nil
+	}
+	if ns.Labels == nil {
+		ns.Labels = make(map[string]string)
+	}
+	ns.Labels[networkPolicyRequiredLabel] = "true"
+	_, err := clientset.CoreV1().Namespaces().Update(ctx, ns, metav1.UpdateOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to add %s label to existing namespace %q: %w", networkPolicyRequiredLabel, namespace, err)
+	}
+	setupLog.Info("added NetworkPolicy-required label to existing managed namespace",
+		"namespace", namespace, "purpose", purpose)
+	return nil
 }
 
 func subscriptionNamespaceExists(ctx context.Context, namespace string, clientset kubernetes.Interface) (bool, error) {

--- a/maas-controller/cmd/manager/main.go
+++ b/maas-controller/cmd/manager/main.go
@@ -73,7 +73,7 @@ func init() {
 	utilruntime.Must(maasv1alpha1.AddToScheme(scheme))
 }
 
-//+kubebuilder:rbac:groups="",resources=namespaces,verbs=get;create;update
+//+kubebuilder:rbac:groups="",resources=namespaces,verbs=get;create;patch
 
 // ensureManagedNamespaceWithClient checks whether a controller-managed namespace exists
 // and creates it if missing. It checks for existence first so that the controller can
@@ -219,13 +219,10 @@ func ensureManagedNamespaceLabels(ctx context.Context, ns *corev1.Namespace, nam
 	if ns.Labels != nil && ns.Labels[networkPolicyRequiredLabel] == "true" {
 		return nil
 	}
-	if ns.Labels == nil {
-		ns.Labels = make(map[string]string)
-	}
-	ns.Labels[networkPolicyRequiredLabel] = "true"
-	_, err := clientset.CoreV1().Namespaces().Update(ctx, ns, metav1.UpdateOptions{})
+	patchData := []byte(`{"metadata":{"labels":{"` + networkPolicyRequiredLabel + `":"true"}}}`)
+	_, err := clientset.CoreV1().Namespaces().Patch(ctx, namespace, types.MergePatchType, patchData, metav1.PatchOptions{})
 	if err != nil {
-		return fmt.Errorf("failed to add %s label to existing namespace %q: %w", networkPolicyRequiredLabel, namespace, err)
+		return fmt.Errorf("failed to patch %s label on existing namespace %q: %w", networkPolicyRequiredLabel, namespace, err)
 	}
 	setupLog.Info("added NetworkPolicy-required label to existing managed namespace",
 		"namespace", namespace, "purpose", purpose)

--- a/maas-controller/cmd/manager/main_test.go
+++ b/maas-controller/cmd/manager/main_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -368,5 +369,86 @@ func TestEnsureDefaultAITenantBootstrapDoesNotRecreateAfterBootstrapMarker(t *te
 		Namespace: tenantreconcile.DefaultAITenantNamespace,
 	}, &maasv1alpha1.AITenant{}); err == nil {
 		t.Fatalf("default AITenant was recreated after bootstrap marker")
+	}
+}
+
+func TestEnsureManagedNamespaceAddsNetworkPolicyLabelWithoutOverwritingOwnership(t *testing.T) {
+	existing := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-infra-ns",
+			Labels: map[string]string{
+				"app.kubernetes.io/part-of":    "ai-gateway",
+				"app.kubernetes.io/managed-by": "ai-gateway-operator",
+			},
+		},
+	}
+	clientset := clientsetfake.NewSimpleClientset(existing)
+
+	if err := ensureManagedNamespaceWithClient(context.Background(), "test-infra-ns", "infra", clientset); err != nil {
+		t.Fatalf("ensure managed namespace: %v", err)
+	}
+
+	ns, err := clientset.CoreV1().Namespaces().Get(context.Background(), "test-infra-ns", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get namespace: %v", err)
+	}
+	if got := ns.Labels["opendatahub.io/generated-namespace"]; got != "true" {
+		t.Fatalf("generated-namespace label = %q, want true", got)
+	}
+	if got := ns.Labels["app.kubernetes.io/managed-by"]; got != "ai-gateway-operator" {
+		t.Fatalf("managed-by label was overwritten to %q, want ai-gateway-operator preserved", got)
+	}
+	if got := ns.Labels["app.kubernetes.io/part-of"]; got != "ai-gateway" {
+		t.Fatalf("part-of label was overwritten to %q, want ai-gateway preserved", got)
+	}
+}
+
+func TestEnsureManagedNamespaceNoUpdateWhenNetworkPolicyLabelPresent(t *testing.T) {
+	existing := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-infra-ns",
+			Labels: map[string]string{
+				"opendatahub.io/generated-namespace": "true",
+				"app.kubernetes.io/managed-by":       "ai-gateway-operator",
+				"app.kubernetes.io/part-of":          "ai-gateway",
+			},
+		},
+	}
+	clientset := clientsetfake.NewSimpleClientset(existing)
+
+	if err := ensureManagedNamespaceWithClient(context.Background(), "test-infra-ns", "infra", clientset); err != nil {
+		t.Fatalf("ensure managed namespace: %v", err)
+	}
+
+	ns, err := clientset.CoreV1().Namespaces().Get(context.Background(), "test-infra-ns", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get namespace: %v", err)
+	}
+	if got := ns.Labels["app.kubernetes.io/managed-by"]; got != "ai-gateway-operator" {
+		t.Fatalf("managed-by label changed to %q, want ai-gateway-operator unchanged", got)
+	}
+}
+
+func TestEnsureManagedNamespacePatchesNilLabels(t *testing.T) {
+	existing := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-infra-ns",
+		},
+	}
+	clientset := clientsetfake.NewSimpleClientset(existing)
+
+	if err := ensureManagedNamespaceWithClient(context.Background(), "test-infra-ns", "infra", clientset); err != nil {
+		t.Fatalf("ensure managed namespace: %v", err)
+	}
+
+	ns, err := clientset.CoreV1().Namespaces().Get(context.Background(), "test-infra-ns", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get namespace: %v", err)
+	}
+	if got := ns.Labels["opendatahub.io/generated-namespace"]; got != "true" {
+		t.Fatalf("generated-namespace label = %q, want true", got)
+	}
+	if _, exists := ns.Labels["app.kubernetes.io/managed-by"]; exists {
+		t.Fatalf("managed-by label was added to namespace not created by maas-controller")
 	}
 }


### PR DESCRIPTION
…pace

ensureManagedNamespaceWithClient() returned immediately when the infrastructure namespace already existed, without ensuring the opendatahub.io/generated-namespace label was present. On the upgrade path the namespace is pre-created by the ai-gateway-operator without this label, so the DSCI NetworkPolicy blocks maas-api from reaching PostgreSQL — causing CrashLoopBackOff and DSC NotReady.

Add ensureManagedNamespaceLabels() to patch only the NetworkPolicy- required label onto existing namespaces without overwriting ownership metadata (managed-by, part-of) that may belong to another component.

Ref: [RHOAIENG-76928](https://redhat.atlassian.net/browse/RHOAIENG-76928)

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Deployed postgres in opendatahub
- deployed maas
- observed error
- restarted maas-controller w/ fix , restarted maas-api 

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


[RHOAIENG-76928]: https://redhat.atlassian.net/browse/RHOAIENG-76928?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Existing managed namespaces now receive the required network policy label.
  * Existing labels are preserved when namespace metadata is updated.
  * Namespaces with missing labels are handled safely without adding unintended ownership labels.

* **Tests**
  * Added coverage for label preservation, already-correct namespaces, and namespaces with no existing labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->