### PR TITLE
fix: removing finalizer to unblock ci

### DIFF
--- a/maas-controller/pkg/controller/maas/aitenant_controller.go
+++ b/maas-controller/pkg/controller/maas/aitenant_controller.go
@@ -116,14 +116,16 @@ func (r *AITenantReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return r.reconcileAITenantDelete(ctx, &aitenant)
 	}
 
-	if !controllerutil.ContainsFinalizer(&aitenant, aitenantFinalizer) {
-		base := aitenant.DeepCopy()
-		controllerutil.AddFinalizer(&aitenant, aitenantFinalizer)
-		if err := r.Patch(ctx, &aitenant, client.MergeFrom(base)); err != nil {
-			return ctrl.Result{}, err
-		}
-		return ctrl.Result{RequeueAfter: time.Second}, nil
-	}
+	// Unblocking UI
+	// TODO: Include adding the finalizer back as part of https://github.com/opendatahub-io/models-as-a-service/pull/1159
+	// if !controllerutil.ContainsFinalizer(&aitenant, aitenantFinalizer) {
+	// 	base := aitenant.DeepCopy()
+	// 	controllerutil.AddFinalizer(&aitenant, aitenantFinalizer)
+	// 	if err := r.Patch(ctx, &aitenant, client.MergeFrom(base)); err != nil {
+	// 		return ctrl.Result{}, err
+	// 	}
+	// 	return ctrl.Result{RequeueAfter: time.Second}, nil
+	// }
 
 	statusSnapshot := aitenant.Status.DeepCopy()
 
@@ -501,9 +503,11 @@ func (r *AITenantReconciler) ensureAITenantObjectRole(ctx context.Context, aiten
 }
 
 func (r *AITenantReconciler) reconcileAITenantDelete(ctx context.Context, aitenant *maasv1alpha1.AITenant) (ctrl.Result, error) {
-	if !controllerutil.ContainsFinalizer(aitenant, aitenantFinalizer) {
-		return ctrl.Result{}, nil
-	}
+	// Unblocking UI
+	// TODO: Include adding the finalizer back as part of https://github.com/opendatahub-io/models-as-a-service/pull/1159
+	// if !controllerutil.ContainsFinalizer(aitenant, aitenantFinalizer) {
+	// 	return ctrl.Result{}, nil
+	// }
 
 	tenantNamespace := r.tenantNamespaceName(aitenant)
 	statusSnapshot := aitenant.Status.DeepCopy()
@@ -567,11 +571,13 @@ func (r *AITenantReconciler) reconcileAITenantDelete(ctx context.Context, aitena
 		return ctrl.Result{}, err
 	}
 
-	base := aitenant.DeepCopy()
-	controllerutil.RemoveFinalizer(aitenant, aitenantFinalizer)
-	if err := r.Patch(ctx, aitenant, client.MergeFrom(base)); err != nil {
-		return ctrl.Result{}, err
-	}
+	// Unblocking UI
+	// TODO: Include adding the finalizer back as part of https://github.com/opendatahub-io/models-as-a-service/pull/1159
+	// base := aitenant.DeepCopy()
+	// controllerutil.RemoveFinalizer(aitenant, aitenantFinalizer)
+	// if err := r.Patch(ctx, aitenant, client.MergeFrom(base)); err != nil {
+	// 	return ctrl.Result{}, err
+	// }
 	return ctrl.Result{}, nil
 }
 

