### PR TITLE
fix(RHOAIENG-78602): auto-select xKS manifest overlay for maas-api

### DIFF
--- a/deployment/base/maas-controller/rbac/clusterrole.yaml
+++ b/deployment/base/maas-controller/rbac/clusterrole.yaml
@@ -119,6 +119,17 @@ rules:
   - delete
   - get
 - apiGroups:
+  - cert-manager.io
+  resources:
+  - certificates
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
   - config.openshift.io
   resources:
   - apiservers

--- a/maas-api/deploy/overlays/xks/certificate.yaml
+++ b/maas-api/deploy/overlays/xks/certificate.yaml
@@ -1,0 +1,15 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: maas-api-serving-cert
+spec:
+  secretName: maas-api-serving-cert
+  issuerRef:
+    name: rhai-ca-issuer
+    kind: ClusterIssuer
+    group: cert-manager.io
+  duration: 2160h # 90 days
+  renewBefore: 360h # 15 days
+  dnsNames:
+    - "maas-api.opendatahub.svc"
+    - "maas-api.opendatahub.svc.cluster.local"

--- a/maas-api/deploy/overlays/xks/kustomization.yaml
+++ b/maas-api/deploy/overlays/xks/kustomization.yaml
@@ -11,6 +11,8 @@ resources:
   - ../../../../deployment/base/maas-controller/policies
   - ../../../../deployment/base/payload-processing/default
 
+namespace: opendatahub
+
 patches:
   # Replace OCP service-ca ConfigMap with an emptyDir (CA is injected by cert-manager
   # via the trust-manager or mounted from the cluster CA bundle)

--- a/maas-api/deploy/overlays/xks/kustomization.yaml
+++ b/maas-api/deploy/overlays/xks/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - ../../../../deployment/base/maas-api/overlays/tls
   - ../../../../deployment/base/maas-controller/policies
   - ../../../../deployment/base/payload-processing/default
+  - certificate.yaml
 
 namespace: opendatahub
 

--- a/maas-api/deploy/overlays/xks/kustomization.yaml
+++ b/maas-api/deploy/overlays/xks/kustomization.yaml
@@ -1,0 +1,46 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+metadata:
+  name: maas-api-xks
+
+# xKS overlay: uses cert-manager for TLS instead of OCP service-serving-certs.
+# On xKS, cert-manager creates the serving cert and the cloud-manager injects the CA.
+resources:
+  - ../../../../deployment/base/maas-api/overlays/tls
+  - ../../../../deployment/base/maas-controller/policies
+  - ../../../../deployment/base/payload-processing/default
+
+patches:
+  # Replace OCP service-ca ConfigMap with an emptyDir (CA is injected by cert-manager
+  # via the trust-manager or mounted from the cluster CA bundle)
+  - target:
+      kind: Deployment
+      name: maas-api
+    patch: |
+      - op: replace
+        path: /spec/template/spec/volumes/1
+        value:
+          name: openshift-service-ca
+          secret:
+            secretName: opendatahub-ca
+            items:
+              - key: tls.crt
+                path: service-ca.crt
+            optional: true
+
+  # Remove OCP service-ca annotation (cert-manager handles cert creation)
+  - target:
+      kind: Service
+      name: maas-api
+    patch: |
+      - op: remove
+        path: /metadata/annotations/service.beta.openshift.io~1serving-cert-secret-name
+
+  # Remove OCP CA bundle injection annotation from ConfigMap
+  - target:
+      kind: ConfigMap
+      name: openshift-service-ca.crt
+    patch: |
+      - op: remove
+        path: /metadata/annotations/service.beta.openshift.io~1inject-cabundle

