### PR TITLE
chore: cherry-pick #922 and #1159 to stable

### DIFF
--- a/deployment/base/maas-controller/rbac/clusterrole.yaml
+++ b/deployment/base/maas-controller/rbac/clusterrole.yaml
@@ -272,7 +272,6 @@ rules:
   resources:
   - tenants
   verbs:
-  - delete
   - get
   - list
   - patch

--- a/docs/content/configuration-and-management/model-listing-flow.md
+++ b/docs/content/configuration-and-management/model-listing-flow.md
@@ -67,6 +67,7 @@ The maas-api deployment supports the following environment variable to control a
 | Variable | Description | Default | Constraints |
 |----------|-------------|---------|-------------|
 | `ACCESS_CHECK_TIMEOUT_SECONDS` | Timeout in seconds for each model access validation probe during `GET /v1/models`. Models that do not respond within this window are excluded from the response (fail-closed). | `15` | Must be ≥ 1 |
+| `DISCOVERY_ENABLE_HTTP2` | Enable HTTP/2 ALPN negotiation on the TLS client used for model discovery probes. Only enable if all model backends support HTTP/2. | `false` | `true` or `false` |
 
 !!! tip "When to increase"
     If models are missing from `GET /v1/models` responses and maas-api logs show probe timeouts, increase `ACCESS_CHECK_TIMEOUT_SECONDS` to give slower backends more time to respond. This is common when model endpoints have cold-start latency or are under heavy load.

--- a/maas-api/cmd/main.go
+++ b/maas-api/cmd/main.go
@@ -233,7 +233,7 @@ func registerHandlers(
 		log.Info("Resolved gateway internal host for access probes", "host", gatewayInternalHost)
 	}
 
-	modelManager, err := models.NewManager(log, cfg.AccessCheckTimeoutSeconds, gatewayInternalHost)
+	modelManager, err := models.NewManager(log, cfg.AccessCheckTimeoutSeconds, gatewayInternalHost, cfg.DiscoveryEnableHTTP2)
 	if err != nil {
 		log.Fatal("Failed to create model manager", "error", err)
 	}

--- a/maas-api/cmd/server.go
+++ b/maas-api/cmd/server.go
@@ -52,6 +52,7 @@ func buildTLSConfig(cfg *config.Config) (*tls.Config, error) {
 	return &tls.Config{
 		Certificates: []tls.Certificate{tlsCert},
 		MinVersion:   cfg.TLS.MinVersion.Value(),
+		NextProtos:   []string{"h2", "http/1.1"},
 	}, nil
 }
 

--- a/maas-api/internal/config/config.go
+++ b/maas-api/internal/config/config.go
@@ -79,6 +79,10 @@ type Config struct {
 
 	MetricsPort int
 
+	// DiscoveryEnableHTTP2 enables HTTP/2 ALPN negotiation on the TLS client used
+	// by model discovery probes. Default: false (HTTP/1.1 only).
+	DiscoveryEnableHTTP2 bool
+
 	// OTELEndpoint is the OTLP gRPC endpoint for trace export (e.g., "localhost:4317").
 	// Tracing is disabled when empty.
 	OTELEndpoint string
@@ -104,6 +108,7 @@ func Load() *Config {
 	sarCacheMaxSize, _ := env.GetInt("SAR_CACHE_MAX_SIZE", constant.DefaultSARCacheMaxSize)
 	lastUsedDebounceSecs, _ := env.GetInt("LAST_USED_DEBOUNCE_SECS", 60)
 	metricsPort, _ := env.GetInt("METRICS_PORT", constant.DefaultMetricsPort)
+	discoveryEnableHTTP2, _ := env.GetBool("DISCOVERY_ENABLE_HTTP2", false)
 	otelInsecure, _ := env.GetBool("OTEL_EXPORTER_OTLP_INSECURE", false)
 	otelSampleRate := 1.0
 	if rateStr := env.GetString("OTEL_TRACES_SAMPLE_RATE", ""); rateStr != "" {
@@ -139,6 +144,7 @@ func Load() *Config {
 		SARCacheMaxSize:           sarCacheMaxSize,
 		LastUsedDebounceSecs:      lastUsedDebounceSecs,
 		MetricsPort:               metricsPort,
+		DiscoveryEnableHTTP2:      discoveryEnableHTTP2,
 		OTELEndpoint:              env.GetString("OTEL_EXPORTER_OTLP_ENDPOINT", ""),
 		OTELInsecure:              otelInsecure,
 		OTELSampleRate:            otelSampleRate,

--- a/maas-api/internal/handlers/models_test.go
+++ b/maas-api/internal/handlers/models_test.go
@@ -349,7 +349,7 @@ func TestListingModels(t *testing.T) { //nolint:maintidx // table-driven test wi
 	}
 	router, _ := fixtures.SetupTestServer(t, config)
 
-	modelMgr, errMgr := models.NewManager(testLogger, 15, "")
+	modelMgr, errMgr := models.NewManager(testLogger, 15, "", false)
 	require.NoError(t, errMgr)
 
 	// Set up test fixtures
@@ -464,7 +464,7 @@ func TestListingModelsWithSubscriptionHeader(t *testing.T) {
 	}
 	router, _ := fixtures.SetupTestServer(t, config)
 
-	modelMgr, errMgr := models.NewManager(testLogger, 15, "")
+	modelMgr, errMgr := models.NewManager(testLogger, 15, "", false)
 	require.NoError(t, errMgr)
 
 	_, cleanup := fixtures.StubTokenProviderAPIs(t)
@@ -692,7 +692,7 @@ func TestListModels_ReturnAllModels(t *testing.T) {
 		},
 	}
 
-	modelMgr, err := models.NewManager(testLogger, 15, "")
+	modelMgr, err := models.NewManager(testLogger, 15, "", false)
 	require.NoError(t, err)
 
 	subscriptionSelector := subscription.NewSelector(testLogger, subscriptionLister, nil, nil)
@@ -881,7 +881,7 @@ func TestListModels_DeduplicationBySubscription(t *testing.T) {
 		},
 	}
 
-	modelMgr, err := models.NewManager(testLogger, 15, "")
+	modelMgr, err := models.NewManager(testLogger, 15, "", false)
 	require.NoError(t, err)
 
 	subscriptionSelector := subscription.NewSelector(testLogger, subscriptionLister, nil, nil)
@@ -999,7 +999,7 @@ func TestListModels_DifferentModelRefsWithSameModelID(t *testing.T) {
 		},
 	}
 
-	modelMgr, err := models.NewManager(testLogger, 15, "")
+	modelMgr, err := models.NewManager(testLogger, 15, "", false)
 	require.NoError(t, err)
 
 	subscriptionSelector := subscription.NewSelector(testLogger, subscriptionLister, nil, nil)
@@ -1106,7 +1106,7 @@ func TestListModels_DifferentModelRefsWithSameURLAndModelID(t *testing.T) {
 		},
 	}
 
-	modelMgr, err := models.NewManager(testLogger, 15, "")
+	modelMgr, err := models.NewManager(testLogger, 15, "", false)
 	require.NoError(t, err)
 
 	subscriptionSelector := subscription.NewSelector(testLogger, subscriptionLister, nil, nil)
@@ -1212,7 +1212,7 @@ func TestListModels_DifferentModelRefsWithSameModelIDAndDifferentSubscriptions(t
 		},
 	}
 
-	modelMgr, err := models.NewManager(testLogger, 15, "")
+	modelMgr, err := models.NewManager(testLogger, 15, "", false)
 	require.NoError(t, err)
 
 	subscriptionSelector := subscription.NewSelector(testLogger, subscriptionLister, nil, nil)
@@ -1305,7 +1305,7 @@ func TestListModels_ExternalModelUsesModelRefName(t *testing.T) {
 		},
 	}
 
-	modelMgr, err := models.NewManager(testLogger, 15, "")
+	modelMgr, err := models.NewManager(testLogger, 15, "", false)
 	require.NoError(t, err)
 
 	subscriptionSelector := subscription.NewSelector(testLogger, &fakeSubscriptionLister{}, lister, nil)

