### PR TITLE
ci: add dependabot configuration for dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,43 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/maas-controller"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "gomod"
+    directory: "/maas-api"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "ci"
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
Add Dependabot configuration to satisfy OpenSSF Scorecard INFO-006 (Dependency-Update-Tool check).

**JIRA:** [RHOAIENG-69258](https://redhat.atlassian.net/browse/RHOAIENG-69258)

## Description
- Adds `.github/dependabot.yml` with weekly version update checks for:
  - `gomod` in `/maas-controller`
  - `gomod` in `/maas-api`
  - `github-actions` in `/`
- Groups minor/patch Go updates into single PRs to reduce noise.
- Caps open PRs at 5 per ecosystem.
- Dependabot security updates were already active (repo settings), but the explicit config file is needed for OpenSSF Scorecard compliance.

## How it was tested
- YAML validated (schema + syntax).
- Verified target directories (`go.mod` files, `.github/workflows/`) exist.
- No runtime impact — Dependabot only opens PRs, never auto-merges.

## Risk analysis
- **Risk rating**: 0
- **Why**: Configuration-only change with no runtime impact. Dependabot opens PRs that still require human review/approval.


Made with [Cursor](https://cursor.com)

[RHOAIENG-69258]: https://redhat.atlassian.net/browse/RHOAIENG-69258?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled weekly automated dependency update checks for Go modules and GitHub Actions.
  * Grouped compatible minor and patch updates to simplify maintenance.
  * Applied labels and limits to keep update proposals organized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->