### PR TITLE
fix: apply an envoy filter for pre/post processing to every gateway not just default

### DIFF
--- a/deployment/base/payload-processing/manager/envoy-filter.yaml
+++ b/deployment/base/payload-processing/manager/envoy-filter.yaml
@@ -1,9 +1,14 @@
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  # Base name; tenant reconcile renames to payload-processing-<gatewayName> so each
+  # AITenant Gateway gets its own copy while IPP Deployments stay shared.
   name: payload-processing
   namespace: openshift-ingress
 spec:
+  # Must run AFTER Kuadrant's EnvoyFilter (default priority 0). Also set by
+  # patchPayloadProcessingEnvoyFilter at reconcile time.
+  priority: 10
   targetRefs:
     - group: gateway.networking.k8s.io
       kind: Gateway

--- a/maas-controller/pkg/platform/tenantreconcile/constants.go
+++ b/maas-controller/pkg/platform/tenantreconcile/constants.go
@@ -5,8 +5,11 @@
 package tenantreconcile
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"reflect"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -73,11 +76,17 @@ const (
 	baseMaaSAPIKeyCleanupScriptConfigMapName       = "maas-api-key-cleanup-script" //nolint:gosec // Kubernetes resource name, not a credential
 	baseMaaSAPIDeploymentNSNetworkPolicyName       = "maas-api-allow-deployment-ns"
 
-	// Non-tenant-specific resource names (shared infrastructure)
+	// Non-tenant-specific resource names (shared infrastructure).
+	// IPP Deployments/Services stay shared; the EnvoyFilter is renamed per Gateway
+	// (see PayloadProcessingEnvoyFilterName) so each AITenant gateway gets its own
+	// filter copy pointing at the same shared IPP pods.
 	PayloadProcessingName                         = "payload-processing"
 	PayloadPreProcessingName                      = "payload-pre-processing"
 	PayloadProcessingPluginsConfigMapName         = "payload-processing-plugins"
 	PayloadProcessingReaderClusterRoleBindingName = "payload-processing-reader"
+	// PayloadProcessingEnvoyFilterPriority runs after Kuadrant's default-priority (0)
+	// EnvoyFilter so RHCL's envoy.filters.http.wasm anchor exists when we INSERT_*.
+	PayloadProcessingEnvoyFilterPriority int64 = 10
 	// MaaSControllerDeploymentName matches deployment/base/maas-controller/manager/manager.yaml.
 	MaaSControllerDeploymentName = "maas-controller"
 	MaaSDBSecretName             = "maas-db-config" //nolint:gosec // secret name reference, not a credential
@@ -137,6 +146,42 @@ func resourceNameForTenant(baseName, tenantID string) string {
 		return baseName
 	}
 	return baseName + "-" + tenantID
+}
+
+// payloadProcessingEnvoyFilterNameMaxLen is under the Kubernetes 63-char DNS1123
+// label limit so truncated names still leave headroom for trailing hyphen cleanup.
+const payloadProcessingEnvoyFilterNameMaxLen = 60
+
+// PayloadProcessingEnvoyFilterName returns the per-Gateway EnvoyFilter name.
+// IPP Deployments remain shared as PayloadProcessingName; only the EnvoyFilter is
+// duplicated so every AITenant gateway gets ext_proc without last-writer-wins on
+// a singleton targetRefs.
+//
+// Long gateway names are truncated to payloadProcessingEnvoyFilterNameMaxLen with an
+// 8-char content hash suffix so names stay unique and DNS1123-safe instead of failing.
+func PayloadProcessingEnvoyFilterName(gatewayName string) string {
+	prefix := PayloadProcessingName + "-"
+	name := prefix + gatewayName
+	if len(name) <= payloadProcessingEnvoyFilterNameMaxLen {
+		return name
+	}
+
+	sum := sha256.Sum256([]byte(gatewayName))
+	hash := hex.EncodeToString(sum[:])[:8]
+	// prefix + trimmed + "-" + hash
+	budget := payloadProcessingEnvoyFilterNameMaxLen - len(prefix) - 1 - len(hash)
+	if budget < 1 {
+		fallback := prefix + hash
+		if len(fallback) > payloadProcessingEnvoyFilterNameMaxLen {
+			fallback = fallback[:payloadProcessingEnvoyFilterNameMaxLen]
+		}
+		return strings.TrimRight(fallback, "-")
+	}
+	trimmed := strings.TrimRight(gatewayName[:budget], "-.")
+	if trimmed == "" {
+		trimmed = hash
+	}
+	return prefix + trimmed + "-" + hash
 }
 
 func GatewayDefaultAuthPolicyName(tenantID string) string {

--- a/maas-controller/pkg/platform/tenantreconcile/params.go
+++ b/maas-controller/pkg/platform/tenantreconcile/params.go
@@ -441,6 +441,19 @@ func grpcClusterName(service, namespace string, port int) string {
 func patchPayloadProcessingEnvoyFilter(log logr.Logger, r *unstructured.Unstructured, params PlatformParams) error {
 	r.SetNamespace(params.GatewayNamespace)
 
+	// One EnvoyFilter copy per Gateway (shared IPP Deployments/Services unchanged).
+	// Name is truncated (with hash) when needed — see PayloadProcessingEnvoyFilterName.
+	efName := PayloadProcessingEnvoyFilterName(params.GatewayName)
+	r.SetName(efName)
+	log.V(4).Info("Patching payload-processing EnvoyFilter for gateway",
+		"envoyFilter", efName, "gateway", params.GatewayName, "namespace", params.GatewayNamespace)
+
+	// Ensure patches run after Kuadrant's wasm INSERT (priority 0). Without this,
+	// RHCL subFilter matches on envoy.filters.http.wasm never fire.
+	if err := unstructured.SetNestedField(r.Object, PayloadProcessingEnvoyFilterPriority, "spec", "priority"); err != nil {
+		return fmt.Errorf("write EnvoyFilter priority: %w", err)
+	}
+
 	targetRefs, found, err := unstructured.NestedSlice(r.Object, "spec", "targetRefs")
 	if err != nil {
 		return fmt.Errorf("read EnvoyFilter targetRefs: %w", err)
@@ -459,6 +472,7 @@ func patchPayloadProcessingEnvoyFilter(log logr.Logger, r *unstructured.Unstruct
 	}
 
 	anchorName := wasmpluginAnchorName(params.GatewayNamespace, params.GatewayName)
+	// Clusters stay on the shared IPP Services (not renamed per gateway).
 	beforeCluster := grpcClusterName(PayloadPreProcessingName, params.GatewayNamespace, 9004)
 	afterCluster := grpcClusterName(PayloadProcessingName, params.GatewayNamespace, 9004)
 

--- a/maas-controller/pkg/platform/tenantreconcile/params_test.go
+++ b/maas-controller/pkg/platform/tenantreconcile/params_test.go
@@ -165,8 +165,12 @@ func TestApplyPlatformParamsWithRenderedOverlay(t *testing.T) {
 	payloadPluginsConfigMap := requireResource(t, resources, GVKConfigMap, PayloadProcessingPluginsConfigMapName)
 	assert.Equal(t, params.GatewayNamespace, payloadPluginsConfigMap.GetNamespace())
 
-	payloadEnvoyFilter := requireResource(t, resources, GVKEnvoyFilter, PayloadProcessingName)
+	payloadEnvoyFilter := requireResource(t, resources, GVKEnvoyFilter, PayloadProcessingEnvoyFilterName(params.GatewayName))
 	assert.Equal(t, params.GatewayNamespace, payloadEnvoyFilter.GetNamespace())
+	priority, found, err := unstructured.NestedInt64(payloadEnvoyFilter.Object, "spec", "priority")
+	require.NoError(t, err)
+	require.True(t, found, "EnvoyFilter spec.priority must be set so RHCL wasm anchors apply after Kuadrant")
+	assert.Equal(t, PayloadProcessingEnvoyFilterPriority, priority)
 	targetRefs, found, err := unstructured.NestedSlice(payloadEnvoyFilter.Object, "spec", "targetRefs")
 	require.NoError(t, err)
 	require.True(t, found)

--- a/maas-controller/pkg/platform/tenantreconcile/pipeline.go
+++ b/maas-controller/pkg/platform/tenantreconcile/pipeline.go
@@ -10,6 +10,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation"
@@ -88,6 +89,12 @@ func RunPlatform(
 
 	if err := ApplyRendered(ctx, c, scheme, tenant, appNs, mcfg, resources); err != nil {
 		return nil, fmt.Errorf("apply: %w", err)
+	}
+
+	// Best-effort: remove the pre-multitenancy singleton EnvoyFilter/payload-processing
+	// so it does not double-attach ext_proc once per-gateway copies exist.
+	if err := deleteLegacySingletonPayloadEnvoyFilter(ctx, c, log, params.GatewayNamespace); err != nil {
+		log.V(1).Info("legacy payload-processing EnvoyFilter cleanup deferred", "error", err)
 	}
 
 	if err := syncMaaSParametersConfigMap(ctx, c, appNs, params, log); err != nil {
@@ -209,4 +216,25 @@ func MaasAPIDeploymentReady(ctx context.Context, c client.Client, appNamespace, 
 		return false, fmt.Sprintf("available replicas %d/%d", dep.Status.AvailableReplicas, desired), nil
 	}
 	return true, "", nil
+}
+
+// deleteLegacySingletonPayloadEnvoyFilter removes EnvoyFilter/payload-processing when
+// present. Per-gateway copies are named payload-processing-<gateway>; leaving the old
+// singleton would double-insert ext_proc on whatever Gateway it still targeted.
+func deleteLegacySingletonPayloadEnvoyFilter(ctx context.Context, c client.Client, log logr.Logger, gatewayNamespace string) error {
+	ef := &unstructured.Unstructured{}
+	ef.SetGroupVersionKind(GVKEnvoyFilter)
+	key := types.NamespacedName{Namespace: gatewayNamespace, Name: PayloadProcessingName}
+	if err := c.Get(ctx, key, ef); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+	log.Info("deleting legacy singleton payload-processing EnvoyFilter (replaced by per-gateway copies)",
+		"namespace", gatewayNamespace, "name", PayloadProcessingName)
+	if err := c.Delete(ctx, ef); err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+	return nil
 }

--- a/maas-controller/pkg/platform/tenantreconcile/pipeline_test.go
+++ b/maas-controller/pkg/platform/tenantreconcile/pipeline_test.go
@@ -2,13 +2,16 @@ package tenantreconcile
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -64,4 +67,60 @@ func TestSyncMaaSParametersConfigMap_UpdatesValue(t *testing.T) {
 	var updated corev1.ConfigMap
 	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: maasParametersConfigMapName, Namespace: "test-ns"}, &updated))
 	assert.Equal(t, "365", updated.Data["api-key-max-expiration-days"])
+}
+
+func TestPayloadProcessingEnvoyFilterName(t *testing.T) {
+	assert.Equal(t, "payload-processing-maas-default-gateway", PayloadProcessingEnvoyFilterName("maas-default-gateway"))
+	assert.Equal(t, "payload-processing-team-a-gw", PayloadProcessingEnvoyFilterName("team-a-gw"))
+
+	longGW := strings.Repeat("a", 50)
+	got := PayloadProcessingEnvoyFilterName(longGW)
+	assert.LessOrEqual(t, len(got), payloadProcessingEnvoyFilterNameMaxLen)
+	assert.True(t, strings.HasPrefix(got, PayloadProcessingName+"-"))
+	assert.NotEqual(t, PayloadProcessingEnvoyFilterName(longGW+"x"), got, "different gateways must not collide after truncate")
+}
+
+func TestDeleteLegacySingletonPayloadEnvoyFilter(t *testing.T) {
+	const gwNS = "openshift-ingress"
+
+	t.Run("noop when missing", func(t *testing.T) {
+		c := fake.NewClientBuilder().Build()
+		err := deleteLegacySingletonPayloadEnvoyFilter(context.Background(), c, logr.Discard(), gwNS)
+		assert.NoError(t, err)
+	})
+
+	t.Run("deletes singleton", func(t *testing.T) {
+		ef := &unstructured.Unstructured{}
+		ef.SetGroupVersionKind(GVKEnvoyFilter)
+		ef.SetNamespace(gwNS)
+		ef.SetName(PayloadProcessingName)
+		c := fake.NewClientBuilder().WithObjects(ef).Build()
+
+		err := deleteLegacySingletonPayloadEnvoyFilter(context.Background(), c, logr.Discard(), gwNS)
+		require.NoError(t, err)
+
+		got := &unstructured.Unstructured{}
+		got.SetGroupVersionKind(GVKEnvoyFilter)
+		err = c.Get(context.Background(), types.NamespacedName{Namespace: gwNS, Name: PayloadProcessingName}, got)
+		assert.True(t, apierrors.IsNotFound(err), "legacy singleton should be deleted")
+	})
+
+	t.Run("does not delete per-gateway copy", func(t *testing.T) {
+		ef := &unstructured.Unstructured{}
+		ef.SetGroupVersionKind(GVKEnvoyFilter)
+		ef.SetNamespace(gwNS)
+		ef.SetName(PayloadProcessingEnvoyFilterName("maas-default-gateway"))
+		c := fake.NewClientBuilder().WithObjects(ef).Build()
+
+		err := deleteLegacySingletonPayloadEnvoyFilter(context.Background(), c, logr.Discard(), gwNS)
+		require.NoError(t, err)
+
+		got := &unstructured.Unstructured{}
+		got.SetGroupVersionKind(GVKEnvoyFilter)
+		err = c.Get(context.Background(), types.NamespacedName{
+			Namespace: gwNS,
+			Name:      PayloadProcessingEnvoyFilterName("maas-default-gateway"),
+		}, got)
+		assert.NoError(t, err, "per-gateway EnvoyFilter must remain")
+	})
 }

--- a/test/e2e/tests/test_tenant.py
+++ b/test/e2e/tests/test_tenant.py
@@ -150,6 +150,42 @@ class TestTenantLifecycle:
             )
         assert result.stdout.strip(), "payload-processing deployment get succeeded but returned no name"
 
+    def test_payload_processing_envoyfilter_per_gateway(self):
+        """Each gateway should have its own payload-processing-<gateway> EnvoyFilter."""
+        st = _wait_tenant_ready()
+        assert st is not None, "MaasTenantConfig not Ready; skip EnvoyFilter checks."
+        if st.get("phase") != "Active":
+            pytest.skip("Tenant not Active; payload-processing EnvoyFilter not asserted")
+
+        gateway_name = os.environ.get("GATEWAY_NAME", "maas-default-gateway")
+        ef_name = f"payload-processing-{gateway_name}"
+        result = _oc_run(
+            [
+                "get",
+                "envoyfilter",
+                ef_name,
+                "-n",
+                GATEWAY_NAMESPACE,
+                "-o",
+                "jsonpath={.spec.targetRefs[0].name}",
+            ]
+        )
+        if result.returncode != 0:
+            if _oc_output_not_found(result):
+                pytest.skip(
+                    f"EnvoyFilter {ef_name} not found in {GATEWAY_NAMESPACE!r}; "
+                    "skipping (optional workload in some CI or partial installs)."
+                )
+            combined = (result.stderr or "") + (result.stdout or "")
+            pytest.fail(
+                f"`oc get envoyfilter {ef_name} -n {GATEWAY_NAMESPACE}` failed: "
+                f"{combined.strip()}"
+            )
+        assert result.stdout.strip() == gateway_name, (
+            f"EnvoyFilter {ef_name} should target Gateway/{gateway_name}, "
+            f"got {result.stdout.strip()!r}"
+        )
+
 
 class TestTenantContract:
     def test_status_has_phase_and_conditions(self):


### PR DESCRIPTION
## Summary

- Create one `EnvoyFilter` copy per Gateway (`payload-processing-<gatewayName>`), still pointing at the **shared** `payload-pre-processing` / `payload-processing` Deployments/Services, so multi-tenant gateways are not last-writer-wins on a singleton `targetRefs`.
- Set `spec.priority: 10` so RHCL Kuadrant wasm anchors exist before our `INSERT_*` patches.
- Delete the legacy singleton `EnvoyFilter/payload-processing` after apply to avoid double `ext_proc`.
- Truncate long EnvoyFilter names to 60 chars (with hash) instead of failing the 63-char DNS1123 limit.

## Hold / decision needed

**Putting this PR on hold.** Ishita is investigating how hard it would be to run **separate payload-processing (IPP) per unique Gateway** instead of shared IPP pods with per-gateway EnvoyFilter copies.

We should decide between:

1. **This PR (freeze-friendly):** per-gateway EnvoyFilter → shared IPP  
2. **Ishita’s direction:** unique IPP Deployment/Service (and EnvoyFilter) per Gateway  

…before merging, so we don’t ship the shared-IPP approach and then rip it out.

Tracking: https://github.com/opendatahub-io/models-as-a-service/issues/1246

## Test plan

- [ ] Unit: `go test ./pkg/platform/tenantreconcile/…` (naming, priority, legacy EF delete)
- [ ] E2E tenant assertions for per-gateway EnvoyFilter name
- [ ] On a multi-tenant cluster: each AITenant Gateway has `payload-processing-<gateway>`; body-routed `/v1/*` works on non-default gateways; default gateway still works after singleton cleanup
- [ ] Confirm long gateway names produce a ≤60-char EnvoyFilter name

## Risk analysis

- **Risk rating:** 3  
- **Why:** Touches gateway dataplane wiring (EnvoyFilter naming + priority + singleton cleanup). Unit/e2e cover the naming path, but multi-tenant gateway behavior is easy to miss in default smoke; shared IPP is intentional for now and may be superseded if we choose per-gateway IPP.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Payload processing now creates a dedicated EnvoyFilter for each gateway.
  * Long gateway names are safely shortened while remaining unique.
  * EnvoyFilter ordering is explicitly configured to ensure consistent processing.
* **Bug Fixes**
  * Legacy shared payload-processing resources are cleaned up to prevent duplicate configuration.
* **Tests**
  * Added coverage for gateway-specific naming, cleanup behavior, priority settings, and end-to-end gateway targeting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->