### PR TITLE
fix(RHOAIENG-79535): disable IPP response api-translation by default

### DIFF
--- a/deployment/base/payload-processing/manager/plugins-configmap.yaml
+++ b/deployment/base/payload-processing/manager/plugins-configmap.yaml
@@ -3,6 +3,11 @@ kind: ConfigMap
 metadata:
   name: payload-processing-plugins
   namespace: openshift-ingress
+  # Do NOT set opendatahub.io/managed=false here: PostRender drops any resource that
+  # already carries that annotation, which would prevent first-time creation.
+  # The tenant reconciler stamps managed=false after bootstrap/migrate so later
+  # SSA leaves this ConfigMap alone (see ApplyRendered). Set managed=true on the
+  # live ConfigMap to opt back into continuous reconciler management.
 data:
   custom-pre-processing-ipp-config.yaml: |
     apiVersion: llm-d.ai/v1alpha1
@@ -39,5 +44,10 @@ data:
         - pluginRef: model-provider-resolver
         - pluginRef: api-translation
         - pluginRef: apikey-injection
-        response:
-        - pluginRef: api-translation
+        # Response api-translation is off by default so SSE streaming for
+        # internal/OpenAI-compatible models is not held by a response processor.
+        # Re-enable for providers that need response rewrite (e.g. Anthropic):
+        #   response:
+        #   - pluginRef: api-translation
+        # See docs/content/install/external-model-setup.md (IPP response translation).
+        response: []

