### PR TITLE
fix: surface infra namespace in MaasTenantConfig status

### DIFF
--- a/deployment/base/maas-controller/crd/bases/maas.opendatahub.io_maastenantconfigs.yaml
+++ b/deployment/base/maas-controller/crd/bases/maas.opendatahub.io_maastenantconfigs.yaml
@@ -26,6 +26,10 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    - jsonPath: .status.infraNamespace
+      name: InfraNamespace
+      priority: 1
+      type: string
     name: v1alpha1
     schema:
       openAPIV3Schema:
@@ -154,6 +158,13 @@ spec:
                   - type
                   type: object
                 type: array
+              infraNamespace:
+                description: |-
+                  InfraNamespace is the infrastructure namespace where maas-api and the
+                  maas-db-config secret are deployed for this tenant.
+                  When credential rotation is needed, update the maas-db-config secret
+                  in this namespace.
+                type: string
               phase:
                 description: Phase is a high-level lifecycle phase for the platform
                   reconcile.

--- a/deployment/base/maas-controller/crd/bases/maas.opendatahub.io_maastenantconfigs.yaml
+++ b/deployment/base/maas-controller/crd/bases/maas.opendatahub.io_maastenantconfigs.yaml
@@ -164,6 +164,8 @@ spec:
                   maas-db-config secret are deployed for this tenant.
                   When credential rotation is needed, update the maas-db-config secret
                   in this namespace.
+                maxLength: 63
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                 type: string
               phase:
                 description: Phase is a high-level lifecycle phase for the platform

--- a/docs/content/configuration-and-management/infra-namespace-migration.md
+++ b/docs/content/configuration-and-management/infra-namespace-migration.md
@@ -86,6 +86,20 @@ Migration happens **automatically** when switching between modes:
 4. **Controller automatically deletes old maas-api** from controller namespace
 5. Services use FQDN for cross-namespace communication
 
+!!! warning "Credential Rotation After Migration"
+    After migration, the `maas-db-config` secret in the **infrastructure namespace** is the
+    source of truth. If you rotate database credentials, you must update the secret in the
+    infrastructure namespace (e.g., `odh-ai-gateway-infra` or `redhat-ai-gateway-infra`).
+
+    The original secret in the controller namespace is **not** synced. Updating only the
+    controller-namespace copy will cause maas-api to crash-loop with authentication failures.
+
+    To check which namespace is active for a tenant:
+
+    ```bash
+    kubectl get maastenantconfig default-tenant -o jsonpath='{.status.infraNamespace}'
+    ```
+
 ## Verification
 
 ### With Namespace Separation (Default)

--- a/docs/content/install/maas-setup.md
+++ b/docs/content/install/maas-setup.md
@@ -14,6 +14,14 @@ Complete [Operator Setup](platform-setup.md) before proceeding.
 
 `maas-api` uses PostgreSQL as its persistence layer for API key metadata: hashed tokens, subscription bindings, expiration dates, and revocation state. The database must be reachable before `maas-api` starts; the pod will crash-loop until the connection succeeds and the schema migration completes.
 
+!!! warning "Namespace Separation"
+    When infrastructure namespace separation is enabled (the default), create `maas-db-config`
+    in the **infrastructure namespace** (e.g., `odh-ai-gateway-infra` for ODH or
+    `redhat-ai-gateway-infra` for RHOAI), not the controller namespace. The infrastructure
+    namespace is the source of truth for database credentials. See
+    [Infrastructure Namespace Separation](../configuration-and-management/infra-namespace-migration.md)
+    for details.
+
 Create the `maas-db-config` Secret in your ODH/RHOAI namespace (typically `opendatahub` for ODH or `redhat-ods-applications` for RHOAI):
 
 ```bash

--- a/docs/content/migration/upgrade-to-3.5.md
+++ b/docs/content/migration/upgrade-to-3.5.md
@@ -33,6 +33,25 @@ oc get deployment -n opendatahub ai-gateway-operator
 oc get datasciencecluster default-dsc -o jsonpath='{.spec.components.aigateway.modelsAsAService}'
 ```
 