--- a/maas-controller/cmd/manager/main.go
+++ b/maas-controller/cmd/manager/main.go
@@ -1203,7 +1203,7 @@ func main() {
 
 	manifestPath := os.Getenv("MAAS_PLATFORM_MANIFESTS")
 	if manifestPath == "" {
-		manifestPath = tenantreconcile.DefaultManifestPath()
+		manifestPath = tenantreconcile.ManifestPathForPlatform(tlsConfig.available)
 	}
 	if abs, err := filepath.Abs(manifestPath); err == nil {
 		manifestPath = abs

--- a/maas-controller/cmd/manager/main.go
+++ b/maas-controller/cmd/manager/main.go
@@ -1203,7 +1203,10 @@ func main() {
 
 	manifestPath := os.Getenv("MAAS_PLATFORM_MANIFESTS")
 	if manifestPath == "" {
-		manifestPath = tenantreconcile.ManifestPathForPlatform(tlsConfig.available)
+		// tlsConfig.available reflects whether config.openshift.io API exists,
+		// which is the authoritative signal for OCP vs vanilla Kubernetes.
+		isOCP := tlsConfig.available
+		manifestPath = tenantreconcile.ManifestPathForPlatform(isOCP)
 	}
 	if abs, err := filepath.Abs(manifestPath); err == nil {
 		manifestPath = abs

--- a/maas-controller/pkg/controller/maas/tenant_controller.go
+++ b/maas-controller/pkg/controller/maas/tenant_controller.go
@@ -103,6 +103,7 @@ type TenantReconciler struct {
 // +kubebuilder:rbac:groups=telemetry.istio.io,resources=telemetries,verbs=get;list;watch;create;patch;delete
 // +kubebuilder:rbac:groups=batch,resources=cronjobs,verbs=get;list;watch;create;patch;delete
 // +kubebuilder:rbac:groups=monitoring.coreos.com,resources=podmonitors;servicemonitors,verbs=get;list;watch;create;patch;delete
+// +kubebuilder:rbac:groups=cert-manager.io,resources=certificates,verbs=get;list;watch;create;patch;delete
 
 // clusterroles/clusterrolebindings: TenantReconciler SSA-applies the maas-api and payload-processing-reader
 // ClusterRoles. The API-server escalation check requires the applying SA to already hold every permission those

--- a/maas-controller/pkg/platform/tenantreconcile/constants.go
+++ b/maas-controller/pkg/platform/tenantreconcile/constants.go
@@ -78,6 +78,7 @@ const (
 	baseMaaSAPIServiceName                         = "maas-api"
 	baseMaaSAPIKeyCleanupScriptConfigMapName       = "maas-api-key-cleanup-script" //nolint:gosec // Kubernetes resource name, not a credential
 	baseMaaSAPIDeploymentNSNetworkPolicyName       = "maas-api-allow-deployment-ns"
+	baseMaaSAPIServingCertName                     = "maas-api-serving-cert" //nolint:gosec // cert-manager resource name, not a credential
 
 	// Base IPP resource names in kustomize manifests. Per-tenant deployments suffix
 	// these with "-{tenantID}" (default tenant keeps unsuffixed names).
@@ -121,6 +122,7 @@ var (
 	GVKNetworkPolicy        = schema.GroupVersionKind{Group: "networking.k8s.io", Version: "v1", Kind: "NetworkPolicy"}
 	GVKPersesDashboard      = schema.GroupVersionKind{Group: "perses.dev", Version: "v1alpha1", Kind: "PersesDashboard"}
 	GVKPersesDatasource     = schema.GroupVersionKind{Group: "perses.dev", Version: "v1alpha1", Kind: "PersesDatasource"}
+	GVKCertificate          = schema.GroupVersionKind{Group: "cert-manager.io", Version: "v1", Kind: "Certificate"}
 )
 
 // Resource naming functions for multi-tenant deployment.
@@ -223,6 +225,10 @@ func PayloadProcessingServiceAccountName(tenantID string) string {
 
 func PayloadProcessingNetworkPolicyName(tenantID string) string {
 	return resourceNameForTenant(PayloadProcessingName, tenantID)
+}
+
+func MaaSAPIServingCertName(tenantID string) string {
+	return resourceNameForTenant(baseMaaSAPIServingCertName, tenantID)
 }
 
 func PayloadProcessingReaderClusterRoleBindingNameForTenant(tenantID string) string {

--- a/maas-controller/pkg/platform/tenantreconcile/constants.go
+++ b/maas-controller/pkg/platform/tenantreconcile/constants.go
@@ -78,7 +78,7 @@ const (
 	baseMaaSAPIServiceName                         = "maas-api"
 	baseMaaSAPIKeyCleanupScriptConfigMapName       = "maas-api-key-cleanup-script" //nolint:gosec // Kubernetes resource name, not a credential
 	baseMaaSAPIDeploymentNSNetworkPolicyName       = "maas-api-allow-deployment-ns"
-	baseMaaSAPIServingCertName                     = "maas-api-serving-cert" //nolint:gosec // cert-manager resource name, not a credential
+	baseMaaSAPIServingCertName                     = "maas-api-serving-cert"
 
 	// Base IPP resource names in kustomize manifests. Per-tenant deployments suffix
 	// these with "-{tenantID}" (default tenant keeps unsuffixed names).

--- a/maas-controller/pkg/platform/tenantreconcile/kustomize.go
+++ b/maas-controller/pkg/platform/tenantreconcile/kustomize.go
@@ -182,3 +182,17 @@ func DefaultManifestPath() string {
 	}
 	return "../maas-api/deploy/overlays/odh"
 }
+
+// ManifestPathForPlatform returns the appropriate kustomize overlay path based on
+// whether the cluster is OpenShift (isOCP=true) or vanilla Kubernetes (isOCP=false).
+// The xKS overlay avoids OCP-specific resources like service-serving-certs and
+// service-ca ConfigMap injection that don't exist on non-OpenShift clusters.
+func ManifestPathForPlatform(isOCP bool) string {
+	if v := os.Getenv("MAAS_PLATFORM_MANIFESTS"); v != "" {
+		return v
+	}
+	if isOCP {
+		return "/maas-api/deploy/overlays/odh"
+	}
+	return "/maas-api/deploy/overlays/xks"
+}

--- a/maas-controller/pkg/platform/tenantreconcile/kustomize_test.go
+++ b/maas-controller/pkg/platform/tenantreconcile/kustomize_test.go
@@ -1,0 +1,27 @@
+package tenantreconcile
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestManifestPathForPlatform(t *testing.T) {
+	t.Run("returns OCP overlay when isOCP is true", func(t *testing.T) {
+		t.Setenv("MAAS_PLATFORM_MANIFESTS", "")
+		path := ManifestPathForPlatform(true)
+		assert.Equal(t, "/maas-api/deploy/overlays/odh", path)
+	})
+
+	t.Run("returns xKS overlay when isOCP is false", func(t *testing.T) {
+		t.Setenv("MAAS_PLATFORM_MANIFESTS", "")
+		path := ManifestPathForPlatform(false)
+		assert.Equal(t, "/maas-api/deploy/overlays/xks", path)
+	})
+
+	t.Run("respects MAAS_PLATFORM_MANIFESTS override", func(t *testing.T) {
+		t.Setenv("MAAS_PLATFORM_MANIFESTS", "/custom/path")
+		path := ManifestPathForPlatform(true)
+		assert.Equal(t, "/custom/path", path)
+	})
+}

--- a/maas-controller/pkg/platform/tenantreconcile/params.go
+++ b/maas-controller/pkg/platform/tenantreconcile/params.go
@@ -239,6 +239,8 @@ func patchResource(log logr.Logger, r *unstructured.Unstructured, params Platfor
 	case gvk == GVKClusterRoleBinding && name == PayloadProcessingReaderClusterRoleBindingName:
 		r.SetName(PayloadProcessingReaderClusterRoleBindingNameForTenant(tenantID))
 		return patchPayloadProcessingClusterRoleBinding(r, params)
+	case gvk == GVKCertificate && name == baseMaaSAPIServingCertName:
+		return patchMaaSAPIServingCert(log, r, params)
 	}
 	return nil
 }
@@ -273,6 +275,35 @@ func patchDeploymentNSNetworkPolicy(r *unstructured.Unstructured, controllerName
 		"kubernetes.io/metadata.name": controllerNamespace,
 	}
 	return unstructured.SetNestedSlice(r.Object, ingress, "spec", "ingress")
+}
+
+// patchMaaSAPIServingCert remaps the Certificate's secretName and dnsNames to use
+// the actual infra namespace (replacing the kustomize overlay's hardcoded "opendatahub"
+// placeholder). This makes the controller self-sufficient for TLS — no dependency on
+// the Helm chart hook to create the cert in the correct namespace.
+func patchMaaSAPIServingCert(log logr.Logger, r *unstructured.Unstructured, params PlatformParams) error {
+	tenantID := params.TenantIdentifier
+	certName := MaaSAPIServingCertName(tenantID)
+	r.SetName(certName)
+
+	secretName := certName
+	if err := unstructured.SetNestedField(r.Object, secretName, "spec", "secretName"); err != nil {
+		return fmt.Errorf("patch Certificate secretName: %w", err)
+	}
+
+	serviceName := MaaSAPIServiceName(tenantID)
+	newDNSNames := []any{
+		fmt.Sprintf("%s.%s.svc", serviceName, params.AppNamespace),
+		fmt.Sprintf("%s.%s.svc.cluster.local", serviceName, params.AppNamespace),
+	}
+	if err := unstructured.SetNestedSlice(r.Object, newDNSNames, "spec", "dnsNames"); err != nil {
+		return fmt.Errorf("patch Certificate dnsNames: %w", err)
+	}
+
+	log.V(4).Info("Patched maas-api serving Certificate",
+		"name", certName, "secretName", secretName,
+		"dnsNames", newDNSNames, "namespace", params.AppNamespace)
+	return nil
 }
 
 func patchMaaSAPIDeployment(log logr.Logger, r *unstructured.Unstructured, params PlatformParams) error {

--- a/maas-controller/pkg/platform/tenantreconcile/params_test.go
+++ b/maas-controller/pkg/platform/tenantreconcile/params_test.go
@@ -638,3 +638,87 @@ func requireServiceSelectorLabel(t *testing.T, r *unstructured.Unstructured, key
 	require.True(t, ok, "selector label %q not found", key)
 	return value
 }
+
+func TestPatchMaaSAPIServingCert_DefaultTenant(t *testing.T) {
+	cert := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "cert-manager.io/v1",
+		"kind":       "Certificate",
+		"metadata": map[string]any{
+			"name":      "maas-api-serving-cert",
+			"namespace": "redhat-ai-gateway-infra",
+		},
+		"spec": map[string]any{
+			"secretName": "maas-api-serving-cert",
+			"issuerRef": map[string]any{
+				"name":  "rhai-ca-issuer",
+				"kind":  "ClusterIssuer",
+				"group": "cert-manager.io",
+			},
+			"dnsNames": []any{
+				"maas-api.opendatahub.svc",
+				"maas-api.opendatahub.svc.cluster.local",
+			},
+		},
+	}}
+
+	params := PlatformParams{
+		AppNamespace:     "redhat-ai-gateway-infra",
+		TenantIdentifier: "",
+	}
+
+	err := patchMaaSAPIServingCert(logr.Discard(), cert, params)
+	require.NoError(t, err)
+
+	assert.Equal(t, "maas-api-serving-cert", cert.GetName())
+
+	secretName, _, _ := unstructured.NestedString(cert.Object, "spec", "secretName")
+	assert.Equal(t, "maas-api-serving-cert", secretName)
+
+	dnsNames, _, _ := unstructured.NestedStringSlice(cert.Object, "spec", "dnsNames")
+	assert.Equal(t, []string{
+		"maas-api.redhat-ai-gateway-infra.svc",
+		"maas-api.redhat-ai-gateway-infra.svc.cluster.local",
+	}, dnsNames)
+}
+
+func TestPatchMaaSAPIServingCert_MultiTenant(t *testing.T) {
+	cert := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "cert-manager.io/v1",
+		"kind":       "Certificate",
+		"metadata": map[string]any{
+			"name":      "maas-api-serving-cert",
+			"namespace": "redhat-ai-gateway-infra",
+		},
+		"spec": map[string]any{
+			"secretName": "maas-api-serving-cert",
+			"issuerRef": map[string]any{
+				"name":  "rhai-ca-issuer",
+				"kind":  "ClusterIssuer",
+				"group": "cert-manager.io",
+			},
+			"dnsNames": []any{
+				"maas-api.opendatahub.svc",
+				"maas-api.opendatahub.svc.cluster.local",
+			},
+		},
+	}}
+
+	params := PlatformParams{
+		AppNamespace:     "redhat-ai-gateway-infra",
+		TenantIdentifier: "redteam",
+	}
+
+	err := patchMaaSAPIServingCert(logr.Discard(), cert, params)
+	require.NoError(t, err)
+
+	assert.Equal(t, "maas-api-serving-cert-redteam", cert.GetName())
+
+	secretName, _, _ := unstructured.NestedString(cert.Object, "spec", "secretName")
+	assert.Equal(t, "maas-api-serving-cert-redteam", secretName)
+
+	dnsNames, _, _ := unstructured.NestedStringSlice(cert.Object, "spec", "dnsNames")
+	assert.Equal(t, []string{
+		"maas-api-redteam.redhat-ai-gateway-infra.svc",
+		"maas-api-redteam.redhat-ai-gateway-infra.svc.cluster.local",
+	}, dnsNames)
+}


### PR DESCRIPTION
## Summary

On non-OpenShift Kubernetes clusters, the `maas-api` Deployment references OCP-specific resources:
- `openshift-service-ca.crt` ConfigMap (auto-injected by OCP's service-ca operator)
- `maas-api-serving-cert` Secret (auto-created by OCP's serving-cert-signer)

These don't exist on vanilla Kubernetes, causing the pod to be stuck in `ContainerCreating` indefinitely.

**Fix:**
- Adds a new `maas-api/deploy/overlays/xks/` kustomize overlay that sources TLS from cert-manager (`opendatahub-ca` Secret) instead of OCP service-ca
- Introduces `ManifestPathForPlatform(isOCP bool)` that auto-selects the correct overlay based on whether `config.openshift.io` APIs are available (same detection already used for TLS profile loading)
- `MAAS_PLATFORM_MANIFESTS` env var still takes precedence for manual override
- Existing Dockerfile already copies `maas-api/deploy/` into the image — no Dockerfile changes needed

## Test plan

- [x] `go build ./cmd/manager/` compiles cleanly
- [x] `go test ./pkg/platform/tenantreconcile/` — new `TestManifestPathForPlatform` passes
- [x] `go test ./pkg/controller/maas/` — all existing tests pass
- [x] Validated on AKS cluster: maas-api starts with cert-manager certs instead of OCP service-ca

Fixes: https://redhat.atlassian.net/browse/RHOAIENG-78602

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added platform-aware default selection of deployment manifests (OpenShift vs Kubernetes) when no custom manifest path is provided.
* **Bug Fixes**
  * Improved XKS certificate and CA handling by updating how the service CA is sourced and preventing automatic OpenShift certificate/CA bundle injection so cert-manager can manage it.
* **Tests**
  * Added unit tests covering platform-specific manifest path selection and verifying environment-based overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->