### PR TITLE
chore: add missing xks resources

### DIFF
--- a/deployment/base/maas-controller/overlays/xks/cert-manager/kustomization.yaml
+++ b/deployment/base/maas-controller/overlays/xks/cert-manager/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - maas-webhook-certificate.yaml

--- a/deployment/base/maas-controller/overlays/xks/cert-manager/maas-webhook-certificate.yaml
+++ b/deployment/base/maas-controller/overlays/xks/cert-manager/maas-webhook-certificate.yaml
@@ -1,0 +1,16 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: maas-controller-webhook-server
+spec:
+  commonName: maas-controller-webhook-service.$(NAMESPACE).svc
+  dnsNames:
+    - maas-controller-webhook-service.$(NAMESPACE).svc
+    - maas-controller-webhook-service.$(NAMESPACE).svc.cluster.local
+  duration: 8760h # 1 year
+  renewBefore: 720h # 30 days
+  issuerRef:
+    name: $(ISSUER_REF_NAME)
+    kind: $(ISSUER_REF_KIND)
+    group: $(ISSUER_REF_GROUP)
+  secretName: maas-controller-webhook-cert

--- a/deployment/base/maas-controller/overlays/xks/kustomization.yaml
+++ b/deployment/base/maas-controller/overlays/xks/kustomization.yaml
@@ -1,0 +1,111 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../crd
+  - ../../rbac
+  - ../../manager
+  - ../../webhook
+  - cert-manager/
+  # monitoring is excluded on xKS (OpenShift-specific ServiceMonitor/PodMonitor)
+
+labels:
+  - pairs:
+      app.kubernetes.io/name: maas-controller
+      app.kubernetes.io/component: models-as-a-service
+      app.kubernetes.io/part-of: models-as-a-service
+
+configMapGenerator:
+  - name: maas-parameters
+    envs:
+      - params.env
+
+generatorOptions:
+  disableNameSuffixHash: true
+
+replacements:
+  - source:
+      kind: ConfigMap
+      name: maas-parameters
+      fieldPath: data.maas-controller-image
+    targets:
+      - select:
+          kind: Deployment
+          name: maas-controller
+        fieldPaths:
+          - spec.template.spec.containers.[name=manager].image
+  - source:
+      kind: ConfigMap
+      name: maas-parameters
+      fieldPath: data.infrastructure-namespace
+    targets:
+      - select:
+          kind: Deployment
+          name: maas-controller
+        fieldPaths:
+          - spec.template.spec.containers.[name=manager].env.[name=INFRA_NAMESPACE].value
+  - source:
+      kind: ConfigMap
+      name: maas-parameters
+      fieldPath: data.gateway-namespace
+    targets:
+      - select:
+          kind: Deployment
+          name: maas-controller
+        fieldPaths:
+          - spec.template.spec.containers.[name=manager].env.[name=GATEWAY_NAMESPACE].value
+
+patches:
+  # Remove OCP service-serving cert annotation (cert-manager handles TLS on xKS)
+  - target:
+      kind: Service
+      name: maas-controller-webhook-service
+    patch: |
+      - op: remove
+        path: /metadata/annotations/service.beta.openshift.io~1serving-cert-secret-name
+      - op: remove
+        path: /metadata/annotations/service.beta.openshift.io~1inject-cabundle
+
+  # Replace OCP CA injection with cert-manager CA injection on webhook
+  - target:
+      kind: ValidatingWebhookConfiguration
+      name: maas-validating-webhook-configuration
+    patch: |
+      - op: remove
+        path: /metadata/annotations/service.beta.openshift.io~1inject-cabundle
+      - op: add
+        path: /metadata/annotations/cert-manager.io~1inject-ca-from
+        value: "$(NAMESPACE)/maas-controller-webhook-server"
+
+vars:
+  - name: NAMESPACE
+    objref:
+      apiVersion: v1
+      kind: ConfigMap
+      name: maas-parameters
+    fieldref:
+      fieldpath: data.namespace
+  - name: ISSUER_REF_NAME
+    objref:
+      apiVersion: v1
+      kind: ConfigMap
+      name: maas-parameters
+    fieldref:
+      fieldpath: data.ISSUER_REF_NAME
+  - name: ISSUER_REF_KIND
+    objref:
+      apiVersion: v1
+      kind: ConfigMap
+      name: maas-parameters
+    fieldref:
+      fieldpath: data.ISSUER_REF_KIND
+  - name: ISSUER_REF_GROUP
+    objref:
+      apiVersion: v1
+      kind: ConfigMap
+      name: maas-parameters
+    fieldref:
+      fieldpath: data.ISSUER_REF_GROUP
+
+configurations:
+  - params.yaml

--- a/deployment/base/maas-controller/overlays/xks/params.env
+++ b/deployment/base/maas-controller/overlays/xks/params.env
@@ -1,0 +1,11 @@
+maas-api-image=quay.io/opendatahub/maas-api:odh-stable
+maas-controller-image=quay.io/opendatahub/maas-controller:odh-stable
+payload-processing-image=quay.io/opendatahub/odh-ai-gateway-payload-processing:odh-stable
+maas-api-key-cleanup-image=registry.redhat.io/ubi9/ubi-minimal:9.7
+monitoring-namespace=
+infrastructure-namespace=AUTO
+gateway-namespace=redhat-ods-applications
+namespace=redhat-ods-applications
+ISSUER_REF_NAME=rhai-ca-issuer
+ISSUER_REF_KIND=ClusterIssuer
+ISSUER_REF_GROUP=cert-manager.io

--- a/deployment/base/maas-controller/overlays/xks/params.yaml
+++ b/deployment/base/maas-controller/overlays/xks/params.yaml
@@ -1,0 +1,13 @@
+varReference:
+  - path: spec/commonName
+    kind: Certificate
+  - path: spec/dnsNames
+    kind: Certificate
+  - path: spec/issuerRef/name
+    kind: Certificate
+  - path: spec/issuerRef/kind
+    kind: Certificate
+  - path: spec/issuerRef/group
+    kind: Certificate
+  - path: metadata/annotations
+    kind: ValidatingWebhookConfiguration


### PR DESCRIPTION
## Description
add maas-controller manifests that were added to overlays/xks in the ai-gateway-operator repository and were missing here.

## How Has This Been Tested?
Tests manually by running `get-manifests.sh` in the ai-gateway-operator repository

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added xKS deployment support for automatically provisioning and renewing the MAAS controller webhook certificate.
  - Configured webhook certificate trust and service integration through cert-manager.
  - Added xKS-specific deployment parameters for images, namespaces, and certificate issuer settings.

- **Bug Fixes**
  - Improved webhook security configuration by replacing platform-specific certificate handling with cert-manager integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->