--- a/maas-api/internal/models/discovery.go
+++ b/maas-api/internal/models/discovery.go
@@ -66,7 +66,7 @@ type Manager struct {
 // gatewayInternalHost, when non-empty, routes all probe TCP connections to this
 // cluster-internal address while preserving the original URL hostname for TLS SNI
 // and the Host header, so gateway routing and Authorino auth work identically.
-func NewManager(log *logger.Logger, accessCheckTimeoutSeconds int, gatewayInternalHost string) (*Manager, error) {
+func NewManager(log *logger.Logger, accessCheckTimeoutSeconds int, gatewayInternalHost string, enableHTTP2 bool) (*Manager, error) {
 	if log == nil {
 		return nil, errors.New("log is required")
 	}
@@ -75,7 +75,7 @@ func NewManager(log *logger.Logger, accessCheckTimeoutSeconds int, gatewayIntern
 		timeout = time.Duration(accessCheckTimeoutSeconds) * time.Second
 	}
 
-	tlsConfig, err := BuildClusterTLSConfigFromPath(log, kubeServiceAccountCAPath)
+	tlsConfig, err := BuildClusterTLSConfigFromPath(log, kubeServiceAccountCAPath, enableHTTP2)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build TLS config: %w", err)
 	}
@@ -115,7 +115,7 @@ func NewManager(log *logger.Logger, accessCheckTimeoutSeconds int, gatewayIntern
 // the default Kubernetes service account CA path. It is a convenience wrapper around
 // BuildClusterTLSConfigFromPath.
 func BuildClusterTLSConfig(log *logger.Logger) (*tls.Config, error) {
-	return BuildClusterTLSConfigFromPath(log, kubeServiceAccountCAPath)
+	return BuildClusterTLSConfigFromPath(log, kubeServiceAccountCAPath, false)
 }
 
 // BuildClusterTLSConfigFromPath creates a TLS config for cluster-internal communication.
@@ -125,7 +125,7 @@ func BuildClusterTLSConfig(log *logger.Logger) (*tls.Config, error) {
 //
 // If caPath does not exist, system root CAs are used alone (development/out-of-cluster mode).
 // If caPath exists but cannot be read or parsed, an error is returned to prevent insecure fallback.
-func BuildClusterTLSConfigFromPath(log *logger.Logger, caPath string) (*tls.Config, error) {
+func BuildClusterTLSConfigFromPath(log *logger.Logger, caPath string, enableHTTP2 bool) (*tls.Config, error) {
 	if log == nil {
 		return nil, errors.New("log is required")
 	}
@@ -140,22 +140,25 @@ func BuildClusterTLSConfigFromPath(log *logger.Logger, caPath string) (*tls.Conf
 		if os.IsNotExist(err) {
 			log.Debug("Kubernetes service account CA not found, using system root CAs only",
 				"path", caPath)
-			return &tls.Config{MinVersion: tls.VersionTLS12, RootCAs: caCertPool}, nil
+		} else {
+			return nil, fmt.Errorf("failed to read CA certificate: %w", err)
 		}
-		return nil, fmt.Errorf("failed to read CA certificate: %w", err)
+	} else {
+		if !caCertPool.AppendCertsFromPEM(caCert) {
+			return nil, errors.New("failed to parse Kubernetes service account CA certificate")
+		}
+		log.Debug("Using system root CAs with Kubernetes service account CA appended",
+			"path", caPath)
 	}
 
-	if !caCertPool.AppendCertsFromPEM(caCert) {
-		return nil, errors.New("failed to parse Kubernetes service account CA certificate")
-	}
-
-	log.Debug("Using system root CAs with Kubernetes service account CA appended",
-		"path", caPath)
-
-	return &tls.Config{
+	tlsCfg := &tls.Config{
 		RootCAs:    caCertPool,
 		MinVersion: tls.VersionTLS12,
-	}, nil
+	}
+	if enableHTTP2 {
+		tlsCfg.NextProtos = []string{"h2", "http/1.1"}
+	}
+	return tlsCfg, nil
 }
 
 // FilterModelsByAccess returns only models the user can access by probing each model's

--- a/maas-api/internal/models/discovery_test.go
+++ b/maas-api/internal/models/discovery_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestNewManager(t *testing.T) {
 	t.Run("returns error when logger is nil", func(t *testing.T) {
-		manager, err := models.NewManager(nil, 15, "")
+		manager, err := models.NewManager(nil, 15, "", false)
 		require.Error(t, err)
 		assert.Nil(t, manager)
 		assert.Contains(t, err.Error(), "log is required")
@@ -31,7 +31,7 @@ func TestNewManager(t *testing.T) {
 	t.Run("creates manager successfully with valid logger", func(t *testing.T) {
 		log := logger.New(true)
 
-		manager, err := models.NewManager(log, 15, "")
+		manager, err := models.NewManager(log, 15, "", false)
 		require.NoError(t, err)
 		assert.NotNil(t, manager)
 	})
@@ -63,7 +63,7 @@ func TestBuildClusterTLSConfig(t *testing.T) {
 
 func TestBuildClusterTLSConfigFromPath(t *testing.T) {
 	t.Run("returns error when logger is nil", func(t *testing.T) {
-		tlsConfig, err := models.BuildClusterTLSConfigFromPath(nil, "/nonexistent")
+		tlsConfig, err := models.BuildClusterTLSConfigFromPath(nil, "/nonexistent", false)
 		require.Error(t, err)
 		assert.Nil(t, tlsConfig)
 	})
@@ -71,7 +71,7 @@ func TestBuildClusterTLSConfigFromPath(t *testing.T) {
 	t.Run("uses system root CAs when CA file is absent", func(t *testing.T) {
 		log := logger.New(true)
 
-		tlsConfig, err := models.BuildClusterTLSConfigFromPath(log, "/nonexistent/ca.crt")
+		tlsConfig, err := models.BuildClusterTLSConfigFromPath(log, "/nonexistent/ca.crt", false)
 		require.NoError(t, err)
 		require.NotNil(t, tlsConfig)
 
@@ -89,7 +89,7 @@ func TestBuildClusterTLSConfigFromPath(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, f.Close())
 
-		tlsConfig, err := models.BuildClusterTLSConfigFromPath(log, f.Name())
+		tlsConfig, err := models.BuildClusterTLSConfigFromPath(log, f.Name(), false)
 		require.Error(t, err)
 		assert.Nil(t, tlsConfig)
 		assert.Contains(t, err.Error(), "failed to parse")
@@ -103,7 +103,7 @@ func TestBuildClusterTLSConfigFromPath(t *testing.T) {
 		require.NoError(t, os.WriteFile(caPath, []byte("placeholder"), 0o000))
 		t.Cleanup(func() { _ = os.Chmod(caPath, 0o644) })
 
-		tlsConfig, err := models.BuildClusterTLSConfigFromPath(log, caPath)
+		tlsConfig, err := models.BuildClusterTLSConfigFromPath(log, caPath, false)
 		require.Error(t, err)
 		assert.Nil(t, tlsConfig)
 	})
@@ -118,13 +118,33 @@ func TestBuildClusterTLSConfigFromPath(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, f.Close())
 
-		tlsConfig, err := models.BuildClusterTLSConfigFromPath(log, f.Name())
+		tlsConfig, err := models.BuildClusterTLSConfigFromPath(log, f.Name(), false)
 		require.NoError(t, err)
 		require.NotNil(t, tlsConfig)
 
 		assert.False(t, tlsConfig.InsecureSkipVerify)
 		assert.Equal(t, uint16(tls.VersionTLS12), tlsConfig.MinVersion)
 		assert.NotNil(t, tlsConfig.RootCAs)
+	})
+
+	t.Run("sets NextProtos when HTTP/2 is enabled", func(t *testing.T) {
+		log := logger.New(true)
+
+		tlsConfig, err := models.BuildClusterTLSConfigFromPath(log, "/nonexistent/ca.crt", true)
+		require.NoError(t, err)
+		require.NotNil(t, tlsConfig)
+
+		assert.Equal(t, []string{"h2", "http/1.1"}, tlsConfig.NextProtos)
+	})
+
+	t.Run("does not set NextProtos when HTTP/2 is disabled", func(t *testing.T) {
+		log := logger.New(true)
+
+		tlsConfig, err := models.BuildClusterTLSConfigFromPath(log, "/nonexistent/ca.crt", false)
+		require.NoError(t, err)
+		require.NotNil(t, tlsConfig)
+
+		assert.Nil(t, tlsConfig.NextProtos)
 	})
 }
 

--- a/maas-controller/cmd/manager/main.go
+++ b/maas-controller/cmd/manager/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
 	stderrors "errors"
 	"flag"
 	"fmt"
@@ -813,9 +814,16 @@ func main() {
 	}
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
-		Scheme:                 scheme,
-		Cache:                  cacheOpts,
-		Metrics:                metricsserver.Options{BindAddress: metricsAddr},
+		Scheme: scheme,
+		Cache:  cacheOpts,
+		Metrics: metricsserver.Options{
+			BindAddress: metricsAddr,
+			TLSOpts: []func(*tls.Config){
+				func(c *tls.Config) {
+					c.NextProtos = []string{"h2", "http/1.1"}
+				},
+			},
+		},
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "maas-controller.models-as-a-service.opendatahub.io",

--- a/maas-controller/cmd/manager/main.go
+++ b/maas-controller/cmd/manager/main.go
@@ -402,6 +402,11 @@ type managedNamespaceMonitor struct {
 	purpose            string
 	interval           time.Duration
 	needLeaderElection bool
+	// pauseCondition, if set, is evaluated before each tick; returning true skips
+	// ensureManagedNamespaceWithClient for that tick (e.g. to avoid recreating a
+	// namespace that is being intentionally torn down). A returned error also skips
+	// the tick (fail-closed) and is logged; the next tick will retry.
+	pauseCondition func(ctx context.Context) (bool, error)
 }
 
 func (m *managedNamespaceMonitor) NeedLeaderElection() bool {
@@ -415,6 +420,18 @@ func (m *managedNamespaceMonitor) Start(ctx context.Context) error {
 	run := func() {
 		innerCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 		defer cancel()
+		if m.pauseCondition != nil {
+			pause, err := m.pauseCondition(innerCtx)
+			if err != nil {
+				setupLog.Error(err, "unable to evaluate pause condition before namespace maintenance", "namespace", m.namespace, "purpose", m.purpose)
+				return
+			}
+			if pause {
+				setupLog.V(1).Info("skipping namespace maintenance; pause condition active",
+					"namespace", m.namespace, "purpose", m.purpose)
+				return
+			}
+		}
 		if err := ensureManagedNamespaceWithClient(innerCtx, m.namespace, m.purpose, m.clientset); err != nil {
 			// Keep running; the next tick will retry. Alerting on sustained failure is better done via
 			// metrics (e.g. Prometheus counter) in a follow-up if product needs it.
@@ -431,6 +448,23 @@ func (m *managedNamespaceMonitor) Start(ctx context.Context) error {
 		case <-ticker.C:
 			run()
 		}
+	}
+}
+
+// aitenantTeardownPauseCondition builds a managedNamespaceMonitor pauseCondition that skips
+// AITenant namespace self-heal while the maas-controller Deployment advertises teardown
+// (or is already gone), so the monitor cannot recreate ai-tenants while cleanup is in
+// progress or the controller pod is winding down.
+func aitenantTeardownPauseCondition(reader client.Reader, deploymentKey client.ObjectKey) func(context.Context) (bool, error) {
+	return func(ctx context.Context) (bool, error) {
+		var dep appsv1.Deployment
+		if err := reader.Get(ctx, deploymentKey, &dep); err != nil {
+			if errors.IsNotFound(err) {
+				return true, nil
+			}
+			return false, err
+		}
+		return maas.TeardownRequestedOnDeployment(&dep), nil
 	}
 }
 
@@ -479,6 +513,9 @@ func ensureDefaultAITenantBootstrap(ctx context.Context, c client.Client, tenant
 		return false, fmt.Errorf("get maas-controller Deployment for bootstrap gate: %w", err)
 	}
 	if !dep.DeletionTimestamp.IsZero() {
+		return false, nil
+	}
+	if maas.TeardownRequestedOnDeployment(&dep) {
 		return false, nil
 	}
 
@@ -911,6 +948,10 @@ func main() {
 		purpose:            "aitenant",
 		interval:           subscriptionNamespaceMaintainInterval,
 		needLeaderElection: enableLeaderElection,
+		pauseCondition: aitenantTeardownPauseCondition(
+			mgr.GetAPIReader(),
+			client.ObjectKey{Name: tenantreconcile.MaaSControllerDeploymentName, Namespace: controllerNamespace},
+		),
 	}); err != nil {
 		setupLog.Error(err, "unable to add AITenant namespace monitor")
 		os.Exit(1)

--- a/maas-controller/cmd/manager/main_test.go
+++ b/maas-controller/cmd/manager/main_test.go
@@ -16,6 +16,7 @@ import (
 	controllerfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	maasv1alpha1 "github.com/opendatahub-io/models-as-a-service/maas-controller/api/maas/v1alpha1"
+	"github.com/opendatahub-io/models-as-a-service/maas-controller/pkg/controller/maas"
 	"github.com/opendatahub-io/models-as-a-service/maas-controller/pkg/platform/tenantreconcile"
 )
 
@@ -321,6 +322,120 @@ func TestEnsureDefaultAITenantBootstrapWaitsForConfigUID(t *testing.T) {
 		Namespace: tenantreconcile.DefaultAITenantNamespace,
 	}, &maasv1alpha1.AITenant{}); err == nil {
 		t.Fatalf("default AITenant was created before Config had a UID")
+	}
+}
+
+func TestEnsureDefaultAITenantBootstrapSkipsWhenTeardownRequested(t *testing.T) {
+	ctx := context.Background()
+	s := managerTestScheme(t)
+	cl := controllerfake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(
+			&appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      tenantreconcile.MaaSControllerDeploymentName,
+					Namespace: "opendatahub",
+					Annotations: map[string]string{
+						maas.TeardownRequestedAnnotation: "true",
+					},
+				},
+			},
+			&maasv1alpha1.Config{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: maasv1alpha1.ConfigInstanceName,
+					UID:  types.UID("cfg-default"),
+				},
+			},
+		).
+		Build()
+
+	created, err := ensureDefaultAITenantBootstrap(
+		ctx,
+		cl,
+		"models-as-a-service",
+		tenantreconcile.DefaultAITenantNamespace,
+		"opendatahub",
+		tenantreconcile.MaaSControllerDeploymentName,
+		"maas-default-gateway",
+		"openshift-ingress",
+	)
+	if err != nil {
+		t.Fatalf("ensure default AITenant: %v", err)
+	}
+	if created {
+		t.Fatalf("created = true, want false")
+	}
+
+	var aitenant maasv1alpha1.AITenant
+	if err := cl.Get(ctx, client.ObjectKey{
+		Name:      tenantreconcile.DefaultAITenantName,
+		Namespace: tenantreconcile.DefaultAITenantNamespace,
+	}, &aitenant); err == nil {
+		t.Fatalf("default AITenant was created during teardown: %#v", aitenant)
+	}
+}
+
+func TestAitenantTeardownPauseConditionPausesWhenDeploymentMissing(t *testing.T) {
+	ctx := context.Background()
+	s := managerTestScheme(t)
+	cl := controllerfake.NewClientBuilder().WithScheme(s).Build()
+
+	deploymentKey := client.ObjectKey{Name: tenantreconcile.MaaSControllerDeploymentName, Namespace: "opendatahub"}
+	pause, err := aitenantTeardownPauseCondition(cl, deploymentKey)(ctx)
+	if err != nil {
+		t.Fatalf("evaluate pause condition: %v", err)
+	}
+	if !pause {
+		t.Fatalf("pause = false, want true when Deployment is missing during teardown")
+	}
+}
+
+func TestAitenantTeardownPauseConditionPausesWhenTeardownRequested(t *testing.T) {
+	ctx := context.Background()
+	s := managerTestScheme(t)
+	deploymentKey := client.ObjectKey{Name: tenantreconcile.MaaSControllerDeploymentName, Namespace: "opendatahub"}
+	cl := controllerfake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      deploymentKey.Name,
+				Namespace: deploymentKey.Namespace,
+				Annotations: map[string]string{
+					maas.TeardownRequestedAnnotation: "true",
+				},
+			},
+		}).
+		Build()
+
+	pause, err := aitenantTeardownPauseCondition(cl, deploymentKey)(ctx)
+	if err != nil {
+		t.Fatalf("evaluate pause condition: %v", err)
+	}
+	if !pause {
+		t.Fatalf("pause = false, want true when Deployment advertises teardown")
+	}
+}
+
+func TestAitenantTeardownPauseConditionRunsWhenDeploymentIsHealthy(t *testing.T) {
+	ctx := context.Background()
+	s := managerTestScheme(t)
+	deploymentKey := client.ObjectKey{Name: tenantreconcile.MaaSControllerDeploymentName, Namespace: "opendatahub"}
+	cl := controllerfake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      deploymentKey.Name,
+				Namespace: deploymentKey.Namespace,
+			},
+		}).
+		Build()
+
+	pause, err := aitenantTeardownPauseCondition(cl, deploymentKey)(ctx)
+	if err != nil {
+		t.Fatalf("evaluate pause condition: %v", err)
+	}
+	if pause {
+		t.Fatalf("pause = true, want false when Deployment does not advertise teardown")
 	}
 }
 

--- a/maas-controller/pkg/controller/maas/aitenant_controller.go
+++ b/maas-controller/pkg/controller/maas/aitenant_controller.go
@@ -97,7 +97,7 @@ type AITenantReconciler struct {
 // +kubebuilder:rbac:groups=maas.opendatahub.io,resources=aitenants/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=maas.opendatahub.io,resources=aitenants/finalizers,verbs=update
 // +kubebuilder:rbac:groups=maas.opendatahub.io,resources=maastenantconfigs,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=maas.opendatahub.io,resources=tenants,verbs=get;list;watch;update;patch;delete
+// +kubebuilder:rbac:groups=maas.opendatahub.io,resources=tenants,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=gateways,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;delete
@@ -116,16 +116,14 @@ func (r *AITenantReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return r.reconcileAITenantDelete(ctx, &aitenant)
 	}
 
-	// Unblocking UI
-	// TODO: Include adding the finalizer back as part of https://github.com/opendatahub-io/models-as-a-service/pull/1159
-	// if !controllerutil.ContainsFinalizer(&aitenant, aitenantFinalizer) {
-	// 	base := aitenant.DeepCopy()
-	// 	controllerutil.AddFinalizer(&aitenant, aitenantFinalizer)
-	// 	if err := r.Patch(ctx, &aitenant, client.MergeFrom(base)); err != nil {
-	// 		return ctrl.Result{}, err
-	// 	}
-	// 	return ctrl.Result{RequeueAfter: time.Second}, nil
-	// }
+	if !controllerutil.ContainsFinalizer(&aitenant, aitenantFinalizer) {
+		base := aitenant.DeepCopy()
+		controllerutil.AddFinalizer(&aitenant, aitenantFinalizer)
+		if err := r.Patch(ctx, &aitenant, client.MergeFrom(base)); err != nil {
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{RequeueAfter: time.Second}, nil
+	}
 
 	statusSnapshot := aitenant.Status.DeepCopy()
 
@@ -422,6 +420,7 @@ func (r *AITenantReconciler) markLegacyTenantDeprecated(ctx context.Context, ten
 	annotations["maas.opendatahub.io/deprecated-by"] = maasv1alpha1.MaasTenantConfigKind
 	annotations["maas.opendatahub.io/migrated-to"] = maasv1alpha1.MaasTenantConfigInstanceName
 	legacy.SetAnnotations(annotations)
+	controllerutil.RemoveFinalizer(&legacy, tenantFinalizer)
 	if equality.Semantic.DeepEqual(base, &legacy) {
 		return nil
 	}
@@ -503,11 +502,9 @@ func (r *AITenantReconciler) ensureAITenantObjectRole(ctx context.Context, aiten
 }
 
 func (r *AITenantReconciler) reconcileAITenantDelete(ctx context.Context, aitenant *maasv1alpha1.AITenant) (ctrl.Result, error) {
-	// Unblocking UI
-	// TODO: Include adding the finalizer back as part of https://github.com/opendatahub-io/models-as-a-service/pull/1159
-	// if !controllerutil.ContainsFinalizer(aitenant, aitenantFinalizer) {
-	// 	return ctrl.Result{}, nil
-	// }
+	if !controllerutil.ContainsFinalizer(aitenant, aitenantFinalizer) {
+		return ctrl.Result{}, nil
+	}
 
 	tenantNamespace := r.tenantNamespaceName(aitenant)
 	statusSnapshot := aitenant.Status.DeepCopy()
@@ -571,13 +568,11 @@ func (r *AITenantReconciler) reconcileAITenantDelete(ctx context.Context, aitena
 		return ctrl.Result{}, err
 	}
 
-	// Unblocking UI
-	// TODO: Include adding the finalizer back as part of https://github.com/opendatahub-io/models-as-a-service/pull/1159
-	// base := aitenant.DeepCopy()
-	// controllerutil.RemoveFinalizer(aitenant, aitenantFinalizer)
-	// if err := r.Patch(ctx, aitenant, client.MergeFrom(base)); err != nil {
-	// 	return ctrl.Result{}, err
-	// }
+	base := aitenant.DeepCopy()
+	controllerutil.RemoveFinalizer(aitenant, aitenantFinalizer)
+	if err := r.Patch(ctx, aitenant, client.MergeFrom(base)); err != nil {
+		return ctrl.Result{}, err
+	}
 	return ctrl.Result{}, nil
 }
 
@@ -598,16 +593,14 @@ func (r *AITenantReconciler) deleteTenantConfig(ctx context.Context, aitenant *m
 	if !tenant.DeletionTimestamp.IsZero() {
 		return false, nil
 	}
-	// Unblocking UI / Config GC teardown
-	// TODO: Include adding the finalizer back as part of https://github.com/opendatahub-io/models-as-a-service/pull/1159
-	// if !controllerutil.ContainsFinalizer(&tenant, tenantFinalizer) {
-	// 	base := tenant.DeepCopy()
-	// 	controllerutil.AddFinalizer(&tenant, tenantFinalizer)
-	// 	if err := r.Patch(ctx, &tenant, client.MergeFrom(base)); err != nil {
-	// 		return false, fmt.Errorf("add cleanup finalizer to MaasTenantConfig %s/%s: %w", key.Namespace, key.Name, err)
-	// 	}
-	// 	return false, nil
-	// }
+	if !controllerutil.ContainsFinalizer(&tenant, tenantFinalizer) {
+		base := tenant.DeepCopy()
+		controllerutil.AddFinalizer(&tenant, tenantFinalizer)
+		if err := r.Patch(ctx, &tenant, client.MergeFrom(base)); err != nil {
+			return false, fmt.Errorf("add cleanup finalizer to MaasTenantConfig %s/%s: %w", key.Namespace, key.Name, err)
+		}
+		return false, nil
+	}
 	if err := r.Delete(ctx, &tenant); client.IgnoreNotFound(err) != nil {
 		return false, fmt.Errorf("delete MaasTenantConfig %s/%s: %w", key.Namespace, key.Name, err)
 	}

--- a/maas-controller/pkg/controller/maas/aitenant_controller_test.go
+++ b/maas-controller/pkg/controller/maas/aitenant_controller_test.go
@@ -83,10 +83,9 @@ func reconcileAITenantTwice(t *testing.T, r *AITenantReconciler, key types.Names
 	t.Helper()
 	g := NewWithT(t)
 
-	// Unblocking UI: finalizer add/requeue removed temporarily in PR #1159 follow-up.
 	res, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
 	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(res.RequeueAfter).To(Equal(time.Duration(0)))
+	g.Expect(res.RequeueAfter).To(Equal(time.Second))
 
 	res, err = r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
 	g.Expect(err).NotTo(HaveOccurred())
@@ -266,6 +265,10 @@ func TestAITenantReconcile_MissingGatewaySetsFailedStatus(t *testing.T) {
 	key := types.NamespacedName{Name: aitenant.Name, Namespace: aitenant.Namespace}
 	res, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
 	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(res.RequeueAfter).To(Equal(time.Second))
+
+	res, err = r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
+	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(res.RequeueAfter).To(Equal(30 * time.Second))
 
 	var updated maasv1alpha1.AITenant
@@ -384,7 +387,7 @@ func TestAITenantReconcile_UpdatesPreExistingTenant(t *testing.T) {
 
 	res, err = r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
 	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(res.RequeueAfter).To(Equal(time.Duration(0)))
+	g.Expect(res.RequeueAfter).To(Equal(time.Second))
 
 	res, err = r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
 	g.Expect(err).NotTo(HaveOccurred())
@@ -411,6 +414,72 @@ func TestAITenantReconcile_UpdatesPreExistingTenant(t *testing.T) {
 		Name:      "old-gateway",
 	}))
 	g.Expect(tenant.Spec.ExternalOIDC).To(BeNil())
+	g.Expect(tenant.Finalizers).NotTo(ContainElement(tenantFinalizer))
+}
+
+func TestAITenantReconcile_StripsStaleFinalizerFromLegacyTenantOnMigration(t *testing.T) {
+	g := NewWithT(t)
+	s := aitenantTestScheme(t)
+
+	aitenant := &maasv1alpha1.AITenant{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "team-stalefinalizer",
+			Namespace: tenantreconcile.DefaultAITenantNamespace,
+		},
+	}
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ai-tenant-team-stalefinalizer"}}
+	// Simulates an install upgraded from a pre-MaasTenantConfig version, where a
+	// reconciler used to add tenantFinalizer directly to Tenant objects. No reconciler
+	// for the Tenant kind exists anymore, so nothing else would ever remove this.
+	preExistingTenant := &maasv1alpha1.Tenant{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       maasv1alpha1.TenantInstanceName,
+			Namespace:  "ai-tenant-team-stalefinalizer",
+			Finalizers: []string{tenantFinalizer},
+		},
+		Spec: maasv1alpha1.TenantSpec{
+			GatewayRef: maasv1alpha1.TenantGatewayRef{
+				Namespace: "openshift-ingress",
+				Name:      "old-gateway",
+			},
+		},
+	}
+	cl := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(&maasv1alpha1.AITenant{}).
+		WithObjects(aitenant, ns, preExistingTenant, existingAITenantGateway("old-gateway")).
+		Build()
+	r := &AITenantReconciler{
+		Client:           cl,
+		Scheme:           s,
+		APIReader:        cl,
+		AppNamespace:     "opendatahub",
+		TenantNamespace:  "models-as-a-service",
+		GatewayNamespace: "openshift-ingress",
+	}
+
+	key := types.NamespacedName{Name: aitenant.Name, Namespace: aitenant.Namespace}
+	for i := 0; i < 3; i++ {
+		_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
+		g.Expect(err).NotTo(HaveOccurred())
+	}
+
+	var tenant maasv1alpha1.Tenant
+	g.Expect(cl.Get(context.Background(), client.ObjectKey{
+		Name:      maasv1alpha1.TenantInstanceName,
+		Namespace: "ai-tenant-team-stalefinalizer",
+	}, &tenant)).To(Succeed())
+	g.Expect(tenant.Finalizers).NotTo(ContainElement(tenantFinalizer),
+		"stale finalizer must be stripped so the legacy Tenant can actually terminate when deleted")
+	g.Expect(tenant.Annotations).To(HaveKeyWithValue("maas.opendatahub.io/deprecated-by", maasv1alpha1.MaasTenantConfigKind))
+
+	// With the finalizer gone, deleting the legacy Tenant (e.g. via tenant namespace
+	// teardown) must actually remove it instead of hanging forever.
+	g.Expect(cl.Delete(context.Background(), &tenant)).To(Succeed())
+	g.Expect(apierrors.IsNotFound(cl.Get(context.Background(), client.ObjectKey{
+		Name:      maasv1alpha1.TenantInstanceName,
+		Namespace: "ai-tenant-team-stalefinalizer",
+	}, &maasv1alpha1.Tenant{}))).To(BeTrue())
 }
 
 func TestAITenantReconcile_IgnoresLegacyDefaultGatewayForNonDefaultTenant(t *testing.T) {
@@ -532,7 +601,11 @@ func TestAITenantReconcile_LegacyGatewayNamespaceMismatchFailsMigration(t *testi
 	key := types.NamespacedName{Name: aitenant.Name, Namespace: aitenant.Namespace}
 	res, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
 	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(res.RequeueAfter).To(Equal(time.Duration(0)))
+	g.Expect(res.RequeueAfter).To(Equal(time.Second))
+
+	res, err = r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(res).To(Equal(ctrl.Result{}))
 
 	var updated maasv1alpha1.AITenant
 	g.Expect(cl.Get(context.Background(), key, &updated)).To(Succeed())
@@ -861,6 +934,10 @@ func TestAITenantReconcile_RejectsNamespaceOwnedByAnotherAITenant(t *testing.T) 
 	key := types.NamespacedName{Name: aitenant.Name, Namespace: aitenant.Namespace}
 	res, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
 	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(res.RequeueAfter).To(Equal(time.Second))
+
+	res, err = r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
+	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(res.RequeueAfter).To(Equal(30 * time.Second))
 
 	var updated maasv1alpha1.AITenant
@@ -1012,9 +1089,7 @@ func TestAITenantReconcile_DeletionCleansChildrenAndRequestsNamespaceDeletionBut
 	err = cl.Get(ctx, key, &remaining)
 	if !apierrors.IsNotFound(err) {
 		g.Expect(err).NotTo(HaveOccurred())
-		// Unblocking UI
-		// TODO: Include adding the finalizer back as part of https://github.com/opendatahub-io/models-as-a-service/pull/1159
-		// g.Expect(remaining.Finalizers).NotTo(ContainElement(aitenantFinalizer))
+		g.Expect(remaining.Finalizers).NotTo(ContainElement(aitenantFinalizer))
 	}
 }
 
@@ -1291,8 +1366,13 @@ func TestAITenantReconcile_GatewayClaimBlocksDuplicateGateway(t *testing.T) {
 
 	key2 := types.NamespacedName{Name: aitenant2.Name, Namespace: aitenant2.Namespace}
 
-	// Reconcile should fail due to gateway claim conflict.
+	// First reconcile adds the finalizer.
 	res, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key2})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(res.RequeueAfter).To(Equal(time.Second))
+
+	// Second reconcile should fail due to gateway claim conflict.
+	res, err = r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key2})
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(res.RequeueAfter).To(Equal(30 * time.Second))
 
@@ -1347,8 +1427,6 @@ func TestAITenantReconcile_GatewayClaimCleanedOnDeletion(t *testing.T) {
 	var toDelete maasv1alpha1.AITenant
 	g.Expect(cl.Get(ctx, key, &toDelete)).To(Succeed())
 	setMapValue(&toDelete.Annotations, aitenantAPIKeysRevokedAnnotation, "true")
-	// Keep the object through deletion reconcile while finalizer add is disabled in controller.
-	toDelete.Finalizers = []string{aitenantFinalizer}
 	g.Expect(cl.Update(ctx, &toDelete)).To(Succeed())
 	g.Expect(cl.Delete(ctx, &maasv1alpha1.MaasTenantConfig{ObjectMeta: metav1.ObjectMeta{Name: maasv1alpha1.MaasTenantConfigInstanceName, Namespace: "ai-tenant-team-cleanup"}})).To(Succeed())
 	g.Expect(cl.Delete(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ai-tenant-team-cleanup"}})).To(Succeed())
@@ -1997,18 +2075,9 @@ func TestAITenantReconcile_DeletionAddsTenantFinalizerBeforeDelete(t *testing.T)
 	g.Expect(res.RequeueAfter).To(Equal(5 * time.Second))
 
 	var updatedTenant maasv1alpha1.MaasTenantConfig
-	err = cl.Get(ctx, client.ObjectKey{Name: maasv1alpha1.MaasTenantConfigInstanceName, Namespace: "models-as-a-service"}, &updatedTenant)
-	// Unblocking UI / Config GC teardown
-	// TODO: Include adding the finalizer back as part of https://github.com/opendatahub-io/models-as-a-service/pull/1159
-	// g.Expect(updatedTenant.Finalizers).To(ContainElement(tenantFinalizer))
-	// g.Expect(updatedTenant.DeletionTimestamp.IsZero()).To(BeTrue())
-	// Without tenant-cleanup, Delete proceeds immediately (object may already be gone in the fake client).
-	if err == nil {
-		g.Expect(updatedTenant.Finalizers).NotTo(ContainElement(tenantFinalizer))
-		g.Expect(updatedTenant.DeletionTimestamp.IsZero()).To(BeFalse(), "MaasTenantConfig delete is requested without adding tenant-cleanup")
-	} else {
-		g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
-	}
+	g.Expect(cl.Get(ctx, client.ObjectKey{Name: maasv1alpha1.MaasTenantConfigInstanceName, Namespace: "models-as-a-service"}, &updatedTenant)).To(Succeed())
+	g.Expect(updatedTenant.Finalizers).To(ContainElement(tenantFinalizer))
+	g.Expect(updatedTenant.DeletionTimestamp.IsZero()).To(BeTrue())
 }
 
 func TestAITenantReconcile_NamespaceFinalizersSetDeletionBlocked(t *testing.T) {
@@ -2148,9 +2217,7 @@ func TestAITenantReconcile_DefaultTenantDeletionCompletesInZeroTenantState(t *te
 	err = cl.Get(ctx, key, &remaining)
 	if !apierrors.IsNotFound(err) {
 		g.Expect(err).NotTo(HaveOccurred())
-		// Unblocking UI
-		// TODO: Include adding the finalizer back as part of https://github.com/opendatahub-io/models-as-a-service/pull/1159
-		// g.Expect(remaining.Finalizers).NotTo(ContainElement(aitenantFinalizer))
+		g.Expect(remaining.Finalizers).NotTo(ContainElement(aitenantFinalizer))
 	}
 }
 

--- a/maas-controller/pkg/controller/maas/self_deployment_controller.go
+++ b/maas-controller/pkg/controller/maas/self_deployment_controller.go
@@ -61,8 +61,13 @@ const envoyFilterName = "maas-model-access-logs"
 // LifecycleReconciler watches the maas-controller Deployment. It is the sole creator of the
 // cluster-scoped Config/default anchor when the Deployment exists and is not terminating (so
 // standalone installs do not race applying a Config manifest before the Config CRD is ready).
-// It links the Deployment, default AITenant, and default MaasTenantConfig to Config via non-controller
-// ownerReferences (same relationship shape for all). Legacy CleanupFinalizer entries are removed when present.
+// It links the default AITenant and default MaasTenantConfig to Config via non-controller
+// ownerReferences. The Deployment itself deliberately does NOT get an ownerReference to
+// Config: this reconciler's own workload must keep running independent of Config's lifecycle
+// (self-heal after an accidental Config deletion, and reporting TeardownCompletedAnnotation
+// once Config is deleted during teardown), so it must not be a GC dependent of the resource
+// it manages. Legacy CleanupFinalizer entries and any legacy Deployment->Config
+// ownerReference (set by older maas-controller versions) are removed when present.
 type LifecycleReconciler struct {
 	client.Client
 	Scheme                      *runtime.Scheme
@@ -93,15 +98,25 @@ func (r *LifecycleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 
 	if dep.DeletionTimestamp.IsZero() {
-		if res, err := r.ensureSingletonConfig(ctx, &dep); err != nil {
+		// Strip before anything else so that, if teardown is requested below, Config
+		// deletion can never cascade-delete the Deployment via a stale ownerReference
+		// from a pre-self-teardown install.
+		if err := r.stripLegacyDeploymentConfigOwnerReference(ctx, log, req.NamespacedName); err != nil {
 			return ctrl.Result{}, err
-		} else if res != nil {
+		}
+		teardownRequested := TeardownRequestedOnDeployment(&dep)
+		cfg, res, err := r.ensureSingletonConfig(ctx, &dep)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		if res != nil {
 			return *res, nil
 		}
-		if res, err := r.ensureDeploymentReferencesConfig(ctx, req.NamespacedName); err != nil {
-			return ctrl.Result{}, err
-		} else if res != nil {
-			return *res, nil
+		if teardownRequested {
+			if cfg == nil {
+				log.Info("teardown requested on maas-controller Deployment; running best-effort cleanup without Config/default")
+			}
+			return r.handleRequestedTeardown(ctx, &dep, cfg)
 		}
 		if res, err := r.ensureDefaultAITenantReferencesConfig(ctx); err != nil {
 			return ctrl.Result{}, err
@@ -199,26 +214,72 @@ func (r *LifecycleReconciler) stripLegacyCleanupFinalizer(ctx context.Context, l
 	return nil
 }
 
+// stripLegacyDeploymentConfigOwnerReference removes an ownerReference from the Deployment
+// to Config/default if present. Pre-self-teardown maas-controller versions set this
+// non-controller ownerReference (see the removed ensureDeploymentReferencesConfig); it must
+// not survive an upgrade, or deleting Config could cascade-delete the Deployment itself
+// before this reconciler can report TeardownCompletedAnnotation. New installs never set
+// this ownerReference, so this is a no-op for them.
+func (r *LifecycleReconciler) stripLegacyDeploymentConfigOwnerReference(ctx context.Context, log logr.Logger, key types.NamespacedName) error {
+	var dep appsv1.Deployment
+	if err := r.Get(ctx, key, &dep); err != nil {
+		return client.IgnoreNotFound(err)
+	}
+
+	filtered := make([]metav1.OwnerReference, 0, len(dep.OwnerReferences))
+	changed := false
+	for _, ref := range dep.OwnerReferences {
+		if isConfigOwnerReference(ref) {
+			changed = true
+			continue
+		}
+		filtered = append(filtered, ref)
+	}
+	if !changed {
+		return nil
+	}
+
+	base := dep.DeepCopy()
+	dep.OwnerReferences = filtered
+	if err := r.Patch(ctx, &dep, client.MergeFrom(base)); err != nil {
+		return fmt.Errorf("remove legacy Config owner reference from Deployment: %w", err)
+	}
+	log.Info("removed legacy Config owner reference from Deployment")
+	return nil
+}
+
+// isConfigOwnerReference reports whether ref points at the singleton Config/default
+// resource. Config is cluster-scoped and singleton, so matching by name (in addition to
+// kind and API version) is precise without needing to fetch Config to compare UIDs.
+func isConfigOwnerReference(ref metav1.OwnerReference) bool {
+	return ref.Kind == maasv1alpha1.ConfigKind &&
+		ref.APIVersion == maasv1alpha1.GroupVersion.String() &&
+		ref.Name == maasv1alpha1.ConfigInstanceName
+}
+
 // ensureSingletonConfig creates Config/default when it is missing and the watched Deployment
 // is still running. If Config is terminating, requeues until teardown completes (avoids racing
 // intentional anchor deletion). After accidental deletion while the Deployment remains, the
 // anchor is recreated on a later reconcile.
-func (r *LifecycleReconciler) ensureSingletonConfig(ctx context.Context, dep *appsv1.Deployment) (*ctrl.Result, error) {
+func (r *LifecycleReconciler) ensureSingletonConfig(ctx context.Context, dep *appsv1.Deployment) (*maasv1alpha1.Config, *ctrl.Result, error) {
 	if dep == nil || !dep.DeletionTimestamp.IsZero() {
-		return nil, nil
+		return nil, nil, nil
 	}
 	key := client.ObjectKey{Name: maasv1alpha1.ConfigInstanceName}
 	var cfg maasv1alpha1.Config
 	switch err := r.Get(ctx, key, &cfg); {
 	case err == nil:
 		if !cfg.DeletionTimestamp.IsZero() {
-			return &ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+			return &cfg, nil, nil
 		}
 		if cfg.UID == "" {
-			return &ctrl.Result{RequeueAfter: 2 * time.Second}, nil
+			return nil, &ctrl.Result{RequeueAfter: 2 * time.Second}, nil
 		}
-		return nil, nil
+		return &cfg, nil, nil
 	case apierrors.IsNotFound(err):
+		if TeardownRequestedOnDeployment(dep) {
+			return nil, nil, nil
+		}
 		toCreate := &maasv1alpha1.Config{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: maasv1alpha1.GroupVersion.String(),
@@ -227,72 +288,21 @@ func (r *LifecycleReconciler) ensureSingletonConfig(ctx context.Context, dep *ap
 			ObjectMeta: metav1.ObjectMeta{Name: maasv1alpha1.ConfigInstanceName},
 		}
 		if err := r.Create(ctx, toCreate); err != nil && !apierrors.IsAlreadyExists(err) {
-			return nil, err
+			return nil, nil, err
 		}
 		if err := r.Get(ctx, key, &cfg); err != nil {
 			if apierrors.IsNotFound(err) {
-				return &ctrl.Result{RequeueAfter: 2 * time.Second}, nil
+				return nil, &ctrl.Result{RequeueAfter: 2 * time.Second}, nil
 			}
-			return nil, err
+			return nil, nil, err
 		}
 		if cfg.UID == "" {
-			return &ctrl.Result{RequeueAfter: 2 * time.Second}, nil
+			return nil, &ctrl.Result{RequeueAfter: 2 * time.Second}, nil
 		}
-		return nil, nil
+		return &cfg, nil, nil
 	default:
-		return nil, err
+		return nil, nil, err
 	}
-}
-
-// ensureDeploymentReferencesConfig links the controller Deployment to Config/default
-// via a non-controller ownerReference so the workload participates in the same GC graph as other
-// operands without competing with the ODH operator's controller owner (when present).
-//
-// Call after ensureSingletonConfig in the same reconcile: Config should exist with a UID and
-// not be terminating. If this function still observes a missing, terminating, or UID-less anchor
-// (cache lag or races), it logs and returns a short requeue instead of succeeding with no work.
-func (r *LifecycleReconciler) ensureDeploymentReferencesConfig(ctx context.Context, key types.NamespacedName) (*ctrl.Result, error) {
-	log := ctrl.LoggerFrom(ctx).WithValues("deployment", key)
-	if r.Scheme == nil {
-		return nil, nil
-	}
-	var cfg maasv1alpha1.Config
-	if err := r.Get(ctx, client.ObjectKey{Name: maasv1alpha1.ConfigInstanceName}, &cfg); err != nil {
-		if apierrors.IsNotFound(err) {
-			log.Info("Config anchor not found when linking Deployment; requeueing (singleton reconcile should create it)")
-			res := ctrl.Result{RequeueAfter: 2 * time.Second}
-			return &res, nil
-		}
-		return nil, err
-	}
-	if !cfg.DeletionTimestamp.IsZero() {
-		log.Info("Config anchor is terminating when linking Deployment; requeueing until teardown completes")
-		res := ctrl.Result{RequeueAfter: 10 * time.Second}
-		return &res, nil
-	}
-	if cfg.UID == "" {
-		log.Info("Config anchor has no UID yet when linking Deployment; requeueing")
-		res := ctrl.Result{RequeueAfter: 2 * time.Second}
-		return &res, nil
-	}
-	var dep appsv1.Deployment
-	if err := r.Get(ctx, key, &dep); err != nil {
-		return nil, client.IgnoreNotFound(err)
-	}
-	for _, ref := range dep.OwnerReferences {
-		if ref.UID == cfg.UID && ref.Kind == maasv1alpha1.ConfigKind && ref.APIVersion == maasv1alpha1.GroupVersion.String() {
-			return nil, nil
-		}
-	}
-	base := dep.DeepCopy()
-	if err := controllerutil.SetOwnerReference(&cfg, &dep, r.Scheme); err != nil {
-		return nil, fmt.Errorf("set Config owner reference on deployment: %w", err)
-	}
-	if err := r.Patch(ctx, &dep, client.MergeFrom(base)); err != nil {
-		return nil, fmt.Errorf("patch deployment ownerReferences: %w", err)
-	}
-	log.Info("set Config owner reference on maas-controller Deployment")
-	return nil, nil
 }
 
 // ensureTenantReferencesConfig links MaasTenantConfig/default-tenant to Config/default via the same non-controller

--- a/maas-controller/pkg/controller/maas/self_deployment_controller_test.go
+++ b/maas-controller/pkg/controller/maas/self_deployment_controller_test.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	goruntime "runtime"
 	"testing"
-	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -14,6 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -34,6 +34,17 @@ func lifecycleTestScheme(t *testing.T) *runtime.Scheme {
 	utilruntime.Must(clientgoscheme.AddToScheme(s))
 	utilruntime.Must(maasv1alpha1.AddToScheme(s))
 	return s
+}
+
+func lifecycleTestUnstructured(gvk schema.GroupVersionKind, namespace, name string, finalizers ...string) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(gvk)
+	obj.SetNamespace(namespace)
+	obj.SetName(name)
+	if len(finalizers) > 0 {
+		obj.SetFinalizers(finalizers)
+	}
+	return obj
 }
 
 func TestLifecycleReconciler_CreatesConfigWhenMissing(t *testing.T) {
@@ -87,12 +98,187 @@ func TestLifecycleReconciler_CreatesConfigWhenMissing(t *testing.T) {
 	g.Expect(cfg.Name).To(Equal(maasv1alpha1.ConfigInstanceName))
 }
 
-func TestLifecycleReconciler_ConfigTerminatingRequeues(t *testing.T) {
+func TestLifecycleReconciler_DoesNotRecreateConfigWhenTeardownRequested(t *testing.T) {
 	g := NewWithT(t)
 	s := lifecycleTestScheme(t)
 
 	const depNS = "opendatahub"
-	now := metav1.NewTime(time.Now())
+	dep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "maas-controller",
+			Namespace: depNS,
+			Annotations: map[string]string{
+				TeardownRequestedAnnotation: "true",
+			},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "maas-controller"}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "maas-controller"}},
+				Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "manager", Image: "test"}}},
+			},
+		},
+	}
+
+	cl := fake.NewClientBuilder().WithScheme(s).WithObjects(dep).Build()
+	r := &LifecycleReconciler{
+		Client:                      cl,
+		Scheme:                      s,
+		DeploymentName:              "maas-controller",
+		DeploymentNS:                depNS,
+		TenantSubscriptionNamespace: "",
+	}
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "maas-controller", Namespace: depNS},
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(res).To(Equal(ctrl.Result{}))
+
+	var cfg maasv1alpha1.Config
+	g.Expect(cl.Get(context.Background(), client.ObjectKey{Name: maasv1alpha1.ConfigInstanceName}, &cfg)).ToNot(Succeed())
+}
+
+func TestLifecycleReconciler_TeardownRequestedDeletesConfigAndMarksCompleted(t *testing.T) {
+	g := NewWithT(t)
+	s := lifecycleTestScheme(t)
+
+	const depNS = "opendatahub"
+	dep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "maas-controller",
+			Namespace: depNS,
+			Annotations: map[string]string{
+				TeardownRequestedAnnotation: "true",
+			},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "maas-controller"}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "maas-controller"}},
+				Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "manager", Image: "test"}}},
+			},
+		},
+	}
+	cfg := &maasv1alpha1.Config{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: maasv1alpha1.ConfigInstanceName,
+			UID:  types.UID("cfg-delete-request"),
+		},
+	}
+
+	cl := fake.NewClientBuilder().WithScheme(s).WithObjects(dep, cfg).Build()
+	r := &LifecycleReconciler{
+		Client:         cl,
+		Scheme:         s,
+		DeploymentName: "maas-controller",
+		DeploymentNS:   depNS,
+	}
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "maas-controller", Namespace: depNS},
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(res).To(Equal(ctrl.Result{}))
+
+	// Config/default is deleted as a plain step, no finalizer involved.
+	var updatedCfg maasv1alpha1.Config
+	g.Expect(apierrors.IsNotFound(cl.Get(context.Background(), client.ObjectKey{Name: maasv1alpha1.ConfigInstanceName}, &updatedCfg))).To(BeTrue())
+
+	// The completion signal must be observable on the Deployment regardless of Config's fate.
+	var updatedDep appsv1.Deployment
+	g.Expect(cl.Get(context.Background(), client.ObjectKey{Name: "maas-controller", Namespace: depNS}, &updatedDep)).To(Succeed())
+	g.Expect(updatedDep.Annotations[TeardownCompletedAnnotation]).To(Equal("true"))
+}
+
+func TestLifecycleReconciler_MarkTeardownCompletedIsIdempotent(t *testing.T) {
+	g := NewWithT(t)
+	s := lifecycleTestScheme(t)
+
+	const depNS = "opendatahub"
+	dep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "maas-controller",
+			Namespace: depNS,
+			Annotations: map[string]string{
+				TeardownCompletedAnnotation: "true",
+			},
+			ResourceVersion: "1",
+		},
+	}
+
+	cl := fake.NewClientBuilder().WithScheme(s).WithObjects(dep).Build()
+	r := &LifecycleReconciler{Client: cl, Scheme: s}
+
+	g.Expect(r.markTeardownCompleted(context.Background(), dep)).To(Succeed())
+
+	var updated appsv1.Deployment
+	g.Expect(cl.Get(context.Background(), client.ObjectKey{Name: "maas-controller", Namespace: depNS}, &updated)).To(Succeed())
+	g.Expect(updated.ResourceVersion).To(Equal("1"), "already-annotated Deployment should not be patched again")
+}
+
+func TestLifecycleReconciler_TeardownRequestedWithoutConfigRequestsOrphanCleanup(t *testing.T) {
+	g := NewWithT(t)
+	s := lifecycleTestScheme(t)
+
+	const depNS = "opendatahub"
+	dep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "maas-controller",
+			Namespace: depNS,
+			Annotations: map[string]string{
+				TeardownRequestedAnnotation: "true",
+			},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "maas-controller"}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "maas-controller"}},
+				Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "manager", Image: "test"}}},
+			},
+		},
+	}
+	aitenant := lifecycleTestUnstructured(
+		schema.GroupVersionKind{Group: "maas.opendatahub.io", Version: "v1alpha1", Kind: "AITenant"},
+		tenantreconcile.DefaultAITenantNamespace,
+		tenantreconcile.DefaultAITenantName,
+		aitenantFinalizer,
+	)
+
+	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(dep, aitenant).Build()
+	r := &LifecycleReconciler{
+		Client:            cl,
+		Scheme:            s,
+		DeploymentName:    "maas-controller",
+		DeploymentNS:      depNS,
+		AITenantNamespace: tenantreconcile.DefaultAITenantNamespace,
+	}
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "maas-controller", Namespace: depNS},
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(res.RequeueAfter).To(Equal(teardownRequeueAfter))
+
+	updated := &unstructured.Unstructured{}
+	updated.SetGroupVersionKind(aitenant.GroupVersionKind())
+	g.Expect(cl.Get(context.Background(), client.ObjectKey{
+		Name:      tenantreconcile.DefaultAITenantName,
+		Namespace: tenantreconcile.DefaultAITenantNamespace,
+	}, updated)).To(Succeed())
+	g.Expect(updated.GetDeletionTimestamp()).NotTo(BeNil())
+
+	// The completion annotation must not be set yet: AITenant deletion is still pending.
+	var updatedDep appsv1.Deployment
+	g.Expect(cl.Get(context.Background(), client.ObjectKey{Name: "maas-controller", Namespace: depNS}, &updatedDep)).To(Succeed())
+	g.Expect(updatedDep.Annotations[TeardownCompletedAnnotation]).To(BeEmpty())
+}
+
+func TestLifecycleReconciler_NormalReconcileDoesNotSetDeploymentOwnerReference(t *testing.T) {
+	g := NewWithT(t)
+	s := lifecycleTestScheme(t)
+
+	const depNS = "opendatahub"
 	dep := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "maas-controller",
@@ -108,10 +294,8 @@ func TestLifecycleReconciler_ConfigTerminatingRequeues(t *testing.T) {
 	}
 	cfg := &maasv1alpha1.Config{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:              maasv1alpha1.ConfigInstanceName,
-			UID:               types.UID("cfg-1"),
-			DeletionTimestamp: &now,
-			Finalizers:        []string{"test.finalizer"},
+			Name: maasv1alpha1.ConfigInstanceName,
+			UID:  types.UID("cfg-1"),
 		},
 	}
 
