### PR TITLE
feat: logs based usage dashboards

### DIFF
--- a/deployment/base/maas-controller/base/params.env
+++ b/deployment/base/maas-controller/base/params.env
@@ -2,5 +2,6 @@ maas-api-image=quay.io/opendatahub/maas-api:odh-stable
 maas-controller-image=quay.io/opendatahub/maas-controller:odh-stable
 payload-processing-image=quay.io/opendatahub/odh-ai-gateway-payload-processing:odh-stable
 maas-api-key-cleanup-image=registry.redhat.io/ubi9/ubi-minimal:9.7
+usage-logs-tenancy-proxy-image=registry.redhat.io/ubi9/python-312@sha256:f6713d327d37e654a443752e6654b5aab88f31690e1161eed9c34dd837870172
 monitoring-namespace=opendatahub
 infrastructure-namespace=AUTO

--- a/deployment/base/maas-controller/default/params.env
+++ b/deployment/base/maas-controller/default/params.env
@@ -2,4 +2,5 @@ maas-api-image=quay.io/opendatahub/maas-api:latest
 maas-controller-image=quay.io/opendatahub/maas-controller:latest
 payload-processing-image=quay.io/opendatahub/odh-ai-gateway-payload-processing:odh-stable
 maas-api-key-cleanup-image=registry.redhat.io/ubi9/ubi-minimal:9.7
+usage-logs-tenancy-proxy-image=registry.redhat.io/ubi9/python-312@sha256:f6713d327d37e654a443752e6654b5aab88f31690e1161eed9c34dd837870172
 monitoring-namespace=opendatahub

--- a/deployment/base/maas-controller/manager/manager.yaml
+++ b/deployment/base/maas-controller/manager/manager.yaml
@@ -74,6 +74,12 @@ spec:
                 key: maas-api-key-cleanup-image
                 name: maas-parameters
                 optional: true
+          - name: RELATED_IMAGE_ODH_PYTHON_312_IMAGE
+            valueFrom:
+              configMapKeyRef:
+                key: usage-logs-tenancy-proxy-image
+                name: maas-parameters
+                optional: true
           - name: MONITORING_NAMESPACE
             valueFrom:
               configMapKeyRef:

--- a/deployment/components/observability/usage-logs/envoy-otel-access-log.yaml
+++ b/deployment/components/observability/usage-logs/envoy-otel-access-log.yaml
@@ -59,7 +59,7 @@ spec:
             - endpoint:
                 address:
                   socket_address:
-                    address: usage-logs-collector.opendatahub.svc.cluster.local
+                    address: usage-logs-collector.opendatahub.svc
                     port_value: 4317
 
   # ── Composite filter: json_to_metadata with path-based pattern matching ────
@@ -381,7 +381,7 @@ spec:
                 values:
                 - key: service.name
                   value:
-                    string_value: maas-gateway
+                    string_value: models-as-a-service
                 - key: service.namespace
                   value:
                     string_value: openshift-ingress

--- a/deployment/components/observability/usage-logs/kustomization.yaml
+++ b/deployment/components/observability/usage-logs/kustomization.yaml
@@ -4,3 +4,21 @@ kind: Kustomization
 resources:
   - otel-collector.yaml
   - otel-collector-rbac.yaml
+  - tenancy-proxy-rbac.yaml
+  - tenancy-proxy.yaml
+  - usage-logs-admin-dashboard.yaml
+  - usage-logs-dashboard.yaml
+
+configMapGenerator:
+  - name: usage-tenancy-proxy-source
+    namespace: opendatahub
+    files:
+      - proxy/main.py
+      - proxy/auth.py
+      - proxy/rewriter.py
+    options:
+      disableNameSuffixHash: true
+      labels:
+        app: usage-tenancy-proxy
+        app.kubernetes.io/managed-by: maas-controller
+        app.kubernetes.io/component: usage-tenancy-proxy

--- a/deployment/components/observability/usage-logs/otel-collector-rbac.yaml
+++ b/deployment/components/observability/usage-logs/otel-collector-rbac.yaml
@@ -1,14 +1,31 @@
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: usage-collector-application-logs-write
+  labels:
+    app.kubernetes.io/part-of: maas-observability
+    app.kubernetes.io/managed-by: maas-controller
+rules:
+  - verbs:
+      - create
+    apiGroups:
+      - loki.grafana.com
+    resources:
+      - application
+    resourceNames:
+      - logs
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: usage-logs-writer
+  name: usage-collector-application-logs-write
   labels:
     app.kubernetes.io/part-of: maas-observability
     app.kubernetes.io/managed-by: maas-controller
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: cluster-logging-application-write
+  name: usage-collector-application-logs-write
 subjects:
 - kind: ServiceAccount
   name: usage-logs-collector

--- a/deployment/components/observability/usage-logs/otel-collector.yaml
+++ b/deployment/components/observability/usage-logs/otel-collector.yaml
@@ -101,7 +101,7 @@ spec:
           value: application
           action: upsert
         - key: service.name
-          value: maas-gateway
+          value: models-as-a-service
           action: upsert
         - key: kubernetes_namespace_name
           value: "${env:NAMESPACE}"
@@ -124,7 +124,7 @@ spec:
         - response_type
     exporters:
       otlp_http/loki:
-        endpoint: "https://maas-loki-gateway-http.opendatahub.svc.cluster.local:8080/api/logs/v1/application/otlp"
+        endpoint: "https://usage-gateway-http.${env:NAMESPACE}.svc:8080/api/logs/v1/application/otlp"
         auth:
           authenticator: bearertokenauth
         tls:

--- a/deployment/components/observability/usage-logs/proxy/auth.py
+++ b/deployment/components/observability/usage-logs/proxy/auth.py
@@ -1,0 +1,111 @@
+"""Authentication via Kubernetes TokenReview API."""
+import json
+import logging
+import os
+import ssl
+from urllib.request import Request, urlopen
+
+SA_TOKEN_PATH = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+logger = logging.getLogger(__name__)
+
+
+class UserInfo:
+    """User information extracted from token."""
+
+    def __init__(self, username):
+        self.username = username
+
+
+def create_ssl_context():
+    """Create SSL context with Kubernetes CA certificates."""
+    ca_paths = [
+        "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt",
+        "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
+    ]
+
+    context = ssl.create_default_context()
+
+    for ca_path in ca_paths:
+        try:
+            context.load_verify_locations(ca_path)
+            logger.info(f"Loaded CA certificate from {ca_path}")
+        except OSError:
+            pass
+
+    return context
+
+
+def extract_from_bearer_token(auth_header, token_review_url, ssl_context):
+    """
+    Extract user info from Authorization: Bearer <token>.
+
+    All tokens are validated server-side via the Kubernetes TokenReview API.
+    """
+    if not auth_header:
+        raise ValueError("missing Authorization header")
+
+    parts = auth_header.split(" ", 1)
+    if len(parts) != 2 or parts[0].lower() != "bearer":
+        raise ValueError("invalid Authorization header format")
+
+    return resolve_token(parts[1], token_review_url, ssl_context)
+
+
+def resolve_token(token, token_review_url, ssl_context):
+    """
+    Call the Kubernetes TokenReview API to validate bearer token.
+
+    This is the sole authentication path -- tokens are never parsed or
+    trusted locally.
+    """
+    try:
+        with open(SA_TOKEN_PATH, "r") as f:
+            sa_token = f.read().strip()
+    except OSError as e:
+        raise ValueError(f"cannot read SA token for TokenReview: {e}") from e
+
+    body = {
+        "apiVersion": "authentication.k8s.io/v1",
+        "kind": "TokenReview",
+        "spec": {"token": token},
+    }
+
+    body_bytes = json.dumps(body).encode("utf-8")
+
+    req = Request(
+        token_review_url,
+        data=body_bytes,
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {sa_token}",
+        },
+        method="POST",
+    )
+
+    try:
+        with urlopen(req, timeout=10, context=ssl_context) as resp:
+            resp_body = resp.read()
+            resp_code = resp.status
+    except Exception as e:
+        raise ValueError(f"TokenReview request failed: {e}") from e
+
+    if resp_code not in (200, 201):
+        raise ValueError(f"TokenReview returned HTTP {resp_code}")
+
+    try:
+        result = json.loads(resp_body)
+    except json.JSONDecodeError as e:
+        raise ValueError(f"failed to parse TokenReview response: {e}") from e
+
+    status = result.get("status", {})
+    if not status.get("authenticated", False):
+        error_msg = status.get("error", "token not authenticated")
+        raise ValueError(f"TokenReview: {error_msg}")
+
+    user = status.get("user", {})
+    username = user.get("username", "")
+    if not username:
+        raise ValueError("TokenReview returned empty username")
+
+    return UserInfo(username=username)