+## Database Credential Management
+
+!!! warning "Source of Truth Change"
+    With infrastructure namespace separation (enabled by default), the `maas-db-config`
+    secret in the infrastructure namespace is the source of truth for database credentials.
+    The controller performs a one-time copy during migration but does **not** sync
+    subsequent changes.
+
+    If you rotate database credentials, update the secret in the infrastructure namespace
+    (e.g., `odh-ai-gateway-infra` or `redhat-ai-gateway-infra`). The `MaasTenantConfig`
+    status now includes an `infraNamespace` field showing where the active secret lives:
+
+    ```bash
+    kubectl get maastenantconfig default-tenant -o jsonpath='{.status.infraNamespace}'
+    ```
+
+    See [Infrastructure Namespace Separation](../configuration-and-management/infra-namespace-migration.md)
+    for details.
+
 ## DSC Field Reference
 
 | 3.4 | 3.5+ |

--- a/maas-controller/api/maas/v1alpha1/maastenantconfig_types.go
+++ b/maas-controller/api/maas/v1alpha1/maastenantconfig_types.go
@@ -32,6 +32,7 @@ const (
 // +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`,description="Ready"
 // +kubebuilder:printcolumn:name="Reason",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].reason`,description="Reason"
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
+// +kubebuilder:printcolumn:name="InfraNamespace",type=string,JSONPath=`.status.infraNamespace`,priority=1
 
 // MaasTenantConfig is the namespace-scoped singleton for MaaS-specific tenant settings.
 // Platform context such as Gateway and OIDC belongs to AITenant; this object only
@@ -61,6 +62,13 @@ type MaasTenantConfigStatus struct {
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:Enum=Pending;Active;Degraded;Failed
 	Phase string `json:"phase,omitempty"`
+
+	// InfraNamespace is the infrastructure namespace where maas-api and the
+	// maas-db-config secret are deployed for this tenant.
+	// When credential rotation is needed, update the maas-db-config secret
+	// in this namespace.
+	// +optional
+	InfraNamespace string `json:"infraNamespace,omitempty"`
 
 	// Conditions represent the latest available observations.
 	// Types mirror ODH modelsasservice / maas-controller status for DSC aggregation: Ready,

--- a/maas-controller/api/maas/v1alpha1/maastenantconfig_types.go
+++ b/maas-controller/api/maas/v1alpha1/maastenantconfig_types.go
@@ -68,6 +68,8 @@ type MaasTenantConfigStatus struct {
 	// When credential rotation is needed, update the maas-db-config secret
 	// in this namespace.
 	// +optional
+	// +kubebuilder:validation:MaxLength=63
+	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`
 	InfraNamespace string `json:"infraNamespace,omitempty"`
 
 	// Conditions represent the latest available observations.

--- a/maas-controller/pkg/controller/maas/tenant_reconcile.go
+++ b/maas-controller/pkg/controller/maas/tenant_reconcile.go
@@ -139,6 +139,9 @@ func (r *TenantReconciler) reconcile(ctx context.Context, req ctrl.Request) (ctr
 		}
 	}
 
+	// Surface the infrastructure namespace so operators know where maas-db-config lives.
+	tenant.Status.InfraNamespace = r.appNamespaceForTenant()
+
 	// Handle management states
 	if result, err := r.handleManagementState(ctx, log, &tenant); result != nil {
 		return *result, err

--- a/maas-controller/pkg/controller/maas/tenant_reconcile_test.go
+++ b/maas-controller/pkg/controller/maas/tenant_reconcile_test.go
@@ -549,6 +549,7 @@ func TestTenantReconcile_UnexpectedManagementStateSetsFailedPhase(t *testing.T) 
 	var updated maasv1alpha1.MaasTenantConfig
 	g.Expect(cl.Get(context.Background(), client.ObjectKey{Name: maasv1alpha1.MaasTenantConfigInstanceName, Namespace: testNS}, &updated)).To(Succeed())
 	g.Expect(updated.Status.Phase).To(Equal("Failed"))
+	g.Expect(updated.Status.InfraNamespace).To(Equal(testNS), "infraNamespace should be set even on error paths")
 	readyCond := apimeta.FindStatusCondition(updated.Status.Conditions, tenantreconcile.ReadyConditionType)
 	g.Expect(readyCond).NotTo(BeNil())
 	g.Expect(readyCond.Reason).To(Equal("UnexpectedManagementState"))
@@ -591,6 +592,44 @@ func TestTenantReconcile_ConfigMissingSkipsPlatform(t *testing.T) {
 	ready := apimeta.FindStatusCondition(updated.Status.Conditions, tenantreconcile.ReadyConditionType)
 	g.Expect(ready).NotTo(BeNil())
 	g.Expect(ready.Reason).To(Equal("ConfigMissing"))
+	g.Expect(updated.Status.InfraNamespace).To(Equal(testNS))
+}
+
+func TestTenantReconcile_InfraNamespaceSetInStatus(t *testing.T) {
+	g := NewWithT(t)
+	s := tenantTestScheme(t)
+
+	const tenantNS = "models-as-a-service"
+	const infraNS = "odh-ai-gateway-infra"
+	tenant := &maasv1alpha1.MaasTenantConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      maasv1alpha1.MaasTenantConfigInstanceName,
+			Namespace: tenantNS,
+		},
+	}
+
+	cl := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(&maasv1alpha1.MaasTenantConfig{}).
+		WithObjects(tenant, tenantTestNamespace(tenantNS)).
+		Build()
+
+	r := &TenantReconciler{
+		Client:           cl,
+		Scheme:           s,
+		AppNamespace:     infraNS,
+		GatewayName:      testTenantGatewayName,
+		GatewayNamespace: testTenantGatewayNamespace,
+	}
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: maasv1alpha1.MaasTenantConfigInstanceName, Namespace: tenantNS},
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+
+	var updated maasv1alpha1.MaasTenantConfig
+	g.Expect(cl.Get(context.Background(), client.ObjectKey{Name: maasv1alpha1.MaasTenantConfigInstanceName, Namespace: tenantNS}, &updated)).To(Succeed())
+	g.Expect(updated.Status.InfraNamespace).To(Equal(infraNS), "status.infraNamespace should reflect the separated infrastructure namespace")
 }
 
 func TestTenantReconcile_ConfigEmptyUIDPatchesWaitingForConfigUID(t *testing.T) {


### PR DESCRIPTION
## Description
Add InfraNamespace field to MaasTenantConfigStatus so operators can immediately identify which namespace holds 
the active maas-db-config secret. 

The reconciler populates the field on every status update, including error paths. Documentation updated with prominent warnings about credential rotation source of truth in infra-namespace-migration, maas-setup, and upgrade-to-3.5 guides.

Ref: https://redhat.atlassian.net/browse/RHOAIENG-68283

<!--- Provide a general summary of your changes in the Title above -->


<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- unit test
- manual:
```
$ oc get crd maastenantconfigs.maas.opendatahub.io -o yaml | grep infraNamespace\: -A 5
              infraNamespace:
                description: |-
                  InfraNamespace is the infrastructure namespace where maas-api and the
                  maas-db-config secret are deployed for this tenant.
                  When credential rotation is needed, update the maas-db-config secret
                  in this namespace.
$ oc get MaaSTenantConfig default-tenant -n models-as-a-service -o yaml | grep infra
  infraNamespace: odh-ai-gateway-infra
$ oc get MaaSTenantConfig default-tenant -n ai-tenant-jim -o yaml | grep infra
  infraNamespace: odh-ai-gateway-infra
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Tenant status now displays the infrastructure namespace hosting MaaS services and database credentials.
  - Infrastructure namespace information is visible in tenant listings and can be queried through Kubernetes commands.

- **Documentation**
  - Added guidance for creating, rotating, and updating database credentials in the infrastructure namespace.
  - Expanded migration and upgrade documentation with credential source-of-truth details and verification steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->