### PR TITLE
fix: use OC bearer token for model discovery and inference in verify …

### DIFF
--- a/scripts/verify-models-and-limits.sh
+++ b/scripts/verify-models-and-limits.sh
@@ -127,7 +127,7 @@ echo -e "${GREEN}✓ API key created successfully (name: $KEY_NAME)${NC}"
 
 echo -e "${BLUE}Discovering available models...${NC}"
 MODELS_RESPONSE=$(curl -sSk \
-    -H "Authorization: Bearer $TOKEN" \
+    -H "Authorization: Bearer $OC_TOKEN" \
     -H "Content-Type: application/json" \
     -w "\nHTTP_STATUS:%{http_code}\n" \
     "${API_BASE}/maas-api/v1/models" 2>&1)
@@ -202,7 +202,7 @@ EOF
 )
         
         response=$(curl -sSk \
-            -H "Authorization: Bearer $TOKEN" \
+            -H "Authorization: Bearer $OC_TOKEN" \
             -H "Content-Type: application/json" \
             -X POST \
             -d "$REQUEST_BODY" \
@@ -273,7 +273,7 @@ EOF
     echo -n "Request status: "
     for i in {1..25}; do
         response=$(curl -sSk \
-            -H "Authorization: Bearer $TOKEN" \
+            -H "Authorization: Bearer $OC_TOKEN" \
             -H "Content-Type: application/json" \
             -X POST \
             -d "$REQUEST_BODY_SIMPLE" \


### PR DESCRIPTION
…script

The verify-models-and-limits.sh script used API key ($TOKEN) for model discovery, inference, and rate limit testing. This fails because:
- /maas-api/v1/models only accepts OC bearer tokens (returns 401 for API keys)
- API key is bound to a single subscription, causing 403 on models outside that subscription

Switch to $OC_TOKEN for these calls so the gateway uses the user's full identity to select the appropriate subscription per model.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated verification requests to authenticate using the OpenShift identity token instead of the temporary MaaS API key, improving model discovery, chat completion, and rate-limit checks.
  * Preserved automatic cleanup of temporary MaaS API keys after verification runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->