### PR TITLE
fix: advertise gateway base url for externalmodel catalog

### DIFF
--- a/maas-api/internal/models/maasmodelref.go
+++ b/maas-api/internal/models/maasmodelref.go
@@ -57,9 +57,10 @@ func GVR() schema.GroupVersionResource {
 // maasModelRefToModel converts a MaaSModelRef unstructured to a Model for the API.
 //
 // For LLMInferenceService-backed models (BBR clusters), the model ID is read from
-// status.resolvedModelAlias (the canonical publishers/{ns}/models/{name} form), and
-// the URL is derived from status.httpRouteHostnames[0] (the shared gateway base URL).
+// status.resolvedModelAlias (the canonical publishers/{ns}/models/{name} form).
 // For ExternalModel refs, the ExternalModel CR name is used as the ID.
+// Both kinds advertise the shared gateway base URL from status.httpRouteHostnames[0]
+// when present (falling back to status.endpoint).
 func maasModelRefToModel(u *unstructured.Unstructured) *Model {
 	if u == nil {
 		return nil
@@ -115,28 +116,17 @@ func maasModelRefToModel(u *unstructured.Unstructured) *Model {
 		}
 	}
 
+	// Both LLMInferenceService and ExternalModel share the gateway base URL on BBR
+	// clusters. Prefer status.httpRouteHostnames[0]; fall back to status.endpoint
+	// (already a base URL after controller reconcile) when hostnames are not set yet.
 	var urlPtr *apis.URL
-	switch kind {
-	case kindExternalModel:
-		// ExternalModel models keep using status.endpoint as their URL.
-		if endpoint != "" {
-			if parsed, err := url.Parse(endpoint); err == nil {
-				urlPtr = (*apis.URL)(parsed)
-			}
+	if hostnames, _, _ := unstructured.NestedStringSlice(u.Object, "status", "httpRouteHostnames"); len(hostnames) > 0 {
+		if parsed, err := url.Parse("https://" + hostnames[0]); err == nil {
+			urlPtr = (*apis.URL)(parsed)
 		}
-	default:
-		// LLMInferenceService-backed models on BBR clusters share the gateway base URL.
-		// Derive it from status.httpRouteHostnames[0] so all models point at the same
-		// gateway entry-point instead of per-model path URLs.
-		if hostnames, _, _ := unstructured.NestedStringSlice(u.Object, "status", "httpRouteHostnames"); len(hostnames) > 0 {
-			if parsed, err := url.Parse("https://" + hostnames[0]); err == nil {
-				urlPtr = (*apis.URL)(parsed)
-			}
-		} else if endpoint != "" {
-			// Fall back to endpoint when httpRouteHostnames is not yet populated.
-			if parsed, err := url.Parse(endpoint); err == nil {
-				urlPtr = (*apis.URL)(parsed)
-			}
+	} else if endpoint != "" {
+		if parsed, err := url.Parse(endpoint); err == nil {
+			urlPtr = (*apis.URL)(parsed)
 		}
 	}
 

--- a/maas-controller/pkg/controller/maas/providers_external.go
+++ b/maas-controller/pkg/controller/maas/providers_external.go
@@ -227,15 +227,14 @@ func (h *externalModelHandler) Status(ctx context.Context, log logr.Logger, mode
 	return endpoint, true, nil
 }
 
-// GetModelEndpoint returns the endpoint URL for the ExternalModel.
-// Uses ExternalModel name (spec.modelRef.name) in the path to match IPP's
-// model-provider-resolver store key. The HTTPRoute object name itself is
-// MaaS-prefixed to avoid colliding with the upstream inference ExternalModel controller.
+// GetModelEndpoint returns the shared gateway base URL for the ExternalModel.
+// Matches LLMInferenceService BBR catalog URLs (https://{gatewayHost}) so clients
+// use one base_url and select the model via body.model / X-Gateway-Model-Name.
+// Path-based HTTPRoute rules remain for backward-compatible clients.
 func (h *externalModelHandler) GetModelEndpoint(ctx context.Context, log logr.Logger, model *maasv1alpha1.MaaSModelRef) (string, error) {
 	extModelName := model.Spec.ModelRef.Name
 	if len(model.Status.HTTPRouteHostnames) > 0 {
-		hostname := model.Status.HTTPRouteHostnames[0]
-		return fmt.Sprintf("https://%s/%s/%s", hostname, model.Namespace, extModelName), nil
+		return fmt.Sprintf("https://%s", model.Status.HTTPRouteHostnames[0]), nil
 	}
 
 	gatewayName := h.r.gatewayName()
@@ -248,19 +247,19 @@ func (h *externalModelHandler) GetModelEndpoint(ctx context.Context, log logr.Lo
 
 	for _, listener := range gateway.Spec.Listeners {
 		if listener.Hostname != nil {
-			return fmt.Sprintf("https://%s/%s/%s", string(*listener.Hostname), model.Namespace, extModelName), nil
+			return fmt.Sprintf("https://%s", string(*listener.Hostname)), nil
 		}
 	}
 
 	for _, addr := range gateway.Status.Addresses {
 		if addr.Type != nil && *addr.Type == gatewayapiv1.HostnameAddressType {
-			return fmt.Sprintf("https://%s/%s/%s", addr.Value, model.Namespace, extModelName), nil
+			return fmt.Sprintf("https://%s", addr.Value), nil
 		}
 	}
 	if len(gateway.Status.Addresses) > 0 {
 		log.Info("Using IP-based gateway address; TLS hostname verification may fail",
 			"address", gateway.Status.Addresses[0].Value, "model", extModelName)
-		return fmt.Sprintf("https://%s/%s/%s", gateway.Status.Addresses[0].Value, model.Namespace, extModelName), nil
+		return fmt.Sprintf("https://%s", gateway.Status.Addresses[0].Value), nil
 	}
 
 	return "", fmt.Errorf("unable to determine endpoint: gateway %s/%s has no hostname or addresses", gatewayNS, gatewayName)

--- a/maas-controller/pkg/controller/maas/providers_external_test.go
+++ b/maas-controller/pkg/controller/maas/providers_external_test.go
@@ -203,8 +203,8 @@ func TestExternalModel_Status_Ready(t *testing.T) {
 	if !ready {
 		t.Error("Status: ready = false, want true")
 	}
-	if endpoint != "https://maas.example.com/default/gpt-4o" {
-		t.Errorf("Status: endpoint = %q, want %q", endpoint, "https://maas.example.com/default/gpt-4o")
+	if endpoint != "https://maas.example.com" {
+		t.Errorf("Status: endpoint = %q, want %q", endpoint, "https://maas.example.com")
 	}
 }
 
@@ -254,8 +254,8 @@ func TestExternalModel_GetModelEndpoint_FromHostnames(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetModelEndpoint: unexpected error: %v", err)
 	}
-	if endpoint != "https://maas.example.com/default/claude-sonnet" {
-		t.Errorf("GetModelEndpoint = %q, want %q", endpoint, "https://maas.example.com/default/claude-sonnet")
+	if endpoint != "https://maas.example.com" {
+		t.Errorf("GetModelEndpoint = %q, want %q", endpoint, "https://maas.example.com")
 	}
 }
 
@@ -273,8 +273,8 @@ func TestExternalModel_GetModelEndpoint_FromGateway(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetModelEndpoint: unexpected error: %v", err)
 	}
-	if endpoint != "https://maas.cluster.example.com/default/gpt-4o" {
-		t.Errorf("GetModelEndpoint = %q, want %q", endpoint, "https://maas.cluster.example.com/default/gpt-4o")
+	if endpoint != "https://maas.cluster.example.com" {
+		t.Errorf("GetModelEndpoint = %q, want %q", endpoint, "https://maas.cluster.example.com")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Make ExternalModel `status.endpoint` the shared gateway base URL (`https://{host}`), matching LLMInferenceService BBR catalog entries.
- Have GET `/v1/models` derive ExternalModel URLs from `status.httpRouteHostnames[0]` the same way as internal models.
- Leave path-based HTTPRoute rules in place for backward-compatible clients.

## Test plan
- [x] Unit tests for `GetModelEndpoint` / ExternalModel Status updated and passing
- [ ] Deploy controller; ExternalModel MaaSModelRef `status.endpoint` is `https://{gateway}` (no `/ns/name`)
- [ ] GET `/v1/models` returns the same base URL for ExternalModel and LLMInferenceService entries
- [ ] Existing path-based ExternalModel inference (`/{ns}/{name}/v1/chat/completions`) still works

## Risk analysis
- **Risk rating**: 2
- **Why**: Catalog and status URL shape change only; path HTTPRoute rules and auth identity are unchanged. Clients that treated the catalog URL as a path-prefixed base may need to send `body.model` on the unified gateway path. Covered by unit tests; smoke still exercises path-built ExternalModel URLs in e2e.

Made with [Cursor](https://cursor.com)