@@ -124,11 +308,134 @@ func TestLifecycleReconciler_ConfigTerminatingRequeues(t *testing.T) {
 		TenantSubscriptionNamespace: "",
 	}
 
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "maas-controller", Namespace: depNS},
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// Config must never own the Deployment: the Deployment carries the teardown
+	// annotations and must survive Config being deleted (accidentally, or during
+	// teardown), so it cannot be a GC dependent of Config.
+	var updated appsv1.Deployment
+	g.Expect(cl.Get(context.Background(), client.ObjectKey{Name: "maas-controller", Namespace: depNS}, &updated)).To(Succeed())
+	g.Expect(updated.OwnerReferences).To(BeEmpty())
+}
+
+func TestLifecycleReconciler_StripsLegacyDeploymentConfigOwnerReferenceOnNormalReconcile(t *testing.T) {
+	g := NewWithT(t)
+	s := lifecycleTestScheme(t)
+
+	const depNS = "opendatahub"
+	dep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "maas-controller",
+			Namespace: depNS,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: maasv1alpha1.GroupVersion.String(),
+					Kind:       maasv1alpha1.ConfigKind,
+					Name:       maasv1alpha1.ConfigInstanceName,
+					UID:        types.UID("cfg-1"),
+				},
+				{
+					APIVersion: "v1",
+					Kind:       "Secret",
+					Name:       "unrelated",
+					UID:        types.UID("secret-1"),
+				},
+			},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "maas-controller"}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "maas-controller"}},
+				Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "manager", Image: "test"}}},
+			},
+		},
+	}
+	cfg := &maasv1alpha1.Config{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: maasv1alpha1.ConfigInstanceName,
+			UID:  types.UID("cfg-1"),
+		},
+	}
+
+	cl := fake.NewClientBuilder().WithScheme(s).WithObjects(dep, cfg).Build()
+	r := &LifecycleReconciler{
+		Client:         cl,
+		Scheme:         s,
+		DeploymentName: "maas-controller",
+		DeploymentNS:   depNS,
+	}
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "maas-controller", Namespace: depNS},
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+
+	var updated appsv1.Deployment
+	g.Expect(cl.Get(context.Background(), client.ObjectKey{Name: "maas-controller", Namespace: depNS}, &updated)).To(Succeed())
+	g.Expect(updated.OwnerReferences).To(HaveLen(1), "only the legacy Config ownerReference should be removed")
+	g.Expect(updated.OwnerReferences[0].Name).To(Equal("unrelated"))
+}
+
+func TestLifecycleReconciler_TeardownStripsLegacyOwnerReferenceBeforeDeletingConfig(t *testing.T) {
+	g := NewWithT(t)
+	s := lifecycleTestScheme(t)
+
+	const depNS = "opendatahub"
+	dep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "maas-controller",
+			Namespace: depNS,
+			Annotations: map[string]string{
+				TeardownRequestedAnnotation: "true",
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: maasv1alpha1.GroupVersion.String(),
+					Kind:       maasv1alpha1.ConfigKind,
+					Name:       maasv1alpha1.ConfigInstanceName,
+					UID:        types.UID("cfg-legacy"),
+				},
+			},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "maas-controller"}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "maas-controller"}},
+				Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "manager", Image: "test"}}},
+			},
+		},
+	}
+	cfg := &maasv1alpha1.Config{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: maasv1alpha1.ConfigInstanceName,
+			UID:  types.UID("cfg-legacy"),
+		},
+	}
+
+	cl := fake.NewClientBuilder().WithScheme(s).WithObjects(dep, cfg).Build()
+	r := &LifecycleReconciler{
+		Client:         cl,
+		Scheme:         s,
+		DeploymentName: "maas-controller",
+		DeploymentNS:   depNS,
+	}
+
 	res, err := r.Reconcile(context.Background(), ctrl.Request{
 		NamespacedName: types.NamespacedName{Name: "maas-controller", Namespace: depNS},
 	})
 	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(res.RequeueAfter).To(Equal(10 * time.Second))
