### PR TITLE
fix: update DSC format from kserve.modelsAsService to aigateway.modelsAsAService

### DIFF
--- a/.github/hack/install-odh.sh
+++ b/.github/hack/install-odh.sh
@@ -209,9 +209,8 @@ EOF
   fi
 fi
 
-# 7. Apply DataScienceCluster (KServe + ModelsAsService Managed)
-# The manifest filename retains "unmanaged" for backward compat; contents include
-# modelsAsService.managementState: Managed so the operator deploys maas-controller.
+# 7. Apply DataScienceCluster (KServe only, modelsAsAService Unmanaged)
+# MaaS is deployed separately via deploy.sh, so aigateway.modelsAsAService is not set here.
 echo "7. Applying DataScienceCluster..."
 if kubectl get datasciencecluster -A --no-headers 2>/dev/null | grep -q .; then
   echo "   DataScienceCluster already exists, skipping"

--- a/deployment/components/odh/operator/datasciencecluster.yaml
+++ b/deployment/components/odh/operator/datasciencecluster.yaml
@@ -1,4 +1,4 @@
-apiVersion: datasciencecluster.opendatahub.io/v1
+apiVersion: datasciencecluster.opendatahub.io/v2
 kind: DataScienceCluster
 metadata:
   name: default-dsc
@@ -8,11 +8,11 @@ spec:
     # Core dashboard component for managing notebooks and models
     dashboard:
       managementState: Managed
-    
+
     # Notebook controller for JupyterLab workbenches
     workbenches:
       managementState: Managed
-    
+
     # Model serving with KServe configured for RawDeployment mode
     # This configuration:
     # - Uses RawDeployment mode instead of Knative/Serverless
@@ -31,9 +31,13 @@ spec:
             type: OpenshiftDefaultIngress  # Use OpenShift's default ingress certificate
         managementState: Removed  # Disable Knative serving (incompatible with RawDeployment)
         name: knative-serving
-      modelsAsService:
+
+    # AI Gateway with MaaS (3.5+)
+    aigateway:
+      managementState: Managed
+      modelsAsAService:
         managementState: Managed
-    
+
     # Other components disabled for MaaS-focused deployment
     modelmeshserving:
       managementState: Removed  # Use KServe instead