--- a/deployment/components/observability/usage-logs/proxy/main.py
+++ b/deployment/components/observability/usage-logs/proxy/main.py
@@ -1,0 +1,389 @@
+#!/usr/bin/env python3
+"""Loki Query Proxy - stdlib-only implementation."""
+import contextvars
+import hashlib
+import json
+import logging
+import os
+import ssl
+import sys
+import time
+import uuid
+from http.server import ThreadingHTTPServer, BaseHTTPRequestHandler
+from threading import Lock
+from urllib.parse import urlparse, parse_qs, urlencode, urljoin
+
+from auth import extract_from_bearer_token, create_ssl_context
+from rewriter import inject_user_filter
+
+# Context variable for request ID
+request_id_var = contextvars.ContextVar('request_id', default='')
+
+# Simple in-memory cache for query results
+query_cache = {}
+cache_lock = Lock()
+CACHE_TTL_SECONDS = 30  # Cache responses for 30 seconds
+MAX_RESPONSE_SIZE = 10 * 1024 * 1024  # 10 MB limit for response bodies
+MAX_CACHEABLE_SIZE = 1 * 1024 * 1024  # Only cache responses up to 1 MB
+
+class RequestIDFilter(logging.Filter):
+    """Inject request ID into log records."""
+    def filter(self, record):
+        record.request_id = request_id_var.get() or '-'
+        return True
+
+# Configure logging with request ID support
+log_level = os.getenv('LOG_LEVEL', 'INFO').upper()
+logging.basicConfig(
+    level=getattr(logging, log_level, logging.INFO),
+    format="%(asctime)s [%(levelname)s] [%(request_id)s] %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+# Add filter to all handlers so request_id is available in all log records
+for handler in logging.getLogger().handlers:
+    handler.addFilter(RequestIDFilter())
+logger = logging.getLogger(__name__)
+
+# Global configuration
+ssl_context = None
+token_review_url = None
+namespace = None
+
+ALLOWED_PATHS = {
+    "/loki/api/v1/query",
+    "/loki/api/v1/query_range",
+    "/health",
+    "/ready",
+}
+
+HOP_BY_HOP_HEADERS = {
+    "connection",
+    "keep-alive",
+    "proxy-authenticate",
+    "proxy-authorization",
+    "te",
+    "trailers",
+    "transfer-encoding",
+    "upgrade",
+    "authorization",
+    "content-length",
+}
+
+
+def safe_read_response(response, max_size=MAX_RESPONSE_SIZE):
+    """
+    Read response body with size limit to prevent memory exhaustion.
+
+    Args:
+        response: HTTP response object with read() method
+        max_size: Maximum bytes to read (default: MAX_RESPONSE_SIZE)
+
+    Returns:
+        bytes: Response body (up to max_size)
+
+    Raises:
+        ValueError: If response exceeds max_size
+    """
+    chunks = []
+    bytes_read = 0
+    chunk_size = 64 * 1024  # Read in 64KB chunks
+
+    while True:
+        chunk = response.read(chunk_size)
+        if not chunk:
+            break
+
+        bytes_read += len(chunk)
+        if bytes_read > max_size:
+            raise ValueError(f"Response exceeds maximum size of {max_size} bytes")
+
+        chunks.append(chunk)
+
+    return b''.join(chunks)
+
+
+def is_allowed_path(path):
+    """Check if path is allowed."""
+    if ".." in path.split("/"):
+        return False
+    if path in ALLOWED_PATHS:
+        return True
+    if path.startswith("/loki/api/v1/label/") and path.endswith("/values"):
+        return True
+    return False
+
+
+class ProxyHandler(BaseHTTPRequestHandler):
+    """HTTP request handler for the Loki proxy."""
+
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, format, *args):
+        """Suppress default logging - we handle it ourselves."""
+        pass
+
+    def send_json_error(self, msg, code):
+        """Send JSON error response."""
+        response = {
+            "status": "error",
+            "error": msg,
+            "errorType": "proxy",
+            "data": None,
+        }
+        body = json.dumps(response).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self):
+        """Handle GET requests."""
+        # Generate unique request ID for log correlation
+        req_id = str(uuid.uuid4())[:8]
+        request_id_var.set(req_id)
+
+        logger.info(f"REQ GET {self.path}")
+
+        # Health check endpoints
+        if self.path in ("/health", "/ready"):
+            try:
+                body = b"OK\n"
+                self.send_response(200)
+                self.send_header("Content-Type", "text/plain")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+            except (BrokenPipeError, ConnectionResetError):
+                # Kubernetes probes may close connection early - this is normal
+                pass
+            return
+
+        # Authenticate and extract username
+        auth_header = self.headers.get("Authorization", "")
+        if not auth_header:
+            logger.error("Missing Authorization header")
+            self.send_json_error("Unauthorized", 401)
+            return
+
+        try:
+            user_info = extract_from_bearer_token(
+                auth_header, token_review_url, ssl_context
+            )
+        except Exception as e:
+            logger.error(f"Auth extraction failed: {e}")
+            self.send_json_error("Unauthorized", 401)
+            return
+
+        username = user_info.username
+
+        # Parse path and check if allowed
+        parsed = urlparse(self.path)
+        if not is_allowed_path(parsed.path):
+            logger.warning(f"Blocked access to {parsed.path} for user={username}")
+            self.send_json_error("Forbidden: endpoint not available", 403)
+            return
+
+        # Parse and rewrite query parameters
+        query_params = parse_qs(parsed.query, keep_blank_values=True)
+
+        if "query" in query_params:
+            original_query = query_params["query"][0]
+            # Label values endpoints only support label matchers, not pipeline filters
+            is_label_values = parsed.path.startswith("/loki/api/v1/label/") and parsed.path.endswith("/values")
+            rewritten_query = inject_user_filter(original_query, username, namespace, labels_only=is_label_values)
+            query_params["query"] = [rewritten_query]
+            logger.debug(
+                f"Query rewritten for user={username} (labels_only={is_label_values}): "
+                f"original={original_query} -> rewritten={rewritten_query}"
+            )
+
+        # Build upstream URL
+        upstream_parsed = urlparse(loki_upstream)
+        upstream_path = upstream_parsed.path + parsed.path
+        if query_params:
+            query_string = urlencode(query_params, doseq=True)
+            upstream_url = f"{upstream_parsed.scheme}://{upstream_parsed.netloc}{upstream_path}?{query_string}"
+        else:
+            upstream_url = f"{upstream_parsed.scheme}://{upstream_parsed.netloc}{upstream_path}"
+
+        # Prepare upstream request
+        from urllib.request import Request, urlopen
+
+        # Copy headers, excluding hop-by-hop
+        headers = {}
+        for key, value in self.headers.items():
+            if key.lower() not in HOP_BY_HOP_HEADERS:
+                headers[key] = value
+
+        headers["Host"] = upstream_parsed.netloc
+        headers["X-Scope-OrgID"] = "application"
+
+        # Add service account token for upstream authentication
+        try:
+            with open("/var/run/secrets/kubernetes.io/serviceaccount/token", "r") as f:
+                sa_token = f.read().strip()
+                headers["Authorization"] = f"Bearer {sa_token}"
+        except OSError:
+            pass
+
+        # Check cache (cache key = rewritten query + user)
+        cache_key = hashlib.sha256(f"{username}:{upstream_url}".encode()).hexdigest()
+        cached_entry = None
+        with cache_lock:
+            if cache_key in query_cache:
+                entry = query_cache[cache_key]
+                if time.time() - entry["timestamp"] < CACHE_TTL_SECONDS:
+                    cached_entry = {
+                        **entry,
+                        "headers": dict(entry["headers"]),
+                    }
+                else:
+                    # Expired entry
+                    del query_cache[cache_key]
+
+        if cached_entry is not None:
+            logger.debug(f"CACHE HIT {parsed.path}")
+            self.send_response(cached_entry["code"])
+            for key, value in cached_entry["headers"].items():
+                self.send_header(key, value)
+            self.end_headers()
+            self.wfile.write(cached_entry["body"])
+            return
+
+        # Make upstream request
+        try:
+            from urllib.error import HTTPError
+            req = Request(upstream_url, headers=headers, method="GET")
+            start_time = time.time()
+            with urlopen(req, timeout=60, context=ssl_context) as resp:
+                try:
+                    resp_body = safe_read_response(resp)
+                except ValueError as e:
+                    logger.error(f"Response too large: {e}")
+                    self.send_json_error(f"Upstream response exceeds size limit", 502)
+                    return
+                resp_code = resp.status
+                resp_headers = resp.headers
+
+            elapsed_ms = int((time.time() - start_time) * 1000)
+            if elapsed_ms > 3000:
+                logger.warning(f"SLOW QUERY {elapsed_ms}ms {parsed.path}")
+            logger.info(f"RESP {parsed.path} {resp_code} ({len(resp_body)} bytes) {elapsed_ms}ms")
+
+            # Handle non-JSON error responses
+            is_json = len(resp_body) > 0 and resp_body[0:1] in (b"{", b"[")
+            if resp_code >= 400 and not is_json:
+                err_msg = resp_body.decode("utf-8", errors="replace").strip()
+                if not err_msg:
+                    err_msg = f"Loki returned HTTP {resp_code}"
+                logger.error(f"Upstream non-JSON error {resp_code}: {err_msg[:200]}")
+                self.send_json_error(err_msg, resp_code)
+                return
+
+            # Filter hop-by-hop headers for forwarding
+            filtered_headers = {
+                k: v for k, v in resp_headers.items()
+                if k.lower() not in HOP_BY_HOP_HEADERS
+            }
+            filtered_headers["Content-Length"] = str(len(resp_body))
+
+            # Store successful responses in cache (with filtered headers)
+            # Only cache responses under MAX_CACHEABLE_SIZE to prevent memory exhaustion
+            if resp_code == 200 and len(resp_body) <= MAX_CACHEABLE_SIZE:
+                with cache_lock:
+                    query_cache[cache_key] = {
+                        "timestamp": time.time(),
+                        "code": resp_code,
+                        "headers": filtered_headers,
+                        "body": resp_body,
+                    }
+                    # Simple cache size limit (keep last 100 entries)
+                    if len(query_cache) > 100:
+                        oldest_key = min(query_cache.keys(), key=lambda k: query_cache[k]["timestamp"])
+                        del query_cache[oldest_key]
+            elif resp_code == 200:
+                logger.debug(f"Response too large to cache ({len(resp_body)} bytes > {MAX_CACHEABLE_SIZE})")
+
+            # Forward response
+            self.send_response(resp_code)
+            for key, value in filtered_headers.items():
+                self.send_header(key, value)
+            self.end_headers()
+            self.wfile.write(resp_body)
+
+        except HTTPError as e:
+            # Log the error response body (with size limit)
+            try:
+                # Limit error body reads to 1MB to prevent memory exhaustion
+                error_body = safe_read_response(e, max_size=1024 * 1024).decode('utf-8', errors='replace')
+                logger.error(f"Upstream HTTP {e.code} error body: {error_body[:500]}")
+            except ValueError:
+                logger.error(f"Upstream HTTP {e.code}: error body too large (>1MB)")
+            except Exception:
+                logger.error(f"Upstream HTTP {e.code}: {e.reason}")
+            self.send_json_error(f"Bad gateway: HTTP {e.code} {e.reason}", 502)
+        except Exception as e:
+            logger.error(f"Upstream request failed: {type(e).__name__}: {e}")
+            self.send_json_error("Bad gateway: upstream request failed", 502)
+
+
+def initialize():
+    """Initialize global configuration."""
+    global loki_upstream, ssl_context, token_review_url, namespace
+
+    namespace = os.getenv("NAMESPACE")
+    if not namespace:
+        logger.fatal("NAMESPACE environment variable is required")
+        sys.exit(1)
+
+    # Build Loki upstream URL from namespace
+    loki_upstream = f"https://usage-gateway-http.{namespace}.svc:8080/api/logs/v1/application"
+    logger.info(f"Loki upstream: {loki_upstream}")
+
+    # Create SSL context with CA certificates
+    ssl_context = create_ssl_context()
+
+    # Build TokenReview URL
+    api_host = os.getenv("KUBERNETES_SERVICE_HOST")
+    api_port = os.getenv("KUBERNETES_SERVICE_PORT", "443")
+    token_review_url = (
+        f"https://{api_host}:{api_port}/apis/authentication.k8s.io/v1/tokenreviews"
+    )
+    logger.info(f"TokenReview endpoint: {token_review_url}")
+
+
+def main():
+    """Main entry point."""
+    initialize()
+
+    tls_cert_file = "/etc/tls/private/tls.crt"
+    tls_key_file = "/etc/tls/private/tls.key"
+
+    if not os.path.exists(tls_cert_file):
+        logger.fatal(f"TLS cert file not found: {tls_cert_file}")
+        sys.exit(1)
+    if not os.path.exists(tls_key_file):
+        logger.fatal(f"TLS key file not found: {tls_key_file}")
+        sys.exit(1)
+
+    server = ThreadingHTTPServer(("0.0.0.0", 8443), ProxyHandler)
+
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    context.load_cert_chain(tls_cert_file, tls_key_file)
+    # Disable client cert verification - authentication is via bearer tokens
+    context.check_hostname = False
+    context.verify_mode = ssl.CERT_NONE
+    server.socket = context.wrap_socket(server.socket, server_side=True)
+
+    logger.info("Proxy listening on https://0.0.0.0:8443")
+
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        logger.info("Shutting down")
+        server.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/deployment/components/observability/usage-logs/proxy/rewriter.py
+++ b/deployment/components/observability/usage-logs/proxy/rewriter.py
@@ -1,0 +1,97 @@
+"""LogQL query rewriting to inject user filters."""
+
+
+def escape_logql_value(value):
+    """Escape special characters in LogQL values."""
+    value = value.replace("\\", "\\\\")
+    value = value.replace('"', '\\"')
+    return value
+
+
+def inject_user_filter(query, username, namespace, labels_only=False):
+    """
+    Inject user filter into LogQL query.
+
+    Modifies stream selectors to add kubernetes_namespace_name label with the provided namespace.
+    If labels_only=False, also adds pipeline filter `| user_id="<user>"` after the selector.
+
+    Args:
+        query: LogQL query string
+        username: User identifier to filter by
+        namespace: Kubernetes namespace to filter by
+        labels_only: If True, skip pipeline filter (for label values endpoints)
+
+    Examples:
+        Normal query (labels_only=False):
+            {app="x"} | line_format "{{.msg}}"
+         -> {app="x", kubernetes_namespace_name="<namespace>"} | user_id="alice" | line_format "{{.msg}}"
+
+        Empty selector (labels_only=False):
+            {}
+         -> {kubernetes_namespace_name="<namespace>"} | user_id="alice"
+
+        Label values query (labels_only=True):
+            {app="x"}
+         -> {app="x", kubernetes_namespace_name="<namespace>"}
+    """
+    if not query or not username:
+        return query
+
+    namespace_label = f'kubernetes_namespace_name="{escape_logql_value(namespace)}"'
+    user_filter = '' if labels_only else f' | user_id="{escape_logql_value(username)}"'
+    result = []
+    in_selector = False
+    selector_start_pos = -1
+    in_double_quote = False
+    in_backtick = False
+    i = 0
+
+    while i < len(query):
+        ch = query[i]
+
+        # Handle escape sequences in double quotes
+        if ch == "\\" and in_double_quote and i + 1 < len(query):
+            result.append(ch)
+            i += 1
+            result.append(query[i])
+            i += 1
+            continue
+
+        # Toggle quote states
+        if ch == '"' and not in_backtick:
+            in_double_quote = not in_double_quote
+        if ch == "`" and not in_double_quote:
+            in_backtick = not in_backtick
+
+        in_quote = in_double_quote or in_backtick
+
+        # Track selector braces
+        if ch == "{" and not in_quote:
+            in_selector = True
+            selector_start_pos = len(result)
+            result.append(ch)
+            i += 1
+            continue
+
+        # Inject namespace label and optionally user filter before closing selector brace
+        if ch == "}" and in_selector and not in_quote:
+            # Check if selector is empty by looking at content since '{'
+            selector_content = "".join(result[selector_start_pos + 1:]).strip()
+            is_empty = len(selector_content) == 0
+
+            # Add comma only if selector has existing matchers
+            if is_empty:
+                result.append(namespace_label)
+            else:
+                result.append(", ")
+                result.append(namespace_label)
+
+            result.append(ch)
+            result.append(user_filter)
+            in_selector = False
+        else:
+            result.append(ch)
+
+        i += 1
+
+    return "".join(result)

