### PR TITLE
feat: replace user TextVariable with LokiLogQLVariable dropdown

### DIFF
--- a/deployment/components/observability/usage-logs/usage-logs-admin-dashboard.yaml
+++ b/deployment/components/observability/usage-logs/usage-logs-admin-dashboard.yaml
@@ -1,8 +1,9 @@
 # Admin usage dashboard — queries Loki structured logs via LogQL.
 # Uses $__range to bind LogQL windows to the native time picker.
-# LokiLabelValuesVariable for model/subscription dropdowns (COO 1.5+).
-# User filter uses TextVariable (regex input) to avoid Loki cardinality issues
-# from indexing high-cardinality user_id as a label. Admins enter regex patterns.
+# All three dropdowns (user, subscription, model) follow the dashboard time
+# picker. User filter uses LokiLogQLVariable with [$__range] — auto-populates
+# from structured metadata via count by (user_id), bypassing /label/values
+# (which requires stream labels). Subscription/model use LokiLabelValuesVariable.
 # customAllValue: ".*" on ListVariables ensures "All" matches entries with
 # absent labels (e.g. subscription when capturing is disabled). Do not remove.
 apiVersion: perses.dev/v1alpha1
@@ -21,13 +22,24 @@ spec:
       rate limiting, and per-user breakdown across all users and subscriptions.
   duration: 1h
   variables:
-    - kind: TextVariable
+    - kind: ListVariable
       spec:
         name: user
         display:
-          name: "User (regex)"
-          description: "Filter by user ID. Use regex: 'user-1' (single), 'user-1|user-2' (multiple), '.*' (all)"
-        defaultValue: ".*"
+          name: "User"
+          description: "Filter by user. Populated from the selected time range."
+        allowMultiple: true
+        allowAllValue: true
+        customAllValue: ".*"
+        defaultValue: "$__all"
+        plugin:
+          kind: LokiLogQLVariable
+          spec:
+            datasource:
+              kind: LokiDatasource
+              name: usage-logs-all
+            expr: 'count by (user_id) (count_over_time({service_name="models-as-a-service"} | user_id!="" | user_id!="-" | keep user_id [$__range]))'
+            labelName: user_id
     - kind: ListVariable
       spec:
         name: subscription


### PR DESCRIPTION
## Description
Replace the admin dashboard user `TextVariable` (manual regex input) with a `LokiLogQLVariable` dropdown that auto-populates from Loki structured metadata. Add `response_type!="error"` filtering to subscription/model dropdowns on both dashboards to exclude error-only entries with inconsistent label values.

## How Has This Been Tested?
Deployed and verified on `amit.dev` cluster — user dropdown populates correctly, subscription/model dropdowns exclude error entries, time picker controls all dropdowns.

## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work

## Risk analysis
- **Risk rating**: 2
- **Why**: Dashboard-only YAML changes — no Go code, no CRD changes. `LokiLogQLVariable` ships stock with COO 1.5.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the “All usage (logs)” dashboard’s user filter to derive options from structured log metadata.
  * User dropdown selections now follow the dashboard time range.
  * Enabled multi-select user filtering and an “All” option.
  * Filter options exclude empty or placeholder user IDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->