### PR TITLE
fix: disable MaasTenantConfig tenant-cleanup finalizer to unblock CI

### DIFF
--- a/maas-controller/pkg/controller/maas/tenant_reconcile.go
+++ b/maas-controller/pkg/controller/maas/tenant_reconcile.go
@@ -34,7 +34,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	// controllerutil temporarily unused — finalizer code commented out (see #1186).
+	// "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	maasv1alpha1 "github.com/opendatahub-io/models-as-a-service/maas-controller/api/maas/v1alpha1"
@@ -111,30 +112,32 @@ func (r *TenantReconciler) reconcile(ctx context.Context, req ctrl.Request) (ctr
 		}
 	}
 
-	usesCleanupFinalizer, err := tenantUsesCleanupFinalizer(&tenant)
-	if err != nil {
-		return ctrl.Result{}, err
-	}
-
 	// Handle deletion
 	if !tenant.DeletionTimestamp.IsZero() {
 		return r.handleDeletion(ctx, log, &tenant)
 	}
 
-	if usesCleanupFinalizer {
-		if !controllerutil.ContainsFinalizer(&tenant, tenantFinalizer) {
-			controllerutil.AddFinalizer(&tenant, tenantFinalizer)
-			if err := r.Update(ctx, &tenant); err != nil {
-				return ctrl.Result{}, err
-			}
-		}
-	} else if controllerutil.ContainsFinalizer(&tenant, tenantFinalizer) {
-		// Converge upgraded clusters: default-tenant teardown is owned by Config GC.
-		controllerutil.RemoveFinalizer(&tenant, tenantFinalizer)
-		if err := r.Update(ctx, &tenant); err != nil {
-			return ctrl.Result{}, err
-		}
-	}
+	// Unblocking CI: finalizer temporarily disabled to prevent MaasTenantConfig from getting
+	// stuck in Terminating when Config cascade-deletes infrastructure resources.
+	// TODO: Re-enable once the proper circuit-breaker fix lands (see #1186).
+	// usesCleanupFinalizer, err := tenantUsesCleanupFinalizer(&tenant)
+	// if err != nil {
+	// 	return ctrl.Result{}, err
+	// }
+	// if usesCleanupFinalizer {
+	// 	if !controllerutil.ContainsFinalizer(&tenant, tenantFinalizer) {
+	// 		controllerutil.AddFinalizer(&tenant, tenantFinalizer)
+	// 		if err := r.Update(ctx, &tenant); err != nil {
+	// 			return ctrl.Result{}, err
+	// 		}
+	// 	}
+	// } else if controllerutil.ContainsFinalizer(&tenant, tenantFinalizer) {
+	// 	// Converge upgraded clusters: default-tenant teardown is owned by Config GC.
+	// 	controllerutil.RemoveFinalizer(&tenant, tenantFinalizer)
+	// 	if err := r.Update(ctx, &tenant); err != nil {
+	// 		return ctrl.Result{}, err
+	// 	}
+	// }
 
 	// Handle management states
 	if result, err := r.handleManagementState(ctx, log, &tenant); result != nil {
@@ -172,27 +175,30 @@ func (r *TenantReconciler) reconcile(ctx context.Context, req ctrl.Request) (ctr
 }
 
 func (r *TenantReconciler) handleDeletion(ctx context.Context, log logr.Logger, tenant *maasv1alpha1.MaasTenantConfig) (ctrl.Result, error) {
-	if controllerutil.ContainsFinalizer(tenant, tenantFinalizer) {
-		if err := r.cleanupMaaSSubscriptions(ctx, log, tenant); err != nil {
-			log.Error(err, "failed to cleanup MaaSSubscriptions")
-			return ctrl.Result{}, err
-		}
-
-		if err := r.cleanupMaaSAuthPolicies(ctx, log, tenant); err != nil {
-			log.Error(err, "failed to cleanup MaaSAuthPolicies")
-			return ctrl.Result{}, err
-		}
-
-		if err := r.cleanupTenantResources(ctx, log, tenant); err != nil {
-			log.Error(err, "failed to cleanup tenant resources")
-			return ctrl.Result{}, err
-		}
-
-		controllerutil.RemoveFinalizer(tenant, tenantFinalizer)
-		if err := r.Update(ctx, tenant); err != nil {
-			return ctrl.Result{}, err
-		}
-	}
+	// Unblocking CI: finalizer temporarily disabled to prevent MaasTenantConfig from getting
+	// stuck in Terminating when Config cascade-deletes infrastructure resources.
+	// TODO: Re-enable once the proper circuit-breaker fix lands (see #1186).
+	// if controllerutil.ContainsFinalizer(tenant, tenantFinalizer) {
+	// 	if err := r.cleanupMaaSSubscriptions(ctx, log, tenant); err != nil {
+	// 		log.Error(err, "failed to cleanup MaaSSubscriptions")
+	// 		return ctrl.Result{}, err
+	// 	}
+	//
+	// 	if err := r.cleanupMaaSAuthPolicies(ctx, log, tenant); err != nil {
+	// 		log.Error(err, "failed to cleanup MaaSAuthPolicies")
+	// 		return ctrl.Result{}, err
+	// 	}
+	//
+	// 	if err := r.cleanupTenantResources(ctx, log, tenant); err != nil {
+	// 		log.Error(err, "failed to cleanup tenant resources")
+	// 		return ctrl.Result{}, err
+	// 	}
+	//
+	// 	controllerutil.RemoveFinalizer(tenant, tenantFinalizer)
+	// 	if err := r.Update(ctx, tenant); err != nil {
+	// 		return ctrl.Result{}, err
+	// 	}
+	// }
 	return ctrl.Result{}, nil
 }
 

--- a/maas-controller/pkg/controller/maas/tenant_reconcile_test.go
+++ b/maas-controller/pkg/controller/maas/tenant_reconcile_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -169,195 +168,29 @@ func TestTenantReconcile_DefaultTenantDoesNotAddCleanupFinalizer(t *testing.T) {
 	g.Expect(updated.Finalizers).To(BeEmpty(), "default-tenant teardown is Config-driven; no tenant-cleanup finalizer")
 }
 
-func TestTenantReconcile_AITenantManagedDefaultAddsCleanupFinalizer(t *testing.T) {
-	g := NewWithT(t)
-	s := tenantTestScheme(t)
+// TODO: Re-enable once the proper circuit-breaker fix lands (see #1186).
+// Finalizer is temporarily disabled to prevent MaasTenantConfig from getting stuck in Terminating.
+// func TestTenantReconcile_AITenantManagedDefaultAddsCleanupFinalizer(t *testing.T) {
+// 	...
+// }
 
-	const testNS = "models-as-a-service"
-	tenant := &maasv1alpha1.MaasTenantConfig{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      maasv1alpha1.MaasTenantConfigInstanceName,
-			Namespace: testNS,
-			Labels: map[string]string{
-				tenantreconcile.LabelManagedByAITenant: "true",
-				tenantreconcile.LabelTenantName:        tenantreconcile.DefaultAITenantName,
-				tenantreconcile.LabelTenantNamespace:   testNS,
-			},
-		},
-	}
+// TODO: Re-enable once the proper circuit-breaker fix lands (see #1186).
+// Finalizer is temporarily disabled to prevent MaasTenantConfig from getting stuck in Terminating.
+// func TestTenantReconcile_DefaultTenantStripsLegacyCleanupFinalizer(t *testing.T) {
+// 	...
+// }
 
-	cl := fake.NewClientBuilder().
-		WithScheme(s).
-		WithStatusSubresource(&maasv1alpha1.MaasTenantConfig{}).
-		WithObjects(tenant, tenantTestNamespace(testNS)).
-		Build()
+// TODO: Re-enable once the proper circuit-breaker fix lands (see #1186).
+// Finalizer is temporarily disabled to prevent MaasTenantConfig from getting stuck in Terminating.
+// func TestTenantReconcile_AITenantManagedAddsCleanupFinalizer(t *testing.T) {
+// 	...
+// }
 
-	r := &TenantReconciler{
-		Client:           cl,
-		Scheme:           s,
-		AppNamespace:     testNS,
-		GatewayName:      testTenantGatewayName,
-		GatewayNamespace: testTenantGatewayNamespace,
-	}
-
-	res, err := r.Reconcile(context.Background(), ctrl.Request{
-		NamespacedName: types.NamespacedName{Name: maasv1alpha1.MaasTenantConfigInstanceName, Namespace: testNS},
-	})
-	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(res.RequeueAfter).To(Equal(10 * time.Second))
-
-	var updated maasv1alpha1.MaasTenantConfig
-	g.Expect(cl.Get(context.Background(), client.ObjectKey{Name: maasv1alpha1.MaasTenantConfigInstanceName, Namespace: testNS}, &updated)).To(Succeed())
-	g.Expect(updated.Finalizers).To(ContainElement(tenantFinalizer))
-}
-
-func TestTenantReconcile_DefaultTenantStripsLegacyCleanupFinalizer(t *testing.T) {
-	g := NewWithT(t)
-	s := tenantTestScheme(t)
-
-	const testNS = "models-as-a-service"
-	tenant := &maasv1alpha1.MaasTenantConfig{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:       maasv1alpha1.MaasTenantConfigInstanceName,
-			Namespace:  testNS,
-			Finalizers: []string{"maas.opendatahub.io/tenant-cleanup"},
-		},
-	}
-
-	cl := fake.NewClientBuilder().
-		WithScheme(s).
-		WithStatusSubresource(&maasv1alpha1.MaasTenantConfig{}).
-		WithObjects(tenant, tenantTestNamespace(testNS)).
-		Build()
-
-	r := &TenantReconciler{
-		Client:           cl,
-		Scheme:           s,
-		AppNamespace:     testNS,
-		GatewayName:      testTenantGatewayName,
-		GatewayNamespace: testTenantGatewayNamespace,
-	}
-
-	_, err := r.Reconcile(context.Background(), ctrl.Request{
-		NamespacedName: types.NamespacedName{Name: maasv1alpha1.MaasTenantConfigInstanceName, Namespace: testNS},
-	})
-	g.Expect(err).NotTo(HaveOccurred())
-
-	var updated maasv1alpha1.MaasTenantConfig
-	g.Expect(cl.Get(context.Background(), client.ObjectKey{Name: maasv1alpha1.MaasTenantConfigInstanceName, Namespace: testNS}, &updated)).To(Succeed())
-	g.Expect(updated.Finalizers).To(BeEmpty())
-}
-
-func TestTenantReconcile_AITenantManagedAddsCleanupFinalizer(t *testing.T) {
-	g := NewWithT(t)
-	s := tenantTestScheme(t)
-
-	const testNS = "ai-tenant-redteam"
-	tenant := &maasv1alpha1.MaasTenantConfig{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      maasv1alpha1.MaasTenantConfigInstanceName,
-			Namespace: testNS,
-			Labels: map[string]string{
-				tenantreconcile.LabelManagedByAITenant: "true",
-				tenantreconcile.LabelTenantName:        "redteam",
-			},
-		},
-	}
-
-	cl := fake.NewClientBuilder().
-		WithScheme(s).
-		WithStatusSubresource(&maasv1alpha1.MaasTenantConfig{}).
-		WithObjects(tenant, tenantTestNamespace(testNS)).
-		Build()
-
-	r := &TenantReconciler{
-		Client:                          cl,
-		Scheme:                          s,
-		AppNamespace:                    "opendatahub",
-		TenantNamespace:                 "models-as-a-service",
-		TenantNamespaceDiscoveryEnabled: true,
-		GatewayName:                     testTenantGatewayName,
-		GatewayNamespace:                testTenantGatewayNamespace,
-	}
-
-	_, err := r.Reconcile(context.Background(), ctrl.Request{
-		NamespacedName: types.NamespacedName{Name: maasv1alpha1.MaasTenantConfigInstanceName, Namespace: testNS},
-	})
-	g.Expect(err).NotTo(HaveOccurred())
-
-	var updated maasv1alpha1.MaasTenantConfig
-	g.Expect(cl.Get(context.Background(), client.ObjectKey{Name: maasv1alpha1.MaasTenantConfigInstanceName, Namespace: testNS}, &updated)).To(Succeed())
-	g.Expect(updated.Finalizers).To(ContainElement("maas.opendatahub.io/tenant-cleanup"))
-}
-
-func TestTenantReconcile_AITenantManagedDefaultDeletionCleansPlatformResources(t *testing.T) {
-	g := NewWithT(t)
-	s := tenantTestScheme(t)
-	ctx := context.Background()
-	now := metav1.NewTime(time.Now())
-
-	const tenantNS = "models-as-a-service"
-	const appNS = "odh-ai-gateway-infra"
-	const gatewayNS = "openshift-ingress"
-
-	tenant := &maasv1alpha1.MaasTenantConfig{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:              maasv1alpha1.MaasTenantConfigInstanceName,
-			Namespace:         tenantNS,
-			DeletionTimestamp: &now,
-			Finalizers:        []string{tenantFinalizer},
-			Labels: map[string]string{
-				tenantreconcile.LabelManagedByAITenant: "true",
-				tenantreconcile.LabelTenantName:        tenantreconcile.DefaultAITenantName,
-				tenantreconcile.LabelTenantNamespace:   tenantNS,
-			},
-		},
-	}
-
-	resources := []client.Object{
-		tenant,
-		tenantTestUnstructured(tenantreconcile.GVKDeployment, appNS, tenantreconcile.MaaSAPIDeploymentName("")),
-		tenantTestUnstructured(tenantreconcile.GVKService, appNS, tenantreconcile.MaaSAPIServiceName("")),
-		tenantTestUnstructured(tenantreconcile.GVKHTTPRoute, appNS, tenantreconcile.MaaSAPIRouteName("")),
-		tenantTestUnstructured(tenantreconcile.GVKCronJob, appNS, tenantreconcile.MaaSAPIKeyCleanupCronJobName("")),
-		tenantTestUnstructured(tenantreconcile.GVKTokenRateLimitPolicy, gatewayNS, tenantreconcile.GatewayTokenRateLimitDefaultDenyPolicyName("")),
-		tenantTestUnstructured(tenantreconcile.GVKDestinationRule, gatewayNS, tenantreconcile.GatewayDestinationRuleName("")),
-	}
-
-	cl := fake.NewClientBuilder().
-		WithScheme(s).
-		WithStatusSubresource(&maasv1alpha1.MaasTenantConfig{}).
-		WithObjects(resources...).
-		Build()
-
-	r := &TenantReconciler{
-		Client:           cl,
-		Scheme:           s,
-		AppNamespace:     appNS,
-		TenantNamespace:  tenantNS,
-		GatewayName:      testTenantGatewayName,
-		GatewayNamespace: gatewayNS,
-	}
-
-	res, err := r.Reconcile(ctx, ctrl.Request{
-		NamespacedName: types.NamespacedName{Name: maasv1alpha1.MaasTenantConfigInstanceName, Namespace: tenantNS},
-	})
-	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(res).To(Equal(ctrl.Result{}))
-
-	for _, obj := range resources[1:] {
-		err := cl.Get(ctx, client.ObjectKeyFromObject(obj), obj)
-		g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "expected %s %s/%s to be deleted", obj.GetObjectKind().GroupVersionKind().Kind, obj.GetNamespace(), obj.GetName())
-	}
-
-	var updated maasv1alpha1.MaasTenantConfig
-	err = cl.Get(ctx, client.ObjectKey{Name: maasv1alpha1.MaasTenantConfigInstanceName, Namespace: tenantNS}, &updated)
-	if err == nil {
-		g.Expect(updated.Finalizers).NotTo(ContainElement(tenantFinalizer))
-	} else {
-		g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
-	}
-}
+// TODO: Re-enable once the proper circuit-breaker fix lands (see #1186).
+// Finalizer is temporarily disabled to prevent MaasTenantConfig from getting stuck in Terminating.
+// func TestTenantReconcile_AITenantManagedDefaultDeletionCleansPlatformResources(t *testing.T) {
+// 	...
+// }
 
 func TestTenantReconcile_ManagementStateRemovedWaitsForConfigTeardown(t *testing.T) {
 	g := NewWithT(t)


### PR DESCRIPTION
Temporarily comments out the finalizer add/check and handleDeletion cleanup. Must be reverted once the proper circuit-breaker fix lands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tenant deletion reconciliation is now handled immediately when deletion begins.
  * Removed tenant cleanup finalizer handling and associated cleanup actions.

* **Tests**
  * Disabled tests covering tenant cleanup finalizers and deletion of related platform resources pending a circuit-breaker fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->