--- a/deployment/components/observability/usage-logs/tenancy-proxy-rbac.yaml
+++ b/deployment/components/observability/usage-logs/tenancy-proxy-rbac.yaml
@@ -1,0 +1,130 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: usage-tenancy-proxy
+  namespace: opendatahub
+  labels:
+    app: usage-tenancy-proxy
+    app.kubernetes.io/managed-by: maas-controller
+    app.kubernetes.io/component: usage-tenancy-proxy
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: usage-tenancy-proxy-pods-log-read
+  labels:
+    app: usage-tenancy-proxy
+    app.kubernetes.io/managed-by: maas-controller
+    app.kubernetes.io/component: usage-tenancy-proxy
+rules:
+- apiGroups:
+  - ''
+  resources:
+  - pods/log
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: usage-tenancy-proxy-pods-log-read
+  namespace: opendatahub
+  labels:
+    app: usage-tenancy-proxy
+    app.kubernetes.io/managed-by: maas-controller
+    app.kubernetes.io/component: usage-tenancy-proxy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: usage-tenancy-proxy-pods-log-read
+subjects:
+- kind: ServiceAccount
+  name: usage-tenancy-proxy
+  namespace: opendatahub
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: usage-tenancy-proxy-application-logs-read
+  labels:
+    app: usage-tenancy-proxy
+    app.kubernetes.io/managed-by: maas-controller
+    app.kubernetes.io/component: usage-tenancy-proxy
+rules:
+  - verbs:
+      - get
+    apiGroups:
+      - loki.grafana.com
+    resources:
+      - application
+    resourceNames:
+      - logs
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: usage-tenancy-proxy-application-logs-read
+  namespace: opendatahub
+  labels:
+    app: usage-tenancy-proxy
+    app.kubernetes.io/component: usage-tenancy-proxy
+    app.kubernetes.io/managed-by: maas-controller
+subjects:
+  - kind: ServiceAccount
+    name: usage-tenancy-proxy
+    namespace: opendatahub
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: usage-tenancy-proxy-application-logs-read
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: usage-tenancy-proxy-tokenreview
+  labels:
+    app: usage-tenancy-proxy
+    app.kubernetes.io/managed-by: maas-controller
+    app.kubernetes.io/component: usage-tenancy-proxy
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: usage-tenancy-proxy-tokenreview
+  labels:
+    app: usage-tenancy-proxy
+    app.kubernetes.io/managed-by: maas-controller
+    app.kubernetes.io/component: usage-tenancy-proxy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: usage-tenancy-proxy-tokenreview
+subjects:
+- kind: ServiceAccount
+  name: usage-tenancy-proxy
+  namespace: opendatahub
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: usage-tenancy-proxy-scc-nonroot-v2
+  namespace: opendatahub
+  labels:
+    app: usage-tenancy-proxy
+    app.kubernetes.io/managed-by: maas-controller
+    app.kubernetes.io/component: usage-tenancy-proxy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:nonroot-v2
+subjects:
+- kind: ServiceAccount
+  name: usage-tenancy-proxy
+  namespace: opendatahub