--- a/docs/content/install/external-model-setup.md
+++ b/docs/content/install/external-model-setup.md
@@ -45,6 +45,33 @@ IPP is required for external models — it injects the provider API key and tran
 
 MaaS deploys the payload-processing component from the [`ai-gateway-payload-processing`](https://github.com/opendatahub-io/ai-gateway-payload-processing) repository. For detailed configuration and usage, see that project's documentation.
 
+### IPP response translation (opt-in)
+
+By default, the `api-translation` plugin runs on the **request** path only. Response-side `api-translation` is off so SSE streaming for internal and OpenAI-compatible models is not held by a response processor.
+
+Providers that rewrite responses (notably Anthropic Messages ↔ OpenAI) need response translation enabled manually on the plugins ConfigMap. After MaaS creates `payload-processing-plugins`, the controller stamps `opendatahub.io/managed: "false"` and then leaves the ConfigMap alone so your edits stick.
+
+```bash
+GATEWAY_NAMESPACE="${GATEWAY_NAMESPACE:-openshift-ingress}"
+
+# 1. Edit the live ConfigMap — under profiles[0].plugins.response add:
+#      - pluginRef: api-translation
+kubectl edit configmap payload-processing-plugins -n "${GATEWAY_NAMESPACE}"
+
+# 2. Reload IPP
+kubectl rollout restart deployment/payload-processing -n "${GATEWAY_NAMESPACE}"
+```
+
+To reset the ConfigMap to product defaults once, remove the opt-out annotation (or set `opendatahub.io/managed=true` for continuous reconciler management), wait for reconcile, then optionally set `opendatahub.io/managed=false` again after editing:
+
+```bash
+# One-shot reset to defaults (controller re-applies, then stamps managed=false again)
+kubectl annotate configmap payload-processing-plugins -n "${GATEWAY_NAMESPACE}" opendatahub.io/managed-
+
+# Or keep the reconciler owning the ConfigMap continuously:
+kubectl annotate configmap payload-processing-plugins -n "${GATEWAY_NAMESPACE}" opendatahub.io/managed=true --overwrite
+```
+
 !!! note
     If MaaS was deployed via the MaasTenantConfig CR (standard RHOAI path), IPP is already deployed as a subcomponent. Verify with:
 

--- a/maas-controller/README.md
+++ b/maas-controller/README.md
@@ -377,6 +377,10 @@ kubectl annotate authpolicy <name> -n <namespace> opendatahub.io/managed-
 kubectl annotate tokenratelimitpolicy <name> -n <namespace> opendatahub.io/managed-
 ```
 
+### IPP plugins ConfigMap
+
+The `payload-processing-plugins` ConfigMap (gateway namespace) is stamped with `opendatahub.io/managed=false` after the controller creates or migrates it, so operators can edit the IPP plugin profile (for example re-enable response `api-translation`) without reconcile overwriting the change. Set `opendatahub.io/managed=true` to opt back into continuous reconciler management, or remove the annotation for a one-shot reset to product defaults. See [External Model Setup — IPP response translation](../docs/content/install/external-model-setup.md#ipp-response-translation-opt-in).
+
 > **Warning: orphaned resources.** An opted-out policy can become permanently orphaned (no longer reconciled and not deleted) in the following situations:
 >
 > - **Last owner deleted.** When the last `MaaSAuthPolicy` or `MaaSSubscription` that references a model is deleted, the controller skips deletion of any opted-out generated policy for that model. The policy will persist until it is manually deleted.

--- a/maas-controller/pkg/platform/tenantreconcile/apply.go
+++ b/maas-controller/pkg/platform/tenantreconcile/apply.go
@@ -37,6 +37,10 @@ func ApplyRendered(ctx context.Context, c client.Client, scheme *runtime.Scheme,
 
 		// Skip resources whose live cluster copy has opendatahub.io/managed=false,
 		// allowing operators to opt specific resources out of reconciliation.
+		// The payload-processing-plugins ConfigMap is stamped with managed=false on
+		// bootstrap/migrate (see preparePayloadProcessingPluginsConfigMapApply) so
+		// subsequent reconciles leave user plugin edits alone unless they set
+		// opendatahub.io/managed=true to opt back into continuous management.
 		if isLiveResourceUnmanaged(ctx, c, u) {
 			ctrl.LoggerFrom(ctx).V(1).Info("Skipping SSA for resource with opendatahub.io/managed=false on cluster",
 				"kind", u.GetKind(), "name", u.GetName(), "namespace", u.GetNamespace())
@@ -68,6 +72,7 @@ func ApplyRendered(ctx context.Context, c client.Client, scheme *runtime.Scheme,
 			}
 			setTenantTrackingLabels(u, tenant)
 		}
+		preparePayloadProcessingPluginsConfigMapApply(ctx, c, u)
 		unstructured.RemoveNestedField(u.Object, "metadata", "managedFields")
 		unstructured.RemoveNestedField(u.Object, "metadata", "resourceVersion")
 		unstructured.RemoveNestedField(u.Object, "status")
@@ -117,6 +122,52 @@ func isLiveResourceUnmanaged(ctx context.Context, c client.Client, rendered *uns
 	}
 	ann := live.GetAnnotations()
 	return ann != nil && ann[AnnotationManaged] == "false"
+}
+
+// isPayloadProcessingPluginsConfigMap reports whether u is the IPP plugins ConfigMap
+// (default name or per-tenant suffix).
+func isPayloadProcessingPluginsConfigMap(u *unstructured.Unstructured) bool {
+	if u == nil || u.GetKind() != "ConfigMap" {
+		return false
+	}
+	name := u.GetName()
+	if name == PayloadProcessingPluginsConfigMapName {
+		return true
+	}
+	return strings.HasPrefix(name, PayloadProcessingPluginsConfigMapName+"-")
+}
+
+// preparePayloadProcessingPluginsConfigMapApply stamps opendatahub.io/managed on the
+// plugins ConfigMap about to be SSA'd:
+//   - managed=false (default): next reconcile skips via isLiveResourceUnmanaged so
+//     operators can edit response plugins (e.g. re-enable api-translation) without
+//     the controller overwriting the ConfigMap.
+//   - managed=true preserved when the live object already opted into continuous
+//     reconciler management.
+//
+// Do not put managed=false in the source YAML: PostRender drops resources that
+// already carry that annotation, which would prevent first-time creation.
+func preparePayloadProcessingPluginsConfigMapApply(ctx context.Context, c client.Client, u *unstructured.Unstructured) {
+	if !isPayloadProcessingPluginsConfigMap(u) {
+		return
+	}
+	managedValue := "false"
+	live := &unstructured.Unstructured{}
+	live.SetGroupVersionKind(u.GroupVersionKind())
+	key := client.ObjectKeyFromObject(u)
+	if key.Name != "" {
+		if err := c.Get(ctx, key, live); err == nil {
+			if ann := live.GetAnnotations(); ann != nil && ann[AnnotationManaged] == "true" {
+				managedValue = "true"
+			}
+		}
+	}
+	ann := u.GetAnnotations()
+	if ann == nil {
+		ann = make(map[string]string)
+	}
+	ann[AnnotationManaged] = managedValue
+	u.SetAnnotations(ann)
 }
 
 // isOwnedByExternalController returns true when the live cluster copy of the

--- a/maas-controller/pkg/platform/tenantreconcile/apply_plugins_configmap_test.go
+++ b/maas-controller/pkg/platform/tenantreconcile/apply_plugins_configmap_test.go
@@ -1,0 +1,98 @@
+package tenantreconcile
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestIsPayloadProcessingPluginsConfigMap(t *testing.T) {
+	t.Parallel()
+
+	cm := func(name string) *unstructured.Unstructured {
+		u := &unstructured.Unstructured{}
+		u.SetGroupVersionKind(GVKConfigMap)
+		u.SetName(name)
+		return u
+	}
+
+	assert.True(t, isPayloadProcessingPluginsConfigMap(cm(PayloadProcessingPluginsConfigMapName)))
+	assert.True(t, isPayloadProcessingPluginsConfigMap(cm(PayloadProcessingPluginsConfigMapForTenant("redteam"))))
+	assert.False(t, isPayloadProcessingPluginsConfigMap(cm("other-config")))
+	assert.False(t, isPayloadProcessingPluginsConfigMap(cm(PayloadProcessingPluginsConfigMapName+"extra")))
+	dep := &unstructured.Unstructured{}
+	dep.SetKind("Deployment")
+	dep.SetName(PayloadProcessingPluginsConfigMapName)
+	assert.False(t, isPayloadProcessingPluginsConfigMap(dep))
+}
+
+func TestPreparePayloadProcessingPluginsConfigMapApply(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	newRendered := func() *unstructured.Unstructured {
+		u := &unstructured.Unstructured{}
+		u.SetGroupVersionKind(GVKConfigMap)
+		u.SetNamespace("openshift-ingress")
+		u.SetName(PayloadProcessingPluginsConfigMapName)
+		return u
+	}
+
+	t.Run("stamps managed=false when ConfigMap does not exist", func(t *testing.T) {
+		t.Parallel()
+		c := fake.NewClientBuilder().WithScheme(scheme).Build()
+		u := newRendered()
+		preparePayloadProcessingPluginsConfigMapApply(context.Background(), c, u)
+		assert.Equal(t, "false", u.GetAnnotations()[AnnotationManaged])
+	})
+
+	t.Run("stamps managed=false when live has no managed annotation", func(t *testing.T) {
+		t.Parallel()
+		live := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      PayloadProcessingPluginsConfigMapName,
+				Namespace: "openshift-ingress",
+			},
+		}
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(live).Build()
+		u := newRendered()
+		preparePayloadProcessingPluginsConfigMapApply(context.Background(), c, u)
+		assert.Equal(t, "false", u.GetAnnotations()[AnnotationManaged])
+	})
+
+	t.Run("preserves managed=true when live opted into management", func(t *testing.T) {
+		t.Parallel()
+		live := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      PayloadProcessingPluginsConfigMapName,
+				Namespace: "openshift-ingress",
+				Annotations: map[string]string{
+					AnnotationManaged: "true",
+				},
+			},
+		}
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(live).Build()
+		u := newRendered()
+		preparePayloadProcessingPluginsConfigMapApply(context.Background(), c, u)
+		assert.Equal(t, "true", u.GetAnnotations()[AnnotationManaged])
+	})
+
+	t.Run("ignores non-plugins ConfigMaps", func(t *testing.T) {
+		t.Parallel()
+		c := fake.NewClientBuilder().WithScheme(scheme).Build()
+		u := &unstructured.Unstructured{}
+		u.SetGroupVersionKind(GVKConfigMap)
+		u.SetName("unrelated")
+		preparePayloadProcessingPluginsConfigMapApply(context.Background(), c, u)
+		assert.Nil(t, u.GetAnnotations())
+	})
+}


### PR DESCRIPTION
## Summary
- Turn off response-path `api-translation` in `payload-processing-plugins` so SSE streaming works for internal / OpenAI-compatible models by default (request-path translation stays enabled).
- After bootstrap/migrate, stamp `opendatahub.io/managed=false` on the plugins ConfigMap so the tenant reconciler leaves operator edits alone; set `managed=true` (or remove the annotation) to opt back into reconciler management / reset defaults.
- Document how to re-enable response translation for providers that need it (e.g. Anthropic).

Fixes: https://redhat.atlassian.net/browse/RHOAIENG-79535

## Test plan
- [ ] Fresh / upgraded deploy: streaming (`"stream": true`) works for an internal model without manual ConfigMap edits
- [ ] `payload-processing-plugins` ends up with `opendatahub.io/managed=false` after reconcile
- [ ] Editing the ConfigMap to add response `api-translation` + restarting `payload-processing` sticks across reconciles
- [ ] Removing `opendatahub.io/managed` triggers a one-shot reset to product defaults
- [ ] Existing external-model e2e (`provider: openai`) still passes

## Risk analysis
- **Risk rating**: 3
- **Why**: Changes default IPP response plugin behavior and reconciler ownership of the plugins ConfigMap. Blast radius is gateway streaming / external-provider response rewrite; Konflux smoke covers OpenAI external models (response translator already a no-op) but not Anthropic response translation. Operators who need response rewrite must follow the opt-in docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Response-side API translation is now disabled by default to preserve SSE streaming.
  - Optional response translation can be enabled for providers that rewrite between different API formats.

- **Documentation**
  - Added “IPP response translation (opt-in)” setup steps, including restart guidance.
  - Documented how to reset payload-processing defaults and how controller management ownership is controlled.

- **Bug Fixes**
  - Improved reconciliation of payload-processing plugin configuration to preserve intentional management settings and user edits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->