### PR TITLE
fix: wait for gateway AuthPolicy Enforced before e2e API calls

### DIFF
--- a/test/e2e/tests/multitenancy_helpers.py
+++ b/test/e2e/tests/multitenancy_helpers.py
@@ -16,6 +16,8 @@ import requests
 
 from test_helper import (
     DEPLOYMENT_NAMESPACE,
+    GATEWAY_PROPAGATION_DELAY,
+    GATEWAY_PROPAGATION_RETRIES,
     MAAS_API_DEPLOYMENT_NAMESPACE,
     MODEL_NAMESPACE,
     MODEL_REF,
@@ -24,6 +26,7 @@ from test_helper import (
     _apply_cr,
     _delete_cr,
     _ns,
+    _request_with_gateway_retry,
     _wait_reconcile,
 )
 
@@ -1281,13 +1284,21 @@ def bearer_headers(token: str) -> dict[str, str]:
 
 
 def create_api_key_at(base_url: str, oc_token: str, name: str, *, subscription: Optional[str] = None) -> requests.Response:
+    """Create an API key against a tenant-scoped maas-api URL.
+
+    Retries empty 403 / Authorino AUTH_FAILURE while per-tenant gateway
+    AuthPolicy enforcement catches up (same flake mode as single-tenant helpers).
+    """
     body: dict[str, str] = {"name": name}
     if subscription:
         body["subscription"] = subscription
-    return requests.post(
+    return _request_with_gateway_retry(
+        requests.post,
         f"{base_url}/v1/api-keys",
         headers=bearer_headers(oc_token),
         json=body,
+        retries=GATEWAY_PROPAGATION_RETRIES,
+        delay=GATEWAY_PROPAGATION_DELAY,
         timeout=TIMEOUT,
         verify=TLS_VERIFY,
     )

--- a/test/e2e/tests/test_api_keys.py
+++ b/test/e2e/tests/test_api_keys.py
@@ -57,57 +57,27 @@ from test_helper import (
     _get_cr,
     _maas_api_url,
     _ns,
+    _request_with_gateway_retry,
     _sa_to_user,
     _scale_controller_down,
     _scale_controller_up,
+    _wait_for_gateway_auth_enforced,
     _wait_for_maas_subscription_phase,
     _wait_reconcile,
 )
 
 log = logging.getLogger(__name__)
 
-# ---------------------------------------------------------------------------
-# Gateway propagation retry helper
-# ---------------------------------------------------------------------------
-# Kuadrant gateway propagation can lag behind MaaS CR readiness.
-# MaaSAuthPolicy "Active" means the controller created the Kuadrant AuthPolicy,
-# but Envoy may not have loaded it yet.  Retry on empty 403 (gateway rejection).
-GATEWAY_PROPAGATION_RETRIES = 6
-GATEWAY_PROPAGATION_DELAY = 5  # seconds
-
-
-def _request_with_gateway_retry(method, url, retries=GATEWAY_PROPAGATION_RETRIES, **kwargs):
-    """Make an HTTP request, retrying on transient gateway/auth errors.
-
-    Retries on:
-    - Empty 403: Envoy hasn't loaded the AuthPolicy yet.
-    - 500 with AUTH_FAILURE: Authorino race condition during AuthConfig updates
-      (metadata evaluators not yet linked after policy reconciliation).
-
-    Returns the last response — the caller's assertion will surface the
-    failure clearly if the gateway never becomes ready.
-    """
-    for attempt in range(1, retries + 1):
-        r = method(url, timeout=kwargs.pop("timeout", 30), verify=kwargs.pop("verify", TLS_VERIFY), **kwargs)
-        retryable = (r.status_code == 403 and not r.text.strip()) or (
-            r.status_code == 500 and "AUTH_FAILURE" in r.text
-        )
-        if retryable and attempt < retries:
-            log.info("Gateway returned %d (attempt %d/%d), retrying in %ds...",
-                     r.status_code, attempt, retries, GATEWAY_PROPAGATION_DELAY)
-            time.sleep(GATEWAY_PROPAGATION_DELAY)
-            continue
-        return r
-    return r  # last attempt's response — assertion will catch the failure
-
 
 @pytest.fixture(scope="session", autouse=True)
 def _warm_gateway(api_keys_base_url: str, headers: dict):
-    """Wait for the gateway to start forwarding requests before running tests.
+    """Wait for gateway AuthPolicy enforcement before running API key tests.
 
-    Makes a single request with gateway retry to absorb the propagation delay.
-    All subsequent tests can then make requests directly without retry logic.
+    MaaSAuthPolicy churn in earlier modules (or this session) can leave
+    maas-gateway-auth reconciling; empty 403s follow until Enforced=True and
+    Envoy loads the config.
     """
+    _wait_for_gateway_auth_enforced(timeout=120)
     r = _request_with_gateway_retry(
         requests.post,
         api_keys_base_url,
@@ -1558,26 +1528,36 @@ class TestAPIKeySubscriptionFilter:
             _delete_cr("maassubscription", sub_a, namespace=ns)
             _delete_cr("maasauthpolicy", f"{sub_a}-auth", namespace=ns)
             _delete_sa(sa_name, namespace=MODEL_NAMESPACE)
-            _wait_reconcile()
+            # Deleting MaaSAuthPolicies rewrites maas-gateway-auth; wait until
+            # Kuadrant reports Enforced again before the next test hits maas-api.
+            _wait_for_gateway_auth_enforced(timeout=120)
 
     def test_search_without_subscription_returns_all(self, api_keys_base_url: str, headers: dict):
         """Search without subscription filter returns keys across all subscriptions."""
+        # Prior tests may have just mutated MaaSAuthPolicies; ensure gateway auth
+        # is Enforced before minting keys (avoids empty 403 flakes).
+        _wait_for_gateway_auth_enforced(timeout=120)
         key_ids = []
         try:
             # Create keys with explicit subscription binding
             for i in range(2):
-                r = requests.post(
+                r = _request_with_gateway_retry(
+                    requests.post,
                     api_keys_base_url,
                     headers=headers,
                     json={"name": f"e2e-nofilter-{i}", "subscription": SIMULATOR_SUBSCRIPTION},
                     timeout=TIMEOUT,
                     verify=TLS_VERIFY,
                 )
-                assert r.status_code in (200, 201), f"Failed to create key: {r.text}"
+                assert r.status_code in (200, 201), (
+                    f"Failed to create key: {r.status_code} "
+                    f"{r.text.strip() or '(empty body — gateway AuthPolicy not ready)'}"
+                )
                 key_ids.append(r.json()["id"])
 
             # Search without subscription filter
-            r_search = requests.post(
+            r_search = _request_with_gateway_retry(
+                requests.post,
                 f"{api_keys_base_url}/search",
                 headers=headers,
                 json={
@@ -1587,7 +1567,10 @@ class TestAPIKeySubscriptionFilter:
                 timeout=TIMEOUT,
                 verify=TLS_VERIFY,
             )
-            assert r_search.status_code == 200, f"Search failed: {r_search.status_code} {r_search.text}"
+            assert r_search.status_code == 200, (
+                f"Search failed: {r_search.status_code} "
+                f"{r_search.text.strip() or '(empty body — gateway AuthPolicy not ready)'}"
+            )
             items = r_search.json().get("items") or r_search.json().get("data") or []
             result_ids = [item["id"] for item in items]
 

--- a/test/e2e/tests/test_api_keys.py
+++ b/test/e2e/tests/test_api_keys.py
@@ -77,7 +77,7 @@ def _warm_gateway(api_keys_base_url: str, headers: dict):
     maas-gateway-auth reconciling; empty 403s follow until Enforced=True and
     Envoy loads the config.
     """
-    _wait_for_gateway_auth_enforced(timeout=120)
+    _wait_for_gateway_auth_enforced()
     r = _request_with_gateway_retry(
         requests.post,
         api_keys_base_url,
@@ -1530,13 +1530,13 @@ class TestAPIKeySubscriptionFilter:
             _delete_sa(sa_name, namespace=MODEL_NAMESPACE)
             # Deleting MaaSAuthPolicies rewrites maas-gateway-auth; wait until
             # Kuadrant reports Enforced again before the next test hits maas-api.
-            _wait_for_gateway_auth_enforced(timeout=120)
+            _wait_for_gateway_auth_enforced()
 
     def test_search_without_subscription_returns_all(self, api_keys_base_url: str, headers: dict):
         """Search without subscription filter returns keys across all subscriptions."""
         # Prior tests may have just mutated MaaSAuthPolicies; ensure gateway auth
         # is Enforced before minting keys (avoids empty 403 flakes).
-        _wait_for_gateway_auth_enforced(timeout=120)
+        _wait_for_gateway_auth_enforced()
         key_ids = []
         try:
             # Create keys with explicit subscription binding

--- a/test/e2e/tests/test_helper.py
+++ b/test/e2e/tests/test_helper.py
@@ -40,7 +40,12 @@ Environment variables (all optional unless noted):
   - E2E_DISTINCT_MODEL_2_ID: Canonical BBR model ID for second distinct model (default: publishers/{MODEL_NAMESPACE}/models/test/e2e-distinct-model-2)
   - E2E_TRLP_TEST_MODEL_REF: TRLP test model ref (default: e2e-trlp-test-simulated)                                                                                                   
   - E2E_TRLP_TEST_MODEL_PATH: Path to TRLP test model (default: /llm/e2e-trlp-test-simulated)
-  - E2E_TRLP_TEST_MODEL_ID: Model ID for TRLP test model (default: test/e2e-trlp-test-model) 
+  - E2E_TRLP_TEST_MODEL_ID: Model ID for TRLP test model (default: test/e2e-trlp-test-model)
+  - E2E_GATEWAY_AUTH_POLICY_NAME: Gateway Kuadrant AuthPolicy name (default: maas-gateway-auth)
+  - E2E_GATEWAY_PROPAGATION_RETRIES: Retries for empty 401/403 / AUTH_FAILURE (default: 6)
+  - E2E_GATEWAY_PROPAGATION_DELAY: Delay between gateway retries in seconds (default: 5)
+  - E2E_GATEWAY_ENFORCED_TIMEOUT: Wait for AuthPolicy Accepted+Enforced (default: 180)
+  - E2E_GATEWAY_ENFORCED_MISSING_GRACE: Fail early if AuthPolicy CR absent this long (default: 30)
 """
 
 import base64
@@ -76,6 +81,12 @@ GATEWAY_AUTH_POLICY_NAME = os.environ.get("E2E_GATEWAY_AUTH_POLICY_NAME", "maas-
 # Empty 403 / Authorino AUTH_FAILURE while Envoy catches up after AuthPolicy updates.
 GATEWAY_PROPAGATION_RETRIES = int(os.environ.get("E2E_GATEWAY_PROPAGATION_RETRIES", "6"))
 GATEWAY_PROPAGATION_DELAY = int(os.environ.get("E2E_GATEWAY_PROPAGATION_DELAY", "5"))
+# Wait for maas-gateway-auth Accepted+Enforced before minting keys / calling maas-api.
+# 180s covers AuthConfig backlog after heavy MaaSAuthPolicy churn in Konflux e2e.
+GATEWAY_ENFORCED_TIMEOUT = int(os.environ.get("E2E_GATEWAY_ENFORCED_TIMEOUT", "180"))
+# If the AuthPolicy CR is missing this long, fail fast (misconfigured name/namespace)
+# instead of burning the full GATEWAY_ENFORCED_TIMEOUT.
+GATEWAY_ENFORCED_MISSING_GRACE = int(os.environ.get("E2E_GATEWAY_ENFORCED_MISSING_GRACE", "30"))
 
 
 def _derive_infra_namespace(controller_namespace: str) -> str:
@@ -253,7 +264,8 @@ def _request_with_gateway_retry(method, url, retries=None, delay=None, **kwargs)
     """Make an HTTP request, retrying transient gateway/auth propagation errors.
 
     Retries on:
-    - Empty 403: Envoy has not loaded the AuthPolicy yet (common after MaaSAuthPolicy churn).
+    - Empty 403 / empty 401: Envoy has not loaded the AuthPolicy yet (common after
+      MaaSAuthPolicy churn; some gateways return 401 instead of 403).
     - 500 with AUTH_FAILURE: Authorino race while AuthConfig is updating.
 
     Returns the last response — callers' assertions surface a permanent failure.
@@ -265,7 +277,8 @@ def _request_with_gateway_retry(method, url, retries=None, delay=None, **kwargs)
     r = None
     for attempt in range(1, retries + 1):
         r = method(url, timeout=timeout, verify=verify, **kwargs)
-        retryable = (r.status_code == 403 and not r.text.strip()) or (
+        empty_auth_reject = r.status_code in (401, 403) and not r.text.strip()
+        retryable = empty_auth_reject or (
             r.status_code == 500 and "AUTH_FAILURE" in r.text
         )
         if retryable and attempt < retries:
@@ -789,23 +802,43 @@ def _wait_reconcile(seconds=None):
     time.sleep(seconds or RECONCILE_WAIT)
 
 
-def _authpolicy_condition(cr, condition_type: str):
-    """Return (status, reason, message) for an AuthPolicy condition type, or (None, None, None)."""
-    conditions = (cr or {}).get("status", {}).get("conditions", [])
-    for condition in conditions:
-        if condition.get("type") == condition_type:
-            return (
+def _authpolicy_conditions(cr, *types):
+    """Return {type: (status, reason, message)} for requested condition types (single pass)."""
+    wanted = set(types)
+    result = {t: (None, None, None) for t in wanted}
+    for condition in (cr or {}).get("status", {}).get("conditions", []):
+        ctype = condition.get("type")
+        if ctype in wanted:
+            result[ctype] = (
                 condition.get("status"),
                 condition.get("reason"),
                 condition.get("message"),
             )
-    return None, None, None
+    return result
+
+
+def _authpolicy_condition(cr, condition_type: str):
+    """Return (status, reason, message) for an AuthPolicy condition type, or (None, None, None)."""
+    return _authpolicy_conditions(cr, condition_type)[condition_type]
+
+
+def _truncate_auth_message(message: Optional[str], limit: int = 240) -> str:
+    """Shrink Kuadrant Enforced messages that list dozens of pending AuthConfigs."""
+    if not message:
+        return ""
+    if len(message) <= limit:
+        return message
+    # Prefer a compact count when Kuadrant dumps AuthConfig hashes.
+    authconfig_count = message.count("AuthConfig (")
+    if authconfig_count:
+        return f"{message[:limit]}… ({authconfig_count} AuthConfigs pending sync)"
+    return message[:limit] + "…"
 
 
 def _wait_for_gateway_auth_enforced(
     name: Optional[str] = None,
     namespace: Optional[str] = None,
-    timeout: int = 120,
+    timeout: Optional[int] = None,
 ):
     """Wait until the gateway Kuadrant AuthPolicy is Accepted and Enforced.
 
@@ -814,13 +847,20 @@ def _wait_for_gateway_auth_enforced(
     (typically maas-gateway-auth) to report Enforced=True; otherwise Envoy
     often returns an empty 403.
 
+    Default timeout is GATEWAY_ENFORCED_TIMEOUT (env E2E_GATEWAY_ENFORCED_TIMEOUT).
+    If the AuthPolicy CR is absent for GATEWAY_ENFORCED_MISSING_GRACE seconds,
+    fail early — that usually means a wrong name/namespace, not slow enforcement.
+
     Raises:
         TimeoutError: with Accepted/Enforced snapshot so failures are actionable
     """
     name = name or GATEWAY_AUTH_POLICY_NAME
     namespace = namespace or GATEWAY_NAMESPACE
+    timeout = GATEWAY_ENFORCED_TIMEOUT if timeout is None else timeout
     deadline = time.time() + timeout
     last_snapshot = "AuthPolicy not found"
+    missing_since = None
+    warned_missing = False
     log.info(
         "Waiting for gateway AuthPolicy %s/%s Accepted+Enforced (timeout: %ds)...",
         namespace,
@@ -832,12 +872,33 @@ def _wait_for_gateway_auth_enforced(
         cr = _get_cr("authpolicy", name, namespace)
         if cr is None:
             last_snapshot = "AuthPolicy not found"
+            now = time.time()
+            if missing_since is None:
+                missing_since = now
+                if not warned_missing:
+                    log.warning(
+                        "Gateway AuthPolicy %s/%s not found yet; will fail after %ds if it never appears "
+                        "(check E2E_GATEWAY_AUTH_POLICY_NAME / GATEWAY_NAMESPACE)",
+                        namespace,
+                        name,
+                        GATEWAY_ENFORCED_MISSING_GRACE,
+                    )
+                    warned_missing = True
+            elif now - missing_since >= GATEWAY_ENFORCED_MISSING_GRACE:
+                raise TimeoutError(
+                    f"Gateway AuthPolicy {namespace}/{name} was not found within "
+                    f"{GATEWAY_ENFORCED_MISSING_GRACE}s (misconfigured name/namespace?). "
+                    f"Empty HTTP 403 from maas-api usually means Kuadrant has not finished "
+                    f"enforcing auth on the gateway after MaaSAuthPolicy changes."
+                )
         else:
-            accepted, a_reason, a_msg = _authpolicy_condition(cr, "Accepted")
-            enforced, e_reason, e_msg = _authpolicy_condition(cr, "Enforced")
+            missing_since = None
+            conds = _authpolicy_conditions(cr, "Accepted", "Enforced")
+            accepted, a_reason, a_msg = conds["Accepted"]
+            enforced, e_reason, e_msg = conds["Enforced"]
             last_snapshot = (
-                f"Accepted={accepted} reason={a_reason!r} message={a_msg!r}; "
-                f"Enforced={enforced} reason={e_reason!r} message={e_msg!r}"
+                f"Accepted={accepted} reason={a_reason!r} message={_truncate_auth_message(a_msg)!r}; "
+                f"Enforced={enforced} reason={e_reason!r} message={_truncate_auth_message(e_msg)!r}"
             )
             if accepted == "True" and enforced == "True":
                 log.info("Gateway AuthPolicy %s/%s is Accepted and Enforced", namespace, name)
@@ -1039,10 +1100,13 @@ def _wait_for_maas_auth_policy_phase(name, expected_phase="Active", namespace=No
             if phase == expected_phase:
                 # No per-model auth policies required — phase match is sufficient for the CR,
                 # but gateway-only mode still needs Kuadrant Enforced before HTTP calls.
+                # Callers that intentionally stop Kuadrant (e.g. TRLP degraded tests) must
+                # pass require_enforced=False — Enforced cannot become True while Kuadrant is down.
                 if not require_auth_policies:
                     if require_enforced and expected_phase == "Active":
                         # Keep a floor so a slow phase wait does not starve Kuadrant Enforced.
-                        remaining = max(60, int(deadline - time.time()))
+                        # AuthConfig backlog after policy churn often needs the full enforced timeout.
+                        remaining = max(GATEWAY_ENFORCED_TIMEOUT, int(deadline - time.time()))
                         _wait_for_gateway_auth_enforced(timeout=remaining)
                     log.info(f"MaaSAuthPolicy {name} reached phase '{expected_phase}'")
                     return cr

--- a/test/e2e/tests/test_helper.py
+++ b/test/e2e/tests/test_helper.py
@@ -71,6 +71,11 @@ MODEL_NAMESPACE = os.environ.get("E2E_MODEL_NAMESPACE", "llm")
 # Clients must use this form in the "model" field when targeting the BBR gateway endpoint.
 MODEL_CANONICAL_ID = os.environ.get("E2E_MODEL_CANONICAL_ID", f"publishers/{MODEL_NAMESPACE}/models/{MODEL_NAME}")
 DEPLOYMENT_NAMESPACE = os.environ.get("DEPLOYMENT_NAMESPACE", "opendatahub")
+# Kuadrant gateway AuthPolicy that Authorino enforces for maas-api + model routes.
+GATEWAY_AUTH_POLICY_NAME = os.environ.get("E2E_GATEWAY_AUTH_POLICY_NAME", "maas-gateway-auth")
+# Empty 403 / Authorino AUTH_FAILURE while Envoy catches up after AuthPolicy updates.
+GATEWAY_PROPAGATION_RETRIES = int(os.environ.get("E2E_GATEWAY_PROPAGATION_RETRIES", "6"))
+GATEWAY_PROPAGATION_DELAY = int(os.environ.get("E2E_GATEWAY_PROPAGATION_DELAY", "5"))
 
 
 def _derive_infra_namespace(controller_namespace: str) -> str:
@@ -244,8 +249,44 @@ def _get_cluster_token():
 # API Key Management
 # ---------------------------------------------------------------------------
 
+def _request_with_gateway_retry(method, url, retries=None, delay=None, **kwargs):
+    """Make an HTTP request, retrying transient gateway/auth propagation errors.
+
+    Retries on:
+    - Empty 403: Envoy has not loaded the AuthPolicy yet (common after MaaSAuthPolicy churn).
+    - 500 with AUTH_FAILURE: Authorino race while AuthConfig is updating.
+
+    Returns the last response — callers' assertions surface a permanent failure.
+    """
+    retries = GATEWAY_PROPAGATION_RETRIES if retries is None else retries
+    delay = GATEWAY_PROPAGATION_DELAY if delay is None else delay
+    timeout = kwargs.pop("timeout", TIMEOUT)
+    verify = kwargs.pop("verify", TLS_VERIFY)
+    r = None
+    for attempt in range(1, retries + 1):
+        r = method(url, timeout=timeout, verify=verify, **kwargs)
+        retryable = (r.status_code == 403 and not r.text.strip()) or (
+            r.status_code == 500 and "AUTH_FAILURE" in r.text
+        )
+        if retryable and attempt < retries:
+            log.info(
+                "Gateway returned %d (attempt %d/%d), retrying in %ds...",
+                r.status_code,
+                attempt,
+                retries,
+                delay,
+            )
+            time.sleep(delay)
+            continue
+        return r
+    return r
+
+
 def _create_api_key_raw(oc_token: str, name: str = None, subscription: str = None):
     """Create an API key and return the raw response (for testing error cases).
+
+    Retries empty 403 / Authorino AUTH_FAILURE so callers see the real API
+    response after gateway AuthPolicy propagation, not a transient reject.
 
     Args:
         oc_token: OC token for authentication with maas-api
@@ -262,7 +303,8 @@ def _create_api_key_raw(oc_token: str, name: str = None, subscription: str = Non
     if subscription:
         body["subscription"] = subscription
 
-    return requests.post(
+    return _request_with_gateway_retry(
+        requests.post,
         url,
         headers={
             "Authorization": f"Bearer {oc_token}",
@@ -287,7 +329,11 @@ def _create_api_key(oc_token: str, name: str = None, subscription: str = None) -
     """
     r = _create_api_key_raw(oc_token, name, subscription)
     if r.status_code not in (200, 201):
-        raise RuntimeError(f"Failed to create API key: {r.status_code} {r.text}")
+        detail = r.text.strip() or (
+            "empty body (likely gateway AuthPolicy not yet Enforced / Envoy not loaded; "
+            f"check: oc get authpolicy {GATEWAY_AUTH_POLICY_NAME} -n {GATEWAY_NAMESPACE})"
+        )
+        raise RuntimeError(f"Failed to create API key: {r.status_code} {detail}")
 
     data = r.json()
     api_key = data.get("key")
@@ -743,6 +789,69 @@ def _wait_reconcile(seconds=None):
     time.sleep(seconds or RECONCILE_WAIT)
 
 
+def _authpolicy_condition(cr, condition_type: str):
+    """Return (status, reason, message) for an AuthPolicy condition type, or (None, None, None)."""
+    conditions = (cr or {}).get("status", {}).get("conditions", [])
+    for condition in conditions:
+        if condition.get("type") == condition_type:
+            return (
+                condition.get("status"),
+                condition.get("reason"),
+                condition.get("message"),
+            )
+    return None, None, None
+
+
+def _wait_for_gateway_auth_enforced(
+    name: Optional[str] = None,
+    namespace: Optional[str] = None,
+    timeout: int = 120,
+):
+    """Wait until the gateway Kuadrant AuthPolicy is Accepted and Enforced.
+
+    MaaSAuthPolicy phase Active only means the controller reconciled CRs.
+    HTTP calls through the gateway still need Kuadrant's AuthPolicy
+    (typically maas-gateway-auth) to report Enforced=True; otherwise Envoy
+    often returns an empty 403.
+
+    Raises:
+        TimeoutError: with Accepted/Enforced snapshot so failures are actionable
+    """
+    name = name or GATEWAY_AUTH_POLICY_NAME
+    namespace = namespace or GATEWAY_NAMESPACE
+    deadline = time.time() + timeout
+    last_snapshot = "AuthPolicy not found"
+    log.info(
+        "Waiting for gateway AuthPolicy %s/%s Accepted+Enforced (timeout: %ds)...",
+        namespace,
+        name,
+        timeout,
+    )
+
+    while time.time() < deadline:
+        cr = _get_cr("authpolicy", name, namespace)
+        if cr is None:
+            last_snapshot = "AuthPolicy not found"
+        else:
+            accepted, a_reason, a_msg = _authpolicy_condition(cr, "Accepted")
+            enforced, e_reason, e_msg = _authpolicy_condition(cr, "Enforced")
+            last_snapshot = (
+                f"Accepted={accepted} reason={a_reason!r} message={a_msg!r}; "
+                f"Enforced={enforced} reason={e_reason!r} message={e_msg!r}"
+            )
+            if accepted == "True" and enforced == "True":
+                log.info("Gateway AuthPolicy %s/%s is Accepted and Enforced", namespace, name)
+                return cr
+            log.debug("Gateway AuthPolicy %s/%s not ready: %s", namespace, name, last_snapshot)
+        time.sleep(2)
+
+    raise TimeoutError(
+        f"Gateway AuthPolicy {namespace}/{name} was not Accepted+Enforced within {timeout}s "
+        f"(last status: {last_snapshot}). Empty HTTP 403 from maas-api usually means Kuadrant "
+        f"has not finished enforcing auth on the gateway after MaaSAuthPolicy changes."
+    )
+
+
 def _wait_for_token_rate_limit_policy(model_ref, model_namespace=MODEL_NAMESPACE, timeout=60):
     """Wait for TokenRateLimitPolicy to be created and enforced for a model.
 
@@ -905,8 +1014,10 @@ def _wait_for_maas_auth_policy_phase(name, expected_phase="Active", namespace=No
         timeout: Maximum wait time in seconds (default: 60)
         require_auth_policies: If True, requires authPolicies to be populated (default: False).
                                Keep False for gateway-only AuthPolicy reconciliation.
-        require_enforced: If True, requires all authPolicies to have ready=True
-                          (default: True). Only applies when require_auth_policies is True.
+        require_enforced: If True (default):
+            - with require_auth_policies=True: all status.authPolicies entries must be ready
+            - with require_auth_policies=False and expected_phase Active: also wait for the
+              gateway Kuadrant AuthPolicy (maas-gateway-auth) to be Accepted+Enforced
 
     Returns:
         The auth policy CR dict when the expected phase is reached
@@ -926,8 +1037,13 @@ def _wait_for_maas_auth_policy_phase(name, expected_phase="Active", namespace=No
             auth_policies = status.get("authPolicies", [])
 
             if phase == expected_phase:
-                # No auth policies required — phase match is sufficient
+                # No per-model auth policies required — phase match is sufficient for the CR,
+                # but gateway-only mode still needs Kuadrant Enforced before HTTP calls.
                 if not require_auth_policies:
+                    if require_enforced and expected_phase == "Active":
+                        # Keep a floor so a slow phase wait does not starve Kuadrant Enforced.
+                        remaining = max(60, int(deadline - time.time()))
+                        _wait_for_gateway_auth_enforced(timeout=remaining)
                     log.info(f"MaaSAuthPolicy {name} reached phase '{expected_phase}'")
                     return cr
 

--- a/test/e2e/tests/test_negative_security.py
+++ b/test/e2e/tests/test_negative_security.py
@@ -83,7 +83,7 @@ class TestHeaderSpoofing:
         """
         # Earlier tests may have rewritten maas-gateway-auth; minting a key
         # against an unenforced gateway yields empty 403 flakes.
-        _wait_for_gateway_auth_enforced(timeout=120)
+        _wait_for_gateway_auth_enforced()
         api_key = _create_api_key(_get_cluster_token(), subscription=SIMULATOR_SUBSCRIPTION)
 
         spoofed_headers = {
@@ -111,6 +111,7 @@ class TestHeaderSpoofing:
         Duplicate or conflicting X-MaaS-Subscription headers must not override
         the key-derived subscription.
         """
+        _wait_for_gateway_auth_enforced()
         api_key = _create_api_key(_get_cluster_token(), subscription=SIMULATOR_SUBSCRIPTION)
 
         # Use http.client to send genuinely duplicate X-MaaS-Subscription headers.
@@ -235,6 +236,7 @@ class TestCrossModelAccess:
         Uses the pre-deployed unconfigured model (a model with no subscription
         granting access to it) to test cross-model access denial.
         """
+        _wait_for_gateway_auth_enforced()
         api_key = _create_api_key(_get_cluster_token(), subscription=SIMULATOR_SUBSCRIPTION)
 
         # The unconfigured model exists but has no subscription granting access.
@@ -424,6 +426,7 @@ class TestHeaderAbuse:
         Ensures the platform returns a clean 403 (subscription not found)
         without leaking errors, stack traces, or SQL/NoSQL injection.
         """
+        _wait_for_gateway_auth_enforced()
         api_key = _create_api_key(_get_cluster_token(), subscription=SIMULATOR_SUBSCRIPTION)
 
         injection_payloads = [

--- a/test/e2e/tests/test_negative_security.py
+++ b/test/e2e/tests/test_negative_security.py
@@ -52,6 +52,7 @@ from test_helper import (
     _inference,
     _maas_api_url,
     _poll_status,
+    _wait_for_gateway_auth_enforced,
     _wait_for_maas_auth_policy_phase,
     _wait_for_maas_subscription_phase,
 )
@@ -80,6 +81,9 @@ class TestHeaderSpoofing:
         The request should succeed (200) using the real key-derived identity,
         proving the spoofed headers had no effect on authorization.
         """
+        # Earlier tests may have rewritten maas-gateway-auth; minting a key
+        # against an unenforced gateway yields empty 403 flakes.
+        _wait_for_gateway_auth_enforced(timeout=120)
         api_key = _create_api_key(_get_cluster_token(), subscription=SIMULATOR_SUBSCRIPTION)
 
         spoofed_headers = {

--- a/test/e2e/tests/test_subscription.py
+++ b/test/e2e/tests/test_subscription.py
@@ -87,6 +87,7 @@ from test_helper import (
     _revoke_api_key,
     _sa_to_user,
     _snapshot_cr,
+    _wait_for_gateway_auth_enforced,
     _wait_for_maas_auth_policy_phase,
     _wait_for_maas_subscription_phase,
     _wait_for_token_rate_limit_policy,
@@ -1980,9 +1981,17 @@ class TestStatusReporting:
             _create_test_subscription(subscription_name, TRLP_TEST_MODEL_REF, users=[sa_user])
 
             # Wait for auth policy to reconcile. In gateway-only mode, it remains Active even when
-            # Kuadrant TRLP reconciliation is degraded.
-            log.info("Waiting for MaaSAuthPolicy to reconcile...")
-            _wait_for_maas_auth_policy_phase(auth_name, "Active", timeout=60, require_auth_policies=False)
+            # Kuadrant TRLP reconciliation is degraded. Do NOT wait for gateway AuthPolicy Enforced
+            # here — Kuadrant is intentionally down, so Enforced can never become True
+            # (AuthConfigs pile up "waiting … to sync").
+            log.info("Waiting for MaaSAuthPolicy to reconcile (Kuadrant down; skip Enforced wait)...")
+            _wait_for_maas_auth_policy_phase(
+                auth_name,
+                "Active",
+                timeout=60,
+                require_auth_policies=False,
+                require_enforced=False,
+            )
 
             # Step 3: Wait for subscription to reach Degraded phase with TRLP not ready
             log.info("Step 3: Waiting for subscription to enter Degraded phase (TRLP not ready)...")
@@ -2014,6 +2023,8 @@ class TestStatusReporting:
             log.info("Step 6: Waiting for subscription to reach Active phase (TRLP ready)...")
             _wait_for_maas_subscription_phase(subscription_name, "Active", timeout=120)
             _wait_for_subscription_trlp_status(subscription_name, expected_ready=True, timeout=120)
+            # Drain AuthConfig backlog from the Kuadrant-down window before HTTP checks.
+            _wait_for_gateway_auth_enforced()
 
             cr = _get_cr("maassubscription", subscription_name, namespace=ns)
             status = cr.get("status", {})


### PR DESCRIPTION
## Summary
- Fix Konflux e2e flakes where API key creates fail with empty HTTP 403 right after tests create/delete `MaaSAuthPolicy` resources (gateway `maas-gateway-auth` still reconciling).
- Add `_wait_for_gateway_auth_enforced()` and centralize empty-403 / `AUTH_FAILURE` retries in `test_helper`; wait after AuthPolicy cleanup and before minting keys in the flaky cases.
- Improve failure messages so a never-Enforced AuthPolicy is obvious instead of a bare empty 403.

Observed on [PR #1260](https://github.com/opendatahub-io/models-as-a-service/pull/1260) group-test (`maas-group-test-ngjk6`): `test_search_without_subscription_returns_all` and `test_injected_identity_headers_ignored` — unrelated to that PR's controller change.

## Test plan
- [ ] Konflux `maas-group-test` / e2e-maas-openshift passes
- [ ] Re-run or watch for recurrence of empty-403 failures on API key create after AuthPolicy churn

## Risk analysis
- **Risk rating**: 1
- **Why**: E2E test harness only (waits + retries). No product/runtime code changes; may add a bit of poll time after AuthPolicy mutations but failure mode becomes clearer if Enforced never arrives.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved end-to-end API key, subscription, and search reliability during gateway authorization propagation and Kuadrant auth policy transitions.
  * Reduced intermittent 403/empty-response flakes by synchronizing requests with gateway authorization readiness.
  * Added retries for transient gateway authentication failures during API key creation.
  * Improved failure messages to better explain when gateway authorization is not yet enforced.

* **Tests**
  * Updated negative security and multitenancy E2E flows to wait for stable gateway authorization before running assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->