--- a/deployment/components/observability/usage-logs/tenancy-proxy.yaml
+++ b/deployment/components/observability/usage-logs/tenancy-proxy.yaml
@@ -1,0 +1,129 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: usage-logs-tenancy-proxy
+  namespace: opendatahub
+  labels:
+    app: usage-tenancy-proxy
+    app.kubernetes.io/managed-by: maas-controller
+    app.kubernetes.io/component: usage-tenancy-proxy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: usage-tenancy-proxy
+  template:
+    metadata:
+      labels:
+        app: usage-tenancy-proxy
+    spec:
+      serviceAccountName: usage-tenancy-proxy
+      securityContext:
+        runAsNonRoot: true
+        fsGroup: 1001
+      containers:
+      - name: proxy
+        # Image is set by controller (DefaultUsageLogsTenancyProxyImage or RELATED_IMAGE override)
+        command:
+        - python3
+        - /opt/app-root/src/proxy/main.py
+        securityContext:
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault
+        ports:
+        - containerPort: 8443
+          name: https
+          protocol: TCP
+        env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: PYTHONPATH
+          value: "/opt/app-root/src/proxy"
+        - name: PYTHONUNBUFFERED
+          value: "1"
+        - name: LOG_LEVEL
+          value: "INFO"
+        volumeMounts:
+        - name: proxy-source
+          mountPath: /opt/app-root/src/proxy
+          readOnly: true
+        - name: tls-cert
+          mountPath: /etc/tls/private
+          readOnly: true
+        - name: service-ca
+          mountPath: /etc/pki/ca-trust/extracted/pem
+          readOnly: true
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8443
+            scheme: HTTPS
+          initialDelaySeconds: 10
+          periodSeconds: 30
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8443
+            scheme: HTTPS
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          requests:
+            cpu: 50m
+            memory: 128Mi
+          limits:
+            cpu: 200m
+            memory: 256Mi
+      volumes:
+      - name: proxy-source
+        configMap:
+          name: usage-tenancy-proxy-source
+      - name: tls-cert
+        secret:
+          secretName: usage-logs-tenancy-proxy-tls
+          defaultMode: 0440
+      - name: service-ca
+        configMap:
+          name: usage-logs-tenancy-proxy-ca-bundle
+          items:
+          - key: service-ca.crt
+            path: tls-ca-bundle.pem
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: usage-logs-tenancy-proxy-ca-bundle
+  namespace: opendatahub
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"
+  labels:
+    app.kubernetes.io/managed-by: maas-controller
+    app.kubernetes.io/component: usage-tenancy-proxy
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: usage-logs-tenancy-proxy
+  namespace: opendatahub
+  labels:
+    app: usage-tenancy-proxy
+    app.kubernetes.io/managed-by: maas-controller
+    app.kubernetes.io/component: usage-tenancy-proxy
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: usage-logs-tenancy-proxy-tls
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8443
+    targetPort: 8443
+    protocol: TCP
+    name: https
+  selector:
+    app: usage-tenancy-proxy

--- a/deployment/components/observability/usage-logs/usage-logs-admin-dashboard.yaml
+++ b/deployment/components/observability/usage-logs/usage-logs-admin-dashboard.yaml
@@ -1,0 +1,479 @@
+# Admin usage dashboard — queries Loki structured logs via LogQL.
+# Uses $__range to bind LogQL windows to the native time picker.
+# LokiLabelValuesVariable for model/subscription dropdowns (COO 1.5+).
+# User filter uses TextVariable (regex input) to avoid Loki cardinality issues
+# from indexing high-cardinality user_id as a label. Admins enter regex patterns.
+# customAllValue: ".*" on ListVariables ensures "All" matches entries with
+# absent labels (e.g. subscription when capturing is disabled). Do not remove.
+apiVersion: perses.dev/v1alpha1
+kind: PersesDashboard
+metadata:
+  name: dashboard-4-maas-usage-logs-admin
+  namespace: opendatahub
+  labels:
+    app.kubernetes.io/managed-by: maas-controller
+    app.kubernetes.io/component: perses
+spec:
+  display:
+    name: "All usage (logs)"
+    description: >-
+      Admin view of model usage. Shows token consumption, request counts,
+      rate limiting, and per-user breakdown across all users and subscriptions.
+  duration: 1h
+  variables:
+    - kind: TextVariable
+      spec:
+        name: user
+        display:
+          name: "User (regex)"
+          description: "Filter by user ID. Use regex: 'user-1' (single), 'user-1|user-2' (multiple), '.*' (all)"
+        defaultValue: ".*"
+    - kind: ListVariable
+      spec:
+        name: subscription
+        display:
+          name: "Subscription"
+        allowMultiple: true
+        allowAllValue: true
+        customAllValue: ".*"
+        defaultValue: "$__all"
+        plugin:
+          kind: LokiLabelValuesVariable
+          spec:
+            datasource:
+              kind: LokiDatasource
+              name: usage-logs-all
+            labelName: subscription
+            matchers:
+              - '{service_name="models-as-a-service", subscription!="-"}'
+    - kind: ListVariable
+      spec:
+        name: model
+        display:
+          name: "Model"
+        allowMultiple: true
+        allowAllValue: true
+        customAllValue: ".*"
+        defaultValue: "$__all"
+        plugin:
+          kind: LokiLabelValuesVariable
+          spec:
+            datasource:
+              kind: LokiDatasource
+              name: usage-logs-all
+            labelName: model
+            matchers:
+              - '{service_name="models-as-a-service", model!="-"}'
+    - kind: ListVariable
+      spec:
+        name: view_by
+        display:
+          name: "View by"
+        allowMultiple: false
+        allowAllValue: false
+        defaultValue: "model"
+        plugin:
+          kind: StaticListVariable
+          spec:
+            values:
+              - value: "model"
+                label: By model
+              - value: "subscription"
+                label: By subscription
+
+  panels:
+    totalTokens:
+      kind: Panel
+      spec:
+        display:
+          name: "Total tokens"
+          description: "Total tokens consumed over the selected time window."
+        plugin:
+          kind: StatChart
+          spec:
+            calculation: last
+            format:
+              unit: decimal
+              shortValues: true
+              decimalPlaces: 0
+        queries:
+          - kind: TimeSeriesQuery
+            spec:
+              plugin:
+                kind: LokiTimeSeriesQuery
+                spec:
+                  datasource:
+                    kind: LokiDatasource
+                    name: usage-logs-all
+                  query: >-
+                    sum(sum_over_time({service_name="models-as-a-service",
+                    subscription=~"$subscription", model=~"$model", response_type="hit"}
+                    | user_id=~"$user"
+                    | unwrap tokens_total [$__range]))
+                    or vector(0)
+
+    totalRequests:
+      kind: Panel
+      spec:
+        display:
+          name: "Total requests"
+          description: "Total API requests over the selected time window."
+        plugin:
+          kind: StatChart
+          spec:
+            calculation: last
+            format:
+              unit: decimal
+              shortValues: true
+              decimalPlaces: 0
+        queries:
+          - kind: TimeSeriesQuery
+            spec:
+              plugin:
+                kind: LokiTimeSeriesQuery
+                spec:
+                  datasource:
+                    kind: LokiDatasource
+                    name: usage-logs-all
+                  query: >-
+                    sum(count_over_time({service_name="models-as-a-service",
+                    subscription=~"$subscription", model=~"$model"}
+                    | user_id=~"$user" [$__range]))
+                    or vector(0)
+
+    totalRateLimited:
+      kind: Panel
+      spec:
+        display:
+          name: "Total rate limited"
+          description: "Total rate-limited requests over the selected time window."
+        plugin:
+          kind: StatChart
+          spec:
+            calculation: last
+            format:
+              unit: decimal
+              shortValues: true
+              decimalPlaces: 0
+        queries:
+          - kind: TimeSeriesQuery
+            spec:
+              plugin:
+                kind: LokiTimeSeriesQuery
+                spec:
+                  datasource:
+                    kind: LokiDatasource
+                    name: usage-logs-all
+                  query: >-
+                    sum(count_over_time({service_name="models-as-a-service",
+                    subscription=~"$subscription", model=~"$model", response_type="rate_limit"}
+                    | user_id=~"$user" [$__range]))
+                    or vector(0)
+
+    successRate:
+      kind: Panel
+      spec:
+        display:
+          description: "Percentage of successful vs total requests over the selected time window."
+          name: Success rate
+        plugin:
+          kind: StatChart
+          spec:
+            calculation: last
+            format:
+              decimalPlaces: 1
+              unit: percent-decimal
+        queries:
+          - kind: TimeSeriesQuery
+            spec:
+              plugin:
+                kind: LokiTimeSeriesQuery
+                spec:
+                  datasource:
+                    kind: LokiDatasource
+                    name: usage-logs-all
+                  query: >-
+                    (
+                      (
+                        sum(count_over_time({service_name="models-as-a-service",
+                        subscription=~"$subscription", model=~"$model", response_type="hit"}
+                        | user_id=~"$user" [$__range]))
+                        or vector(0)
+                      )
+                      /
+                      sum(count_over_time({service_name="models-as-a-service",
+                      subscription=~"$subscription", model=~"$model"}
+                      | user_id=~"$user" [$__range]))
+                    )
+                    or vector(1)
+
+    activeUsers:
+      kind: Panel
+      spec:
+        display:
+          name: "Active users"
+          description: "Distinct users with API activity over the selected time window."
+        plugin:
+          kind: StatChart
+          spec:
+            calculation: last
+            format:
+              unit: decimal
+              decimalPlaces: 0
+        queries:
+          - kind: TimeSeriesQuery
+            spec:
+              plugin:
+                kind: LokiTimeSeriesQuery
+                spec:
+                  datasource:
+                    kind: LokiDatasource
+                    name: usage-logs-all
+                  query: >-
+                    count(sum by (user_id) (count_over_time({service_name="models-as-a-service",
+                    subscription=~"$subscription", model=~"$model"}
+                    | user_id=~"$user" | user_id!="" | user_id!="-" [$__range])))
+                    or vector(0)
+
+    tokenConsumptionOverTime:
+      kind: Panel
+      spec:
+        display:
+          name: "Token consumption chart"
+          description: >-
+            Tokens from successful requests (2xx) over time by model or subscription.
+            **View by** drives chart ``sum by (${view_by:raw})``. Table uses hardcoded ``sum by (model, subscription)``.
+            LogQL ``[30m]`` is the range window for ``sum_over_time`` (Perses time-series step).
+            Visual: OpenShift Perses pattern — ``line`` + ``areaOpacity: 1`` + ``stack: all``.
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              position: bottom
+              mode: table
+              values: []
+            visual:
+              display: line
+              lineWidth: 3
+              areaOpacity: 1
+              connectNulls: true
+              stack: all
+              showPoints: always
+              pointRadius: 6
+            yAxis:
+              min: 0
+              format:
+                unit: decimal
+        queries:
+          - kind: TimeSeriesQuery
+            spec:
+              plugin:
+                kind: LokiTimeSeriesQuery
+                spec:
+                  datasource:
+                    kind: LokiDatasource
+                    name: usage-logs-all
+                  query: >-
+                    sum by (${view_by:raw}) (sum_over_time({service_name="models-as-a-service",
+                    subscription=~"$subscription", model=~"$model", response_type="hit"}
+                    | user_id=~"$user"
+                    | unwrap tokens_total [30m]))
+
+    tokenConsumptionTable:
+      kind: Panel
+      spec:
+        display:
+          name: "Usage breakdown"
+          description: >-
+            All model/subscription pairs. **View by** changes the chart; table always shows full detail.
+        plugin:
+          kind: Table
+          spec:
+            density: "compact"
+            pagination: true
+            transforms:
+              - kind: "MergeSeries"
+                spec: {}
+            columnSettings:
+              - name: "timestamp"
+                hide: true
+              - name: "user_id"
+                header: "User"
+                align: "left"
+                enableSorting: true
+              - name: "model"
+                header: "Model"
+                align: "left"
+                enableSorting: true
+              - name: "subscription"
+                header: "Subscription"
+                align: "left"
+                enableSorting: true
+              - name: "value #1"
+                header: "Tokens used"
+                align: "right"
+                enableSorting: true
+                sort: "desc"
+                format:
+                  unit: decimal
+                  shortValues: true
+              - name: "value #2"
+                header: "Successful requests"
+                align: "right"
+                enableSorting: true
+                format:
+                  unit: decimal
+                  decimalPlaces: 0
+              - name: "value #3"
+                header: "Rate limited requests"
+                align: "right"
+                enableSorting: true
+                format:
+                  unit: decimal
+                  decimalPlaces: 0
+        queries:
+          - kind: TimeSeriesQuery
+            spec:
+              plugin:
+                kind: LokiTimeSeriesQuery
+                spec:
+                  datasource:
+                    kind: LokiDatasource
+                    name: usage-logs-all
+                  query: >-
+                    sum by (user_id, model, subscription) (sum_over_time(
+                    {service_name="models-as-a-service",
+                    subscription=~"$subscription", model=~"$model", response_type="hit"}
+                    | user_id=~"$user"
+                    | unwrap tokens_total [$__range]))
+          - kind: TimeSeriesQuery
+            spec:
+              plugin:
+                kind: LokiTimeSeriesQuery
+                spec:
+                  datasource:
+                    kind: LokiDatasource
+                    name: usage-logs-all
+                  query: >-
+                    sum by (user_id, model, subscription) (count_over_time(
+                    {service_name="models-as-a-service",
+                    subscription=~"$subscription", model=~"$model", response_type="hit"}
+                    | user_id=~"$user" [$__range]))
+          - kind: TimeSeriesQuery
+            spec:
+              plugin:
+                kind: LokiTimeSeriesQuery
+                spec:
+                  datasource:
+                    kind: LokiDatasource
+                    name: usage-logs-all
+                  query: >-
+                    sum by (user_id, model, subscription) (count_over_time(
+                    {service_name="models-as-a-service",
+                    subscription=~"$subscription", model=~"$model", response_type="rate_limit"}
+                    | user_id=~"$user" [$__range]))
+                    or
+                    (sum by (user_id, model, subscription) (count_over_time(
+                    {service_name="models-as-a-service",
+                    subscription=~"$subscription", model=~"$model", response_type="hit"}
+                    | user_id=~"$user" [$__range])) * 0)
+
+  layouts:
+    - kind: Grid
+      spec:
+        display:
+          title: "Overview"
+          collapse:
+            open: true
+        items:
+          - x: 0
+            "y": 0
+            width: 5
+            height: 5
+            content:
+              "$ref": "#/spec/panels/totalTokens"
+          - x: 5
+            "y": 0
+            width: 5
+            height: 5
+            content:
+              "$ref": "#/spec/panels/totalRequests"
+          - x: 10
+            "y": 0
+            width: 5
+            height: 5
+            content:
+              "$ref": "#/spec/panels/totalRateLimited"
+          - x: 15
+            "y": 0
+            width: 5
+            height: 5
+            content:
+              "$ref": "#/spec/panels/successRate"
+          - x: 20
+            "y": 0
+            width: 4
+            height: 5
+            content:
+              "$ref": "#/spec/panels/activeUsers"
+
+    - kind: Grid
+      spec:
+        display:
+          title: "Token consumption"
+          collapse:
+            open: true
+        items:
+          - x: 0
+            "y": 0
+            width: 24
+            height: 10
+            content:
+              "$ref": "#/spec/panels/tokenConsumptionOverTime"
+          - x: 0
+            "y": 10
+            width: 24
+            height: 8
+            content:
+              "$ref": "#/spec/panels/tokenConsumptionTable"
+---
+apiVersion: perses.dev/v1alpha1
+kind: PersesDatasource
+metadata:
+  name: usage-logs-all
+  namespace: opendatahub
+  labels:
+    app.kubernetes.io/managed-by: maas-controller
+    app.kubernetes.io/component: perses
+spec:
+  config:
+    display:
+      name: "All usage (logs)"
+    default: false
+    plugin:
+      kind: "LokiDatasource"
+      spec:
+        proxy:
+          kind: HTTPProxy
+          spec:
+            url: 'https://usage-gateway-http:8080/api/logs/v1/application'
+            allowedEndpoints:
+              - endpointPattern: "/loki/api/v1/query"
+                method: GET
+              - endpointPattern: "/loki/api/v1/query_range"
+                method: GET
+              - endpointPattern: "/loki/api/v1/labels"
+                method: GET
+              - endpointPattern: "/loki/api/v1/label/([a-zA-Z0-9_-]+)/values"
+                method: GET
+            secret: usage-logs-all-secret
+  client:
+    kubernetesAuth:
+      enable: true
+    tls:
+      enable: true
+      insecureSkipVerify: false
+      caCert:
+        type: configmap
+        name: usage-gateway-ca-bundle
+        certPath: service-ca.crt