+	g.Expect(res).To(Equal(ctrl.Result{}))
+
+	var updatedDep appsv1.Deployment
+	g.Expect(cl.Get(context.Background(), client.ObjectKey{Name: "maas-controller", Namespace: depNS}, &updatedDep)).To(Succeed())
+	g.Expect(updatedDep.OwnerReferences).To(BeEmpty(), "legacy Config ownerReference must be gone before Config is deleted")
+	g.Expect(updatedDep.Annotations[TeardownCompletedAnnotation]).To(Equal("true"))
+
+	var updatedCfg maasv1alpha1.Config
+	g.Expect(apierrors.IsNotFound(cl.Get(context.Background(), client.ObjectKey{Name: maasv1alpha1.ConfigInstanceName}, &updatedCfg))).To(BeTrue())
 }
 
 func TestLifecycleReconciler_LinksDefaultTenantToConfig(t *testing.T) {

--- a/maas-controller/pkg/controller/maas/self_teardown.go
+++ b/maas-controller/pkg/controller/maas/self_teardown.go
@@ -1,0 +1,207 @@
+package maas
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	maasv1alpha1 "github.com/opendatahub-io/models-as-a-service/maas-controller/api/maas/v1alpha1"
+)
+
+// TeardownRequestedAnnotation on the maas-controller Deployment tells LifecycleReconciler
+// to start teardown: bootstrap/self-heal behaviors stay disabled, the default AITenant
+// and the AITenant namespace are deleted in order, then Config/default is deleted as a
+// plain step, and finally TeardownCompletedAnnotation is set once nothing is pending.
+const TeardownRequestedAnnotation = "maas.opendatahub.io/teardown-requested"
+
+// TeardownCompletedAnnotation is set on the maas-controller Deployment by LifecycleReconciler
+// once every ordered teardown step, including Config/default deletion, has finished.
+// External operators watch or poll this annotation as the "self-teardown is done" signal
+// instead of depending on Config (or anything cascade-deleted through it) to still exist.
+const TeardownCompletedAnnotation = "maas.opendatahub.io/teardown-completed"
+
+const (
+	teardownRequeueAfter        = 5 * time.Second
+	maasManagedByLabelKey       = "app.kubernetes.io/managed-by"
+	maasManagedByLabelValue     = "maas-controller"
+	maasGeneratedNamespaceLabel = "opendatahub.io/generated-namespace"
+	maasGeneratedNamespaceValue = "true"
+)
+
+// TeardownRequestedOnDeployment reports whether the maas-controller Deployment has been
+// annotated to start teardown. Callers outside this file (e.g. the Reconcile entrypoint,
+// the default AITenant bootstrap gate, and the AITenant namespace monitor in cmd/manager)
+// use this as the single source of truth for "is teardown in progress".
+func TeardownRequestedOnDeployment(dep *appsv1.Deployment) bool {
+	if dep == nil {
+		return false
+	}
+	return dep.GetAnnotations()[TeardownRequestedAnnotation] == "true"
+}
+
+var resourceTypesToRemove = []schema.GroupVersionKind{
+	{Group: "maas.opendatahub.io", Version: "v1alpha1", Kind: "AITenant"},
+}
+
+// handleRequestedTeardown runs on every reconcile while TeardownRequestedAnnotation is
+// present on the maas-controller Deployment. It deletes the default AITenant and the
+// AITenant namespace, requeueing until nothing is pending; once clean, it deletes
+// Config/default and then marks TeardownCompletedAnnotation on the Deployment.
+//
+// Config deletion is a plain, unguarded step (no finalizer): this reconciler is the only
+// actor that deletes Config while teardown is requested, so ordering is enforced here in
+// Go, not by the API server. Deleting Config before writing the completion annotation is
+// safe because Reconcile strips any legacy Deployment->Config ownerReference on every pass
+// (see stripLegacyDeploymentConfigOwnerReference): the Deployment is never a GC dependent
+// of Config, so cascade-deleting Config's other dependents (ServiceMonitor, dashboards,
+// EnvoyFilter) cannot take the Deployment down with it before the annotation is written.
+// If the process crashes between the two steps, the next reconcile finds nothing pending
+// and no Config, and simply (idempotently) marks completion.
+func (r *LifecycleReconciler) handleRequestedTeardown(ctx context.Context, dep *appsv1.Deployment, cfg *maasv1alpha1.Config) (ctrl.Result, error) {
+	pending, err := r.cleanupTeardownResources(ctx)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if pending {
+		return ctrl.Result{RequeueAfter: teardownRequeueAfter}, nil
+	}
+
+	if cfg != nil {
+		if err := r.Delete(ctx, cfg); client.IgnoreNotFound(err) != nil {
+			return ctrl.Result{}, fmt.Errorf("delete Config/default during teardown: %w", err)
+		}
+	}
+
+	if err := r.markTeardownCompleted(ctx, dep); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// markTeardownCompleted sets TeardownCompletedAnnotation on the Deployment so external
+// operators have a single durable signal for "self-teardown is done" that survives
+// Config (and anything cascade-deleted through it) disappearing. Idempotent so patching
+// it does not re-trigger this reconciler indefinitely through the Deployment watch.
+func (r *LifecycleReconciler) markTeardownCompleted(ctx context.Context, dep *appsv1.Deployment) error {
+	if dep == nil {
+		return nil
+	}
+	if dep.GetAnnotations()[TeardownCompletedAnnotation] == "true" {
+		return nil
+	}
+	base := dep.DeepCopy()
+	if dep.Annotations == nil {
+		dep.Annotations = map[string]string{}
+	}
+	dep.Annotations[TeardownCompletedAnnotation] = "true"
+	if err := r.Patch(ctx, dep, client.MergeFrom(base)); err != nil {
+		return fmt.Errorf("annotate Deployment with %s: %w", TeardownCompletedAnnotation, err)
+	}
+	return nil
+}
+
+func (r *LifecycleReconciler) cleanupTeardownResources(ctx context.Context) (bool, error) {
+	resourcesPending := false
+	for _, resourceGVK := range resourceTypesToRemove {
+		items, err := listUnstructuredByGVK(ctx, r.Client, resourceGVK)
+		if err != nil {
+			return false, err
+		}
+		if len(items) == 0 {
+			continue
+		}
+		resourcesPending = true
+
+		for i := range items {
+			obj := items[i].DeepCopy()
+			if !obj.GetDeletionTimestamp().IsZero() {
+				continue
+			}
+			if err := r.Delete(ctx, obj); client.IgnoreNotFound(err) != nil {
+				return false, fmt.Errorf("delete %s %s/%s during teardown: %w",
+					resourceGVK.Kind, obj.GetNamespace(), obj.GetName(), err)
+			}
+		}
+	}
+	if resourcesPending {
+		return true, nil
+	}
+
+	namespacePending, err := r.ensureAITenantNamespaceDeleted(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	return namespacePending, nil
+}
+
+func (r *LifecycleReconciler) ensureAITenantNamespaceDeleted(ctx context.Context) (bool, error) {
+	if r.AITenantNamespace == "" {
+		return false, nil
+	}
+
+	var ns corev1.Namespace
+	err := r.Get(ctx, client.ObjectKey{Name: r.AITenantNamespace}, &ns)
+	switch {
+	case errors.IsNotFound(err):
+		return false, nil
+	case err != nil:
+		return false, fmt.Errorf("get AITenant namespace %q during teardown: %w", r.AITenantNamespace, err)
+	}
+
+	if !shouldDeleteAITenantNamespace(&ns, r.DeploymentNS) {
+		return false, nil
+	}
+
+	if ns.DeletionTimestamp.IsZero() {
+		if err := r.Delete(ctx, &ns); client.IgnoreNotFound(err) != nil {
+			return false, fmt.Errorf("delete AITenant namespace %q during teardown: %w", r.AITenantNamespace, err)
+		}
+	}
+
+	return true, nil
+}
+
+func shouldDeleteAITenantNamespace(ns *corev1.Namespace, protectedNamespace string) bool {
+	if ns == nil || ns.Name == "" || ns.Name == protectedNamespace {
+		return false
+	}
+	labels := ns.GetLabels()
+	if labels == nil {
+		return false
+	}
+	return labels[maasManagedByLabelKey] == maasManagedByLabelValue ||
+		labels[maasGeneratedNamespaceLabel] == maasGeneratedNamespaceValue
+}
+
+func listUnstructuredByGVK(ctx context.Context, cli client.Client, resourceGVK schema.GroupVersionKind) ([]unstructured.Unstructured, error) {
+	list := &unstructured.UnstructuredList{}
+	list.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   resourceGVK.Group,
+		Version: resourceGVK.Version,
+		Kind:    resourceGVK.Kind + "List",
+	})
+
+	if err := cli.List(ctx, list); err != nil {
+		if isNoMatchOrNotFound(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("list %s during teardown: %w", resourceGVK.String(), err)
+	}
+
+	return list.Items, nil
+}
+
+func isNoMatchOrNotFound(err error) bool {
+	return errors.IsNotFound(err) || apimeta.IsNoMatchError(err)
+}

--- a/maas-controller/pkg/controller/maas/tenant_reconcile.go
+++ b/maas-controller/pkg/controller/maas/tenant_reconcile.go
@@ -121,17 +121,14 @@ func (r *TenantReconciler) reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return r.handleDeletion(ctx, log, &tenant)
 	}
 
