### PR TITLE
feat: detect and surface MaaSModelRef model-identity collisions

### DIFF
--- a/deployment/base/maas-controller/crd/bases/maas.opendatahub.io_maasmodelrefs.yaml
+++ b/deployment/base/maas-controller/crd/bases/maas.opendatahub.io_maasmodelrefs.yaml
@@ -117,6 +117,11 @@ spec:
                   or UIDs appear in any status field.
                 - RuntimeReady: whether the model backend is healthy and serving, independent
                   of governance state.
+                - ModelIdentityUnique: whether this model's ResolvedModelAlias collides with
+                  another MaaSModelRef in the same namespace. False on a collision — body-based
+                  routing cannot disambiguate two MaaSModelRefs with the same resolved alias, so
+                  requests may be routed to the wrong backend/subscription. Informational only;
+                  does not affect Phase.
             properties:
               conditions:
                 description: |-
@@ -125,6 +130,8 @@ spec:
                     - Ready: overall readiness (governance + runtime).
                     - GovernanceAttached: active MaaSSubscription + MaaSAuthPolicy pairing exists.
                     - RuntimeReady: backend is healthy and serving.
+                    - ModelIdentityUnique: no other MaaSModelRef in this namespace resolves to the
+                      same model alias (see MaaSModelStatus doc for details).
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.

--- a/docs/samples/models/README.md
+++ b/docs/samples/models/README.md
@@ -53,6 +53,14 @@ The two simulator models can be distinguished by:
   - Standard: `facebook-opt-125m-simulated`
   - Premium: `premium-simulated-simulated-premium`
 
+- **Model identity** (`spec.model.name`, used by body-based routing):
+  - Standard: `facebook/opt-125m`
+  - Premium: `facebook/opt-125m-premium`
+
+  These must stay distinct — two `MaaSModelRef`s that resolve to the same model
+  identity in the same namespace cannot be disambiguated by body-based routing
+  (see `ModelIdentityUnique` on `MaaSModelRef.status.conditions`).
+
 Subscription-based access is configured via MaaSAuthPolicy and MaaSSubscription (see [docs/samples/maas-system/](../maas-system/)), not via LLMInferenceService annotations.
 
 ### Verifying Deployment

