### PR TITLE
fix(RHOAIENG-78942): gracefully handle empty monitoring-namespace

### DIFF
--- a/maas-controller/cmd/manager/main.go
+++ b/maas-controller/cmd/manager/main.go
@@ -935,11 +935,15 @@ func main() {
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
 
-	if errs := validation.IsDNS1123Label(monitoringNamespace); len(errs) > 0 {
-		setupLog.Error(stderrors.New("invalid monitoring namespace"),
-			"--monitoring-namespace must be a valid Kubernetes namespace name",
-			"namespace", monitoringNamespace, "errors", errs)
-		os.Exit(1)
+	// Allow empty monitoring-namespace to disable observability features (e.g. on xKS
+	// where the monitoring namespace may not exist). Non-empty values must be valid.
+	if monitoringNamespace != "" {
+		if errs := validation.IsDNS1123Label(monitoringNamespace); len(errs) > 0 {
+			setupLog.Error(stderrors.New("invalid monitoring namespace"),
+				"--monitoring-namespace must be a valid Kubernetes namespace name or empty to disable monitoring",
+				"namespace", monitoringNamespace, "errors", errs)
+			os.Exit(1)
+		}
 	}
 
 	if gatewayName == "" || gatewayNamespace == "" {

--- a/maas-controller/pkg/controller/maas/self_deployment_controller.go
+++ b/maas-controller/pkg/controller/maas/self_deployment_controller.go
@@ -397,6 +397,21 @@ func aitenantReferencesConfig(aitenant *maasv1alpha1.AITenant, ct *maasv1alpha1.
 }
 
 func (r *LifecycleReconciler) ensureObservability(ctx context.Context, log logr.Logger) error {
+	if r.MonitoringNamespace == "" {
+		log.V(1).Info("monitoring namespace not configured; skipping observability setup")
+		return nil
+	}
+
+	var ns corev1.Namespace
+	if err := r.Get(ctx, client.ObjectKey{Name: r.MonitoringNamespace}, &ns); err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Info("monitoring namespace does not exist; skipping observability setup",
+				"namespace", r.MonitoringNamespace)
+			return nil
+		}
+		return fmt.Errorf("checking monitoring namespace %q: %w", r.MonitoringNamespace, err)
+	}
+
 	if err := r.ensureLimitadorServiceMonitor(ctx); err != nil {
 		return err
 	}

--- a/maas-controller/pkg/controller/maas/self_deployment_controller_test.go
+++ b/maas-controller/pkg/controller/maas/self_deployment_controller_test.go
@@ -979,6 +979,38 @@ func TestEnsureUsageLogs(t *testing.T) {
 	})
 }
 
+func TestEnsureObservability_EmptyMonitoringNamespace(t *testing.T) {
+	t.Run("skips when monitoring namespace is empty", func(t *testing.T) {
+		g := NewWithT(t)
+		s := lifecycleTestScheme(t)
+
+		cl := fake.NewClientBuilder().WithScheme(s).Build()
+		r := &LifecycleReconciler{
+			Client:             cl,
+			Scheme:             s,
+			MonitoringNamespace: "",
+		}
+
+		err := r.ensureObservability(context.Background(), ctrl.Log)
+		g.Expect(err).NotTo(HaveOccurred())
+	})
+
+	t.Run("skips when monitoring namespace does not exist", func(t *testing.T) {
+		g := NewWithT(t)
+		s := lifecycleTestScheme(t)
+
+		cl := fake.NewClientBuilder().WithScheme(s).Build()
+		r := &LifecycleReconciler{
+			Client:             cl,
+			Scheme:             s,
+			MonitoringNamespace: "nonexistent-ns",
+		}
+
+		err := r.ensureObservability(context.Background(), ctrl.Log)
+		g.Expect(err).NotTo(HaveOccurred())
+	})
+}
+
 func TestPatchTenancyProxyImage(t *testing.T) {
 	t.Run("patches proxy container image when RELATED_IMAGE set", func(t *testing.T) {
 		g := NewWithT(t)

--- a/maas-controller/pkg/controller/maas/self_deployment_controller_test.go
+++ b/maas-controller/pkg/controller/maas/self_deployment_controller_test.go
@@ -986,8 +986,8 @@ func TestEnsureObservability_EmptyMonitoringNamespace(t *testing.T) {
 
 		cl := fake.NewClientBuilder().WithScheme(s).Build()
 		r := &LifecycleReconciler{
-			Client:             cl,
-			Scheme:             s,
+			Client:              cl,
+			Scheme:              s,
 			MonitoringNamespace: "",
 		}
 
@@ -1001,8 +1001,8 @@ func TestEnsureObservability_EmptyMonitoringNamespace(t *testing.T) {
 
 		cl := fake.NewClientBuilder().WithScheme(s).Build()
 		r := &LifecycleReconciler{
-			Client:             cl,
-			Scheme:             s,
+			Client:              cl,
+			Scheme:              s,
 			MonitoringNamespace: "nonexistent-ns",
 		}
 


### PR DESCRIPTION
## Summary

On xKS clusters, the `monitoring-namespace` parameter in `params.env` may be empty (the ai-gateway-operator sets it from the platform config, which on xKS has no monitoring namespace). This causes the maas-controller to crash immediately on startup with exit code 1 and **no log output**, making it very hard to debug.

**Root cause:** `validation.IsDNS1123Label("")` rejects empty strings, and `os.Exit(1)` runs before `ctrl.SetLogger()` is called — so there's no log output at all.

**Fix:**
- Allow empty `--monitoring-namespace` to gracefully disable observability (matching `--infra-namespace` semantics which already allows empty)
- Add namespace existence check in `ensureObservability` to skip when the namespace doesn't exist on the cluster
- Unit tests for both scenarios

## Test plan

- [x] `go build ./cmd/manager/` compiles cleanly
- [x] `go test ./pkg/controller/maas/` — all existing tests pass
- [x] New test `TestEnsureObservability_EmptyMonitoringNamespace` passes (both "empty" and "nonexistent" cases)
- [x] Manually verified on AKS cluster: controller starts and runs with empty monitoring-namespace instead of crashing

Fixes: https://redhat.atlassian.net/browse/RHOAIENG-78942

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Monitoring and observability are now optional when no monitoring namespace is configured.
  * Observability setup is skipped when the configured namespace does not exist.

* **Bug Fixes**
  * Invalid configured monitoring namespaces now produce clear validation errors.
  * Missing monitoring namespaces no longer cause unnecessary reconciliation failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->