### PR TITLE
fix: increase chart range vector from [30m] to [2h]

### DIFF
--- a/deployment/components/observability/observability/dashboards/usage-dashboard.yaml
+++ b/deployment/components/observability/observability/dashboards/usage-dashboard.yaml
@@ -174,6 +174,7 @@ spec:
       spec:
         display:
           name: Token consumption chart
+          # [2h] matches the Loki dashboards' step for consistent cross-dashboard granularity.
           description: >-
             Tokens over time by model or subscription.
             View by drives chart sum by (${view_by:raw}).
@@ -209,7 +210,7 @@ spec:
                   query: >-
                     round(sum by (${view_by:raw}) (increase(authorized_hits_total{user!="",
                     user=~"$user", subscription=~"$subscription",
-                    model=~"$model"}[30m])))
+                    model=~"$model"}[2h])))
     tokenConsumptionByUser:
       kind: Panel
       spec:

--- a/deployment/components/observability/usage-logs/usage-logs-admin-dashboard.yaml
+++ b/deployment/components/observability/usage-logs/usage-logs-admin-dashboard.yaml
@@ -240,11 +240,11 @@ spec:
       spec:
         display:
           name: "Token consumption chart"
+          # [2h] is the minimal stable step. Loki split_queries_by_interval is 30m; 1h still produces
+          # gaps at chunk boundaries. 2h is the lowest value that returns consistent results.
           description: >-
             Tokens from successful requests (2xx) over time by model or subscription.
-            **View by** drives chart ``sum by (${view_by:raw})``. Table uses hardcoded ``sum by (model, subscription)``.
-            LogQL ``[30m]`` is the range window for ``sum_over_time`` (Perses time-series step).
-            Visual: OpenShift Perses pattern — ``line`` + ``areaOpacity: 1`` + ``stack: all``.
+            **View by** drives the chart grouping.
         plugin:
           kind: TimeSeriesChart
           spec:
@@ -277,7 +277,7 @@ spec:
                     sum by (${view_by:raw}) (sum_over_time({service_name="models-as-a-service",
                     subscription=~"$subscription", model=~"$model", response_type="hit"}
                     | user_id=~"$user"
-                    | unwrap tokens_total [30m]))
+                    | unwrap tokens_total [2h]))
 
     tokenConsumptionTable:
       kind: Panel

--- a/deployment/components/observability/usage-logs/usage-logs-dashboard.yaml
+++ b/deployment/components/observability/usage-logs/usage-logs-dashboard.yaml
@@ -204,6 +204,8 @@ spec:
       spec:
         display:
           name: "Token consumption chart"
+          # [2h] is the minimal stable step. Loki split_queries_by_interval is 30m; 1h still produces
+          # gaps at chunk boundaries. 2h is the lowest value that returns consistent results.
           description: >-
             Tokens from successful requests (2xx) over time by model or subscription.
         plugin:
@@ -237,7 +239,7 @@ spec:
                   query: >-
                     sum by (${view_by:raw}) (sum_over_time({service_name="models-as-a-service",
                     subscription=~"$subscription", model=~"$model", response_type="hit"}
-                    | unwrap tokens_total [30m]))
+                    | unwrap tokens_total [2h]))
 
     tokenConsumptionTable:
       kind: Panel


### PR DESCRIPTION
## Description

Increases the chart range vector from `[30m]` to `[2h]` across all usage dashboards.

**Loki dashboards**: `split_queries_by_interval` is hardcoded to `30m` by the Loki Operator. Testing confirmed `[1h]` still produces gaps at chunk boundaries — `[2h]` is the minimal stable step.

**Prometheus dashboard**: updated to `[2h]` for consistent cross-dashboard granularity.

Affects `tokenConsumptionOverTime` panel on all three dashboards (admin Loki, user Loki, Prometheus). Stat panels and tables are unaffected (`[$__range]` + instant mode).

## How Has This Been Tested?

Tested manually on a dev cluster with `[30m]`, `[1h]`, and `[2h]` range vectors. Only `[2h]` returned consistent results across all chunk boundaries. Prometheus dashboard deployed and validated by Perses.

## Risk analysis

- **Risk rating**: 1
- **Why**: Only range vector windows change in three dashboard YAMLs. No code, no CRD, no RBAC. Stat panels and tables remain on `[$__range]`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved token consumption charts by using a consistent two-hour calculation window.
  * Reduced gaps and empty results caused by shorter query intervals.
  * Aligned token usage views across dashboards for more reliable reporting.

* **Documentation**
  * Updated chart descriptions and inline guidance to explain the two-hour window and its stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->