### PR TITLE
fix: requeue quietly on stale-cache conflict in TenantReconciler

### DIFF
--- a/maas-controller/pkg/controller/maas/tenant_controller.go
+++ b/maas-controller/pkg/controller/maas/tenant_controller.go
@@ -22,6 +22,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -133,7 +134,16 @@ type TenantReconciler struct {
 // Reconcile drives the MaasTenantConfig platform lifecycle. ODH deploys maas-controller; the controller
 // owns the full deploy pipeline via the MaasTenantConfig CR (no standalone ModelsAsService instance CR exists).
 func (r *TenantReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	return r.reconcile(ctx, req)
+	result, err := r.reconcile(ctx, req)
+	if apierrors.IsConflict(err) {
+		// Stale-cache conflict: the in-memory object's UID/ResourceVersion diverged from etcd
+		// (e.g. MaasTenantConfig was deleted and recreated between Get and Status.Update).
+		// Requeue without surfacing an error so controller-runtime doesn't log "Reconciler error"
+		// and apply exponential back-off; the next reconcile will re-read a fresh copy.
+		ctrl.LoggerFrom(ctx).V(1).Info("requeuing after stale-cache conflict", "error", err)
+		return ctrl.Result{Requeue: true}, nil
+	}
+	return result, err
 }
 
 const openshiftAuthenticationClusterName = "cluster"

--- a/maas-controller/pkg/controller/maas/tenant_controller.go
+++ b/maas-controller/pkg/controller/maas/tenant_controller.go
@@ -18,6 +18,7 @@ package maas
 
 import (
 	"context"
+	"errors"
 	"sync"
 
 	corev1 "k8s.io/api/core/v1"
@@ -135,15 +136,28 @@ type TenantReconciler struct {
 // owns the full deploy pipeline via the MaasTenantConfig CR (no standalone ModelsAsService instance CR exists).
 func (r *TenantReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	result, err := r.reconcile(ctx, req)
-	if apierrors.IsConflict(err) {
-		// Stale-cache conflict: the in-memory object's UID/ResourceVersion diverged from etcd
-		// (e.g. MaasTenantConfig was deleted and recreated between Get and Status.Update).
-		// Requeue without surfacing an error so controller-runtime doesn't log "Reconciler error"
-		// and apply exponential back-off; the next reconcile will re-read a fresh copy.
-		ctrl.LoggerFrom(ctx).V(1).Info("requeuing after stale-cache conflict", "error", err)
+	if apierrors.IsConflict(err) && isMaasTenantConfigConflict(err, req) {
+		// Stale-cache conflict on the MaasTenantConfig itself: the in-memory object's
+		// UID/ResourceVersion diverged from etcd (e.g. deleted and recreated between
+		// Get and Status.Update). Requeue without surfacing an error so controller-runtime
+		// doesn't log "Reconciler error" or apply exponential back-off; the next reconcile
+		// will re-read a fresh copy. Conflicts on child resources are propagated unchanged.
+		ctrl.LoggerFrom(ctx).V(1).Info("requeuing after stale-cache conflict on MaasTenantConfig", "error", err)
 		return ctrl.Result{Requeue: true}, nil
 	}
 	return result, err
+}
+
+// isMaasTenantConfigConflict returns true when the conflict error originates from
+// the MaasTenantConfig being reconciled (identified by object name in the Status
+// details), as opposed to a conflict on a child resource managed by the reconciler.
+func isMaasTenantConfigConflict(err error, req ctrl.Request) bool {
+	var statusErr *apierrors.StatusError
+	if !errors.As(err, &statusErr) {
+		return false
+	}
+	details := statusErr.ErrStatus.Details
+	return details != nil && details.Name == req.Name
 }
 
 const openshiftAuthenticationClusterName = "cluster"


### PR DESCRIPTION
When MaasTenantConfig is deleted and recreated (e.g. during e2ereinstall), the reconciler's in-memory copy retains the old UID. The subsequent Status().Update hits an etcd precondition failure(StorageError Code 4, UID mismatch), which surfaces as an apierrors.IsConflict error.
Wrap r.reconcile() in Reconcile() to catch this: convert conflict errors into a silent ctrl.Result{Requeue: true} so controller-runtime does not log "Reconciler error" or apply exponential back-off. The next reconcile re-reads a fresh copy of the object.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of update conflicts during tenant reconciliation.
  * Automatically retries affected operations instead of reporting stale-cache conflicts as failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->