### PR TITLE
fix: add CEL has() guards to telemetry cost_center and organization_id labels

### DIFF
--- a/maas-controller/pkg/platform/tenantreconcile/postrender.go
+++ b/maas-controller/pkg/platform/tenantreconcile/postrender.go
@@ -364,10 +364,10 @@ func buildTelemetryLabels(log logr.Logger, config *maasv1alpha1.TenantTelemetryC
 	}
 	labels := map[string]any{
 		"subscription": "auth.identity.selected_subscription",
-		"cost_center":  "auth.identity.subscription_info.costCenter",
+		"cost_center":  `has(auth.identity.subscription_info.costCenter) ? auth.identity.subscription_info.costCenter : ""`,
 	}
 	if captureOrganization {
-		labels["organization_id"] = "auth.identity.subscription_info.organizationId"
+		labels["organization_id"] = `has(auth.identity.subscription_info.organizationId) ? auth.identity.subscription_info.organizationId : ""`
 	}
 	if captureUser {
 		log.Info("WARNING: User identity metrics enabled - ensure GDPR/privacy compliance", "field", "captureUser", "value", true)

--- a/maas-controller/pkg/platform/tenantreconcile/postrender_test.go
+++ b/maas-controller/pkg/platform/tenantreconcile/postrender_test.go
@@ -23,8 +23,8 @@ func TestBuildTelemetryLabels(t *testing.T) {
 			config: nil,
 			expectedLabels: map[string]any{
 				"subscription":    "auth.identity.selected_subscription",
-				"cost_center":     "auth.identity.subscription_info.costCenter",
-				"organization_id": "auth.identity.subscription_info.organizationId",
+				"cost_center":     `has(auth.identity.subscription_info.costCenter) ? auth.identity.subscription_info.costCenter : ""`,
+				"organization_id": `has(auth.identity.subscription_info.organizationId) ? auth.identity.subscription_info.organizationId : ""`,
 				"model":           "responseBodyJSON(\"/model\")",
 			},
 			absentKeys: []string{"user", "group"},
@@ -90,8 +90,8 @@ func TestBuildTelemetryLabels(t *testing.T) {
 			},
 			expectedLabels: map[string]any{
 				"subscription":    "auth.identity.selected_subscription",
-				"cost_center":     "auth.identity.subscription_info.costCenter",
-				"organization_id": "auth.identity.subscription_info.organizationId",
+				"cost_center":     `has(auth.identity.subscription_info.costCenter) ? auth.identity.subscription_info.costCenter : ""`,
+				"organization_id": `has(auth.identity.subscription_info.organizationId) ? auth.identity.subscription_info.organizationId : ""`,
 				"user":            "auth.identity.userid",
 				"group":           "auth.identity.groups_str",
 				"model":           "responseBodyJSON(\"/model\")",


### PR DESCRIPTION
## Summary

The `buildTelemetryLabels` function unconditionally includes `cost_center` (`auth.identity.subscription_info.costCenter`) and conditionally includes `organization_id` (`auth.identity.subscription_info.organizationId`) in the TelemetryPolicy labels. When the subscription response doesn't include these fields (common case — `costCenter` and `organizationId` are not standard subscription fields), the wasm-shim fails with `CelError::Resolve { NoSuchKey("costCenter") }` and drops the entire rate limit descriptor — `authorized_hits` stops incrementing and the MaaS monitoring dashboard shows all zeros.

Adds CEL `has()` guards so missing fields resolve to empty string instead of crashing the wasm-shim.

**Verified on a live RHOAI 3.4.2 cluster:** removing `cost_center` and `organization_id` from the TelemetryPolicy immediately fixed the metrics:
```
authorized_hits{model="gemma-4-31b-it-nvfp4",subscription="demo",user="admin",...} 17
```

## Test plan
- [ ] Unit tests pass (`go test ./pkg/platform/tenantreconcile/...`)
- [ ] On a cluster with telemetry enabled, `authorized_hits` includes user/subscription/model labels
- [ ] No `CelError::Resolve { NoSuchKey }` in gateway wasm logs

## Risk analysis
- **Risk rating**: 1
- **Why**: Two string literal changes in telemetry label CEL expressions. No logic change — only adds `has()` guards around existing property accesses. If the fields exist, behavior is identical; if they don't, empty string instead of crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved telemetry label handling when cost center or organization information is unavailable.
  * Missing values now safely default to empty strings instead of causing lookup issues.
* **Other Changes**
  * Telemetry labels now use safer conditional lookups for cost center and organization ID.
  * When group capture is enabled, the group telemetry label now sources from the groups string field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->