-	// Unblocking UI / Config GC teardown
-	// TODO: Include adding the finalizer back as part of https://github.com/opendatahub-io/models-as-a-service/pull/1159
-	// if usesCleanupFinalizer {
-	// 	if !controllerutil.ContainsFinalizer(&tenant, tenantFinalizer) {
-	// 		controllerutil.AddFinalizer(&tenant, tenantFinalizer)
-	// 		if err := r.Update(ctx, &tenant); err != nil {
-	// 			return ctrl.Result{}, err
-	// 		}
-	// 	}
-	// } else if controllerutil.ContainsFinalizer(&tenant, tenantFinalizer) {
-	if !usesCleanupFinalizer && controllerutil.ContainsFinalizer(&tenant, tenantFinalizer) {
+	if usesCleanupFinalizer {
+		if !controllerutil.ContainsFinalizer(&tenant, tenantFinalizer) {
+			controllerutil.AddFinalizer(&tenant, tenantFinalizer)
+			if err := r.Update(ctx, &tenant); err != nil {
+				return ctrl.Result{}, err
+			}
+		}
+	} else if controllerutil.ContainsFinalizer(&tenant, tenantFinalizer) {
 		// Converge upgraded clusters: default-tenant teardown is owned by Config GC.
 		controllerutil.RemoveFinalizer(&tenant, tenantFinalizer)
 		if err := r.Update(ctx, &tenant); err != nil {

--- a/maas-controller/pkg/controller/maas/tenant_reconcile_test.go
+++ b/maas-controller/pkg/controller/maas/tenant_reconcile_test.go
@@ -208,10 +208,7 @@ func TestTenantReconcile_AITenantManagedDefaultAddsCleanupFinalizer(t *testing.T
 
 	var updated maasv1alpha1.MaasTenantConfig
 	g.Expect(cl.Get(context.Background(), client.ObjectKey{Name: maasv1alpha1.MaasTenantConfigInstanceName, Namespace: testNS}, &updated)).To(Succeed())
-	// Unblocking UI / Config GC teardown
-	// TODO: Include adding the finalizer back as part of https://github.com/opendatahub-io/models-as-a-service/pull/1159
-	// g.Expect(updated.Finalizers).To(ContainElement(tenantFinalizer))
-	g.Expect(updated.Finalizers).To(BeEmpty(), "tenant-cleanup finalizer temporarily disabled")
+	g.Expect(updated.Finalizers).To(ContainElement(tenantFinalizer))
 }
 
 func TestTenantReconcile_DefaultTenantStripsLegacyCleanupFinalizer(t *testing.T) {
@@ -290,10 +287,7 @@ func TestTenantReconcile_AITenantManagedAddsCleanupFinalizer(t *testing.T) {
 
 	var updated maasv1alpha1.MaasTenantConfig
 	g.Expect(cl.Get(context.Background(), client.ObjectKey{Name: maasv1alpha1.MaasTenantConfigInstanceName, Namespace: testNS}, &updated)).To(Succeed())
-	// Unblocking UI / Config GC teardown
-	// TODO: Include adding the finalizer back as part of https://github.com/opendatahub-io/models-as-a-service/pull/1159
-	// g.Expect(updated.Finalizers).To(ContainElement("maas.opendatahub.io/tenant-cleanup"))
-	g.Expect(updated.Finalizers).To(BeEmpty(), "tenant-cleanup finalizer temporarily disabled")
+	g.Expect(updated.Finalizers).To(ContainElement("maas.opendatahub.io/tenant-cleanup"))
 }
 
 func TestTenantReconcile_AITenantManagedDefaultDeletionCleansPlatformResources(t *testing.T) {

--- a/test/e2e/tests/test_aitenant_lifecycle.py
+++ b/test/e2e/tests/test_aitenant_lifecycle.py
@@ -502,29 +502,27 @@ class TestAITenantLifecycle:
             _delete_best_effort("gateway", gateway_name, GATEWAY_NAMESPACE)
             _delete_best_effort("namespace", tenant_ns, timeout="90s")
 
-    # Unblocking UI
-    # TODO: Include adding the finalizer back as part of https://github.com/opendatahub-io/models-as-a-service/pull/1159
-    # def test_aitenant_delete_cleans_up_bootstrap_resources(self):
-    #     case = _new_aitenant_case()
-    #
-    #     try:
-    #         _apply_gateway_fixture(case)
-    #         _apply_aitenant(case)
-    #         _assert_aitenant_bootstrap_resources(case)
-    #
-    #         _delete_aitenant(case)
-    #         _wait_for_not_found(TENANT_CONFIG_KIND, TENANT_NAME, case["tenant_ns"])
-    #         _wait_for_not_found("role", case["tenant_admin_role"], case["tenant_ns"])
-    #         _wait_for_not_found("role", case["object_admin_role"], AITENANT_NAMESPACE)
-    #         _wait_for_not_found("namespace", case["tenant_ns"], timeout=180)
-    #
-    #         gateway = _get_json_or_none("gateway", case["gateway_name"], GATEWAY_NAMESPACE)
-    #         assert gateway is not None
-    #         assert gateway["metadata"]["labels"]["e2e.maas.opendatahub.io/fixture"] == case["aitenant_name"]
-    #     finally:
-    #         _delete_best_effort(AITENANT_KIND, case["aitenant_name"], AITENANT_NAMESPACE, timeout="180s")
-    #         _delete_best_effort("gateway", case["gateway_name"], GATEWAY_NAMESPACE)
-    #         _delete_best_effort("namespace", case["tenant_ns"], timeout="90s")
+    def test_aitenant_delete_cleans_up_bootstrap_resources(self):
+        case = _new_aitenant_case()
+
+        try:
+            _apply_gateway_fixture(case)
+            _apply_aitenant(case)
+            _assert_aitenant_bootstrap_resources(case)
+
+            _delete_aitenant(case)
+            _wait_for_not_found(TENANT_CONFIG_KIND, TENANT_NAME, case["tenant_ns"])
+            _wait_for_not_found("role", case["tenant_admin_role"], case["tenant_ns"])
+            _wait_for_not_found("role", case["object_admin_role"], AITENANT_NAMESPACE)
+            _wait_for_not_found("namespace", case["tenant_ns"], timeout=180)
+
+            gateway = _get_json_or_none("gateway", case["gateway_name"], GATEWAY_NAMESPACE)
+            assert gateway is not None
+            assert gateway["metadata"]["labels"]["e2e.maas.opendatahub.io/fixture"] == case["aitenant_name"]
+        finally:
+            _delete_best_effort(AITENANT_KIND, case["aitenant_name"], AITENANT_NAMESPACE, timeout="180s")
+            _delete_best_effort("gateway", case["gateway_name"], GATEWAY_NAMESPACE)
+            _delete_best_effort("namespace", case["tenant_ns"], timeout="90s")
 
     def test_aitenant_derives_non_default_tenant_namespace(self):
         """RHOAIENG-66836: non-default AITenant must not use models-as-a-service tenant namespace."""

--- a/test/e2e/tests/test_config_tenant.py
+++ b/test/e2e/tests/test_config_tenant.py
@@ -179,7 +179,7 @@ class TestConfigTenantOwnership:
             "(LifecycleReconciler links the anchor for GC)."
         )
 
-    def test_maas_controller_deployment_lists_config_owner_reference(self):
+    def test_maas_controller_deployment_does_not_list_config_owner_reference(self):
         result = _oc_run(
             [
                 "get",
@@ -204,7 +204,9 @@ class TestConfigTenantOwnership:
             )
         doc = json.loads(result.stdout)
         ref = _ref_to_config(doc.get("metadata", {}).get("ownerReferences"))
-        assert ref is not None, (
-            f"Deployment {CONTROLLER_DEPLOYMENT}/{CONTROLLER_DEPLOY_NS} should list an owner "
-            f"reference to Config/{CONFIG_NAME}."
+        assert ref is None, (
+            f"Deployment {CONTROLLER_DEPLOYMENT}/{CONTROLLER_DEPLOY_NS} should not reference "
+            f"Config/{CONFIG_NAME}: the controller's own workload must keep running independent "
+            "of Config's lifecycle (self-heal, TeardownCompletedAnnotation reporting), so it must "
+            "not be a GC dependent of the resource it manages."
         )

--- a/test/e2e/tests/test_multi_tenant_integration.py
+++ b/test/e2e/tests/test_multi_tenant_integration.py
@@ -67,58 +67,56 @@ def _require_multitenancy_prerequisites():
 class TestMultiTenantIntegration:
     """S27 section 7 — multi-tenant integration scenarios."""
 
-    # Unblocking UI
-    # TODO: Include adding the finalizer back as part of https://github.com/opendatahub-io/models-as-a-service/pull/1159
-    # def test_full_tenant_lifecycle_create_to_delete(self):
-    #     """7.1: Full tenant lifecycle from create through policy/subscription reconcile to delete."""
-    #     case = new_discovery_case()
-    #     role_name = f"aitenant-{case['tenant_label_name']}-tenant-admin"
-    #     try:
-    #         bootstrap_aitenant_tenant(case)
-    #
-    #         tenant = wait_for_json(TENANT_CONFIG_KIND, TENANT_CR_NAME, case["tenant_ns"], timeout=180)
-    #         tenant_labels = tenant["metadata"].get("labels") or {}
-    #         tenant_annotations = tenant["metadata"].get("annotations") or {}
-    #         assert tenant_labels[LABEL_MANAGED_BY_AITENANT] == "true"
-    #         assert tenant_labels[LABEL_TENANT_NAME] == case["tenant_label_name"]
-    #         assert tenant_labels[LABEL_TENANT_NAMESPACE] == case["tenant_ns"]
-    #         assert tenant_annotations[ANNOTATION_AITENANT_NAME] == case["tenant_label_name"]
-    #         assert tenant_annotations[ANNOTATION_AITENANT_NAMESPACE] == AITENANT_NAMESPACE
-    #         aitenant = wait_for_json(AITENANT_KIND, case["tenant_label_name"], AITENANT_NAMESPACE, timeout=180)
-    #         assert aitenant["status"]["gatewayRef"]["name"] == case["gateway_name"]
-    #         assert get_json_or_none("role", role_name, case["tenant_ns"]) is not None
-    #
-    #         model_name = f"e2e-lifecycle-model-{case['suffix']}"
-    #         provision_tenant_model(model_name, case["tenant_ns"], case["gateway_name"])
-    #
-    #         apply_maas_auth_policy(
-    #             case["policy_name"],
-    #             case["tenant_ns"],
-    #             model_ref=model_name,
-    #             model_namespace=case["tenant_ns"],
-    #         )
-    #         apply_maas_subscription(
-    #             case["subscription_name"],
-    #             case["tenant_ns"],
-    #             model_ref=model_name,
-    #             model_namespace=case["tenant_ns"],
-    #         )
-    #         wait_for_status_phase("maasauthpolicy", case["policy_name"], case["tenant_ns"], expected_phase="Active")
-    #         wait_for_status_phase(
-    #             "maassubscription",
-    #             case["subscription_name"],
-    #             case["tenant_ns"],
-    #             expected_phase="Active",
-    #         )
-    #         wait_for_aitenant_cleanup_resources(case)
-    #
-    #         delete_best_effort(AITENANT_KIND, case["tenant_label_name"], AITENANT_NAMESPACE, timeout="180s")
-    #         wait_for_not_found(TENANT_CONFIG_KIND, TENANT_CR_NAME, case["tenant_ns"], timeout=180)
-    #         wait_for_not_found("role", role_name, case["tenant_ns"], timeout=180)
-    #         wait_for_not_found("namespace", case["tenant_ns"], timeout=180)
-    #         wait_for_aitenant_cleanup_resources_deleted(case)
-    #     finally:
-    #         cleanup_discovery_case(case)
+    def test_full_tenant_lifecycle_create_to_delete(self):
+        """7.1: Full tenant lifecycle from create through policy/subscription reconcile to delete."""
+        case = new_discovery_case()
+        role_name = f"aitenant-{case['tenant_label_name']}-tenant-admin"
+        try:
+            bootstrap_aitenant_tenant(case)
+
+            tenant = wait_for_json(TENANT_CONFIG_KIND, TENANT_CR_NAME, case["tenant_ns"], timeout=180)
+            tenant_labels = tenant["metadata"].get("labels") or {}
+            tenant_annotations = tenant["metadata"].get("annotations") or {}
+            assert tenant_labels[LABEL_MANAGED_BY_AITENANT] == "true"
+            assert tenant_labels[LABEL_TENANT_NAME] == case["tenant_label_name"]
+            assert tenant_labels[LABEL_TENANT_NAMESPACE] == case["tenant_ns"]
+            assert tenant_annotations[ANNOTATION_AITENANT_NAME] == case["tenant_label_name"]
+            assert tenant_annotations[ANNOTATION_AITENANT_NAMESPACE] == AITENANT_NAMESPACE
+            aitenant = wait_for_json(AITENANT_KIND, case["tenant_label_name"], AITENANT_NAMESPACE, timeout=180)
+            assert aitenant["status"]["gatewayRef"]["name"] == case["gateway_name"]
+            assert get_json_or_none("role", role_name, case["tenant_ns"]) is not None
+
+            model_name = f"e2e-lifecycle-model-{case['suffix']}"
+            provision_tenant_model(model_name, case["tenant_ns"], case["gateway_name"])
+
+            apply_maas_auth_policy(
+                case["policy_name"],
+                case["tenant_ns"],
+                model_ref=model_name,
+                model_namespace=case["tenant_ns"],
+            )
+            apply_maas_subscription(
+                case["subscription_name"],
+                case["tenant_ns"],
+                model_ref=model_name,
+                model_namespace=case["tenant_ns"],
+            )
+            wait_for_status_phase("maasauthpolicy", case["policy_name"], case["tenant_ns"], expected_phase="Active")
+            wait_for_status_phase(
+                "maassubscription",
+                case["subscription_name"],
+                case["tenant_ns"],
+                expected_phase="Active",
+            )
+            wait_for_aitenant_cleanup_resources(case)
+
+            delete_best_effort(AITENANT_KIND, case["tenant_label_name"], AITENANT_NAMESPACE, timeout="180s")
+            wait_for_not_found(TENANT_CONFIG_KIND, TENANT_CR_NAME, case["tenant_ns"], timeout=180)
+            wait_for_not_found("role", role_name, case["tenant_ns"], timeout=180)
+            wait_for_not_found("namespace", case["tenant_ns"], timeout=180)
+            wait_for_aitenant_cleanup_resources_deleted(case)
+        finally:
+            cleanup_discovery_case(case)
 
     def test_default_tenant_unaffected_by_multitenancy_enablement(self):
         """7.2: Default tenant namespace still reconciles while discovery mode is enabled."""


### PR DESCRIPTION
## Summary
Cherry-pick onto `stable` everything from `main` through Ryan's [#1159](https://github.com/opendatahub-io/models-as-a-service/pull/1159) (`637625bd`), and nothing after that.

## Description
Target commit set (in order):

| Commit | PR | Status |
| --- | --- | --- |
| `53214b55` | [#1188](https://github.com/opendatahub-io/models-as-a-service/pull/1188) | Already on `stable` via [#1197](https://github.com/opendatahub-io/models-as-a-service/pull/1197) |
| `b7d02895` | [#1195](https://github.com/opendatahub-io/models-as-a-service/pull/1195) | Already on `stable` via [#1197](https://github.com/opendatahub-io/models-as-a-service/pull/1197) |
| `ad76b358` | [#922](https://github.com/opendatahub-io/models-as-a-service/pull/922) | Cherry-picked in this PR |
| `637625bd` | [#1159](https://github.com/opendatahub-io/models-as-a-service/pull/1159) | Cherry-picked in this PR |

**Excluded** (intentionally — landed after `#1159` on `main`):
- `#1199` — surface infra namespace in MaasTenantConfig status
- `#1032` — OTel Collector for usage logs
- `#1130` — request body size limit (FIND-011)
- `#1117` — gateway host / HTTPS probe URL checks (FIND-010)

## How it was tested
- Both cherry-picks applied cleanly onto current `upstream/stable`.
- Diff for `#922` and `#1159` matches the corresponding commits on `main`.

## Risk analysis
- **Risk rating**: 3
- **Why**: Includes `#1159` controller self-teardown behavior (lifecycle/teardown path) already merged to `main`, plus a small TLS `nextProtos` change from `#922`. No commits after `#1159`.