--- a/deployment/components/observability/usage-logs/usage-logs-dashboard.yaml
+++ b/deployment/components/observability/usage-logs/usage-logs-dashboard.yaml
@@ -1,0 +1,428 @@
+# User-scoped usage dashboard — queries go through loki-query-proxy which
+# injects user_id filtering based on the logged-in user's Kubernetes token.
+# CEL filter restricts logs to inference-only paths; no probe traffic to filter.
+# customAllValue: ".*" on ListVariables ensures "All" matches entries with
+# absent labels (e.g. user_id when capturing is disabled). Do not remove.
+apiVersion: perses.dev/v1alpha1
+kind: PersesDashboard
+metadata:
+  name: dashboard-5-maas-usage-logs
+  namespace: opendatahub
+  labels:
+    app.kubernetes.io/managed-by: maas-controller
+    app.kubernetes.io/component: perses
+spec:
+  display:
+    name: "Usage (logs)"
+    description: >-
+      Personal view of model usage. Shows your token consumption, request
+      counts, and rate limiting. Queries are automatically filtered to your
+      user identity via the Loki query proxy.
+  duration: 1h
+
+  variables:
+    - kind: ListVariable
+      spec:
+        name: subscription
+        display:
+          name: "Subscription"
+        allowMultiple: true
+        allowAllValue: true
+        customAllValue: ".*"
+        defaultValue: "$__all"
+        plugin:
+          kind: LokiLabelValuesVariable
+          spec:
+            datasource:
+              kind: LokiDatasource
+              name: usage-logs-multi-tenancy
+            labelName: subscription
+            matchers:
+              - '{service_name="models-as-a-service", subscription!="-"}'
+    - kind: ListVariable
+      spec:
+        name: model
+        display:
+          name: "Model"
+        allowMultiple: true
+        allowAllValue: true
+        customAllValue: ".*"
+        defaultValue: "$__all"
+        plugin:
+          kind: LokiLabelValuesVariable
+          spec:
+            datasource:
+              kind: LokiDatasource
+              name: usage-logs-multi-tenancy
+            labelName: model
+            matchers:
+              - '{service_name="models-as-a-service", model!="-"}'
+    - kind: ListVariable
+      spec:
+        name: view_by
+        display:
+          name: "View by"
+        allowMultiple: false
+        allowAllValue: false
+        defaultValue: "model"
+        plugin:
+          kind: StaticListVariable
+          spec:
+            values:
+              - value: "model"
+                label: By model
+              - value: "subscription"
+                label: By subscription
+
+  panels:
+    totalTokens:
+      kind: Panel
+      spec:
+        display:
+          name: "Total tokens"
+          description: "Total tokens consumed over the selected time window."
+        plugin:
+          kind: StatChart
+          spec:
+            calculation: last
+            format:
+              unit: decimal
+              shortValues: true
+              decimalPlaces: 0
+        queries:
+          - kind: TimeSeriesQuery
+            spec:
+              plugin:
+                kind: LokiTimeSeriesQuery
+                spec:
+                  datasource:
+                    kind: LokiDatasource
+                    name: usage-logs-multi-tenancy
+                  query: >-
+                    sum(sum_over_time({service_name="models-as-a-service",
+                    subscription=~"$subscription", model=~"$model", response_type="hit"}
+                    | unwrap tokens_total [$__range]))
+                    or vector(0)
+
+    totalRequests:
+      kind: Panel
+      spec:
+        display:
+          name: "Total requests"
+          description: "Total API requests over the selected time window."
+        plugin:
+          kind: StatChart
+          spec:
+            calculation: last
+            format:
+              unit: decimal
+              shortValues: true
+              decimalPlaces: 0
+        queries:
+          - kind: TimeSeriesQuery
+            spec:
+              plugin:
+                kind: LokiTimeSeriesQuery
+                spec:
+                  datasource:
+                    kind: LokiDatasource
+                    name: usage-logs-multi-tenancy
+                  query: >-
+                    sum(count_over_time({service_name="models-as-a-service",
+                    subscription=~"$subscription", model=~"$model"}
+                    [$__range]))
+                    or vector(0)
+
+    totalRateLimited:
+      kind: Panel
+      spec:
+        display:
+          name: "Total rate limited"
+          description: "Total rate-limited requests over the selected time window."
+        plugin:
+          kind: StatChart
+          spec:
+            calculation: last
+            format:
+              unit: decimal
+              shortValues: true
+              decimalPlaces: 0
+        queries:
+          - kind: TimeSeriesQuery
+            spec:
+              plugin:
+                kind: LokiTimeSeriesQuery
+                spec:
+                  datasource:
+                    kind: LokiDatasource
+                    name: usage-logs-multi-tenancy
+                  query: >-
+                    sum(count_over_time({service_name="models-as-a-service",
+                    subscription=~"$subscription", model=~"$model", response_type="rate_limit"}
+                    [$__range]))
+                    or vector(0)
+
+    successRate:
+      kind: Panel
+      spec:
+        display:
+          description: "Percentage of authorized vs total requests over the selected time window."
+          name: Success rate
+        plugin:
+          kind: StatChart
+          spec:
+            calculation: last
+            format:
+              decimalPlaces: 1
+              unit: percent-decimal
+        queries:
+          - kind: TimeSeriesQuery
+            spec:
+              plugin:
+                kind: LokiTimeSeriesQuery
+                spec:
+                  datasource:
+                    kind: LokiDatasource
+                    name: usage-logs-multi-tenancy
+                  query: >-
+                    (
+                      (
+                        sum(count_over_time({service_name="models-as-a-service",
+                        subscription=~"$subscription", model=~"$model", response_type="hit"}
+                        [$__range]))
+                        or vector(0)
+                      )
+                      /
+                      sum(count_over_time({service_name="models-as-a-service",
+                      subscription=~"$subscription", model=~"$model"}
+                      [$__range]))
+                    )
+                    or vector(1)
+
+    tokenConsumptionOverTime:
+      kind: Panel
+      spec:
+        display:
+          name: "Token consumption chart"
+          description: >-
+            Tokens from successful requests (2xx) over time by model or subscription.
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              position: bottom
+              mode: table
+              values: []
+            visual:
+              display: line
+              lineWidth: 3
+              areaOpacity: 1
+              connectNulls: true
+              stack: all
+              showPoints: always
+              pointRadius: 6
+            yAxis:
+              min: 0
+              format:
+                unit: decimal
+        queries:
+          - kind: TimeSeriesQuery
+            spec:
+              plugin:
+                kind: LokiTimeSeriesQuery
+                spec:
+                  datasource:
+                    kind: LokiDatasource
+                    name: usage-logs-multi-tenancy
+                  query: >-
+                    sum by (${view_by:raw}) (sum_over_time({service_name="models-as-a-service",
+                    subscription=~"$subscription", model=~"$model", response_type="hit"}
+                    | unwrap tokens_total [30m]))
+
+    tokenConsumptionTable:
+      kind: Panel
+      spec:
+        display:
+          name: "Usage breakdown"
+          description: >-
+            All model/subscription pairs. **View by** changes the chart; table always shows full detail.
+        plugin:
+          kind: Table
+          spec:
+            density: "compact"
+            pagination: true
+            transforms:
+              - kind: "MergeSeries"
+                spec: {}
+            columnSettings:
+              - name: "timestamp"
+                hide: true
+              - name: "model"
+                header: "Model"
+                align: "left"
+                enableSorting: true
+              - name: "subscription"
+                header: "Subscription"
+                align: "left"
+                enableSorting: true
+              - name: "key_name"
+                header: "API key"
+                align: "left"
+                enableSorting: true
+              - name: "value #1"
+                header: "Tokens used"
+                align: "right"
+                enableSorting: true
+                sort: "desc"
+                format:
+                  unit: decimal
+                  shortValues: true
+              - name: "value #2"
+                header: "Successful requests"
+                align: "right"
+                enableSorting: true
+                format:
+                  unit: decimal
+                  decimalPlaces: 0
+              - name: "value #3"
+                header: "Rate limited requests"
+                align: "right"
+                enableSorting: true
+                format:
+                  unit: decimal
+                  decimalPlaces: 0
+        queries:
+          - kind: TimeSeriesQuery
+            spec:
+              plugin:
+                kind: LokiTimeSeriesQuery
+                spec:
+                  datasource:
+                    kind: LokiDatasource
+                    name: usage-logs-multi-tenancy
+                  query: >-
+                    sum by (model, subscription, key_name) (sum_over_time(
+                    {service_name="models-as-a-service",
+                    subscription=~"$subscription", model=~"$model", response_type="hit"}
+                    | unwrap tokens_total [$__range]))
+          - kind: TimeSeriesQuery
+            spec:
+              plugin:
+                kind: LokiTimeSeriesQuery
+                spec:
+                  datasource:
+                    kind: LokiDatasource
+                    name: usage-logs-multi-tenancy
+                  query: >-
+                    sum by (model, subscription, key_name) (count_over_time(
+                    {service_name="models-as-a-service",
+                    subscription=~"$subscription", model=~"$model", response_type="hit"}
+                    [$__range]))
+          - kind: TimeSeriesQuery
+            spec:
+              plugin:
+                kind: LokiTimeSeriesQuery
+                spec:
+                  datasource:
+                    kind: LokiDatasource
+                    name: usage-logs-multi-tenancy
+                  query: >-
+                    sum by (model, subscription, key_name) (count_over_time(
+                    {service_name="models-as-a-service",
+                    subscription=~"$subscription", model=~"$model", response_type="rate_limit"}
+                    [$__range]))
+                    or
+                    (sum by (model, subscription, key_name) (count_over_time(
+                    {service_name="models-as-a-service",
+                    subscription=~"$subscription", model=~"$model", response_type="hit"}
+                    [$__range])) * 0)
+
+  layouts:
+    - kind: Grid
+      spec:
+        display:
+          title: "Overview"
+          collapse:
+            open: true
+        items:
+          - x: 0
+            "y": 0
+            width: 6
+            height: 5
+            content:
+              "$ref": "#/spec/panels/totalTokens"
+          - x: 6
+            "y": 0
+            width: 6
+            height: 5
+            content:
+              "$ref": "#/spec/panels/totalRequests"
+          - x: 12
+            "y": 0
+            width: 6
+            height: 5
+            content:
+              "$ref": "#/spec/panels/totalRateLimited"
+          - x: 18
+            "y": 0
+            width: 6
+            height: 5
+            content:
+              "$ref": "#/spec/panels/successRate"
+
+    - kind: Grid
+      spec:
+        display:
+          title: "Token consumption"
+          collapse:
+            open: true
+        items:
+          - x: 0
+            "y": 0
+            width: 24
+            height: 10
+            content:
+              "$ref": "#/spec/panels/tokenConsumptionOverTime"
+          - x: 0
+            "y": 10
+            width: 24
+            height: 8
+            content:
+              "$ref": "#/spec/panels/tokenConsumptionTable"
+---
+# User-scoped Loki datasource — routes through usage-logs-tenancy-proxy which
+# injects user_id filtering. Named "usage-logs-multi-tenancy" to avoid
+# collision with the admin "usage-logs" datasource.
+apiVersion: perses.dev/v1alpha1
+kind: PersesDatasource
+metadata:
+  name: usage-logs-multi-tenancy
+  namespace: opendatahub
+  labels:
+    app.kubernetes.io/managed-by: maas-controller
+    app.kubernetes.io/component: perses
+spec:
+  config:
+    display:
+      name: "Usage (logs)"
+    default: false
+    plugin:
+      kind: "LokiDatasource"
+      spec:
+        proxy:
+          kind: HTTPProxy
+          spec:
+            secret: usage-logs-multi-tenancy-secret
+            url: https://usage-logs-tenancy-proxy:8443
+            allowedEndpoints:
+              - endpointPattern: "/loki/api/v1/.*"
+                method: GET
+  client:
+    kubernetesAuth:
+      enable: true
+    tls:
+      enable: true
+      caCert:
+        type: configmap
+        name: usage-logs-tenancy-proxy-ca-bundle
+        certPath: service-ca.crt

