### PR TITLE
fix: skip OpenShift-only watchers on xKS to prevent cache-sync timeout

### DIFF
--- a/maas-controller/pkg/controller/maas/tenant_controller.go
+++ b/maas-controller/pkg/controller/maas/tenant_controller.go
@@ -290,26 +290,8 @@ func (r *TenantReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		return err
 	}
 
-	if !authExists {
-		if err := registerWatchWhenCRDAppears(c, mgr, authCRD, func() source.Source {
-			auth := &unstructured.Unstructured{}
-			auth.SetGroupVersionKind(schema.GroupVersionKind{
-				Group: "config.openshift.io", Version: "v1", Kind: "Authentication",
-			})
-			return source.Kind(mgr.GetCache(), auth,
-				handler.TypedEnqueueRequestsFromMapFunc[*unstructured.Unstructured](
-					func(ctx context.Context, obj *unstructured.Unstructured) []reconcile.Request {
-						if obj.GetName() != openshiftAuthenticationClusterName {
-							return nil
-						}
-						return r.enqueueDefaultTenant(ctx, obj)
-					},
-				),
-			)
-		}); err != nil {
-			return fmt.Errorf("failed to register CRD watcher for Authentication: %w", err)
-		}
-	}
+	// No dynamic watch for Authentication CRD: it ships with OpenShift itself,
+	// so it is either present at boot (OCP) or will never appear (xKS).
 
 	if !dsciExists {
 		if err := registerWatchWhenCRDAppears(c, mgr, dsciCRD, func() source.Source {
@@ -323,6 +305,7 @@ func (r *TenantReconciler) SetupWithManager(mgr ctrl.Manager) error {
 						return r.enqueueDefaultTenant(ctx, obj)
 					},
 				),
+				predicate.TypedResourceVersionChangedPredicate[*unstructured.Unstructured]{},
 			)
 		}); err != nil {
 			return fmt.Errorf("failed to register CRD watcher for DSCInitialization: %w", err)

--- a/maas-controller/pkg/controller/maas/tenant_controller.go
+++ b/maas-controller/pkg/controller/maas/tenant_controller.go
@@ -19,6 +19,7 @@ package maas
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 
 	corev1 "k8s.io/api/core/v1"
@@ -35,6 +36,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	maasv1alpha1 "github.com/opendatahub-io/models-as-a-service/maas-controller/api/maas/v1alpha1"
 	"github.com/opendatahub-io/models-as-a-service/maas-controller/pkg/platform/tenantreconcile"
@@ -218,21 +220,9 @@ func configResourceDefault() predicate.Predicate {
 
 // SetupWithManager registers the MaasTenantConfig controller.
 func (r *TenantReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	authMeta := &metav1.PartialObjectMetadata{}
-	authMeta.SetGroupVersionKind(schema.GroupVersionKind{
-		Group:   "config.openshift.io",
-		Version: "v1",
-		Kind:    "Authentication",
-	})
+	ctx := context.Background()
 
-	dsci := &unstructured.Unstructured{}
-	dsci.SetGroupVersionKind(schema.GroupVersionKind{
-		Group:   "dscinitialization.opendatahub.io",
-		Version: "v1",
-		Kind:    "DSCInitialization",
-	})
-
-	return ctrl.NewControllerManagedBy(mgr).
+	b := ctrl.NewControllerManagedBy(mgr).
 		For(&maasv1alpha1.MaasTenantConfig{}).
 		Watches(
 			&maasv1alpha1.Config{},
@@ -257,16 +247,87 @@ func (r *TenantReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			&corev1.Secret{},
 			handler.EnqueueRequestsFromMapFunc(r.enqueueDefaultTenant),
 			builder.WithPredicates(secretNamedMaaSDB(), r.inTenantWorkNamespaces()),
-		).
-		WatchesMetadata(
+		)
+
+	const authCRD = "authentications.config.openshift.io"
+	authExists := crdExists(ctx, mgr.GetAPIReader(), authCRD)
+	if authExists {
+		authMeta := &metav1.PartialObjectMetadata{}
+		authMeta.SetGroupVersionKind(schema.GroupVersionKind{
+			Group:   "config.openshift.io",
+			Version: "v1",
+			Kind:    "Authentication",
+		})
+		b = b.WatchesMetadata(
 			authMeta,
 			handler.EnqueueRequestsFromMapFunc(r.enqueueDefaultTenant),
 			builder.WithPredicates(authenticationClusterSingleton()),
-		).
-		Watches(
+		)
+	} else {
+		ctrl.Log.Info("Authentication CRD not registered; skipping static watch")
+	}
+
+	const dsciCRD = "dscinitializations.dscinitialization.opendatahub.io"
+	dsciExists := crdExists(ctx, mgr.GetAPIReader(), dsciCRD)
+	if dsciExists {
+		dsci := &unstructured.Unstructured{}
+		dsci.SetGroupVersionKind(schema.GroupVersionKind{
+			Group:   "dscinitialization.opendatahub.io",
+			Version: "v1",
+			Kind:    "DSCInitialization",
+		})
+		b = b.Watches(
 			dsci,
 			handler.EnqueueRequestsFromMapFunc(r.enqueueDefaultTenant),
 			builder.WithPredicates(predicate.ResourceVersionChangedPredicate{}),
-		).
-		Complete(r)
+		)
+	} else {
+		ctrl.Log.Info("DSCInitialization CRD not registered; skipping static watch")
+	}
+
+	c, err := b.Build(r)
+	if err != nil {
+		return err
+	}
+
+	if !authExists {
+		if err := registerWatchWhenCRDAppears(c, mgr, authCRD, func() source.Source {
+			auth := &unstructured.Unstructured{}
+			auth.SetGroupVersionKind(schema.GroupVersionKind{
+				Group: "config.openshift.io", Version: "v1", Kind: "Authentication",
+			})
+			return source.Kind(mgr.GetCache(), auth,
+				handler.TypedEnqueueRequestsFromMapFunc[*unstructured.Unstructured](
+					func(ctx context.Context, obj *unstructured.Unstructured) []reconcile.Request {
+						if obj.GetName() != openshiftAuthenticationClusterName {
+							return nil
+						}
+						return r.enqueueDefaultTenant(ctx, obj)
+					},
+				),
+			)
+		}); err != nil {
+			return fmt.Errorf("failed to register CRD watcher for Authentication: %w", err)
+		}
+	}
+
+	if !dsciExists {
+		if err := registerWatchWhenCRDAppears(c, mgr, dsciCRD, func() source.Source {
+			dsci := &unstructured.Unstructured{}
+			dsci.SetGroupVersionKind(schema.GroupVersionKind{
+				Group: "dscinitialization.opendatahub.io", Version: "v1", Kind: "DSCInitialization",
+			})
+			return source.Kind(mgr.GetCache(), dsci,
+				handler.TypedEnqueueRequestsFromMapFunc[*unstructured.Unstructured](
+					func(ctx context.Context, obj *unstructured.Unstructured) []reconcile.Request {
+						return r.enqueueDefaultTenant(ctx, obj)
+					},
+				),
+			)
+		}); err != nil {
+			return fmt.Errorf("failed to register CRD watcher for DSCInitialization: %w", err)
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
## Summary

On xKS (vanilla Kubernetes), the `TenantReconciler` unconditionally watches `DSCInitialization` and `config.openshift.io/Authentication` — both OpenShift-only CRDs that don't exist on xKS. This causes a cache-sync timeout after ~2 minutes and the controller shuts down.

**Fix:** Use `crdExists()` + `registerWatchWhenCRDAppears()` — the same pattern already used for LLMInferenceService, AuthPolicy, and TokenRateLimitPolicy watchers in this codebase. No env var dependency needed.

## Problem

```
error: "failed to wait for maastenantconfig caches to sync"
```

The controller-runtime manager tries to sync all registered informers. The DSCInitialization watcher can't sync because the CRD doesn't exist → 2-minute timeout → `os.Exit(1)`.

## Changes

- `tenant_controller.go`:
  - **Authentication:** Static watch when CRD exists at boot; no dynamic fallback (CRD ships with OpenShift — present at install or never)
  - **DSCInitialization:** Static watch when CRD exists; dynamic `registerWatchWhenCRDAppears` fallback with `ResourceVersionChangedPredicate` for parity with static path

## Context

Part of xKS MaaS enablement. E2E validated on AKS — maas-controller stays running without cache-sync timeout.

Related PRs:
- [ai-gateway-operator#65](https://github.com/opendatahub-io/ai-gateway-operator/pull/65) — gateway-namespace fix (merged)
- [ai-gateway-operator#69](https://github.com/opendatahub-io/ai-gateway-operator/pull/69) — RBAC escalation fix (merged)

## Test plan

- [x] `go build ./...` compiles
- [x] `go test ./pkg/controller/maas/ -short` passes
- [x] AKS E2E: maas-controller starts clean, no cache-sync timeout (Jul 22 run with custom image containing this fix)