--- a/maas-controller/pkg/controller/maas/aitenant_controller_test.go
+++ b/maas-controller/pkg/controller/maas/aitenant_controller_test.go
@@ -83,9 +83,10 @@ func reconcileAITenantTwice(t *testing.T, r *AITenantReconciler, key types.Names
 	t.Helper()
 	g := NewWithT(t)
 
+	// Unblocking UI: finalizer add/requeue removed temporarily in PR #1159 follow-up.
 	res, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
 	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(res.RequeueAfter).To(Equal(time.Second))
+	g.Expect(res.RequeueAfter).To(Equal(time.Duration(0)))
 
 	res, err = r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
 	g.Expect(err).NotTo(HaveOccurred())
@@ -265,10 +266,6 @@ func TestAITenantReconcile_MissingGatewaySetsFailedStatus(t *testing.T) {
 	key := types.NamespacedName{Name: aitenant.Name, Namespace: aitenant.Namespace}
 	res, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
 	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(res.RequeueAfter).To(Equal(time.Second))
-
-	res, err = r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
-	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(res.RequeueAfter).To(Equal(30 * time.Second))
 
 	var updated maasv1alpha1.AITenant
@@ -387,7 +384,7 @@ func TestAITenantReconcile_UpdatesPreExistingTenant(t *testing.T) {
 
 	res, err = r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
 	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(res.RequeueAfter).To(Equal(time.Second))
+	g.Expect(res.RequeueAfter).To(Equal(time.Duration(0)))
 
 	res, err = r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
 	g.Expect(err).NotTo(HaveOccurred())
@@ -535,11 +532,7 @@ func TestAITenantReconcile_LegacyGatewayNamespaceMismatchFailsMigration(t *testi
 	key := types.NamespacedName{Name: aitenant.Name, Namespace: aitenant.Namespace}
 	res, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
 	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(res.RequeueAfter).To(Equal(time.Second))
-
-	res, err = r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
-	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(res).To(Equal(ctrl.Result{}))
+	g.Expect(res.RequeueAfter).To(Equal(time.Duration(0)))
 
 	var updated maasv1alpha1.AITenant
 	g.Expect(cl.Get(context.Background(), key, &updated)).To(Succeed())
@@ -868,10 +861,6 @@ func TestAITenantReconcile_RejectsNamespaceOwnedByAnotherAITenant(t *testing.T) 
 	key := types.NamespacedName{Name: aitenant.Name, Namespace: aitenant.Namespace}
 	res, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
 	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(res.RequeueAfter).To(Equal(time.Second))
-
-	res, err = r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
-	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(res.RequeueAfter).To(Equal(30 * time.Second))
 
 	var updated maasv1alpha1.AITenant
@@ -1023,7 +1012,9 @@ func TestAITenantReconcile_DeletionCleansChildrenAndRequestsNamespaceDeletionBut
 	err = cl.Get(ctx, key, &remaining)
 	if !apierrors.IsNotFound(err) {
 		g.Expect(err).NotTo(HaveOccurred())
-		g.Expect(remaining.Finalizers).NotTo(ContainElement(aitenantFinalizer))
+		// Unblocking UI
+		// TODO: Include adding the finalizer back as part of https://github.com/opendatahub-io/models-as-a-service/pull/1159
+		// g.Expect(remaining.Finalizers).NotTo(ContainElement(aitenantFinalizer))
 	}
 }
 
@@ -1300,13 +1291,8 @@ func TestAITenantReconcile_GatewayClaimBlocksDuplicateGateway(t *testing.T) {
 
 	key2 := types.NamespacedName{Name: aitenant2.Name, Namespace: aitenant2.Namespace}
 
-	// First reconcile adds the finalizer.
+	// Reconcile should fail due to gateway claim conflict.
 	res, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key2})
-	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(res.RequeueAfter).To(Equal(time.Second))
-
-	// Second reconcile should fail due to gateway claim conflict.
-	res, err = r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key2})
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(res.RequeueAfter).To(Equal(30 * time.Second))
 
