### PR TITLE
fix: filter error entries from subscription and model dropdowns

### DIFF
--- a/deployment/components/observability/usage-logs/usage-logs-admin-dashboard.yaml
+++ b/deployment/components/observability/usage-logs/usage-logs-admin-dashboard.yaml
@@ -57,7 +57,7 @@ spec:
               name: usage-logs-all
             labelName: subscription
             matchers:
-              - '{service_name="models-as-a-service", subscription!="-"}'
+              - '{service_name="models-as-a-service", subscription!="-", response_type!="error"}'
     - kind: ListVariable
       spec:
         name: model
@@ -75,7 +75,7 @@ spec:
               name: usage-logs-all
             labelName: model
             matchers:
-              - '{service_name="models-as-a-service", model!="-"}'
+              - '{service_name="models-as-a-service", model!="-", response_type!="error"}'
     - kind: ListVariable
       spec:
         name: view_by

--- a/deployment/components/observability/usage-logs/usage-logs-dashboard.yaml
+++ b/deployment/components/observability/usage-logs/usage-logs-dashboard.yaml
@@ -38,7 +38,7 @@ spec:
               name: usage-logs-multi-tenancy
             labelName: subscription
             matchers:
-              - '{service_name="models-as-a-service", subscription!="-"}'
+              - '{service_name="models-as-a-service", subscription!="-", response_type!="error"}'
     - kind: ListVariable
       spec:
         name: model
@@ -56,7 +56,7 @@ spec:
               name: usage-logs-multi-tenancy
             labelName: model
             matchers:
-              - '{service_name="models-as-a-service", model!="-"}'
+              - '{service_name="models-as-a-service", model!="-", response_type!="error"}'
     - kind: ListVariable
       spec:
         name: view_by


### PR DESCRIPTION
## Description

Adds `response_type!="error"` to subscription and model `LokiLabelValuesVariable` matchers on both usage dashboards.

The EnvoyFilter's `json_to_metadata` uses `on_present` only for the response model rule — on 200 hits, the authoritative backend model name overwrites the request-extracted value. On errors (401, 403, 5xx), the request never reaches the backend, so the `model` stream label retains the raw request body value (KServe routing name format, e.g. `facebook-opt-125m-simulated` instead of `facebook/opt-125m`). This causes duplicate model entries in the dropdown with different naming formats.

Similarly, on 403 (subscription mismatch), FILTER_STATE holds the **rejected** subscription — one that failed authorization. The `subscription!="-"` matcher doesn't catch these because they have real string values, not the `-` sentinel.

Filtering `response_type!="error"` from dropdown population ensures only values from successful request flows (where model is authoritative and subscription is valid) appear as selectable options. Panel data queries are unaffected — "Total requests" and success rate still count all response types.

## How Has This Been Tested?

Tested on a dev cluster. Verified that error-only model names (routing format) and rejected subscriptions no longer appear in dropdowns. Panel totals unchanged.

## Risk analysis

- **Risk rating**: 1
- **Why**: Only `LokiLabelValuesVariable` matchers change on two dashboard YAMLs. No code, no CRD, no RBAC. Panel queries untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved usage-log dashboard filters so Subscription and Model dropdowns exclude entries from error responses.
  - Dropdown values now show only valid, non-error usage data in both standard and admin dashboards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->