### PR TITLE
fix: cap revoke-keys Job retries to prevent infinite deletion loop

### DIFF
--- a/maas-controller/pkg/controller/maas/aitenant_controller.go
+++ b/maas-controller/pkg/controller/maas/aitenant_controller.go
@@ -748,7 +748,10 @@ func (r *AITenantReconciler) ensureTenantAPIKeysRevoked(ctx context.Context, ait
 		}
 
 		log := ctrl.LoggerFrom(ctx)
-		attempts := r.incrementRevocationAttempts(ctx, aitenant)
+		attempts, err := r.incrementRevocationAttempts(ctx, aitenant)
+		if err != nil {
+			return false, err
+		}
 		if attempts >= maxRevocationAttempts {
 			log.Error(errTenantAPIKeyRevocationJobFailed,
 				"API key revocation failed after max attempts, proceeding with deletion",
@@ -779,7 +782,7 @@ func (r *AITenantReconciler) markTenantAPIKeysRevoked(ctx context.Context, aiten
 	return nil
 }
 
-func (r *AITenantReconciler) incrementRevocationAttempts(ctx context.Context, aitenant *maasv1alpha1.AITenant) int {
+func (r *AITenantReconciler) incrementRevocationAttempts(ctx context.Context, aitenant *maasv1alpha1.AITenant) (int, error) {
 	current := 0
 	if v, ok := aitenant.Annotations[aitenantRevocationAttemptsAnnotation]; ok {
 		current, _ = strconv.Atoi(v)
@@ -788,9 +791,9 @@ func (r *AITenantReconciler) incrementRevocationAttempts(ctx context.Context, ai
 	base := aitenant.DeepCopy()
 	setMapValue(&aitenant.Annotations, aitenantRevocationAttemptsAnnotation, strconv.Itoa(current))
 	if err := r.Patch(ctx, aitenant, client.MergeFrom(base)); err != nil {
-		ctrl.LoggerFrom(ctx).Error(err, "failed to update revocation attempt counter")
+		return 0, fmt.Errorf("update revocation attempt counter: %w", err)
 	}
-	return current
+	return current, nil
 }
 
 func (r *AITenantReconciler) annotateNamespaceRevocationWarning(ctx context.Context, aitenant *maasv1alpha1.AITenant, attempts int) {

--- a/maas-controller/pkg/controller/maas/aitenant_controller.go
+++ b/maas-controller/pkg/controller/maas/aitenant_controller.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -38,6 +39,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -65,6 +67,10 @@ const (
 
 	aitenantAPIKeysRevokedAnnotation = "maas.opendatahub.io/api-keys-revoked" //nolint:gosec // Annotation name, not a credential.
 
+	aitenantRevocationAttemptsAnnotation = "maas.opendatahub.io/api-key-revocation-attempts"
+	aitenantAPIKeysRevocationWarning     = "maas.opendatahub.io/api-keys-revocation-warning" //nolint:gosec // Annotation name, not a credential.
+	maxRevocationAttempts                = 3
+
 	aitenantAPIKeyCleanupServiceAccountName = "maas-api-cleanup"
 	aitenantAPIKeyCleanupCABundleName       = "openshift-service-ca.crt"         //nolint:gosec // ConfigMap name for a public CA bundle, not a credential.
 	aitenantAPIKeyCleanupCABundlePath       = "/etc/pki/maas-api/service-ca.crt" //nolint:gosec // Public CA bundle mount path, not a credential.
@@ -75,7 +81,8 @@ var errTenantAPIKeyRevocationJobFailed = errors.New("API key revocation Job fail
 // AITenantReconciler reconciles AITenant tenant bootstrap resources.
 type AITenantReconciler struct {
 	client.Client
-	Scheme *runtime.Scheme
+	Scheme   *runtime.Scheme
+	Recorder record.EventRecorder
 	// APIReader is used for reads that must bypass the Tenant namespace cache scope.
 	APIReader client.Reader
 
@@ -104,6 +111,7 @@ type AITenantReconciler struct {
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;delete
 // +kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;create;delete
+// +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 
 // Reconcile drives AITenant bootstrap lifecycle.
 func (r *AITenantReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -197,6 +205,9 @@ func (r *AITenantReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 // SetupWithManager registers the AITenant controller.
 func (r *AITenantReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	if r.Recorder == nil {
+		r.Recorder = mgr.GetEventRecorderFor("aitenant-controller")
+	}
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&maasv1alpha1.AITenant{}, builder.WithPredicates(
 			predicate.Or(predicate.GenerationChangedPredicate{}, predicate.Funcs{UpdateFunc: deletionTimestampSet}),
@@ -732,10 +743,29 @@ func (r *AITenantReconciler) ensureTenantAPIKeysRevoked(ctx context.Context, ait
 		return true, nil
 	}
 	if jobFailed(&existing) {
-		if err := r.Delete(ctx, &existing); client.IgnoreNotFound(err) != nil {
+		if err := r.Delete(ctx, &existing, client.PropagationPolicy(metav1.DeletePropagationBackground)); client.IgnoreNotFound(err) != nil {
 			return false, fmt.Errorf("delete failed API key revocation Job %s/%s: %w", existing.Namespace, existing.Name, err)
 		}
-		return false, fmt.Errorf("%w: %s/%s", errTenantAPIKeyRevocationJobFailed, existing.Namespace, existing.Name)
+
+		log := ctrl.LoggerFrom(ctx)
+		attempts := r.incrementRevocationAttempts(ctx, aitenant)
+		if attempts >= maxRevocationAttempts {
+			log.Error(errTenantAPIKeyRevocationJobFailed,
+				"API key revocation failed after max attempts, proceeding with deletion",
+				"attempts", attempts, "tenant", aitenant.Name)
+			if r.Recorder != nil {
+				r.Recorder.Eventf(aitenant, "Warning", "APIKeyRevocationFailed",
+					"API key revocation failed after %d attempts; proceeding with tenant deletion. Keys may still be active.", attempts)
+			}
+			r.annotateNamespaceRevocationWarning(ctx, aitenant, attempts)
+			if err := r.markTenantAPIKeysRevoked(ctx, aitenant); err != nil {
+				return false, err
+			}
+			return true, nil
+		}
+
+		return false, fmt.Errorf("%w: %s/%s (attempt %d/%d)",
+			errTenantAPIKeyRevocationJobFailed, existing.Namespace, existing.Name, attempts, maxRevocationAttempts)
 	}
 	return false, nil
 }
@@ -747,6 +777,35 @@ func (r *AITenantReconciler) markTenantAPIKeysRevoked(ctx context.Context, aiten
 		return fmt.Errorf("mark tenant API keys revoked on AITenant %s/%s: %w", aitenant.Namespace, aitenant.Name, err)
 	}
 	return nil
+}
+
+func (r *AITenantReconciler) incrementRevocationAttempts(ctx context.Context, aitenant *maasv1alpha1.AITenant) int {
+	current := 0
+	if v, ok := aitenant.Annotations[aitenantRevocationAttemptsAnnotation]; ok {
+		current, _ = strconv.Atoi(v)
+	}
+	current++
+	base := aitenant.DeepCopy()
+	setMapValue(&aitenant.Annotations, aitenantRevocationAttemptsAnnotation, strconv.Itoa(current))
+	if err := r.Patch(ctx, aitenant, client.MergeFrom(base)); err != nil {
+		ctrl.LoggerFrom(ctx).Error(err, "failed to update revocation attempt counter")
+	}
+	return current
+}
+
+func (r *AITenantReconciler) annotateNamespaceRevocationWarning(ctx context.Context, aitenant *maasv1alpha1.AITenant, attempts int) {
+	nsName := r.tenantNamespaceName(aitenant)
+	var ns corev1.Namespace
+	if err := r.get(ctx, client.ObjectKey{Name: nsName}, &ns); err != nil {
+		ctrl.LoggerFrom(ctx).Error(err, "failed to get tenant namespace for revocation warning", "namespace", nsName)
+		return
+	}
+	base := ns.DeepCopy()
+	setMapValue(&ns.Annotations, aitenantAPIKeysRevocationWarning,
+		fmt.Sprintf("API key revocation failed after %d attempts. Keys may still be active.", attempts))
+	if err := r.Patch(ctx, &ns, client.MergeFrom(base)); err != nil {
+		ctrl.LoggerFrom(ctx).Error(err, "failed to annotate tenant namespace with revocation warning", "namespace", nsName)
+	}
 }
 
 func tenantAPIKeyRevocationJob(aitenant *maasv1alpha1.AITenant, namespace string) *batcv1.Job {

--- a/maas-controller/pkg/controller/maas/aitenant_controller_test.go
+++ b/maas-controller/pkg/controller/maas/aitenant_controller_test.go
@@ -2000,6 +2000,9 @@ func TestAITenantReconcile_FailedAPIKeyRevocationJobSetsDeletionBlockedAndRequeu
 	g.Expect(ready).NotTo(BeNil())
 	g.Expect(ready.Reason).To(Equal("DeletionBlocked"))
 	g.Expect(ready.Message).To(ContainSubstring("API key revocation Job"))
+	g.Expect(ready.Message).To(ContainSubstring("attempt 1/3"))
+
+	g.Expect(updated.Annotations).To(HaveKeyWithValue(aitenantRevocationAttemptsAnnotation, "1"))
 
 	err = cl.Get(ctx, client.ObjectKeyFromObject(job), &batcv1.Job{})
 	g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
@@ -2012,6 +2015,88 @@ func TestAITenantReconcile_FailedAPIKeyRevocationJobSetsDeletionBlockedAndRequeu
 	var remainingNS corev1.Namespace
 	g.Expect(cl.Get(ctx, client.ObjectKey{Name: tenantNamespace}, &remainingNS)).To(Succeed())
 	g.Expect(remainingNS.DeletionTimestamp.IsZero()).To(BeTrue())
+}
+
+func TestAITenantReconcile_RevocationGivesUpAfterMaxAttempts(t *testing.T) {
+	g := NewWithT(t)
+	s := aitenantTestScheme(t)
+	ctx := context.Background()
+
+	aitenant := &maasv1alpha1.AITenant{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "team-revoke-giveup",
+			Namespace:  tenantreconcile.DefaultAITenantNamespace,
+			Finalizers: []string{aitenantFinalizer},
+			Annotations: map[string]string{
+				aitenantRevocationAttemptsAnnotation: "2",
+			},
+		},
+	}
+	tenantNamespace := tenantreconcile.TenantNamespaceForAITenant(aitenant.Name, "models-as-a-service")
+	tenant := &maasv1alpha1.MaasTenantConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      maasv1alpha1.MaasTenantConfigInstanceName,
+			Namespace: tenantNamespace,
+			Annotations: map[string]string{
+				aitenantNameAnnotation:      aitenant.Name,
+				aitenantNamespaceAnnotation: aitenant.Namespace,
+			},
+		},
+	}
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: tenantNamespace,
+			Annotations: map[string]string{
+				aitenantNameAnnotation:      aitenant.Name,
+				aitenantNamespaceAnnotation: aitenant.Namespace,
+			},
+		},
+	}
+	job := tenantAPIKeyRevocationJob(aitenant, "odh-ai-gateway-infra")
+	job.Status.Conditions = []batcv1.JobCondition{
+		{
+			Type:               batcv1.JobFailed,
+			Status:             corev1.ConditionTrue,
+			Reason:             "BackoffLimitExceeded",
+			Message:            "pod failed",
+			LastProbeTime:      metav1.Now(),
+			LastTransitionTime: metav1.Now(),
+		},
+	}
+	cl := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(&maasv1alpha1.AITenant{}).
+		WithObjects(aitenant, tenant, ns, job).
+		Build()
+	r := &AITenantReconciler{
+		Client:           cl,
+		Scheme:           s,
+		APIReader:        cl,
+		AppNamespace:     "odh-ai-gateway-infra",
+		TenantNamespace:  "models-as-a-service",
+		GatewayNamespace: "openshift-ingress",
+	}
+
+	key := types.NamespacedName{Name: aitenant.Name, Namespace: aitenant.Namespace}
+	g.Expect(cl.Delete(ctx, aitenant)).To(Succeed())
+
+	res, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: key})
+	g.Expect(err).NotTo(HaveOccurred())
+	// Should not requeue with 30s — revocation gave up, deletion proceeds.
+	g.Expect(res.RequeueAfter).NotTo(Equal(30 * time.Second))
+
+	var updated maasv1alpha1.AITenant
+	g.Expect(cl.Get(ctx, key, &updated)).To(Succeed())
+	g.Expect(updated.Annotations).To(HaveKeyWithValue(aitenantAPIKeysRevokedAnnotation, "true"))
+	g.Expect(updated.Annotations).To(HaveKeyWithValue(aitenantRevocationAttemptsAnnotation, "3"))
+
+	err = cl.Get(ctx, client.ObjectKeyFromObject(job), &batcv1.Job{})
+	g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+
+	var warningNS corev1.Namespace
+	g.Expect(cl.Get(ctx, client.ObjectKey{Name: tenantNamespace}, &warningNS)).To(Succeed())
+	g.Expect(warningNS.Annotations).To(HaveKey(aitenantAPIKeysRevocationWarning))
+	g.Expect(warningNS.Annotations[aitenantAPIKeysRevocationWarning]).To(ContainSubstring("failed after 3 attempts"))
 }
 
 func TestAITenantReconcile_DeletionAddsTenantFinalizerBeforeDelete(t *testing.T) {

--- a/maas-controller/pkg/controller/maas/self_deployment_controller_test.go
+++ b/maas-controller/pkg/controller/maas/self_deployment_controller_test.go
@@ -305,6 +305,10 @@ func TestLifecycleReconciler_NormalReconcileDoesNotSetDeploymentOwnerReference(t
 		},
 	}
 
+	_, testFile, _, ok := goruntime.Caller(0)
+	g.Expect(ok).To(BeTrue())
+	usageLogsPath := filepath.Join(filepath.Dir(testFile), "../../../../deployment/components/observability/usage-logs")
+
 	cl := fake.NewClientBuilder().WithScheme(s).WithObjects(dep, cfg).Build()
 	r := &LifecycleReconciler{
 		Client:                      cl,
@@ -312,6 +316,7 @@ func TestLifecycleReconciler_NormalReconcileDoesNotSetDeploymentOwnerReference(t
 		DeploymentName:              "maas-controller",
 		DeploymentNS:                depNS,
 		TenantSubscriptionNamespace: "",
+		UsageLogsManifestPath:       usageLogsPath,
 	}
 
 	_, err := r.Reconcile(context.Background(), ctrl.Request{
@@ -366,12 +371,17 @@ func TestLifecycleReconciler_StripsLegacyDeploymentConfigOwnerReferenceOnNormalR
 		},
 	}
 
+	_, testFile, _, ok := goruntime.Caller(0)
+	g.Expect(ok).To(BeTrue())
+	usageLogsPath := filepath.Join(filepath.Dir(testFile), "../../../../deployment/components/observability/usage-logs")
+
 	cl := fake.NewClientBuilder().WithScheme(s).WithObjects(dep, cfg).Build()
 	r := &LifecycleReconciler{
-		Client:         cl,
-		Scheme:         s,
-		DeploymentName: "maas-controller",
-		DeploymentNS:   depNS,
+		Client:                cl,
+		Scheme:                s,
+		DeploymentName:        "maas-controller",
+		DeploymentNS:          depNS,
+		UsageLogsManifestPath: usageLogsPath,
 	}
 
 	_, err := r.Reconcile(context.Background(), ctrl.Request{


### PR DESCRIPTION
When maas-api is unreachable during AITenant deletion, the revoke-keys Job fails and the controller enters an infinite delete-recreate loop with no retry cap and no error logging. This blocks AITenant deletion permanently — confirmed across multiple E2E runs on main.

Add a 3-attempt cap via an annotation counter on the AITenant. After max attempts: log at error level, emit a Warning Kubernetes Event (APIKeyRevocationFailed), annotate the tenant namespace with a revocation warning, mark keys as revoked, and proceed with deletion. Also add PropagationPolicy(Background) to failed Job deletion to fix orphaned pods.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of repeated API-key revocation failures during tenant deletion.
  * Failed revocation jobs are cleaned up and retried with tracked attempt counts.
  * After the maximum number of attempts, deletion proceeds and a warning is recorded.
  * Tenant status now reports the current revocation attempt when deletion is blocked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->