@@ -1361,6 +1347,8 @@ func TestAITenantReconcile_GatewayClaimCleanedOnDeletion(t *testing.T) {
 	var toDelete maasv1alpha1.AITenant
 	g.Expect(cl.Get(ctx, key, &toDelete)).To(Succeed())
 	setMapValue(&toDelete.Annotations, aitenantAPIKeysRevokedAnnotation, "true")
+	// Keep the object through deletion reconcile while finalizer add is disabled in controller.
+	toDelete.Finalizers = []string{aitenantFinalizer}
 	g.Expect(cl.Update(ctx, &toDelete)).To(Succeed())
 	g.Expect(cl.Delete(ctx, &maasv1alpha1.MaasTenantConfig{ObjectMeta: metav1.ObjectMeta{Name: maasv1alpha1.MaasTenantConfigInstanceName, Namespace: "ai-tenant-team-cleanup"}})).To(Succeed())
 	g.Expect(cl.Delete(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ai-tenant-team-cleanup"}})).To(Succeed())
@@ -2151,7 +2139,9 @@ func TestAITenantReconcile_DefaultTenantDeletionCompletesInZeroTenantState(t *te
 	err = cl.Get(ctx, key, &remaining)
 	if !apierrors.IsNotFound(err) {
 		g.Expect(err).NotTo(HaveOccurred())
-		g.Expect(remaining.Finalizers).NotTo(ContainElement(aitenantFinalizer))
+		// Unblocking UI
+		// TODO: Include adding the finalizer back as part of https://github.com/opendatahub-io/models-as-a-service/pull/1159
+		// g.Expect(remaining.Finalizers).NotTo(ContainElement(aitenantFinalizer))
 	}
 }
 

--- a/test/e2e/tests/test_aitenant_lifecycle.py
+++ b/test/e2e/tests/test_aitenant_lifecycle.py
@@ -502,27 +502,29 @@ class TestAITenantLifecycle:
             _delete_best_effort("gateway", gateway_name, GATEWAY_NAMESPACE)
             _delete_best_effort("namespace", tenant_ns, timeout="90s")
 
-    def test_aitenant_delete_cleans_up_bootstrap_resources(self):
-        case = _new_aitenant_case()
-
-        try:
-            _apply_gateway_fixture(case)
-            _apply_aitenant(case)
-            _assert_aitenant_bootstrap_resources(case)
-
-            _delete_aitenant(case)
-            _wait_for_not_found(TENANT_CONFIG_KIND, TENANT_NAME, case["tenant_ns"])
-            _wait_for_not_found("role", case["tenant_admin_role"], case["tenant_ns"])
-            _wait_for_not_found("role", case["object_admin_role"], AITENANT_NAMESPACE)
-            _wait_for_not_found("namespace", case["tenant_ns"], timeout=180)
-
-            gateway = _get_json_or_none("gateway", case["gateway_name"], GATEWAY_NAMESPACE)
-            assert gateway is not None
-            assert gateway["metadata"]["labels"]["e2e.maas.opendatahub.io/fixture"] == case["aitenant_name"]
-        finally:
-            _delete_best_effort(AITENANT_KIND, case["aitenant_name"], AITENANT_NAMESPACE, timeout="180s")
-            _delete_best_effort("gateway", case["gateway_name"], GATEWAY_NAMESPACE)
-            _delete_best_effort("namespace", case["tenant_ns"], timeout="90s")
+    # Unblocking UI
+    # TODO: Include adding the finalizer back as part of https://github.com/opendatahub-io/models-as-a-service/pull/1159
+    # def test_aitenant_delete_cleans_up_bootstrap_resources(self):
+    #     case = _new_aitenant_case()
+    #
+    #     try:
+    #         _apply_gateway_fixture(case)
+    #         _apply_aitenant(case)
+    #         _assert_aitenant_bootstrap_resources(case)
+    #
+    #         _delete_aitenant(case)
+    #         _wait_for_not_found(TENANT_CONFIG_KIND, TENANT_NAME, case["tenant_ns"])
+    #         _wait_for_not_found("role", case["tenant_admin_role"], case["tenant_ns"])
+    #         _wait_for_not_found("role", case["object_admin_role"], AITENANT_NAMESPACE)
+    #         _wait_for_not_found("namespace", case["tenant_ns"], timeout=180)
+    #
+    #         gateway = _get_json_or_none("gateway", case["gateway_name"], GATEWAY_NAMESPACE)
+    #         assert gateway is not None
+    #         assert gateway["metadata"]["labels"]["e2e.maas.opendatahub.io/fixture"] == case["aitenant_name"]
+    #     finally:
+    #         _delete_best_effort(AITENANT_KIND, case["aitenant_name"], AITENANT_NAMESPACE, timeout="180s")
+    #         _delete_best_effort("gateway", case["gateway_name"], GATEWAY_NAMESPACE)
+    #         _delete_best_effort("namespace", case["tenant_ns"], timeout="90s")
 
     def test_aitenant_derives_non_default_tenant_namespace(self):
         """RHOAIENG-66836: non-default AITenant must not use models-as-a-service tenant namespace."""

--- a/test/e2e/tests/test_multi_tenant_integration.py
+++ b/test/e2e/tests/test_multi_tenant_integration.py
@@ -67,56 +67,58 @@ def _require_multitenancy_prerequisites():
 class TestMultiTenantIntegration:
     """S27 section 7 — multi-tenant integration scenarios."""
 
-    def test_full_tenant_lifecycle_create_to_delete(self):
-        """7.1: Full tenant lifecycle from create through policy/subscription reconcile to delete."""
-        case = new_discovery_case()
-        role_name = f"aitenant-{case['tenant_label_name']}-tenant-admin"
-        try:
-            bootstrap_aitenant_tenant(case)
-
-            tenant = wait_for_json(TENANT_CONFIG_KIND, TENANT_CR_NAME, case["tenant_ns"], timeout=180)
-            tenant_labels = tenant["metadata"].get("labels") or {}
-            tenant_annotations = tenant["metadata"].get("annotations") or {}
-            assert tenant_labels[LABEL_MANAGED_BY_AITENANT] == "true"
-            assert tenant_labels[LABEL_TENANT_NAME] == case["tenant_label_name"]
-            assert tenant_labels[LABEL_TENANT_NAMESPACE] == case["tenant_ns"]
-            assert tenant_annotations[ANNOTATION_AITENANT_NAME] == case["tenant_label_name"]
-            assert tenant_annotations[ANNOTATION_AITENANT_NAMESPACE] == AITENANT_NAMESPACE
-            aitenant = wait_for_json(AITENANT_KIND, case["tenant_label_name"], AITENANT_NAMESPACE, timeout=180)
-            assert aitenant["status"]["gatewayRef"]["name"] == case["gateway_name"]
-            assert get_json_or_none("role", role_name, case["tenant_ns"]) is not None
-
-            model_name = f"e2e-lifecycle-model-{case['suffix']}"
-            provision_tenant_model(model_name, case["tenant_ns"], case["gateway_name"])
-
-            apply_maas_auth_policy(
-                case["policy_name"],
-                case["tenant_ns"],
-                model_ref=model_name,
-                model_namespace=case["tenant_ns"],
-            )
-            apply_maas_subscription(
-                case["subscription_name"],
-                case["tenant_ns"],
-                model_ref=model_name,
-                model_namespace=case["tenant_ns"],
-            )
-            wait_for_status_phase("maasauthpolicy", case["policy_name"], case["tenant_ns"], expected_phase="Active")
-            wait_for_status_phase(
-                "maassubscription",
-                case["subscription_name"],
-                case["tenant_ns"],
-                expected_phase="Active",
-            )
-            wait_for_aitenant_cleanup_resources(case)
-
-            delete_best_effort(AITENANT_KIND, case["tenant_label_name"], AITENANT_NAMESPACE, timeout="180s")
-            wait_for_not_found(TENANT_CONFIG_KIND, TENANT_CR_NAME, case["tenant_ns"], timeout=180)
-            wait_for_not_found("role", role_name, case["tenant_ns"], timeout=180)
-            wait_for_not_found("namespace", case["tenant_ns"], timeout=180)
-            wait_for_aitenant_cleanup_resources_deleted(case)
-        finally:
-            cleanup_discovery_case(case)
+    # Unblocking UI
+    # TODO: Include adding the finalizer back as part of https://github.com/opendatahub-io/models-as-a-service/pull/1159
+    # def test_full_tenant_lifecycle_create_to_delete(self):
+    #     """7.1: Full tenant lifecycle from create through policy/subscription reconcile to delete."""
+    #     case = new_discovery_case()
+    #     role_name = f"aitenant-{case['tenant_label_name']}-tenant-admin"
+    #     try:
+    #         bootstrap_aitenant_tenant(case)
+    #
+    #         tenant = wait_for_json(TENANT_CONFIG_KIND, TENANT_CR_NAME, case["tenant_ns"], timeout=180)
+    #         tenant_labels = tenant["metadata"].get("labels") or {}
+    #         tenant_annotations = tenant["metadata"].get("annotations") or {}
+    #         assert tenant_labels[LABEL_MANAGED_BY_AITENANT] == "true"
+    #         assert tenant_labels[LABEL_TENANT_NAME] == case["tenant_label_name"]
+    #         assert tenant_labels[LABEL_TENANT_NAMESPACE] == case["tenant_ns"]
+    #         assert tenant_annotations[ANNOTATION_AITENANT_NAME] == case["tenant_label_name"]
+    #         assert tenant_annotations[ANNOTATION_AITENANT_NAMESPACE] == AITENANT_NAMESPACE
+    #         aitenant = wait_for_json(AITENANT_KIND, case["tenant_label_name"], AITENANT_NAMESPACE, timeout=180)
+    #         assert aitenant["status"]["gatewayRef"]["name"] == case["gateway_name"]
+    #         assert get_json_or_none("role", role_name, case["tenant_ns"]) is not None
+    #
+    #         model_name = f"e2e-lifecycle-model-{case['suffix']}"
+    #         provision_tenant_model(model_name, case["tenant_ns"], case["gateway_name"])
+    #
+    #         apply_maas_auth_policy(
+    #             case["policy_name"],
+    #             case["tenant_ns"],
+    #             model_ref=model_name,
+    #             model_namespace=case["tenant_ns"],
+    #         )
+    #         apply_maas_subscription(
+    #             case["subscription_name"],
+    #             case["tenant_ns"],
+    #             model_ref=model_name,
+    #             model_namespace=case["tenant_ns"],
+    #         )
+    #         wait_for_status_phase("maasauthpolicy", case["policy_name"], case["tenant_ns"], expected_phase="Active")
+    #         wait_for_status_phase(
+    #             "maassubscription",
+    #             case["subscription_name"],
+    #             case["tenant_ns"],
+    #             expected_phase="Active",
+    #         )
+    #         wait_for_aitenant_cleanup_resources(case)
+    #
+    #         delete_best_effort(AITENANT_KIND, case["tenant_label_name"], AITENANT_NAMESPACE, timeout="180s")
+    #         wait_for_not_found(TENANT_CONFIG_KIND, TENANT_CR_NAME, case["tenant_ns"], timeout=180)
+    #         wait_for_not_found("role", role_name, case["tenant_ns"], timeout=180)
+    #         wait_for_not_found("namespace", case["tenant_ns"], timeout=180)
+    #         wait_for_aitenant_cleanup_resources_deleted(case)
+    #     finally:
+    #         cleanup_discovery_case(case)
 
     def test_default_tenant_unaffected_by_multitenancy_enablement(self):
         """7.2: Default tenant namespace still reconciles while discovery mode is enabled."""


### PR DESCRIPTION
Temporary fix to remove finilizer in order to unblock UI test

Should be added back in this PR:
https://github.com/opendatahub-io/models-as-a-service/pull/1159

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * AITenant reconciliation no longer waits for finalizer handling before processing updates or deletions.
  * Deletion workflows proceed without being blocked by finalizer checks.

* **Tests**
  * Updated controller tests to reflect the revised reconciliation timing and deletion behavior.
  * Temporarily disabled end-to-end lifecycle cleanup tests while deletion behavior is being revised.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->