### PR TITLE
fix: remove unused authentications RBAC from maas-controller

### DIFF
--- a/deployment/base/maas-controller/rbac/clusterrole.yaml
+++ b/deployment/base/maas-controller/rbac/clusterrole.yaml
@@ -121,7 +121,7 @@ rules:
 - apiGroups:
   - config.openshift.io
   resources:
-  - authentications
+  - apiservers
   verbs:
   - get
   - list


### PR DESCRIPTION
## Parent operator PRs

- ai-gateway-operator: https://github.com/opendatahub-io/ai-gateway-operator/pull/76
- opendatahub-operator: TBD (needs similar RBAC update)

## Description

Removes the unused `authentications` resource from maas-controller ClusterRole RBAC.

### Problem

The maas-controller ClusterRole included `authentications` under `config.openshift.io` resources, but:
1. This resource is not used anywhere in the maas-controller code
2. It causes RBAC escalation errors when parent operators (ai-gateway-operator, opendatahub-operator) try to deploy this ClusterRole without holding that permission themselves

### Solution

Replace `authentications` with `apiservers` which is the only `config.openshift.io` resource actually used by the controller (for reading the cluster TLS profile).

### Impact

Fixes ai-gateway-operator e2e test failures:
```
clusterroles.rbac.authorization.k8s.io "maas-controller-role" is forbidden:
user "system:serviceaccount:ai-gateway-system:ai-gateway-operator"
is attempting to grant RBAC permissions not currently held:
{APIGroups:["config.openshift.io"], Resources:["authentications"], ...}
```

## Risk analysis

**Risk rating**: 2

**Why**: Changes RBAC permissions for the maas-controller, removing an unused permission. Low risk because:
- The `authentications` resource is not referenced in any controller code (grep confirms)
- Only `apiservers` is used (for TLS profile reading in cmd/manager/main.go)
- The change narrows permissions rather than expanding them
- Parent operator e2e tests (ai-gateway-operator) validate the change works correctly
- No code changes required, only manifest update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected access permissions for API server resources.
  * Preserved existing permissions and actions while updating the targeted resource.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->