--- a/deployment/overlays/odh/params.env
+++ b/deployment/overlays/odh/params.env
@@ -2,6 +2,7 @@ maas-api-image=quay.io/opendatahub/maas-api:odh-stable
 maas-controller-image=quay.io/opendatahub/maas-controller:odh-stable
 payload-processing-image=quay.io/opendatahub/odh-ai-gateway-payload-processing:odh-stable
 maas-api-key-cleanup-image=registry.redhat.io/ubi9/ubi-minimal:9.7
+usage-logs-tenancy-proxy-image=registry.redhat.io/ubi9/python-312@sha256:f6713d327d37e654a443752e6654b5aab88f31690e1161eed9c34dd837870172
 payload-processing-replicas=1
 gateway-namespace=openshift-ingress
 gateway-name=maas-default-gateway

--- a/maas-controller/pkg/controller/maas/constants.go
+++ b/maas-controller/pkg/controller/maas/constants.go
@@ -1,5 +1,11 @@
 package maas
 
+const (
+	// DefaultUsageLogsTenancyProxyImage is the default image for the usage-logs tenancy proxy container.
+	// Can be overridden via RELATED_IMAGE_ODH_PYTHON_312_IMAGE for disconnected environments.
+	DefaultUsageLogsTenancyProxyImage = "registry.redhat.io/ubi9/python-312@sha256:f6713d327d37e654a443752e6654b5aab88f31690e1161eed9c34dd837870172"
+)
+
 // OptionalAPIGroups lists API groups whose CRDs are installed by optional platform
 // components (e.g. COO for Perses). Resources in these groups are skipped gracefully
 // when their CRDs are not yet registered, instead of failing the Tenant reconcile.

--- a/maas-controller/pkg/controller/maas/self_deployment_controller.go
+++ b/maas-controller/pkg/controller/maas/self_deployment_controller.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"regexp"
 	"strings"
 	"time"
 
@@ -62,10 +63,11 @@ const envoyFilterManifestPath = "/deployment/components/observability/usage-logs
 // usageLogsCollectorName is the OpenTelemetryCollector resource for gateway usage logs.
 const usageLogsCollectorName = "usage-logs"
 
-// lokiGatewayHTTPService is the Loki gateway Service fronting the application logs OTLP endpoint.
-const lokiGatewayHTTPService = "maas-loki-gateway-http"
+// usageLogsTenancyProxyDeploymentName is the Deployment for the Loki query tenancy proxy.
+const usageLogsTenancyProxyDeploymentName = "usage-logs-tenancy-proxy"
 
