### PR TITLE
feat: use stable branch as default base for release workflow

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,7 +1,7 @@
 # Create Release Workflow
 #
 # This workflow creates a release following the data-science-pipelines-operator pattern:
-#   1. Creates a release branch (e.g., v1.x) from main
+#   1. Creates a release branch (e.g., v1.x) from the base branch (default: stable)
 #   2. Updates kustomization files and MAAS_REF references on the release branch
 #   3. Creates and pushes the release tag from the release branch
 #   4. Builds and pushes the maas-api image
@@ -16,7 +16,7 @@
 #
 # The workflow will:
 #   - Extract minor version (e.g., v1.0.0 -> v1.x)
-#   - Create/update release branch (e.g., v1.x)
+#   - Create/update release branch (e.g., v1.x) from the base branch (default: stable)
 #   - Update files on the release branch
 #   - Create tag from the release branch
 #   - Build image and deploy docs
@@ -41,6 +41,11 @@ on:
         required: false
         type: boolean
         default: false
+      base_branch:
+        description: 'Base branch to create the release from (default: stable)'
+        required: false
+        type: string
+        default: 'stable'
       create_release:
         description: 'Create GitHub release'
         required: false
@@ -137,26 +142,30 @@ jobs:
           git config user.email "${{ env.GH_USER_EMAIL }}"
 
       - name: Create or update release branch
+        env:
+          BASE_BRANCH: ${{ inputs.base_branch || 'stable' }}
         run: |
           BRANCH="${{ needs.prepare-release.outputs.minor_release_branch }}"
+          
+          git fetch origin "$BASE_BRANCH"
           
           # Check if branch exists (use exact ref path to avoid matching v1.0.x-test when looking for v1.0.x)
           if git ls-remote --exit-code --heads origin "refs/heads/$BRANCH" &>/dev/null; then
             echo "Release branch $BRANCH already exists, checking it out"
             git fetch origin "$BRANCH"
             git checkout -b "$BRANCH" "origin/$BRANCH" || git checkout "$BRANCH"
-            # Attempt to merge main, but don't fail if already up-to-date
-            if ! git merge main --no-edit; then
+            # Attempt to merge base branch, but don't fail if already up-to-date
+            if ! git merge "origin/$BASE_BRANCH" --no-edit; then
               # Check if merge failed due to conflicts vs already up-to-date
               if git diff --name-only --diff-filter=U | grep -q .; then
                 echo "❌ Merge conflicts detected. Please resolve manually."
                 exit 1
               fi
-              echo "Branch is already up to date with main"
+              echo "Branch is already up to date with $BASE_BRANCH"
             fi
           else
-            echo "Creating new release branch $BRANCH from main"
-            git checkout -b "$BRANCH" main
+            echo "Creating new release branch $BRANCH from $BASE_BRANCH"
+            git checkout -b "$BRANCH" "origin/$BASE_BRANCH"
           fi
 
       - name: Update kustomization files with new tag
@@ -248,7 +257,7 @@ jobs:
             ### Updated Files
             - `deployment/base/maas-api/kustomization.yaml`
             - `maas-api/deploy/overlays/dev/kustomization.yaml`
-            - MAAS_REF references updated to use `${{ needs.create-release-branch.outputs.version_tag }}` instead of `main`
+            - MAAS_REF references updated to use `${{ needs.create-release-branch.outputs.version_tag }}`
             
             ### Release Branch
             - Branch: `${{ needs.create-release-branch.outputs.minor_release_branch }}`

--- a/.github/workflows/disconnected-readiness.yml
+++ b/.github/workflows/disconnected-readiness.yml
@@ -7,6 +7,6 @@ on:
 
 jobs:
   check:
-    uses: opendatahub-io/disconnected-readiness-scorer/.github/workflows/disconnected-readiness-check.yml@28f88a60c184a9c29e823918f0fba56b32f577e1 # main (includes MaaS params-env-wiring exceptions)
+    uses: opendatahub-io/disconnected-readiness-scorer/.github/workflows/disconnected-readiness-check.yml@6f7fc06230f5eeabfd134d819219314d54f0c7e7 # v1
     with:
       rules: ""

--- a/.github/workflows/disconnected-readiness.yml
+++ b/.github/workflows/disconnected-readiness.yml
@@ -7,6 +7,6 @@ on:
 
 jobs:
   check:
-    uses: opendatahub-io/disconnected-readiness-scorer/.github/workflows/disconnected-readiness-check.yml@6f7fc06230f5eeabfd134d819219314d54f0c7e7 # v1
+    uses: opendatahub-io/disconnected-readiness-scorer/.github/workflows/disconnected-readiness-check.yml@28f88a60c184a9c29e823918f0fba56b32f577e1 # main (includes MaaS params-env-wiring exceptions)
     with:
       rules: ""


### PR DESCRIPTION
## Summary

Switch the `create-release` workflow to cut release branches from `stable` instead of `main`, aligning with the Stream-Lake-Ocean release strategy where `stable` (Lake) is the source of truth for releases.

## Description

- Add a configurable `base_branch` workflow input (type: `string`, default: `stable`) so operators can override the base to `main` or any other branch when needed.
- Replace the two hardcoded `main` references in the `create-release-branch` job (`git merge main` and `git checkout -b ... main`) with `origin/$BASE_BRANCH`.
- Add an explicit `git fetch origin "$BASE_BRANCH"` to ensure the ref is fresh regardless of which branch was selected in "Use workflow from".
- Update header comments, log messages, and GitHub Release body to remove hardcoded `main` references.
- No changes to helper scripts (`update-kustomize-tag.sh`, `update-maas-ref.sh`) — they already handle both `main` and semver patterns.
- No changes to downstream jobs (`create-tag`, `build-and-push-image`, `deploy-documentation`, `summary`) — they already operate on the release branch / tag, not the base branch.

## How it was tested

- Ran the updated workflow from a fork (`chaitanya1731/models-as-a-service`) with tag `v0.3.0-test` and `base_branch=stable`.
- Verified from job logs that `BASE_BRANCH: stable` was set and the release branch `v0.3.x` was created from `stable` (not `main`).
- All jobs passed except `Build and Push Image`, which failed due to missing Quay credentials on the fork (expected).
- YAML syntax validated locally with `yaml.safe_load`.

## Risk analysis

- **Risk rating**: 2
- **Why**: Change is scoped to a single workflow file with only two functional line changes. The `base_branch` input defaults to `stable` so existing behavior shifts intentionally. The workflow was end-to-end validated on a fork. Image build, tagging, and docs deployment logic are untouched.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable base branch when creating releases, defaulting to `stable`.
  * Release branch creation now fetches and merges from the selected base branch.

* **Documentation**
  * Updated release workflow guidance and status messages to reflect the configurable base branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->