--- a/maas-controller/pkg/controller/maas/tenant_controller.go
+++ b/maas-controller/pkg/controller/maas/tenant_controller.go
@@ -40,7 +40,7 @@ import (
 
 // TenantReconciler reconciles the MaasTenantConfig CR (platform singleton).
 // Platform manifest logic follows the ODH operator's component deploy pattern (kustomize + post-render + SSA apply).
-// The MaasTenantConfig CR is the runtime object; DSC.modelsAsService controls only enablement.
+// The MaasTenantConfig CR is the runtime object; DSC aigateway.modelsAsAService controls only enablement.
 type TenantReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme

--- a/maas-controller/pkg/platform/tenantreconcile/constants.go
+++ b/maas-controller/pkg/platform/tenantreconcile/constants.go
@@ -1,7 +1,7 @@
 // Package tenantreconcile implements the Tenant platform reconcile pipeline
 // (initialize → dependencies → prerequisites → gateway → params → kustomize → post-render → apply → deployment status).
 // The pipeline stages mirror the ODH operator's component deploy pattern; the MaasTenantConfig CR is the
-// runtime object that drives this lifecycle (DSC.modelsAsService controls enablement only).
+// runtime object that drives this lifecycle (DSC aigateway.modelsAsAService controls enablement only).
 package tenantreconcile
 
 import (

--- a/scripts/data/datasciencecluster-unmanaged.yaml
+++ b/scripts/data/datasciencecluster-unmanaged.yaml
@@ -1,7 +1,7 @@
 ---
-# DataScienceCluster for ODH with modelsAsService Unmanaged (hack script / kustomize flow).
+# DataScienceCluster for ODH with modelsAsAService Unmanaged (hack script / kustomize flow).
 # Use this when MaaS is deployed separately via deploy.sh --deployment-mode kustomize.
-# Compatible with ODH versions that do not yet support modelsAsService in DSC.
+# Compatible with ODH versions that do not yet support aigateway.modelsAsAService in DSC.
 apiVersion: datasciencecluster.opendatahub.io/v2
 kind: DataScienceCluster
 metadata:

--- a/scripts/data/datasciencecluster.yaml
+++ b/scripts/data/datasciencecluster.yaml
@@ -1,6 +1,6 @@
 ---
-# DataScienceCluster for RHOAI 3.x and ODH with the modelsAsService DSC component enabled.
-# Requires operator version that supports modelsAsService in DSC v2 API.
+# DataScienceCluster for RHOAI 3.5+ and ODH with aigateway.modelsAsAService enabled.
+# Requires operator version that supports aigateway in DSC v2 API.
 apiVersion: datasciencecluster.opendatahub.io/v2
 kind: DataScienceCluster
 metadata:
@@ -10,7 +10,9 @@ spec:
     kserve:
       managementState: Managed
       rawDeploymentServiceConfig: Headed
-      modelsAsService:
+    aigateway:
+      managementState: Managed
+      modelsAsAService:
         managementState: Managed
     dashboard:
       managementState: Removed

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1081,7 +1081,7 @@ install_primary_operator() {
   case "$OPERATOR_TYPE" in
     rhoai)
       # Support custom catalog for RHOAI snapshot/development builds
-      # This allows testing with pre-release RHOAI versions that have modelsAsService support
+      # This allows testing with pre-release RHOAI versions that have modelsAsAService support
       if [[ -n "$OPERATOR_CATALOG" ]]; then
         log_info "Using custom RHOAI catalog: $OPERATOR_CATALOG"
         create_custom_catalogsource "rhoai-custom-catalog" "openshift-marketplace" "$OPERATOR_CATALOG"
@@ -1091,7 +1091,7 @@ install_primary_operator() {
       else
         catalog_source="redhat-operators"
         # Use 'stable-3.x' channel for RHOAI v3 (with MaaS support)
-        # RHOAI 2.x (fast channel) does not support modelsAsService
+        # RHOAI 2.x (fast channel) does not support modelsAsAService
         channel="${OPERATOR_CHANNEL:-stable-3.x}"
       fi
 
@@ -1259,7 +1259,7 @@ EOF
 }
 
 apply_dsc() {
-  log_info "Applying DataScienceCluster with ModelsAsService..."
+  log_info "Applying DataScienceCluster with ModelsAsAService..."
 
   local data_dir="${SCRIPT_DIR}/data"
 
@@ -1315,12 +1315,9 @@ apply_dsc() {
     return 1
   fi
 
-  # Apply DSC with modelsAsService - this is REQUIRED for MaaS deployment
-  # Without modelsAsService, only KServe deploys (no maas-api, no HTTPRoutes, no AuthPolicy)
-  # If the operator doesn't support modelsAsService, kubectl will fail with a clear error
-  #
-  # Note: RHOAI 3.2.0 does NOT support modelsAsService in DSC schema
-  #       Only ODH currently supports this feature
+  # Apply DSC with aigateway.modelsAsAService - this is REQUIRED for MaaS deployment
+  # Without modelsAsAService, only KServe deploys (no maas-api, no HTTPRoutes, no AuthPolicy)
+  # If the operator doesn't support modelsAsAService, kubectl will fail with a clear error
   kubectl apply --server-side=true -f "${data_dir}/datasciencecluster.yaml"
 }
 
@@ -1331,7 +1328,7 @@ apply_dsc() {
 apply_kuadrant_cr() {
   local namespace=$1
 
-  log_info "Initializing Gateway API and ModelsAsService gateway..."
+  log_info "Initializing Gateway API and ModelsAsAService gateway..."
 
   # Setup Gateway using standalone script (replaces inline setup_gateway_api + setup_maas_gateway)
   # The script handles GatewayClass creation, Gateway creation with TLS cert detection,


### PR DESCRIPTION
## Summary

- Migrates all DSC manifests from the deprecated `kserve.modelsAsService` (API v1) to the new `aigateway.modelsAsAService` (API v2) format introduced by MaaS modularization in RHOAI 3.5+
- Updates comments across deploy scripts, install scripts, and Go source files to reference the new field path
- Fixes a misleading comment in `install-odh.sh` that incorrectly stated the unmanaged DSC manifest included `modelsAsService: Managed`

Resolves [RHOAIENG-77653](https://redhat.atlassian.net/browse/RHOAIENG-77653)

## Files changed

| File | Change |
|------|--------|
| `deployment/components/odh/operator/datasciencecluster.yaml` | API v1→v2, `modelsAsService` moved from `kserve` to new `aigateway` component |
| `scripts/data/datasciencecluster.yaml` | `modelsAsService` moved from `kserve` to `aigateway.modelsAsAService` |
| `scripts/data/datasciencecluster-unmanaged.yaml` | Comments updated |
| `scripts/deploy.sh` | 5 comment references updated |
| `.github/hack/install-odh.sh` | Fixed incorrect comment |
| `maas-controller/.../constants.go` | Package doc comment updated |
| `maas-controller/.../tenant_controller.go` | Type doc comment updated |

## Risk analysis

- **Risk rating**: 4
- **Why**: These DSC manifests are applied during nightly CI and e2e deploy flows. Incorrect format would prevent MaaS from deploying. The new format requires operator versions that support `aigateway` in the DSC v2 API. Cannot be fully validated without deploying to a cluster with RHOAI 3.5+ or a compatible ODH build.

## Test plan

- [x] Kustomize manifest validation passes (`./scripts/ci/validate-manifests.sh`)
- [x] Go unit tests pass (`make -C maas-controller test`)
- [ ] Deploy to a cluster with RHOAI 3.5+ / ODH and verify DSC reconciles with `aigateway.modelsAsAService`
- [ ] Run e2e smoke test (`prow_run_smoke_test.sh`) to confirm nightly path works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RHOAIENG-77653]: https://redhat.atlassian.net/browse/RHOAIENG-77653?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added managed AI Gateway and Models as a Service configuration for supported deployments.
  * Updated deployment settings to support KServe in RawDeployment mode.
  * Ensured workbench management is explicitly enabled.

* **Documentation**
  * Updated deployment guidance, comments, and status messages to consistently reference Models as a Service and its current configuration path.
  * Clarified compatibility notes for supported platform versions and deployment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->