-const lokiGatewayOTLPEndpointPath = "/api/logs/v1/application/otlp"
+// usageLogsTenancyProxyContainerName is the proxy container in the tenancy proxy Deployment.
+const usageLogsTenancyProxyContainerName = "proxy"
 
 // envoyFilterName is the name of the usage-logs EnvoyFilter resource.
 const envoyFilterName = "maas-model-access-logs"
@@ -584,7 +586,10 @@ func (r *LifecycleReconciler) ensureUsageLogs(ctx context.Context, log logr.Logg
 
 		for _, resource := range resources {
 			res := resource // avoid loop variable aliasing
-			if err := patchUsageLogsOpenTelemetryCollector(&res, r.MonitoringNamespace); err != nil {
+			if err := patchTenancyProxyImage(&res); err != nil {
+				return fmt.Errorf("patch %s %s: %w", res.GetKind(), res.GetName(), err)
+			}
+			if err := patchPersesDatasourceURL(&res); err != nil {
 				return fmt.Errorf("patch %s %s: %w", res.GetKind(), res.GetName(), err)
 			}
 			if err := controllerutil.SetControllerReference(&cfg, &res, r.Scheme); err != nil {
@@ -613,7 +618,7 @@ func (r *LifecycleReconciler) ensureUsageLogs(ctx context.Context, log logr.Logg
 			}
 			crb := &unstructured.Unstructured{}
 			crb.SetGroupVersionKind(gvkClusterRoleBinding)
-			crb.SetName("usage-logs-writer")
+			crb.SetName("usage-collector-application-logs-write")
 
 			if err := r.Get(ctx, client.ObjectKeyFromObject(crb), crb); err == nil {
 				if isOwnedByConfigOrController(crb, cfg.UID) {
@@ -649,27 +654,78 @@ func isOwnedByConfigOrController(obj client.Object, configUID types.UID) bool {
 	return false
 }
 
-func lokiGatewayEndpoint(monitoringNamespace string) string {
-	return fmt.Sprintf(
-		"https://%s.%s.svc.cluster.local:8080%s",
-		lokiGatewayHTTPService,
-		monitoringNamespace,
-		lokiGatewayOTLPEndpointPath,
-	)
-}
-
-// patchUsageLogsOpenTelemetryCollector rewrites the Loki OTLP exporter endpoint to target the
-// monitoring namespace. The manifest keeps the overlay default namespace as a build-time placeholder.
-func patchUsageLogsOpenTelemetryCollector(res *unstructured.Unstructured, monitoringNamespace string) error {
-	if res.GetKind() != "OpenTelemetryCollector" || res.GetName() != usageLogsCollectorName {
+// patchPersesDatasourceURL expands short service references in PersesDatasource URLs to FQDNs.
+// Rewrites URLs like "https://service-name:port" to "https://service-name.{namespace}.svc:port"
+// using the datasource's deployed namespace. This allows YAML to use simple service references
+// while ensuring they work correctly in any namespace.
+func patchPersesDatasourceURL(res *unstructured.Unstructured) error {
+	if res.GetKind() != "PersesDatasource" {
 		return nil
 	}
-	endpoint := lokiGatewayEndpoint(monitoringNamespace)
-	if err := unstructured.SetNestedField(res.Object, endpoint,
-		"spec", "config", "exporters", "otlp_http/loki", "endpoint"); err != nil {
-		return fmt.Errorf("set loki exporter endpoint: %w", err)
+
+	namespace := res.GetNamespace()
+	if namespace == "" {
+		// No namespace set, skip patching
+		return nil
 	}
+
+	urlPath := []string{"spec", "config", "plugin", "spec", "proxy", "spec", "url"}
+	url, found, err := unstructured.NestedString(res.Object, urlPath...)
+	if err != nil {
+		return fmt.Errorf("read datasource URL: %w", err)
+	}
+	if !found {
+		// URL field doesn't exist in this datasource
+		return nil
+	}
+
+	// Only patch if URL doesn't already have .svc (i.e., it's a short service reference)
+	if !strings.Contains(url, ".svc") {
+		// Pattern: https://service-name:port/path -> https://service-name.{namespace}.svc:port/path
+		// Use regex to insert .{namespace}.svc before the port
+		re := regexp.MustCompile(`(https?://[^:]+)(:\d+)`)
+		patchedURL := re.ReplaceAllString(url, fmt.Sprintf("$1.%s.svc$2", namespace))
+
+		if err := unstructured.SetNestedField(res.Object, patchedURL, urlPath...); err != nil {
+			return fmt.Errorf("set datasource URL: %w", err)
+		}
+	}
+
 	return nil
+}
+
+// patchTenancyProxyImage sets the tenancy-proxy container image to RELATED_IMAGE_ODH_PYTHON_312_IMAGE
+// if configured, otherwise uses DefaultUsageLogsTenancyProxyImage. This enables disconnected deployments
+// to mirror the image while maintaining a code-defined default.
+func patchTenancyProxyImage(res *unstructured.Unstructured) error {
+	if res.GetKind() != "Deployment" || res.GetName() != usageLogsTenancyProxyDeploymentName {
+		return nil
+	}
+
+	image := os.Getenv("RELATED_IMAGE_ODH_PYTHON_312_IMAGE")
+	if image == "" {
+		image = DefaultUsageLogsTenancyProxyImage
+	}
+
+	containers, found, err := unstructured.NestedSlice(res.Object, "spec", "template", "spec", "containers")
+	if err != nil {
+		return fmt.Errorf("read containers in deployment: %w", err)
+	}
+	if !found {
+		return errors.New("containers not found in usage-logs-tenancy-proxy deployment")
+	}
+
+	for i, c := range containers {
+		cm, ok := c.(map[string]any)
+		if !ok || cm["name"] != usageLogsTenancyProxyContainerName {
+			continue
+		}
+		cm["image"] = image
+		containers[i] = cm
+		return unstructured.SetNestedSlice(res.Object, containers, "spec", "template", "spec", "containers")
+	}
+
+	return errors.New("proxy container not found in usage-logs-tenancy-proxy deployment")
 }
 
 // ensureUsageLogsEnvoyFilter deploys or removes the OTel usage logs EnvoyFilter based on
@@ -728,7 +784,7 @@ func (r *LifecycleReconciler) applyUsageLogsEnvoyFilter(ctx context.Context, log
 		return fmt.Errorf("decode EnvoyFilter manifest: %w", err)
 	}
 
-	collectorAddress := fmt.Sprintf("usage-logs-collector.%s.svc.cluster.local", r.MonitoringNamespace)
+	collectorAddress := fmt.Sprintf("usage-logs-collector.%s.svc", r.MonitoringNamespace)
 	if err := patchClusterAddress(ef, collectorAddress); err != nil {
 		return fmt.Errorf("patch collector address in EnvoyFilter: %w", err)
 	}

--- a/maas-controller/pkg/controller/maas/self_deployment_controller_test.go
+++ b/maas-controller/pkg/controller/maas/self_deployment_controller_test.go
@@ -784,7 +784,7 @@ func TestEnsureUsageLogsEnvoyFilter(t *testing.T) {
 		g.Expect(lbEndpoints).NotTo(BeEmpty())
 		lbe0, _ := lbEndpoints[0].(map[string]any)
 		addr, _, _ := unstructured.NestedString(lbe0, "endpoint", "address", "socket_address", "address")
-		g.Expect(addr).To(Equal("usage-logs-collector.opendatahub.svc.cluster.local"),
+		g.Expect(addr).To(Equal("usage-logs-collector.opendatahub.svc"),
 			"collector address should be patched with MonitoringNamespace")
 	})
 
@@ -857,7 +857,7 @@ func TestEnsureUsageLogs(t *testing.T) {
 
 		crb := &unstructured.Unstructured{}
 		crb.SetGroupVersionKind(gvkClusterRoleBinding)
-		crb.SetName("usage-logs-writer")
+		crb.SetName("usage-collector-application-logs-write")
 		crb.SetOwnerReferences([]metav1.OwnerReference{{
 			APIVersion: "maas.opendatahub.io/v1alpha1",
 			Kind:       "Config",
@@ -883,7 +883,7 @@ func TestEnsureUsageLogs(t *testing.T) {
 		g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "controller-managed OpenTelemetryCollector should be deleted")
 
 		got.SetGroupVersionKind(gvkClusterRoleBinding)
-		err = cl.Get(context.Background(), client.ObjectKey{Name: "usage-logs-writer"}, got)
+		err = cl.Get(context.Background(), client.ObjectKey{Name: "usage-collector-application-logs-write"}, got)
 		g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "controller-owned ClusterRoleBinding should be deleted")
 	})
 
@@ -906,7 +906,7 @@ func TestEnsureUsageLogs(t *testing.T) {
 		// Pre-existing foreign ClusterRoleBinding with same name
 		foreignCRB := &unstructured.Unstructured{}
 		foreignCRB.SetGroupVersionKind(gvkClusterRoleBinding)
-		foreignCRB.SetName("usage-logs-writer")
+		foreignCRB.SetName("usage-collector-application-logs-write")
 		// No ownership metadata
 
 		cl := fake.NewClientBuilder().WithScheme(s).WithObjects(cfg, foreignOtelCR, foreignCRB).Build()
@@ -928,7 +928,7 @@ func TestEnsureUsageLogs(t *testing.T) {
 			"foreign resource should not have managed-by label")
 
 		got.SetGroupVersionKind(gvkClusterRoleBinding)
-		err = cl.Get(context.Background(), client.ObjectKey{Name: "usage-logs-writer"}, got)
+		err = cl.Get(context.Background(), client.ObjectKey{Name: "usage-collector-application-logs-write"}, got)
 		g.Expect(err).NotTo(HaveOccurred(), "foreign ClusterRoleBinding should be preserved (CWE-284)")
 		g.Expect(got.GetOwnerReferences()).To(BeEmpty(),
 			"foreign resource should not have OwnerReferences")
@@ -959,16 +959,9 @@ func TestEnsureUsageLogs(t *testing.T) {
 		g.Expect(cl.Get(context.Background(), client.ObjectKey{Name: "usage-logs", Namespace: monitoringNS}, got)).
 			To(Succeed(), "OpenTelemetryCollector should exist when usageLogging is enabled")
 
-		endpoint, found, err := unstructured.NestedString(got.Object,
-			"spec", "config", "exporters", "otlp_http/loki", "endpoint")
-		g.Expect(err).NotTo(HaveOccurred())
-		g.Expect(found).To(BeTrue())
-		g.Expect(endpoint).To(Equal(lokiGatewayEndpoint(monitoringNS)),
-			"Loki exporter endpoint should target MonitoringNamespace")
-
 		got = &unstructured.Unstructured{}
 		got.SetGroupVersionKind(gvkClusterRoleBinding)
-		g.Expect(cl.Get(context.Background(), client.ObjectKey{Name: "usage-logs-writer"}, got)).
+		g.Expect(cl.Get(context.Background(), client.ObjectKey{Name: "usage-collector-application-logs-write"}, got)).
 			To(Succeed(), "ClusterRoleBinding should exist when usageLogging is enabled")
 
 		subjects, found, err := unstructured.NestedSlice(got.Object, "subjects")
@@ -978,5 +971,257 @@ func TestEnsureUsageLogs(t *testing.T) {
 		subj, ok := subjects[0].(map[string]any)
 		g.Expect(ok).To(BeTrue())
 		g.Expect(subj["namespace"]).To(Equal(monitoringNS))
+
+		dep := &appsv1.Deployment{}
+		g.Expect(cl.Get(context.Background(), client.ObjectKey{
+			Name: usageLogsTenancyProxyDeploymentName, Namespace: monitoringNS,
+		}, dep)).To(Succeed(), "tenancy proxy Deployment should exist when usageLogging is enabled")
+	})
+}
+
+func TestPatchTenancyProxyImage(t *testing.T) {
+	t.Run("patches proxy container image when RELATED_IMAGE set", func(t *testing.T) {
+		g := NewWithT(t)
+		t.Setenv("RELATED_IMAGE_ODH_PYTHON_312_IMAGE", "quay.io/example/tenancy-proxy:test")
+
+		deployment := &unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": "apps/v1",
+				"kind":       "Deployment",
+				"metadata": map[string]any{
+					"name": "usage-logs-tenancy-proxy",
+				},
+				"spec": map[string]any{
+					"template": map[string]any{
+						"spec": map[string]any{
+							"containers": []any{
+								map[string]any{
+									"name":  "proxy",
+									"image": "registry.redhat.io/ubi9/python-312@sha256:f6713d327d37e654a443752e6654b5aab88f31690e1161eed9c34dd837870172",
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		err := patchTenancyProxyImage(deployment)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		containers, found, err := unstructured.NestedSlice(deployment.Object, "spec", "template", "spec", "containers")
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(found).To(BeTrue())
+		g.Expect(containers).To(HaveLen(1))
+
+		container, ok := containers[0].(map[string]any)
+		g.Expect(ok).To(BeTrue())
+		g.Expect(container["image"]).To(Equal("quay.io/example/tenancy-proxy:test"))
+	})
+
+	t.Run("uses default image when RELATED_IMAGE not set", func(t *testing.T) {
+		g := NewWithT(t)
+
+		deployment := &unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": "apps/v1",
+				"kind":       "Deployment",
+				"metadata": map[string]any{
+					"name": "usage-logs-tenancy-proxy",
+				},
+				"spec": map[string]any{
+					"template": map[string]any{
+						"spec": map[string]any{
+							"containers": []any{
+								map[string]any{
+									"name": "proxy",
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		err := patchTenancyProxyImage(deployment)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		containers, found, err := unstructured.NestedSlice(deployment.Object, "spec", "template", "spec", "containers")
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(found).To(BeTrue())
+
+		container, ok := containers[0].(map[string]any)
+		g.Expect(ok).To(BeTrue())
+		g.Expect(container["image"]).To(Equal(DefaultUsageLogsTenancyProxyImage))
+	})
+
+	t.Run("ignores non-matching deployment", func(t *testing.T) {
+		g := NewWithT(t)
+		t.Setenv("RELATED_IMAGE_ODH_PYTHON_312_IMAGE", "quay.io/example/tenancy-proxy:test")
+
+		deployment := &unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": "apps/v1",
+				"kind":       "Deployment",
+				"metadata": map[string]any{
+					"name": "some-other-deployment",
+				},
+				"spec": map[string]any{
+					"template": map[string]any{
+						"spec": map[string]any{
+							"containers": []any{
+								map[string]any{
+									"name":  "proxy",
+									"image": "registry.redhat.io/ubi9/python-312@sha256:f6713d327d37e654a443752e6654b5aab88f31690e1161eed9c34dd837870172",
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		err := patchTenancyProxyImage(deployment)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		containers, found, err := unstructured.NestedSlice(deployment.Object, "spec", "template", "spec", "containers")
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(found).To(BeTrue())
+
+		container, ok := containers[0].(map[string]any)
+		g.Expect(ok).To(BeTrue())
+		g.Expect(container["image"]).To(Equal("registry.redhat.io/ubi9/python-312@sha256:f6713d327d37e654a443752e6654b5aab88f31690e1161eed9c34dd837870172"))
+	})
+}
+
+func TestPatchPersesDatasourceURL(t *testing.T) {
+	t.Run("expands short service reference to FQDN", func(t *testing.T) {
+		g := NewWithT(t)
+
+		datasource := &unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": "perses.dev/v1alpha1",
+				"kind":       "PersesDatasource",
+				"metadata": map[string]any{
+					"name":      "usage-logs",
+					"namespace": "redhat-ods-monitoring",
+				},
+				"spec": map[string]any{
+					"config": map[string]any{
+						"plugin": map[string]any{
+							"spec": map[string]any{
+								"proxy": map[string]any{
+									"spec": map[string]any{
+										"url": "https://usage-logs-tenancy-proxy:8443",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		err := patchPersesDatasourceURL(datasource)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		url, found, err := unstructured.NestedString(datasource.Object,
+			"spec", "config", "plugin", "spec", "proxy", "spec", "url")
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(found).To(BeTrue())
+		g.Expect(url).To(Equal("https://usage-logs-tenancy-proxy.redhat-ods-monitoring.svc:8443"))
+	})
+
+	t.Run("expands service reference with path", func(t *testing.T) {
+		g := NewWithT(t)
+
+		datasource := &unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": "perses.dev/v1alpha1",
+				"kind":       "PersesDatasource",
+				"metadata": map[string]any{
+					"name":      "usage-logs-admin",
+					"namespace": "opendatahub",
+				},
+				"spec": map[string]any{
+					"config": map[string]any{
+						"plugin": map[string]any{
+							"spec": map[string]any{
+								"proxy": map[string]any{
+									"spec": map[string]any{
+										"url": "https://usage-gateway-http:8080/api/logs/v1/application",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		err := patchPersesDatasourceURL(datasource)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		url, found, err := unstructured.NestedString(datasource.Object,
+			"spec", "config", "plugin", "spec", "proxy", "spec", "url")
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(found).To(BeTrue())
+		g.Expect(url).To(Equal("https://usage-gateway-http.opendatahub.svc:8080/api/logs/v1/application"))
+	})
+
+	t.Run("skips already-qualified URLs", func(t *testing.T) {
+		g := NewWithT(t)
+
+		datasource := &unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": "perses.dev/v1alpha1",
+				"kind":       "PersesDatasource",
+				"metadata": map[string]any{
+					"name":      "usage-logs",
+					"namespace": "opendatahub",
+				},
+				"spec": map[string]any{
+					"config": map[string]any{
+						"plugin": map[string]any{
+							"spec": map[string]any{
+								"proxy": map[string]any{
+									"spec": map[string]any{
+										"url": "https://usage-logs-tenancy-proxy.opendatahub.svc:8443",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		err := patchPersesDatasourceURL(datasource)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		url, found, err := unstructured.NestedString(datasource.Object,
+			"spec", "config", "plugin", "spec", "proxy", "spec", "url")
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(found).To(BeTrue())
+		g.Expect(url).To(Equal("https://usage-logs-tenancy-proxy.opendatahub.svc:8443"),
+			"should not modify already-qualified URL")
+	})
+
+	t.Run("ignores non-PersesDatasource resources", func(t *testing.T) {
+		g := NewWithT(t)
+
+		configMap := &unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]any{
+					"name":      "test",
+					"namespace": "opendatahub",
+				},
+			},
+		}
+
+		err := patchPersesDatasourceURL(configMap)
+		g.Expect(err).NotTo(HaveOccurred())
 	})
 }


### PR DESCRIPTION
## Description
This PR includes the last pieces for logs based usage dashboards - after creating an EnvoyFilter that emits usage logs, and an OTel Collector that exports them to Loki, we now add Perses dashboards that query the usage data from Loki.
There are two dashboards: for admin users and for non-admin users.
The dashboard for non-admin users queries data through a reverse proxy that returns user-scoped data.

## How Has This Been Tested?
Tested manually.

## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tenant-aware Usage Logs Perses dashboards (admin and user) with token, request, rate-limit, success-rate, and model/subscription breakdowns.
  * Introduced a Loki tenancy proxy (new Deployment + Service) providing authenticated, allowlisted HTTPS querying with health/readiness and response caching.
* **Configuration**
  * Added a configurable, pinned tenancy-proxy image setting and ensured the controller injects the tenancy-proxy image and expands service URLs to fully-qualified addresses.
  * Updated Usage Logs observability routing to use shorter internal service DNS names.
* **Security**
  * Added hardened proxy runtime settings plus RBAC for TokenReview and log access; requests are gated by bearer-token validation and restricted endpoint access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->