### PR TITLE
fix: add ext_proc timeout settings to EnvoyFilter template

### DIFF
--- a/deployment/base/payload-processing/manager/envoy-filter.yaml
+++ b/deployment/base/payload-processing/manager/envoy-filter.yaml
@@ -36,6 +36,8 @@ spec:
             grpc_service:
               envoy_grpc:
                 cluster_name: outbound|9004||payload-pre-processing.openshift-ingress.svc.cluster.local
+              timeout: 300s
+            message_timeout: 300s
     # Stage 2: must run AFTER the WasmPlugin (needs auth to have completed).
     - applyTo: HTTP_FILTER
       match:
@@ -64,6 +66,8 @@ spec:
             grpc_service:
               envoy_grpc:
                 cluster_name: outbound|9004||payload-processing.openshift-ingress.svc.cluster.local
+              timeout: 300s
+            message_timeout: 300s
     # RHCL 1.4 injects auth via envoy.filters.http.wasm (no WasmPlugin CR). Only one anchor
     # pair matches per cluster: WasmPlugin on ODH/community Kuadrant, wasm filter on RHCL 1.4.
     - applyTo: HTTP_FILTER
@@ -92,6 +96,8 @@ spec:
             grpc_service:
               envoy_grpc:
                 cluster_name: outbound|9004||payload-pre-processing.openshift-ingress.svc.cluster.local
+              timeout: 300s
+            message_timeout: 300s
     - applyTo: HTTP_FILTER
       match:
         context: GATEWAY
@@ -119,6 +125,8 @@ spec:
             grpc_service:
               envoy_grpc:
                 cluster_name: outbound|9004||payload-processing.openshift-ingress.svc.cluster.local
+              timeout: 300s
+            message_timeout: 300s
     # Disable ext_proc on all non-inference maas-api routes.
     # Route name follows Istio's Gateway API naming: <namespace>.<httproute-name>.<rule-index>
     # Rule indices correspond to httproute.yaml rules:


### PR DESCRIPTION
## Summary
- Added `timeout: 300s` and `message_timeout: 300s` to all 4 ext_proc blocks in the EnvoyFilter template

## Problem
The EnvoyFilter template for ext_proc filters does not set explicit `message_timeout` or `grpc_service.timeout` values. Without these, Envoy uses very short defaults that cause timeout errors on large-context streaming requests where Time To First Token (TTFT) exceeds the default.

Users see a timeout error on large-context requests, which resolves once the first token arrives — but the client reports an error.

## Fix
Set both `timeout: 300s` (gRPC service timeout) and `message_timeout: 300s` (per-message processing timeout) on all 4 ext_proc blocks (ipp-pre and ipp, for both WasmPlugin and wasm filter variants), matching the HTTPRoute request timeout.

## Test plan
- [x] Applied fix to dogfood cluster (sandbox311)
- [x] Verified 58K-token (322KB) streaming request completes without timeout errors
- [x] Verified normal-sized requests still work

## Risk analysis
- **Risk rating**: 1
- **Why**: deployment config only, no Go code changes. The timeout values match the already-configured HTTPRoute timeout. Omitting them caused the bug; adding them restores expected behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the external processing timeout to 300 seconds across supported request-processing flows.
  * Helps prevent interruptions during longer-running operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->