### PR TITLE
docs: document external models limitation in multi-tenant deployments

### DIFF
--- a/docs/content/install/external-model-setup.md
+++ b/docs/content/install/external-model-setup.md
@@ -5,6 +5,15 @@
 
 This guide walks through deploying an external AI/ML model (e.g., OpenAI, Anthropic) through the MaaS gateway. External models are hosted outside the cluster — MaaS handles authentication, rate limiting, and API key management while routing inference requests to the external provider.
 
+## Multi-Tenant Limitation
+
+!!! danger "External models are not supported in multi-tenant deployments"
+    When multiple AITenants are deployed, each tenant gets a dedicated Gateway and Inference Payload Processor (IPP) stack. The ExternalModel reconciler is not tenant-aware — it always creates HTTPRoutes pointing to the default tenant's gateway (`--gateway-name` / `--gateway-namespace` controller flags). Each tenant's IPP EnvoyFilter targets its own gateway, which conflicts with the ExternalModel HTTPRoute's static gateway reference.
+
+    **Result:** External models do not work for any tenant — including the default tenant — when multiple IPP instances are running.
+
+    External models are only supported in single-tenant deployments. This limitation is tracked for a future fix.
+
 ## Prerequisites
 
 - MaaS platform deployed per the [Installation Guide](maas-setup.md)

--- a/docs/content/install/multi-tenant-setup.md
+++ b/docs/content/install/multi-tenant-setup.md
@@ -309,6 +309,11 @@ The controller finalizer cleans up:
     ./scripts/delete-ai-tenant.sh red-team
     ```
 
+## Known Limitations
+
+!!! danger "External models are not supported in multi-tenant deployments"
+    The ExternalModel reconciler is not tenant-aware — it hardcodes HTTPRoutes to the default tenant's gateway. When multiple tenants are running, each tenant's IPP stack conflicts with these routes, breaking external models for all tenants including the default. See [External Model Setup — Multi-Tenant Limitation](external-model-setup.md#multi-tenant-limitation) for details.
+
 ## See Also
 
 - [AITenant CRD Reference](../reference/crds/ai-tenant.md)


### PR DESCRIPTION
The ExternalModel reconciler hardcodes HTTPRoutes to the default tenant's gateway, which conflicts with per-tenant IPP stacks. This breaks external models for all tenants when multiple AITenants exist.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented that external models are currently supported only in single-tenant deployments.
  * Added guidance explaining the multi-tenant limitation and its impact on tenant-specific routing.
  * Linked the multi-tenant setup documentation to the detailed external model limitation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->