### PR TITLE
fix: set missing path to usage logs resources in tests

### DIFF
--- a/maas-controller/pkg/controller/maas/self_deployment_controller_test.go
+++ b/maas-controller/pkg/controller/maas/self_deployment_controller_test.go
@@ -305,6 +305,10 @@ func TestLifecycleReconciler_NormalReconcileDoesNotSetDeploymentOwnerReference(t
 		},
 	}
 
+	_, testFile, _, ok := goruntime.Caller(0)
+	g.Expect(ok).To(BeTrue())
+	usageLogsPath := filepath.Join(filepath.Dir(testFile), "../../../../deployment/components/observability/usage-logs")
+
 	cl := fake.NewClientBuilder().WithScheme(s).WithObjects(dep, cfg).Build()
 	r := &LifecycleReconciler{
 		Client:                      cl,
@@ -312,6 +316,7 @@ func TestLifecycleReconciler_NormalReconcileDoesNotSetDeploymentOwnerReference(t
 		DeploymentName:              "maas-controller",
 		DeploymentNS:                depNS,
 		TenantSubscriptionNamespace: "",
+		UsageLogsManifestPath:       usageLogsPath,
 	}
 
 	_, err := r.Reconcile(context.Background(), ctrl.Request{
@@ -366,12 +371,17 @@ func TestLifecycleReconciler_StripsLegacyDeploymentConfigOwnerReferenceOnNormalR
 		},
 	}
 
+	_, testFile, _, ok := goruntime.Caller(0)
+	g.Expect(ok).To(BeTrue())
+	usageLogsPath := filepath.Join(filepath.Dir(testFile), "../../../../deployment/components/observability/usage-logs")
+
 	cl := fake.NewClientBuilder().WithScheme(s).WithObjects(dep, cfg).Build()
 	r := &LifecycleReconciler{
-		Client:         cl,
-		Scheme:         s,
-		DeploymentName: "maas-controller",
-		DeploymentNS:   depNS,
+		Client:                cl,
+		Scheme:                s,
+		DeploymentName:        "maas-controller",
+		DeploymentNS:          depNS,
+		UsageLogsManifestPath: usageLogsPath,
 	}
 
 	_, err := r.Reconcile(context.Background(), ctrl.Request{


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Tests fail because the path to usage log resources is needed also when the usage logs feature is disabled (because then the resources are deleted).

## How Has This Been Tested?
Tests manually

## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Build & Packaging**
  * Updated Docker builder stages to use the target platform for Go toolchain selection and improved build parallelism.
* **Bug Fixes / Reliability**
  * API key revocation now only schedules when the required service is present; failed or overdue revocation jobs are removed so reconciliation can retry safely.
* **Tests**
  * Normal reconciliation tests now configure `UsageLogsManifestPath` via an absolute `usage-logs` location.
  * Improved AITenant e2e deletion failures with richer diagnostics collected during best-effort cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->