### PR TITLE
fix: sync ExternalModel and ExternalProvider CRDs from IPP

### DIFF
--- a/deployment/base/maas-controller/crd/bases/inference.opendatahub.io_externalmodels.yaml
+++ b/deployment/base/maas-controller/crd/bases/inference.opendatahub.io_externalmodels.yaml
@@ -88,8 +88,9 @@ spec:
                         type:
                           description: |-
                             Type identifies the auth type for this provider.
-                            e.g. "simple" (header based), "sigv4", etc.
+                            e.g. "apikey" (header based), "sigv4", etc.
                           enum:
+                          - apikey
                           - simple
                           - sigv4
                           - oauth2
@@ -139,9 +140,10 @@ spec:
                       description: |-
                         Weight determines the relative traffic proportion for this provider binding.
                         Higher weight means more traffic. Used for weighted random selection across
-                        multiple provider refs. Defaults to 1 if not set.
+                        multiple provider refs. A weight of 0 disables the ref (no traffic routed
+                        to it). Defaults to 1 if not set.
                       maximum: 100
-                      minimum: 1
+                      minimum: 0
                       type: integer
                   required:
                   - apiFormat

--- a/deployment/base/maas-controller/crd/bases/inference.opendatahub.io_externalproviders.yaml
+++ b/deployment/base/maas-controller/crd/bases/inference.opendatahub.io_externalproviders.yaml
@@ -74,8 +74,9 @@ spec:
                   type:
                     description: |-
                       Type identifies the auth type for this provider.
-                      e.g. "simple" (header based), "sigv4", etc.
+                      e.g. "apikey" (header based), "sigv4", etc.
                     enum:
+                    - apikey
                     - simple
                     - sigv4
                     - oauth2


### PR DESCRIPTION
## Summary
Sync `inference.opendatahub.io` CRD schemas from the IPP repo (source of truth) to fix stale definitions in the MaaS kustomize manifests.

## Changes
- **Auth type enum**: `simple` → `apikey` (both ExternalProvider and ExternalModel CRDs)
- **ExternalModel weight minimum**: `1` → `0` (supports disabling providers with weight=0)
- **Weight description**: updated to document weight=0 disable behavior

## Risk analysis
- **Risk rating**: 2
- **Why**: CRD schema change. Clusters using `type: simple` will need to update to `type: apikey`. Weight minimum=0 is additive (allows new behavior without breaking existing configs with weight >= 1).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for API key authentication for external models and providers.
  * External provider weights can now be set to `0` to disable traffic to a provider while retaining it in the configuration.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->