--- a/maas-controller/api/maas/v1alpha1/maasmodelref_types.go
+++ b/maas-controller/api/maas/v1alpha1/maasmodelref_types.go
@@ -91,6 +91,11 @@ type ModelReference struct {
 //     or UIDs appear in any status field.
 //   - RuntimeReady: whether the model backend is healthy and serving, independent
 //     of governance state.
+//   - ModelIdentityUnique: whether this model's ResolvedModelAlias collides with
+//     another MaaSModelRef in the same namespace. False on a collision — body-based
+//     routing cannot disambiguate two MaaSModelRefs with the same resolved alias, so
+//     requests may be routed to the wrong backend/subscription. Informational only;
+//     does not affect Phase.
 type MaaSModelStatus struct {
 	// Phase represents the current phase of the model.
 	// Pending = awaiting governance pairing or backend readiness.
@@ -143,6 +148,8 @@ type MaaSModelStatus struct {
 	//   - Ready: overall readiness (governance + runtime).
 	//   - GovernanceAttached: active MaaSSubscription + MaaSAuthPolicy pairing exists.
 	//   - RuntimeReady: backend is healthy and serving.
+	//   - ModelIdentityUnique: no other MaaSModelRef in this namespace resolves to the
+	//     same model alias (see MaaSModelStatus doc for details).
 	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }

--- a/maas-controller/pkg/controller/maas/maasmodelref_controller.go
+++ b/maas-controller/pkg/controller/maas/maasmodelref_controller.go
@@ -527,9 +527,28 @@ func (r *MaaSModelRefReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		// current: a newly created/deleted sibling, or one whose resolved alias
 		// changed, can introduce or resolve a conflict for every other model in
 		// the namespace even though those models' own specs didn't change.
-		Watches(&maasv1alpha1.MaaSModelRef{}, handler.EnqueueRequestsFromMapFunc(
-			r.mapModelRefSiblings,
-		), builder.WithPredicates(resolvedModelAliasChangedPredicate{}))
+		//
+		// Only siblings sharing the affected alias are enqueued (not the entire
+		// namespace) to avoid O(N²) fan-out in namespaces with many models.
+		Watches(&maasv1alpha1.MaaSModelRef{}, &handler.Funcs{
+			CreateFunc: func(ctx context.Context, e event.CreateEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+				if m, ok := e.Object.(*maasv1alpha1.MaaSModelRef); ok {
+					r.enqueueSiblingsWithAlias(ctx, m, q, "")
+				}
+			},
+			UpdateFunc: func(ctx context.Context, e event.UpdateEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+				oldM, ok1 := e.ObjectOld.(*maasv1alpha1.MaaSModelRef)
+				newM, ok2 := e.ObjectNew.(*maasv1alpha1.MaaSModelRef)
+				if ok1 && ok2 && oldM.Status.ResolvedModelAlias != newM.Status.ResolvedModelAlias {
+					r.enqueueSiblingsWithAlias(ctx, newM, q, oldM.Status.ResolvedModelAlias)
+				}
+			},
+			DeleteFunc: func(ctx context.Context, e event.DeleteEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+				if m, ok := e.Object.(*maasv1alpha1.MaaSModelRef); ok {
+					r.enqueueSiblingsWithAlias(ctx, m, q, "")
+				}
+			},
+		})
 
 	const llmisvcCRD = "llminferenceservices.serving.kserve.io"
 	llmisvcExists := crdExists(ctx, mgr.GetAPIReader(), llmisvcCRD)
@@ -625,30 +644,32 @@ func (r *MaaSModelRefReconciler) mapHTTPRouteToMaaSModelRefs(ctx context.Context
 	return requests
 }
 
-// mapModelRefSiblings returns reconcile requests for every other MaaSModelRef
-// in the same namespace as the changed one, so model-identity-conflict
-// detection re-evaluates when a sibling's resolved alias appears, disappears,
-// or changes.
-func (r *MaaSModelRefReconciler) mapModelRefSiblings(ctx context.Context, obj client.Object) []reconcile.Request {
-	changed, ok := obj.(*maasv1alpha1.MaaSModelRef)
-	if !ok {
-		return nil
+// enqueueSiblingsWithAlias enqueues only the sibling MaaSModelRefs whose
+// ResolvedModelAlias matches the current alias of the changed object or, on an
+// update, the previous alias (so siblings that previously conflicted can clear
+// their condition). Empty aliases are skipped — they cannot produce collisions.
+func (r *MaaSModelRefReconciler) enqueueSiblingsWithAlias(ctx context.Context, changed *maasv1alpha1.MaaSModelRef, q workqueue.TypedRateLimitingInterface[reconcile.Request], oldAlias string) {
+	if changed == nil {
+		return
+	}
+	newAlias := changed.Status.ResolvedModelAlias
+	if newAlias == "" && oldAlias == "" {
+		return
 	}
 	var siblings maasv1alpha1.MaaSModelRefList
 	if err := r.List(ctx, &siblings, client.InNamespace(changed.Namespace)); err != nil {
 		logr.FromContextOrDiscard(ctx).Error(err, "failed to list sibling MaaSModelRefs", "namespace", changed.Namespace)
-		return nil
+		return
 	}
-	var requests []reconcile.Request
 	for _, m := range siblings.Items {
 		if m.Name == changed.Name {
 			continue
 		}
-		requests = append(requests, reconcile.Request{
-			NamespacedName: types.NamespacedName{Name: m.Name, Namespace: m.Namespace},
-		})
+		if (newAlias != "" && m.Status.ResolvedModelAlias == newAlias) ||
+			(oldAlias != "" && m.Status.ResolvedModelAlias == oldAlias) {
+			q.Add(reconcile.Request{NamespacedName: types.NamespacedName{Name: m.Name, Namespace: m.Namespace}})
+		}
 	}
-	return requests
 }
 
 // mapMaaSSubscriptionToMaaSModelRefs returns reconcile requests for all MaaSModelRefs

--- a/maas-controller/pkg/controller/maas/maasmodelref_controller.go
+++ b/maas-controller/pkg/controller/maas/maasmodelref_controller.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 	"knative.dev/pkg/apis"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -67,6 +68,9 @@ type MaaSModelRefReconciler struct {
 
 	// AITenantNamespace is the infrastructure namespace where AITenant CRs live.
 	AITenantNamespace string
+
+	// Recorder emits Kubernetes events for model identity conflict warnings.
+	Recorder record.EventRecorder
 }
 
 func (r *MaaSModelRefReconciler) gatewayName() string {
@@ -196,6 +200,7 @@ func (r *MaaSModelRefReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	governed := r.checkGovernanceAttached(ctx, model)
 	r.setGovernanceCondition(model, governed)
 	r.setRuntimeReadyCondition(model, runtimeReady)
+	r.checkModelIdentityConflict(ctx, log, model)
 
 	phase, message := deriveModelPhase(governed, runtimeReady)
 	if phase != "Ready" {
@@ -499,6 +504,11 @@ func unstructuredLLMIsvcReadyStatus(obj *unstructured.Unstructured) string {
 
 func (r *MaaSModelRefReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	ctx := context.Background()
+
+	if r.Recorder == nil {
+		r.Recorder = mgr.GetEventRecorderFor("maas-modelref-controller")
+	}
+
 	if err := mgr.GetFieldIndexer().IndexField(ctx, &maasv1alpha1.MaaSModelRef{}, modelRefNameIndex, modelRefNameIndexer); err != nil {
 		return fmt.Errorf("failed to create field index %s: %w", modelRefNameIndex, err)
 	}
@@ -512,7 +522,14 @@ func (r *MaaSModelRefReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		// (fixes race condition where MaaSModelRef is created before HTTPRoute exists).
 		Watches(&gatewayapiv1.HTTPRoute{}, handler.EnqueueRequestsFromMapFunc(
 			r.mapHTTPRouteToMaaSModelRefs,
-		))
+		)).
+		// Watch sibling MaaSModelRefs so model-identity-conflict detection stays
+		// current: a newly created/deleted sibling, or one whose resolved alias
+		// changed, can introduce or resolve a conflict for every other model in
+		// the namespace even though those models' own specs didn't change.
+		Watches(&maasv1alpha1.MaaSModelRef{}, handler.EnqueueRequestsFromMapFunc(
+			r.mapModelRefSiblings,
+		), builder.WithPredicates(resolvedModelAliasChangedPredicate{}))
 
 	const llmisvcCRD = "llminferenceservices.serving.kserve.io"
 	llmisvcExists := crdExists(ctx, mgr.GetAPIReader(), llmisvcCRD)
@@ -601,6 +618,32 @@ func (r *MaaSModelRefReconciler) mapHTTPRouteToMaaSModelRefs(ctx context.Context
 	}
 	var requests []reconcile.Request
 	for _, m := range models.Items {
+		requests = append(requests, reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: m.Name, Namespace: m.Namespace},
+		})
+	}
+	return requests
+}
+
+// mapModelRefSiblings returns reconcile requests for every other MaaSModelRef
+// in the same namespace as the changed one, so model-identity-conflict
+// detection re-evaluates when a sibling's resolved alias appears, disappears,
+// or changes.
+func (r *MaaSModelRefReconciler) mapModelRefSiblings(ctx context.Context, obj client.Object) []reconcile.Request {
+	changed, ok := obj.(*maasv1alpha1.MaaSModelRef)
+	if !ok {
+		return nil
+	}
+	var siblings maasv1alpha1.MaaSModelRefList
+	if err := r.List(ctx, &siblings, client.InNamespace(changed.Namespace)); err != nil {
+		logr.FromContextOrDiscard(ctx).Error(err, "failed to list sibling MaaSModelRefs", "namespace", changed.Namespace)
+		return nil
+	}
+	var requests []reconcile.Request
+	for _, m := range siblings.Items {
+		if m.Name == changed.Name {
+			continue
+		}
 		requests = append(requests, reconcile.Request{
 			NamespacedName: types.NamespacedName{Name: m.Name, Namespace: m.Namespace},
 		})

--- a/maas-controller/pkg/controller/maas/maasmodelref_controller_test.go
+++ b/maas-controller/pkg/controller/maas/maasmodelref_controller_test.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/util/workqueue"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -40,6 +41,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	maasv1alpha1 "github.com/opendatahub-io/models-as-a-service/maas-controller/api/maas/v1alpha1"
@@ -1446,5 +1448,192 @@ func TestRegisterWatchWhenCRDAppears_OnlyFiredForMatchingCRD(t *testing.T) {
 
 	if called != 1 {
 		t.Errorf("makeSource called %d times, want 1", called)
+	}
+}
+
+// TestCheckModelIdentityConflict_AliasNotResolved verifies that when
+// ResolvedModelAlias is blank, the condition is set to Unknown.
+func TestCheckModelIdentityConflict_AliasNotResolved(t *testing.T) {
+	model := &maasv1alpha1.MaaSModelRef{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-model", Namespace: "default", Generation: 1},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := &MaaSModelRefReconciler{Client: c, Scheme: scheme}
+
+	r.checkModelIdentityConflict(context.Background(), ctrl.Log.WithName("test"), model)
+
+	cond := findCondition(model.Status.Conditions, ConditionModelIdentityUnique)
+	if cond == nil {
+		t.Fatal("ModelIdentityUnique condition not set")
+	}
+	if cond.Status != metav1.ConditionUnknown {
+		t.Errorf("expected Unknown, got %v", cond.Status)
+	}
+	if cond.Reason != "AliasNotResolved" {
+		t.Errorf("expected reason AliasNotResolved, got %q", cond.Reason)
+	}
+	if cond.ObservedGeneration != 1 {
+		t.Errorf("expected observedGeneration 1, got %d", cond.ObservedGeneration)
+	}
+}
+
+// TestCheckModelIdentityConflict_NoConflicts verifies that when the alias is
+// resolved and unique, the condition is True.
+func TestCheckModelIdentityConflict_NoConflicts(t *testing.T) {
+	model := &maasv1alpha1.MaaSModelRef{
+		ObjectMeta: metav1.ObjectMeta{Name: "model-a", Namespace: "default", Generation: 1},
+		Status:     maasv1alpha1.MaaSModelStatus{ResolvedModelAlias: "publishers/default/models/unique-model"},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(model).
+		WithStatusSubresource(&maasv1alpha1.MaaSModelRef{}).
+		Build()
+	r := &MaaSModelRefReconciler{Client: c, Scheme: scheme}
+
+	r.checkModelIdentityConflict(context.Background(), ctrl.Log.WithName("test"), model)
+
+	cond := findCondition(model.Status.Conditions, ConditionModelIdentityUnique)
+	if cond == nil {
+		t.Fatal("ModelIdentityUnique condition not set")
+	}
+	if cond.Status != metav1.ConditionTrue {
+		t.Errorf("expected True, got %v", cond.Status)
+	}
+	if cond.Reason != "UniqueIdentity" {
+		t.Errorf("expected reason UniqueIdentity, got %q", cond.Reason)
+	}
+}
+
+// TestCheckModelIdentityConflict_ConflictDetected verifies that when two
+// MaaSModelRefs share the same ResolvedModelAlias, the condition is False.
+func TestCheckModelIdentityConflict_ConflictDetected(t *testing.T) {
+	const sharedAlias = "publishers/default/models/shared-model"
+
+	modelA := &maasv1alpha1.MaaSModelRef{
+		ObjectMeta: metav1.ObjectMeta{Name: "model-a", Namespace: "default", Generation: 1},
+		Status:     maasv1alpha1.MaaSModelStatus{ResolvedModelAlias: sharedAlias},
+	}
+	modelB := &maasv1alpha1.MaaSModelRef{
+		ObjectMeta: metav1.ObjectMeta{Name: "model-b", Namespace: "default"},
+		Status:     maasv1alpha1.MaaSModelStatus{ResolvedModelAlias: sharedAlias},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(modelA, modelB).
+		WithStatusSubresource(&maasv1alpha1.MaaSModelRef{}).
+		Build()
+	r := &MaaSModelRefReconciler{Client: c, Scheme: scheme}
+
+	r.checkModelIdentityConflict(context.Background(), ctrl.Log.WithName("test"), modelA)
+
+	cond := findCondition(modelA.Status.Conditions, ConditionModelIdentityUnique)
+	if cond == nil {
+		t.Fatal("ModelIdentityUnique condition not set")
+	}
+	if cond.Status != metav1.ConditionFalse {
+		t.Errorf("expected False, got %v", cond.Status)
+	}
+	if cond.Reason != "ModelNameConflict" {
+		t.Errorf("expected reason ModelNameConflict, got %q", cond.Reason)
+	}
+}
+
+func findCondition(conditions []metav1.Condition, condType string) *metav1.Condition {
+	for i := range conditions {
+		if conditions[i].Type == condType {
+			return &conditions[i]
+		}
+	}
+	return nil
+}
+
+// fakeQueue collects enqueued requests without rate-limiting.
+type fakeQueue struct {
+	workqueue.TypedRateLimitingInterface[reconcile.Request]
+	items []reconcile.Request
+}
+
+func (q *fakeQueue) Add(item reconcile.Request) { q.items = append(q.items, item) }
+
+func TestEnqueueSiblingsWithAlias(t *testing.T) {
+	const (
+		aliasA = "publishers/default/models/a"
+		aliasB = "publishers/default/models/b"
+		ns     = "default"
+	)
+
+	modelA := &maasv1alpha1.MaaSModelRef{
+		ObjectMeta: metav1.ObjectMeta{Name: "model-a", Namespace: ns},
+		Status:     maasv1alpha1.MaaSModelStatus{ResolvedModelAlias: aliasA},
+	}
+	modelB := &maasv1alpha1.MaaSModelRef{
+		ObjectMeta: metav1.ObjectMeta{Name: "model-b", Namespace: ns},
+		Status:     maasv1alpha1.MaaSModelStatus{ResolvedModelAlias: aliasA},
+	}
+	modelC := &maasv1alpha1.MaaSModelRef{
+		ObjectMeta: metav1.ObjectMeta{Name: "model-c", Namespace: ns},
+		Status:     maasv1alpha1.MaaSModelStatus{ResolvedModelAlias: aliasB},
+	}
+	modelNoAlias := &maasv1alpha1.MaaSModelRef{
+		ObjectMeta: metav1.ObjectMeta{Name: "model-none", Namespace: ns},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(modelA, modelB, modelC, modelNoAlias).
+		WithStatusSubresource(&maasv1alpha1.MaaSModelRef{}).
+		Build()
+	r := &MaaSModelRefReconciler{Client: c, Scheme: scheme}
+
+	tests := []struct {
+		name     string
+		changed  *maasv1alpha1.MaaSModelRef
+		oldAlias string
+		want     []string
+	}{
+		{
+			name:    "create with aliasA enqueues only model-b",
+			changed: modelA,
+			want:    []string{"model-b"},
+		},
+		{
+			name:     "alias change from A to B enqueues model-b (old) and model-c (new)",
+			changed:  &maasv1alpha1.MaaSModelRef{ObjectMeta: metav1.ObjectMeta{Name: "model-a", Namespace: ns}, Status: maasv1alpha1.MaaSModelStatus{ResolvedModelAlias: aliasB}},
+			oldAlias: aliasA,
+			want:     []string{"model-b", "model-c"},
+		},
+		{
+			name:    "empty alias skips enqueue",
+			changed: modelNoAlias,
+			want:    nil,
+		},
+		{
+			name:    "create with aliasB enqueues only model-c",
+			changed: modelC,
+			want:    nil, // model-c is the changed object itself — no other aliasB siblings
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			q := &fakeQueue{}
+			r.enqueueSiblingsWithAlias(context.Background(), tc.changed, q, tc.oldAlias)
+			var got []string
+			for _, req := range q.items {
+				got = append(got, req.Name)
+			}
+			if len(got) != len(tc.want) {
+				t.Fatalf("enqueued %v, want %v", got, tc.want)
+			}
+			for i, name := range tc.want {
+				if got[i] != name {
+					t.Errorf("enqueued[%d] = %q, want %q", i, got[i], name)
+				}
+			}
+		})
 	}
 }

--- a/maas-controller/pkg/controller/maas/model_identity_conflict.go
+++ b/maas-controller/pkg/controller/maas/model_identity_conflict.go
@@ -26,7 +26,6 @@ import (
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/event"
 
 	maasv1alpha1 "github.com/opendatahub-io/models-as-a-service/maas-controller/api/maas/v1alpha1"
 )
@@ -78,6 +77,17 @@ func (r *MaaSModelRefReconciler) findModelAliasConflicts(ctx context.Context, mo
 // visible via `kubectl describe`/`oc get events` without spamming an event on
 // every reconcile.
 func (r *MaaSModelRefReconciler) checkModelIdentityConflict(ctx context.Context, log logr.Logger, model *maasv1alpha1.MaaSModelRef) {
+	if model.Status.ResolvedModelAlias == "" {
+		apimeta.SetStatusCondition(&model.Status.Conditions, metav1.Condition{
+			Type:               ConditionModelIdentityUnique,
+			Status:             metav1.ConditionUnknown,
+			Reason:             "AliasNotResolved",
+			Message:            "Model alias has not been resolved yet; conflict status is unknown",
+			ObservedGeneration: model.GetGeneration(),
+		})
+		return
+	}
+
 	prev := apimeta.FindStatusCondition(model.Status.Conditions, ConditionModelIdentityUnique)
 
 	conflicts, err := r.findModelAliasConflicts(ctx, model)
@@ -158,26 +168,4 @@ func pluralS(n int) string {
 		return ""
 	}
 	return "s"
-}
-
-// resolvedModelAliasChangedPredicate fires on Create/Delete of any MaaSModelRef
-// (a new sibling may introduce or remove a conflict) and on Update only when
-// status.resolvedModelAlias changed — this keeps conflict detection reactive
-// without re-triggering siblings on unrelated status churn (e.g. endpoint or
-// runtime-readiness changes).
-type resolvedModelAliasChangedPredicate struct{}
-
-func (resolvedModelAliasChangedPredicate) Create(event.CreateEvent) bool   { return true }
-func (resolvedModelAliasChangedPredicate) Delete(event.DeleteEvent) bool   { return true }
-func (resolvedModelAliasChangedPredicate) Generic(event.GenericEvent) bool { return false }
-func (resolvedModelAliasChangedPredicate) Update(e event.UpdateEvent) bool {
-	oldModel, ok := e.ObjectOld.(*maasv1alpha1.MaaSModelRef)
-	if !ok {
-		return true
-	}
-	newModel, ok := e.ObjectNew.(*maasv1alpha1.MaaSModelRef)
-	if !ok {
-		return true
-	}
-	return oldModel.Status.ResolvedModelAlias != newModel.Status.ResolvedModelAlias
 }

--- a/maas-controller/pkg/controller/maas/model_identity_conflict.go
+++ b/maas-controller/pkg/controller/maas/model_identity_conflict.go
@@ -1,0 +1,183 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package maas
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/go-logr/logr"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+
+	maasv1alpha1 "github.com/opendatahub-io/models-as-a-service/maas-controller/api/maas/v1alpha1"
+)
+
+// ConditionModelIdentityUnique indicates whether this MaaSModelRef's resolved
+// model alias (the canonical identity used for body-based routing, e.g.
+// publishers/{namespace}/models/{name}) is unique among other MaaSModelRefs in
+// the same namespace.
+const ConditionModelIdentityUnique = "ModelIdentityUnique"
+
+// findModelAliasConflicts returns the (sorted) names of other MaaSModelRefs in
+// the same namespace whose ResolvedModelAlias collides with this model's alias.
+//
+// Body-based routing (BBR) selects a backend using the model identity carried
+// in the request (e.g. the "model" field or x-gateway-model-name header) —
+// it has no notion of which MaaSModelRef/subscription the caller intended.
+// When two MaaSModelRefs resolve to the same alias (most commonly because two
+// LLMInferenceServices in the same namespace declare the same spec.model.name),
+// a request can be matched against the wrong backend and/or evaluated against
+// the wrong subscription, causing spurious "subscription does not include
+// model" denials or, worse, silently serving the wrong model.
+func (r *MaaSModelRefReconciler) findModelAliasConflicts(ctx context.Context, model *maasv1alpha1.MaaSModelRef) ([]string, error) {
+	if model.Status.ResolvedModelAlias == "" {
+		return nil, nil
+	}
+
+	var siblings maasv1alpha1.MaaSModelRefList
+	if err := r.List(ctx, &siblings, client.InNamespace(model.Namespace)); err != nil {
+		return nil, fmt.Errorf("list MaaSModelRefs in namespace %s: %w", model.Namespace, err)
+	}
+
+	var conflicts []string
+	for i := range siblings.Items {
+		other := &siblings.Items[i]
+		if other.Name == model.Name {
+			continue
+		}
+		if other.Status.ResolvedModelAlias == model.Status.ResolvedModelAlias {
+			conflicts = append(conflicts, other.Name)
+		}
+	}
+	sort.Strings(conflicts)
+	return conflicts, nil
+}
+
+// checkModelIdentityConflict detects sibling MaaSModelRefs that resolve to the
+// same model alias, updates the ModelIdentityUnique condition, and emits a
+// Warning/Normal event on transition (detected/resolved) so the conflict is
+// visible via `kubectl describe`/`oc get events` without spamming an event on
+// every reconcile.
+func (r *MaaSModelRefReconciler) checkModelIdentityConflict(ctx context.Context, log logr.Logger, model *maasv1alpha1.MaaSModelRef) {
+	prev := apimeta.FindStatusCondition(model.Status.Conditions, ConditionModelIdentityUnique)
+
+	conflicts, err := r.findModelAliasConflicts(ctx, model)
+	if err != nil {
+		log.Error(err, "failed to check for model identity conflicts")
+		apimeta.SetStatusCondition(&model.Status.Conditions, metav1.Condition{
+			Type:               ConditionModelIdentityUnique,
+			Status:             metav1.ConditionUnknown,
+			Reason:             "ConflictCheckFailed",
+			Message:            err.Error(),
+			ObservedGeneration: model.GetGeneration(),
+		})
+		return
+	}
+	setModelIdentityCondition(model, conflicts)
+
+	curr := apimeta.FindStatusCondition(model.Status.Conditions, ConditionModelIdentityUnique)
+	if curr == nil || r.Recorder == nil {
+		return
+	}
+
+	shouldEmitConflictEvent := curr.Status == metav1.ConditionFalse &&
+		(prev == nil || prev.Status != curr.Status || prev.Message != curr.Message)
+	if shouldEmitConflictEvent {
+		r.Recorder.Eventf(model, "Warning", "ModelNameConflict",
+			"Model identity %q is shared with %d other MaaSModelRef%s in this namespace: %s",
+			model.Status.ResolvedModelAlias, len(conflicts), pluralS(len(conflicts)), strings.Join(conflicts, ", "))
+	}
+
+	shouldEmitResolvedEvent := curr.Status == metav1.ConditionTrue &&
+		prev != nil && prev.Status == metav1.ConditionFalse
+	if shouldEmitResolvedEvent {
+		r.Recorder.Event(model, "Normal", "ModelNameConflictResolved",
+			"Model identity is no longer shared with any other MaaSModelRef in this namespace")
+	}
+}
+
+// setModelIdentityCondition updates the ModelIdentityUnique condition on a
+// MaaSModelRef based on the sibling MaaSModelRef names that resolve to the
+// same model alias. This is purely informational — it does not affect Phase —
+// so an existing, previously-working deployment does not regress just because
+// two models happen to share a name.
+func setModelIdentityCondition(model *maasv1alpha1.MaaSModelRef, conflicts []string) {
+	if len(conflicts) == 0 {
+		apimeta.SetStatusCondition(&model.Status.Conditions, metav1.Condition{
+			Type:               ConditionModelIdentityUnique,
+			Status:             metav1.ConditionTrue,
+			Reason:             "UniqueIdentity",
+			Message:            "No other MaaSModelRef in this namespace resolves to the same model identity",
+			ObservedGeneration: model.GetGeneration(),
+		})
+		return
+	}
+
+	msg := fmt.Sprintf(
+		"Model identity %q is shared with %d other MaaSModelRef%s in namespace %s: %s. "+
+			"Body-based routing selects a backend by model identity alone and cannot "+
+			"disambiguate MaaSModelRefs that resolve to the same identity — requests may be "+
+			"routed to the wrong backend or evaluated against the wrong subscription. "+
+			"Give each model a unique spec.model.name to resolve this.",
+		model.Status.ResolvedModelAlias, len(conflicts), pluralS(len(conflicts)), model.Namespace, strings.Join(conflicts, ", "),
+	)
+	if len(msg) > 1024 {
+		msg = msg[:1021] + "..."
+	}
+
+	apimeta.SetStatusCondition(&model.Status.Conditions, metav1.Condition{
+		Type:               ConditionModelIdentityUnique,
+		Status:             metav1.ConditionFalse,
+		Reason:             "ModelNameConflict",
+		Message:            msg,
+		ObservedGeneration: model.GetGeneration(),
+	})
+}
+
+func pluralS(n int) string {
+	if n == 1 {
+		return ""
+	}
+	return "s"
+}
+
+// resolvedModelAliasChangedPredicate fires on Create/Delete of any MaaSModelRef
+// (a new sibling may introduce or remove a conflict) and on Update only when
+// status.resolvedModelAlias changed — this keeps conflict detection reactive
+// without re-triggering siblings on unrelated status churn (e.g. endpoint or
+// runtime-readiness changes).
+type resolvedModelAliasChangedPredicate struct{}
+
+func (resolvedModelAliasChangedPredicate) Create(event.CreateEvent) bool   { return true }
+func (resolvedModelAliasChangedPredicate) Delete(event.DeleteEvent) bool   { return true }
+func (resolvedModelAliasChangedPredicate) Generic(event.GenericEvent) bool { return false }
+func (resolvedModelAliasChangedPredicate) Update(e event.UpdateEvent) bool {
+	oldModel, ok := e.ObjectOld.(*maasv1alpha1.MaaSModelRef)
+	if !ok {
+		return true
+	}
+	newModel, ok := e.ObjectNew.(*maasv1alpha1.MaaSModelRef)
+	if !ok {
+		return true
+	}
+	return oldModel.Status.ResolvedModelAlias != newModel.Status.ResolvedModelAlias
+}

--- a/test/e2e/fixtures/unconfigured/llm/llmis.yaml
+++ b/test/e2e/fixtures/unconfigured/llm/llmis.yaml
@@ -1,0 +1,79 @@
+apiVersion: serving.kserve.io/v1alpha1
+kind: LLMInferenceService
+metadata:
+  name: e2e-unconfigured-facebook-opt-125m-simulated
+spec:
+  model:
+    # uri is required by the LLMIS schema but not used by llm-d-inference-sim.
+    uri: hf://placeholder/no-model
+    # Deliberately distinct from facebook/opt-125m (served by the free/premium
+    # samples) so this fixture doesn't collide with them under body-based
+    # routing (ModelIdentityUnique) — this model is only ever reached via
+    # path-based routing to validate default-deny (no subscription attached).
+    name: test/e2e-unconfigured-model
+  # Skip storage-initializer; simulator generates responses without model weights.
+  storageInitializer:
+    enabled: false
+  replicas: 1
+  router:
+    route: {}
+    # Connect to MaaS-enabled gateway
+    gateway:
+      refs:
+        - name: maas-default-gateway
+          namespace: openshift-ingress
+  template:
+    containers:
+      - name: main
+        image: "ghcr.io/llm-d/llm-d-inference-sim:v0.8.2"
+        imagePullPolicy: Always
+        command: ["/app/llm-d-inference-sim"]
+        args:
+        - --port
+        - "8000"
+        - --model
+        - test/e2e-unconfigured-model
+        - --mode
+        - random
+        - --no-mm-encoder-only
+        - --ssl-certfile
+        - /var/run/kserve/tls/tls.crt
+        - --ssl-keyfile
+        - /var/run/kserve/tls/tls.key
+        env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.namespace
+          - name: POD_IP
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: status.podIP
+        ports:
+          - name: https
+            containerPort: 8000
+            protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: https
+            scheme: HTTPS
+        resources:
+          requests:
+            cpu: 100m
+            memory: 256Mi
+          limits:
+            cpu: 500m
+            memory: 512Mi
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: https
+            scheme: HTTPS

--- a/test/e2e/tests/test_helper.py
+++ b/test/e2e/tests/test_helper.py
@@ -1336,7 +1336,9 @@ def _create_llmis(
         namespace: Namespace to create LLMIS in
         gateway_name: Gateway name to route through
         gateway_namespace: Gateway namespace (default: openshift-ingress)
-        model_name: Served model ID (spec.model.name and simulator --model)
+        model_name: spec.model.name (the model identity used for BBR/ResolvedModelAlias).
+            Defaults to "facebook/opt-125m"; override to test model-identity-collision
+            scenarios where two LLMISs intentionally share a model name.
     """
     _apply_cr({
         "apiVersion": "serving.kserve.io/v1alpha1",

--- a/test/e2e/tests/test_model_identity_conflict.py
+++ b/test/e2e/tests/test_model_identity_conflict.py
@@ -1,0 +1,126 @@
+"""
+E2E tests for MaaSModelRef model-identity-conflict detection.
+
+Body-based routing (BBR) selects a backend using the model identity carried in
+the request (the "model" field / x-gateway-model-name header) alone — it has
+no notion of which MaaSModelRef or subscription the caller intended. When two
+MaaSModelRefs in the same namespace resolve to the same model identity (most
+commonly because two LLMInferenceServices declare the same spec.model.name),
+requests can be routed to the wrong backend and/or evaluated against the wrong
+subscription (observed in production as spurious "subscription does not
+include model" denials for facebook/opt-125m served by two distinct
+LLMInferenceServices in the "llm" namespace).
+
+The controller surfaces this as a `ModelIdentityUnique` status condition
+(informational only — it does not affect Phase) plus a Warning/Normal event on
+transition. These tests create an intentional collision, assert detection and
+event emission, then remove it and assert recovery.
+"""
+
+import json
+import uuid
+
+from multitenancy_helpers import DEFAULT_GATEWAY_NAME, _oc_run, wait_for_status_condition
+from test_helper import (
+    GATEWAY_NAMESPACE,
+    MODEL_NAMESPACE,
+    _create_llmis,
+    _create_maas_model_ref,
+    _delete_cr,
+)
+
+CONDITION = "ModelIdentityUnique"
+
+
+def _events_for(name: str, namespace: str, reason: str) -> list[dict]:
+    """Return Kubernetes Events for `reason` involving object `name`, or [] if none/unavailable."""
+    result = _oc_run(
+        [
+            "get",
+            "events",
+            "-n",
+            namespace,
+            "--field-selector",
+            f"involvedObject.name={name},reason={reason}",
+            "-o",
+            "json",
+        ]
+    )
+    if result.returncode != 0:
+        return []
+    return json.loads(result.stdout).get("items") or []
+
+
+def _condition(obj: dict, condition_type: str) -> dict:
+    conditions = ((obj.get("status") or {}).get("conditions")) or []
+    for condition in conditions:
+        if condition.get("type") == condition_type:
+            return condition
+    raise AssertionError(f"condition {condition_type!r} not found in {conditions!r}")
+
+
+class TestModelIdentityConflictDetection:
+    """Two MaaSModelRefs sharing a resolved model identity must be flagged, not silently misrouted."""
+
+    def test_colliding_model_names_flagged_then_resolved(self):
+        suffix = uuid.uuid4().hex[:8]
+        shared_model_name = f"test/e2e-identity-conflict-{suffix}"
+        llmis_a = f"e2e-conflict-a-{suffix}"
+        llmis_b = f"e2e-conflict-b-{suffix}"
+        ref_a, ref_b = llmis_a, llmis_b
+
+        try:
+            # A single model with no siblings must be reported unique.
+            _create_llmis(llmis_a, MODEL_NAMESPACE, DEFAULT_GATEWAY_NAME, GATEWAY_NAMESPACE, model_name=shared_model_name)
+            _create_maas_model_ref(ref_a, MODEL_NAMESPACE, llmis_a)
+
+            obj_a = wait_for_status_condition(
+                "maasmodelref", ref_a, MODEL_NAMESPACE,
+                condition_type=CONDITION, expected_status="True", timeout=120,
+            )
+            assert (obj_a.get("status") or {}).get("resolvedModelAlias"), (
+                f"expected {ref_a} to have a resolvedModelAlias once the LLMIS exists"
+            )
+
+            # A second MaaSModelRef whose LLMIS declares the SAME spec.model.name
+            # introduces a collision — this mirrors the reported production bug.
+            _create_llmis(llmis_b, MODEL_NAMESPACE, DEFAULT_GATEWAY_NAME, GATEWAY_NAMESPACE, model_name=shared_model_name)
+            _create_maas_model_ref(ref_b, MODEL_NAMESPACE, llmis_b)
+
+            obj_a = wait_for_status_condition(
+                "maasmodelref", ref_a, MODEL_NAMESPACE,
+                condition_type=CONDITION, expected_status="False", timeout=120,
+            )
+            obj_b = wait_for_status_condition(
+                "maasmodelref", ref_b, MODEL_NAMESPACE,
+                condition_type=CONDITION, expected_status="False", timeout=120,
+            )
+
+            cond_a = _condition(obj_a, CONDITION)
+            cond_b = _condition(obj_b, CONDITION)
+            assert ref_b in cond_a["message"], f"expected {ref_a}'s condition to name {ref_b}: {cond_a['message']!r}"
+            assert ref_a in cond_b["message"], f"expected {ref_b}'s condition to name {ref_a}: {cond_b['message']!r}"
+
+            events_a = _events_for(ref_a, MODEL_NAMESPACE, "ModelNameConflict")
+            events_b = _events_for(ref_b, MODEL_NAMESPACE, "ModelNameConflict")
+            assert events_a or events_b, (
+                "expected a Warning ModelNameConflict event on at least one of the "
+                f"colliding MaaSModelRefs ({ref_a}, {ref_b})"
+            )
+
+            # Removing one sibling must clear the conflict on the survivor (exercises
+            # the sibling-watch that re-reconciles on Delete) and emit a Normal event.
+            _delete_cr("maasmodelref", ref_b, MODEL_NAMESPACE)
+            _delete_cr("llminferenceservice", llmis_b, MODEL_NAMESPACE)
+
+            wait_for_status_condition(
+                "maasmodelref", ref_a, MODEL_NAMESPACE,
+                condition_type=CONDITION, expected_status="True", timeout=120,
+            )
+            resolved_events = _events_for(ref_a, MODEL_NAMESPACE, "ModelNameConflictResolved")
+            assert resolved_events, f"expected a Normal ModelNameConflictResolved event on {ref_a}"
+        finally:
+            _delete_cr("maasmodelref", ref_a, MODEL_NAMESPACE)
+            _delete_cr("maasmodelref", ref_b, MODEL_NAMESPACE)
+            _delete_cr("llminferenceservice", llmis_a, MODEL_NAMESPACE)
+            _delete_cr("llminferenceservice", llmis_b, MODEL_NAMESPACE)


### PR DESCRIPTION
## Summary

- Add a `ModelIdentityUnique` status condition to `MaaSModelRef` that detects when its resolved model identity (`ResolvedModelAlias`) collides with another `MaaSModelRef` in the same namespace.
- Emit a `Warning`/`ModelNameConflict` event when a collision is detected and a `Normal`/`ModelNameConflictResolved` event when it clears, so the issue is visible via `kubectl describe` / `oc get events` instead of only manifesting as confusing runtime 403s.
- Watch sibling `MaaSModelRef`s so the condition stays current when a sibling is created, deleted, or its resolved alias changes — not just when the model's own spec changes.
- Add an e2e test (`test_model_identity_conflict.py`) that reproduces the collision, asserts detection + events, then asserts recovery.

## Context / root cause

Reported in production: two `LLMInferenceService`s in the `llm` namespace both declare `spec.model.name: facebook/opt-125m`. Because body-based routing (BBR) selects a backend purely from the model identity in the request, it can't disambiguate the two — requests were intermittently evaluated against the wrong subscription:

```
curl -sSk -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
  -d '{"model": "publishers/llm/models/facebook/opt-125m", "messages": [...], "max_tokens": 50}' \
  https://maas.example.com/v1/chat/completions

# => subscription simulator-subscription does not include model
#    llm/premium-simulated-simulated-premium
```

Both models were serving `spec.model.name: facebook/opt-125m`, so the gateway couldn't tell them apart. This PR doesn't change routing behavior (that's a separate, larger fix); it makes the collision **visible** so operators can catch it before it causes silent misrouting or spurious denials, and gives us a signal to alert/dashboard on.

## What it looks like

```
$ oc get maasmodelref facebook-opt-125m-simulated -n llm -o jsonpath='{.status.conditions}' | jq
[
  {
    "type": "ModelIdentityUnique",
    "status": "False",
    "reason": "ModelNameConflict",
    "message": "Model identity \"publishers/llm/models/facebook/opt-125m\" is shared with 1 other MaaSModelRef in namespace llm: premium-simulated-simulated-premium. Body-based routing selects a backend by model identity alone and cannot disambiguate MaaSModelRefs that resolve to the same identity — requests may be routed to the wrong backend or evaluated against the wrong subscription. Give each model a unique spec.model.name to resolve this."
  }
]
```

```
$ oc get events -n llm --field-selector involvedObject.name=facebook-opt-125m-simulated,reason=ModelNameConflict
LAST SEEN   TYPE      REASON              OBJECT                                      MESSAGE
2m          Warning   ModelNameConflict   maasmodelref/facebook-opt-125m-simulated   Model identity "publishers/llm/models/facebook/opt-125m" is shared with 1 other MaaSModelRef in this namespace: premium-simulated-simulated-premium
```

Note: this PR does not change the fixture models above — that name collision is real, pre-existing, and now correctly flagged by this change. Renaming the affected fixtures is tracked separately.

## Design notes

- **Informational only.** `ModelIdentityUnique` never affects `status.phase` or the `Ready` condition — an existing, working deployment doesn't regress into "unhealthy" just because it shares a name with another model.
- **Event de-duplication.** Events fire only on transition (unset/True → False, or False → True), not on every reconcile, to avoid spamming `oc get events`.
- **Reactive, not just self-triggered.** A dedicated `resolvedModelAliasChangedPredicate` watch on sibling `MaaSModelRef`s (Create/Delete always, Update only when `resolvedModelAlias` changed) re-enqueues every other `MaaSModelRef` in the namespace, so a new colliding sibling — or one that stops colliding — is detected without needing to touch the other model's own spec.

## Risk

- **Low.** New condition/watch/event only; no change to routing, governance, or `Phase`/`Ready` semantics. Verified no existing e2e test asserts an exhaustive condition list, event set, or resourceVersion/generation stability for `MaaSModelRef` that this would break.
- Sibling watch adds reconcile fan-out proportional to `MaaSModelRef` count per namespace on every create/delete in that namespace — acceptable at current model counts, worth watching at scale.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `golangci-lint run ./...` (0 issues), `go test ./...` — all pass.
- [x] New e2e test: `pytest tests/test_model_identity_conflict.py -v`
- [x] Manual: reproduce original curl repro against a cluster with the known free/premium collision and confirm the condition + event appear.


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added detection of duplicate model identities within the same namespace.
  * Added `ModelIdentityUnique` status reporting for model references.
  * Added notifications when identity conflicts are detected or resolved.
  * Automatically rechecks related model references when identities change.

* **Bug Fixes**
  * Helps prevent ambiguous or incorrect body-based routing when models share an identity.

* **Documentation**
  * Clarified how model identity affects body-based routing.

* **Tests**
  * Added coverage for conflict detection, notifications, and recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->