### PR TITLE
fix(RHOAIENG-79568): always verify gateway AuthPolicy enforcement bef…

### DIFF
--- a/maas-controller/pkg/controller/maas/conflict_detection_test.go
+++ b/maas-controller/pkg/controller/maas/conflict_detection_test.go
@@ -120,6 +120,7 @@ func TestDetectConflictingAuthPolicies_RogueDetected(t *testing.T) {
 		httpRouteName  = "maas-" + modelName
 		maasPolicyName = "policy-a"
 		rogueName      = "kserve-route-authn"
+		gatewayNS      = "openshift-ingress"
 	)
 
 	model := newMaaSModelRef(modelName, namespace, "ExternalModel", modelName)
@@ -130,11 +131,11 @@ func TestDetectConflictingAuthPolicies_RogueDetected(t *testing.T) {
 	c := fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithRESTMapper(testRESTMapper()).
-		WithObjects(model, route, maasPolicy, rogueAP).
+		WithObjects(model, route, maasPolicy, rogueAP, newReadyGatewayAuthPolicy(gatewayNS, maasGatewayAuthPolicyName)).
 		WithStatusSubresource(&maasv1alpha1.MaaSAuthPolicy{}).
 		Build()
 
-	r := &MaaSAuthPolicyReconciler{Client: c, Scheme: scheme, InfraNamespace: "maas-system"}
+	r := &MaaSAuthPolicyReconciler{Client: c, Scheme: scheme, InfraNamespace: "maas-system", GatewayNamespace: gatewayNS, GatewayName: "maas-default-gateway"}
 	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: maasPolicyName, Namespace: namespace}}
 	if _, err := r.Reconcile(context.Background(), req); err != nil {
 		t.Fatalf("Reconcile: unexpected error: %v", err)
@@ -168,6 +169,7 @@ func TestDetectConflictingAuthPolicies_MultipleRogues(t *testing.T) {
 		namespace      = "default"
 		httpRouteName  = "maas-" + modelName
 		maasPolicyName = "policy-a"
+		gatewayNS      = "openshift-ingress"
 	)
 
 	model := newMaaSModelRef(modelName, namespace, "ExternalModel", modelName)
@@ -179,11 +181,11 @@ func TestDetectConflictingAuthPolicies_MultipleRogues(t *testing.T) {
 	c := fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithRESTMapper(testRESTMapper()).
-		WithObjects(model, route, maasPolicy, rogue1, rogue2).
+		WithObjects(model, route, maasPolicy, rogue1, rogue2, newReadyGatewayAuthPolicy(gatewayNS, maasGatewayAuthPolicyName)).
 		WithStatusSubresource(&maasv1alpha1.MaaSAuthPolicy{}).
 		Build()
 
-	r := &MaaSAuthPolicyReconciler{Client: c, Scheme: scheme, InfraNamespace: "maas-system"}
+	r := &MaaSAuthPolicyReconciler{Client: c, Scheme: scheme, InfraNamespace: "maas-system", GatewayNamespace: gatewayNS, GatewayName: "maas-default-gateway"}
 	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: maasPolicyName, Namespace: namespace}}
 	if _, err := r.Reconcile(context.Background(), req); err != nil {
 		t.Fatalf("Reconcile: unexpected error: %v", err)
@@ -220,6 +222,7 @@ func TestDetectConflictingAuthPolicies_DifferentRoute(t *testing.T) {
 		namespace      = "default"
 		httpRouteName  = "maas-" + modelName
 		maasPolicyName = "policy-a"
+		gatewayNS      = "openshift-ingress"
 	)
 
 	model := newMaaSModelRef(modelName, namespace, "ExternalModel", modelName)
@@ -230,11 +233,11 @@ func TestDetectConflictingAuthPolicies_DifferentRoute(t *testing.T) {
 	c := fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithRESTMapper(testRESTMapper()).
-		WithObjects(model, route, maasPolicy, unrelatedAP).
+		WithObjects(model, route, maasPolicy, unrelatedAP, newReadyGatewayAuthPolicy(gatewayNS, maasGatewayAuthPolicyName)).
 		WithStatusSubresource(&maasv1alpha1.MaaSAuthPolicy{}).
 		Build()
 
-	r := &MaaSAuthPolicyReconciler{Client: c, Scheme: scheme, InfraNamespace: "maas-system"}
+	r := &MaaSAuthPolicyReconciler{Client: c, Scheme: scheme, InfraNamespace: "maas-system", GatewayNamespace: gatewayNS, GatewayName: "maas-default-gateway"}
 	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: maasPolicyName, Namespace: namespace}}
 	if _, err := r.Reconcile(context.Background(), req); err != nil {
 		t.Fatalf("Reconcile: unexpected error: %v", err)
@@ -264,6 +267,7 @@ func TestDetectConflictingAuthPolicies_CrossNamespaceIsolation(t *testing.T) {
 		otherNS        = "other-ns"
 		httpRouteName  = "maas-" + modelName
 		maasPolicyName = "policy-a"
+		gatewayNS      = "openshift-ingress"
 	)
 
 	model := newMaaSModelRef(modelName, modelNamespace, "ExternalModel", modelName)
@@ -274,11 +278,11 @@ func TestDetectConflictingAuthPolicies_CrossNamespaceIsolation(t *testing.T) {
 	c := fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithRESTMapper(testRESTMapper()).
-		WithObjects(model, route, maasPolicy, rogueInOtherNS).
+		WithObjects(model, route, maasPolicy, rogueInOtherNS, newReadyGatewayAuthPolicy(gatewayNS, maasGatewayAuthPolicyName)).
 		WithStatusSubresource(&maasv1alpha1.MaaSAuthPolicy{}).
 		Build()
 
-	r := &MaaSAuthPolicyReconciler{Client: c, Scheme: scheme, InfraNamespace: "maas-system"}
+	r := &MaaSAuthPolicyReconciler{Client: c, Scheme: scheme, InfraNamespace: "maas-system", GatewayNamespace: gatewayNS, GatewayName: "maas-default-gateway"}
 	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: maasPolicyName, Namespace: policyNS}}
 	if _, err := r.Reconcile(context.Background(), req); err != nil {
 		t.Fatalf("Reconcile: unexpected error: %v", err)
@@ -307,6 +311,7 @@ func TestDetectConflictingAuthPolicies_ConflictResolved(t *testing.T) {
 		httpRouteName  = "maas-" + modelName
 		maasPolicyName = "policy-a"
 		rogueName      = "kserve-route-authn"
+		gatewayNS      = "openshift-ingress"
 	)
 
 	model := newMaaSModelRef(modelName, namespace, "ExternalModel", modelName)
@@ -317,11 +322,11 @@ func TestDetectConflictingAuthPolicies_ConflictResolved(t *testing.T) {
 	c := fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithRESTMapper(testRESTMapper()).
-		WithObjects(model, route, maasPolicy, rogueAP).
+		WithObjects(model, route, maasPolicy, rogueAP, newReadyGatewayAuthPolicy(gatewayNS, maasGatewayAuthPolicyName)).
 		WithStatusSubresource(&maasv1alpha1.MaaSAuthPolicy{}).
 		Build()
 
-	r := &MaaSAuthPolicyReconciler{Client: c, Scheme: scheme, InfraNamespace: "maas-system"}
+	r := &MaaSAuthPolicyReconciler{Client: c, Scheme: scheme, InfraNamespace: "maas-system", GatewayNamespace: gatewayNS, GatewayName: "maas-default-gateway"}
 	ctx := context.Background()
 	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: maasPolicyName, Namespace: namespace}}
 
@@ -367,6 +372,7 @@ func TestDetectConflictingAuthPolicies_MissingModel(t *testing.T) {
 	const (
 		namespace      = "default"
 		maasPolicyName = "policy-a"
+		gatewayNS      = "openshift-ingress"
 	)
 
 	maasPolicy := newMaaSAuthPolicy(maasPolicyName, namespace, "team-a",
@@ -375,11 +381,11 @@ func TestDetectConflictingAuthPolicies_MissingModel(t *testing.T) {
 	c := fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithRESTMapper(testRESTMapper()).
-		WithObjects(maasPolicy).
+		WithObjects(maasPolicy, newReadyGatewayAuthPolicy(gatewayNS, maasGatewayAuthPolicyName)).
 		WithStatusSubresource(&maasv1alpha1.MaaSAuthPolicy{}).
 		Build()
 
-	r := &MaaSAuthPolicyReconciler{Client: c, Scheme: scheme, InfraNamespace: "maas-system"}
+	r := &MaaSAuthPolicyReconciler{Client: c, Scheme: scheme, InfraNamespace: "maas-system", GatewayNamespace: gatewayNS, GatewayName: "maas-default-gateway"}
 	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: maasPolicyName, Namespace: namespace}}
 	if _, err := r.Reconcile(context.Background(), req); err != nil {
 		t.Fatalf("Reconcile: %v", err)
@@ -414,6 +420,8 @@ func TestDetectConflictingAuthPolicies_GatewayTarget(t *testing.T) {
 	route := newHTTPRoute(httpRouteName, namespace)
 	maasPolicy := newMaaSAuthPolicy(maasPolicyName, namespace, "team-a", maasv1alpha1.ModelRef{Name: modelName, Namespace: namespace})
 
+	gatewayNS := "openshift-ingress"
+
 	gatewayAP := &unstructured.Unstructured{}
 	gatewayAP.SetGroupVersionKind(schema.GroupVersionKind{Group: "kuadrant.io", Version: "v1", Kind: "AuthPolicy"})
 	gatewayAP.SetName("gateway-default-auth")
@@ -429,11 +437,11 @@ func TestDetectConflictingAuthPolicies_GatewayTarget(t *testing.T) {
 	c := fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithRESTMapper(testRESTMapper()).
-		WithObjects(model, route, maasPolicy, gatewayAP).
+		WithObjects(model, route, maasPolicy, gatewayAP, newReadyGatewayAuthPolicy(gatewayNS, maasGatewayAuthPolicyName)).
 		WithStatusSubresource(&maasv1alpha1.MaaSAuthPolicy{}).
 		Build()
 
-	r := &MaaSAuthPolicyReconciler{Client: c, Scheme: scheme, InfraNamespace: "maas-system"}
+	r := &MaaSAuthPolicyReconciler{Client: c, Scheme: scheme, InfraNamespace: "maas-system", GatewayNamespace: gatewayNS, GatewayName: "maas-default-gateway"}
 	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: maasPolicyName, Namespace: namespace}}
 	if _, err := r.Reconcile(context.Background(), req); err != nil {
 		t.Fatalf("Reconcile: %v", err)

--- a/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
@@ -1211,10 +1211,9 @@ allow {
 
 	return map[string]any{
 		"targetRef": map[string]any{
-			"group":     "gateway.networking.k8s.io",
-			"kind":      "Gateway",
-			"name":      gatewayName,
-			"namespace": gatewayNamespace,
+			"group": "gateway.networking.k8s.io",
+			"kind":  "Gateway",
+			"name":  gatewayName,
 		},
 		// "when" must live inside "defaults" (not at spec level) because Kuadrant treats
 		// top-level "when" as implicit defaults, which conflicts with explicit "defaults".
@@ -1280,6 +1279,69 @@ func (r *MaaSAuthPolicyReconciler) gatewayAuthPolicyReady(ctx context.Context, g
 		message = "Accepted and Enforced conditions are not both True"
 	}
 	return ready, message, nil
+}
+
+// specMatchesDesired reports whether the current spec (from the API server)
+// contains all fields present in the desired spec with equal values. Fields
+// added by the API server or its controllers (e.g. Kuadrant defaults like
+// "allValues", "strategy") are ignored — only the fields we explicitly set
+// are compared. Both sides are JSON-round-tripped first so Go type
+// differences (int64 vs float64) are normalised.
+func specMatchesDesired(desired, current map[string]any) bool {
+	desiredJSON, err := json.Marshal(desired)
+	if err != nil {
+		return false
+	}
+	currentJSON, err := json.Marshal(current)
+	if err != nil {
+		return false
+	}
+	var desiredNorm, currentNorm map[string]any
+	if err := json.Unmarshal(desiredJSON, &desiredNorm); err != nil {
+		return false
+	}
+	if err := json.Unmarshal(currentJSON, &currentNorm); err != nil {
+		return false
+	}
+	stripExtraFields(currentNorm, desiredNorm)
+	return reflect.DeepEqual(desiredNorm, currentNorm)
+}
+
+// stripExtraFields recursively removes keys from current that do not exist
+// in desired, so that server-added defaults do not cause false mismatches.
+func stripExtraFields(current, desired map[string]any) {
+	for k, cv := range current {
+		dv, exists := desired[k]
+		if !exists {
+			delete(current, k)
+			continue
+		}
+		if dMap, ok := dv.(map[string]any); ok {
+			if cMap, ok := cv.(map[string]any); ok {
+				stripExtraFields(cMap, dMap)
+			}
+		}
+		if dSlice, ok := dv.([]any); ok {
+			if cSlice, ok := cv.([]any); ok {
+				stripExtraFieldsSlice(cSlice, dSlice)
+			}
+		}
+	}
+}
+
+func stripExtraFieldsSlice(current, desired []any) {
+	for i := 0; i < len(current) && i < len(desired); i++ {
+		if dMap, ok := desired[i].(map[string]any); ok {
+			if cMap, ok := current[i].(map[string]any); ok {
+				stripExtraFields(cMap, dMap)
+			}
+		}
+		if dSlice, ok := desired[i].([]any); ok {
+			if cSlice, ok := current[i].([]any); ok {
+				stripExtraFieldsSlice(cSlice, dSlice)
+			}
+		}
+	}
 }
 
 // reconcileGatewayAuthPolicy creates or updates the singleton Gateway-level AuthPolicy in
@@ -1370,7 +1432,7 @@ func (r *MaaSAuthPolicyReconciler) reconcileGatewayAuthPolicy(
 		return false, nil
 	}
 
-	snapshot := existing.DeepCopy()
+	currentSpec, _, _ := unstructured.NestedMap(existing.Object, "spec")
 	if err := unstructured.SetNestedMap(existing.Object, spec, "spec"); err != nil {
 		return false, fmt.Errorf("failed to set gateway AuthPolicy spec for update: %w", err)
 	}
@@ -1379,7 +1441,7 @@ func (r *MaaSAuthPolicyReconciler) reconcileGatewayAuthPolicy(
 	if isTenantGateway {
 		setGatewayOwnerReference(gateway, existing)
 	}
-	if equality.Semantic.DeepEqual(snapshot.Object, existing.Object) {
+	if specMatchesDesired(spec, currentSpec) {
 		log.Info("gateway AuthPolicy unchanged, skipping update", "name", authPolicyName)
 		r.deleteGatewayDefaultAuthPolicy(ctx, log)
 		return false, nil

--- a/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
@@ -600,12 +600,12 @@ func (r *MaaSAuthPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		}
 	}
 
-	if err := r.reconcileGatewayAuthPolicy(ctx, log, string(modelAllowlistsJSON), oidc, xAPIKeyEnabled, tenantID, gatewayNs, gatewayName); err != nil {
-		log.Error(err, "failed to reconcile gateway AuthPolicy")
-		r.updateStatus(ctx, policy, maasv1alpha1.PhaseFailed, fmt.Sprintf("Failed to reconcile gateway AuthPolicy: %v", err), statusSnapshot)
-		return ctrl.Result{}, err
+	if _, reconcileErr := r.reconcileGatewayAuthPolicy(ctx, log, string(modelAllowlistsJSON), oidc, xAPIKeyEnabled, tenantID, gatewayNs, gatewayName); reconcileErr != nil {
+		log.Error(reconcileErr, "failed to reconcile gateway AuthPolicy")
+		r.updateStatus(ctx, policy, maasv1alpha1.PhaseFailed, fmt.Sprintf("Failed to reconcile gateway AuthPolicy: %v", reconcileErr), statusSnapshot)
+		return ctrl.Result{}, reconcileErr
 	}
-	if legacyPolicyExists {
+	{
 		gatewayPolicyReady, readinessMessage, readinessErr := r.gatewayAuthPolicyReady(ctx, gatewayNs, gatewayName)
 		if readinessErr != nil {
 			log.Error(readinessErr, "failed to check gateway AuthPolicy readiness")
@@ -614,7 +614,7 @@ func (r *MaaSAuthPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		}
 		if !gatewayPolicyReady {
 			message := fmt.Sprintf(
-				"Waiting for gateway AuthPolicy %s/%s to be accepted and enforced before removing the working legacy AuthPolicy: %s",
+				"Waiting for gateway AuthPolicy %s/%s to be accepted and enforced: %s",
 				gatewayNs,
 				r.gatewayAuthPolicyName(gatewayNs, gatewayName),
 				readinessMessage,
@@ -1283,7 +1283,10 @@ func (r *MaaSAuthPolicyReconciler) gatewayAuthPolicyReady(ctx context.Context, g
 
 // reconcileGatewayAuthPolicy creates or updates the singleton Gateway-level AuthPolicy in
 // the gateway namespace. All MaaSAuthPolicy reconciliations converge on this one resource.
-func (r *MaaSAuthPolicyReconciler) reconcileGatewayAuthPolicy(ctx context.Context, log logr.Logger, modelAccessJSON string, oidc *oidcConfig, xAPIKeyEnabled bool, tenantID, gatewayNamespace, gatewayName string) error {
+func (r *MaaSAuthPolicyReconciler) reconcileGatewayAuthPolicy(
+	ctx context.Context, log logr.Logger, modelAccessJSON string,
+	oidc *oidcConfig, xAPIKeyEnabled bool, tenantID, gatewayNamespace, gatewayName string,
+) (bool, error) {
 	log.Info("reconcileGatewayAuthPolicy entered", "gatewayNamespace", gatewayNamespace, "gatewayName", gatewayName, "tenantID", tenantID, "xAPIKeyEnabled", xAPIKeyEnabled)
 
 	// Calculate tenantName from tenantID
@@ -1316,7 +1319,7 @@ func (r *MaaSAuthPolicyReconciler) reconcileGatewayAuthPolicy(ctx context.Contex
 	existing.SetGroupVersionKind(gwPolicy.GroupVersionKind())
 	err := r.Get(ctx, client.ObjectKeyFromObject(gwPolicy), existing)
 	if err != nil && !apierrors.IsNotFound(err) {
-		return fmt.Errorf("failed to get gateway AuthPolicy: %w", err)
+		return false, fmt.Errorf("failed to get gateway AuthPolicy: %w", err)
 	}
 	existingFound := err == nil
 
@@ -1334,14 +1337,14 @@ func (r *MaaSAuthPolicyReconciler) reconcileGatewayAuthPolicy(ctx context.Contex
 				// delete it to prevent orphaned resources.
 				if existingFound && isManaged(existing) {
 					if delErr := r.Delete(ctx, existing); delErr != nil {
-						return fmt.Errorf("failed to delete stale tenant gateway AuthPolicy %s/%s: %w", gatewayNamespace, authPolicyName, delErr)
+						return false, fmt.Errorf("failed to delete stale tenant gateway AuthPolicy %s/%s: %w", gatewayNamespace, authPolicyName, delErr)
 					}
 					log.Info("deleted stale tenant gateway AuthPolicy (Gateway no longer exists)", "name", authPolicyName, "namespace", gatewayNamespace)
 				}
 				// Nothing to create or update without a Gateway.
-				return nil
+				return false, nil
 			}
-			return fmt.Errorf("failed to get Gateway %s/%s for OwnerReference: %w", gatewayNamespace, gatewayName, gwErr)
+			return false, fmt.Errorf("failed to get Gateway %s/%s for OwnerReference: %w", gatewayNamespace, gatewayName, gwErr)
 		}
 	}
 
@@ -1351,24 +1354,24 @@ func (r *MaaSAuthPolicyReconciler) reconcileGatewayAuthPolicy(ctx context.Contex
 			setGatewayOwnerReference(gateway, gwPolicy)
 		}
 		if err := unstructured.SetNestedMap(gwPolicy.Object, spec, "spec"); err != nil {
-			return fmt.Errorf("failed to set gateway AuthPolicy spec: %w", err)
+			return false, fmt.Errorf("failed to set gateway AuthPolicy spec: %w", err)
 		}
 		if err := r.Create(ctx, gwPolicy); err != nil {
-			return fmt.Errorf("failed to create gateway AuthPolicy: %w", err)
+			return false, fmt.Errorf("failed to create gateway AuthPolicy: %w", err)
 		}
 		log.Info("gateway AuthPolicy created", "name", authPolicyName, "namespace", gatewayNamespace)
 		r.deleteGatewayDefaultAuthPolicy(ctx, log)
-		return nil
+		return true, nil
 	}
 
 	if !isManaged(existing) {
 		log.Info("gateway AuthPolicy opted out of management, skipping", "name", authPolicyName)
-		return nil
+		return false, nil
 	}
 
 	snapshot := existing.DeepCopy()
 	if err := unstructured.SetNestedMap(existing.Object, spec, "spec"); err != nil {
-		return fmt.Errorf("failed to set gateway AuthPolicy spec for update: %w", err)
+		return false, fmt.Errorf("failed to set gateway AuthPolicy spec for update: %w", err)
 	}
 	// Ensure OwnerReferences are set on existing tenant gateway AuthPolicies
 	// (handles upgrade from pre-ownerref versions).
@@ -1378,14 +1381,14 @@ func (r *MaaSAuthPolicyReconciler) reconcileGatewayAuthPolicy(ctx context.Contex
 	if equality.Semantic.DeepEqual(snapshot.Object, existing.Object) {
 		log.Info("gateway AuthPolicy unchanged, skipping update", "name", authPolicyName)
 		r.deleteGatewayDefaultAuthPolicy(ctx, log)
-		return nil
+		return false, nil
 	}
 	if err := r.Update(ctx, existing); err != nil {
-		return fmt.Errorf("failed to update gateway AuthPolicy: %w", err)
+		return false, fmt.Errorf("failed to update gateway AuthPolicy: %w", err)
 	}
 	log.Info("gateway AuthPolicy updated", "name", authPolicyName, "namespace", gatewayNamespace)
 	r.deleteGatewayDefaultAuthPolicy(ctx, log)
-	return nil
+	return true, nil
 }
 
 // reconcileModelAuthPolicies creates or updates the per-model group-membership AuthPolicy for

--- a/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
@@ -600,12 +600,13 @@ func (r *MaaSAuthPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		}
 	}
 
-	if _, reconcileErr := r.reconcileGatewayAuthPolicy(ctx, log, string(modelAllowlistsJSON), oidc, xAPIKeyEnabled, tenantID, gatewayNs, gatewayName); reconcileErr != nil {
+	gwChanged, reconcileErr := r.reconcileGatewayAuthPolicy(ctx, log, string(modelAllowlistsJSON), oidc, xAPIKeyEnabled, tenantID, gatewayNs, gatewayName)
+	if reconcileErr != nil {
 		log.Error(reconcileErr, "failed to reconcile gateway AuthPolicy")
 		r.updateStatus(ctx, policy, maasv1alpha1.PhaseFailed, fmt.Sprintf("Failed to reconcile gateway AuthPolicy: %v", reconcileErr), statusSnapshot)
 		return ctrl.Result{}, reconcileErr
 	}
-	{
+	if gwChanged || legacyPolicyExists || policy.Status.Phase != maasv1alpha1.PhaseActive {
 		gatewayPolicyReady, readinessMessage, readinessErr := r.gatewayAuthPolicyReady(ctx, gatewayNs, gatewayName)
 		if readinessErr != nil {
 			log.Error(readinessErr, "failed to check gateway AuthPolicy readiness")

--- a/maas-controller/pkg/controller/maas/maasauthpolicy_controller_test.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_controller_test.go
@@ -2119,6 +2119,7 @@ func TestMaaSAuthPolicyReconciler_MissingModelRef_FailedPhase(t *testing.T) {
 		namespace    = "default"
 		maasAuthName = "auth-missing"
 		missingModel = "non-existent-model"
+		gatewayNS    = "openshift-ingress"
 	)
 
 	// Create auth policy referencing a non-existent model
@@ -2128,15 +2129,16 @@ func TestMaaSAuthPolicyReconciler_MissingModelRef_FailedPhase(t *testing.T) {
 	c := fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithRESTMapper(testRESTMapper()).
-		WithObjects(maasAuth).
+		WithObjects(maasAuth, newReadyGatewayAuthPolicy(gatewayNS, maasGatewayAuthPolicyName)).
 		WithStatusSubresource(&maasv1alpha1.MaaSAuthPolicy{}).
 		Build()
 
 	r := &MaaSAuthPolicyReconciler{
-		Client:         c,
-		Scheme:         scheme,
-		InfraNamespace: namespace,
-		GatewayName:    "openshift-ingress/maas-default-gateway",
+		Client:           c,
+		Scheme:           scheme,
+		InfraNamespace:   namespace,
+		GatewayNamespace: gatewayNS,
+		GatewayName:      "maas-default-gateway",
 	}
 	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: maasAuthName, Namespace: namespace}}
 	if _, err := r.Reconcile(context.Background(), req); err != nil {
@@ -2173,6 +2175,7 @@ func TestMaaSAuthPolicyReconciler_PartialModelRefs_DegradedPhase(t *testing.T) {
 		validModel    = "valid-model"
 		missingModel  = "missing-model"
 		httpRouteName = "maas-" + validModel
+		gatewayNS     = "openshift-ingress"
 	)
 
 	// Create valid model and route
@@ -2187,15 +2190,16 @@ func TestMaaSAuthPolicyReconciler_PartialModelRefs_DegradedPhase(t *testing.T) {
 	c := fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithRESTMapper(testRESTMapper()).
-		WithObjects(model, route, maasAuth).
+		WithObjects(model, route, maasAuth, newReadyGatewayAuthPolicy(gatewayNS, maasGatewayAuthPolicyName)).
 		WithStatusSubresource(&maasv1alpha1.MaaSAuthPolicy{}).
 		Build()
 
 	r := &MaaSAuthPolicyReconciler{
-		Client:         c,
-		Scheme:         scheme,
-		InfraNamespace: namespace,
-		GatewayName:    "openshift-ingress/maas-default-gateway",
+		Client:           c,
+		Scheme:           scheme,
+		InfraNamespace:   namespace,
+		GatewayNamespace: gatewayNS,
+		GatewayName:      "maas-default-gateway",
 	}
 	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: maasAuthName, Namespace: namespace}}
 	if _, err := r.Reconcile(context.Background(), req); err != nil {
@@ -3028,5 +3032,146 @@ func TestMaaSAuthPolicyReconciler_TenantGateway_StaleCleanup_UnmanagedPreserved(
 	getErr := c.Get(context.Background(), types.NamespacedName{Name: staleAuthPolicyName, Namespace: tenantGwNS}, got)
 	if getErr != nil {
 		t.Fatalf("expected unmanaged stale tenant gateway AuthPolicy %q to be preserved, but Get returned error: %v", staleAuthPolicyName, getErr)
+	}
+}
+
+// TestMaaSAuthPolicyReconciler_RequeuesUntilEnforcedAfterUpdate verifies that
+// the controller requeues until the gateway AuthPolicy is both Accepted and
+// Enforced after creating or updating it — not just during legacy upgrades.
+func TestMaaSAuthPolicyReconciler_RequeuesUntilEnforcedAfterUpdate(t *testing.T) {
+	const (
+		modelName      = "llm"
+		namespace      = "default"
+		gatewayNS      = "openshift-ingress"
+		maasPolicyName = "policy-a"
+	)
+
+	model := newMaaSModelRef(modelName, namespace, "ExternalModel", modelName)
+	route := newHTTPRoute("maas-"+modelName, namespace)
+	maasPolicy := newMaaSAuthPolicy(maasPolicyName, namespace, "team-a",
+		maasv1alpha1.ModelRef{Name: modelName, Namespace: namespace})
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithRESTMapper(testRESTMapper()).
+		WithObjects(model, route, maasPolicy).
+		WithStatusSubresource(&maasv1alpha1.MaaSAuthPolicy{}).
+		Build()
+
+	r := &MaaSAuthPolicyReconciler{
+		Client:           c,
+		Scheme:           scheme,
+		InfraNamespace:   "maas-system",
+		GatewayNamespace: gatewayNS,
+		GatewayName:      "maas-default-gateway",
+	}
+	ctx := context.Background()
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: maasPolicyName, Namespace: namespace}}
+
+	// Step 1: First reconcile creates the gateway AuthPolicy. No status yet → requeue.
+	result, err := r.Reconcile(ctx, req)
+	if err != nil {
+		t.Fatalf("step 1: Reconcile error: %v", err)
+	}
+	if result.RequeueAfter != 10*time.Second {
+		t.Fatalf("step 1: RequeueAfter = %s, want 10s (gateway AuthPolicy not yet enforced)", result.RequeueAfter)
+	}
+
+	// Verify the gateway AuthPolicy was created.
+	gwAP := &unstructured.Unstructured{}
+	gwAP.SetGroupVersionKind(schema.GroupVersionKind{Group: "kuadrant.io", Version: "v1", Kind: "AuthPolicy"})
+	if err := c.Get(ctx, types.NamespacedName{Name: maasGatewayAuthPolicyName, Namespace: gatewayNS}, gwAP); err != nil {
+		t.Fatalf("step 1: gateway AuthPolicy not found: %v", err)
+	}
+
+	// Step 2: Set Accepted=True but Enforced=False → still requeues.
+	_ = unstructured.SetNestedSlice(gwAP.Object, []any{
+		map[string]any{"type": "Accepted", "status": "True"},
+		map[string]any{"type": "Enforced", "status": "False"},
+	}, "status", "conditions")
+	_ = unstructured.SetNestedField(gwAP.Object, gwAP.GetGeneration(), "status", "observedGeneration")
+	if err := c.Update(ctx, gwAP); err != nil {
+		t.Fatalf("step 2: update gateway AuthPolicy status: %v", err)
+	}
+
+	result, err = r.Reconcile(ctx, req)
+	if err != nil {
+		t.Fatalf("step 2: Reconcile error: %v", err)
+	}
+	if result.RequeueAfter != 10*time.Second {
+		t.Fatalf("step 2: RequeueAfter = %s, want 10s (Enforced still False)", result.RequeueAfter)
+	}
+
+	// Step 3: Set both Accepted=True and Enforced=True → reconcile completes.
+	if err := c.Get(ctx, types.NamespacedName{Name: maasGatewayAuthPolicyName, Namespace: gatewayNS}, gwAP); err != nil {
+		t.Fatalf("step 3: get gateway AuthPolicy: %v", err)
+	}
+	_ = unstructured.SetNestedSlice(gwAP.Object, []any{
+		map[string]any{"type": "Accepted", "status": "True"},
+		map[string]any{"type": "Enforced", "status": "True"},
+	}, "status", "conditions")
+	_ = unstructured.SetNestedField(gwAP.Object, gwAP.GetGeneration(), "status", "observedGeneration")
+	if err := c.Update(ctx, gwAP); err != nil {
+		t.Fatalf("step 3: update gateway AuthPolicy status: %v", err)
+	}
+
+	result, err = r.Reconcile(ctx, req)
+	if err != nil {
+		t.Fatalf("step 3: Reconcile error: %v", err)
+	}
+	if result.RequeueAfter != 0 {
+		t.Fatalf("step 3: RequeueAfter = %s, want 0 (gateway AuthPolicy is enforced)", result.RequeueAfter)
+	}
+}
+
+// TestMaaSAuthPolicyReconciler_NoRequeueWhenUnchanged verifies that when the
+// gateway AuthPolicy spec is already up to date, the controller does not
+// requeue for enforcement — the policy is already enforced from a prior reconcile.
+func TestMaaSAuthPolicyReconciler_NoRequeueWhenUnchanged(t *testing.T) {
+	const (
+		modelName      = "llm"
+		namespace      = "default"
+		gatewayNS      = "openshift-ingress"
+		maasPolicyName = "policy-a"
+	)
+
+	model := newMaaSModelRef(modelName, namespace, "ExternalModel", modelName)
+	route := newHTTPRoute("maas-"+modelName, namespace)
+	maasPolicy := newMaaSAuthPolicy(maasPolicyName, namespace, "team-a",
+		maasv1alpha1.ModelRef{Name: modelName, Namespace: namespace})
+	readyGatewayPolicy := newReadyGatewayAuthPolicy(gatewayNS, maasGatewayAuthPolicyName)
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithRESTMapper(testRESTMapper()).
+		WithObjects(model, route, maasPolicy, readyGatewayPolicy).
+		WithStatusSubresource(&maasv1alpha1.MaaSAuthPolicy{}).
+		Build()
+
+	r := &MaaSAuthPolicyReconciler{
+		Client:           c,
+		Scheme:           scheme,
+		InfraNamespace:   "maas-system",
+		GatewayNamespace: gatewayNS,
+		GatewayName:      "maas-default-gateway",
+	}
+	ctx := context.Background()
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: maasPolicyName, Namespace: namespace}}
+
+	// First reconcile: updates the gateway AuthPolicy with real spec.
+	// Since the pre-populated policy has no real spec, this IS a change.
+	// But the policy is pre-populated with ready conditions, so enforcement
+	// check should pass.
+	if _, err := r.Reconcile(ctx, req); err != nil {
+		t.Fatalf("first Reconcile: %v", err)
+	}
+
+	// Second reconcile: same content, no change → should not requeue.
+	result, err := r.Reconcile(ctx, req)
+	if err != nil {
+		t.Fatalf("second Reconcile: %v", err)
+	}
+	if result.RequeueAfter != 0 {
+		t.Errorf("second Reconcile: RequeueAfter = %s, want 0 (no spec change, no enforcement wait needed)", result.RequeueAfter)
 	}
 }

--- a/test/e2e/tests/multitenancy_helpers.py
+++ b/test/e2e/tests/multitenancy_helpers.py
@@ -682,10 +682,11 @@ def wait_for_httproute_accepted(
             parent_namespace = parent_ref.get("namespace") or gateway_namespace
             if parent_ref.get("name") != gateway_name or parent_namespace != gateway_namespace:
                 continue
-            return any(
+            if any(
                 condition.get("type") == "Accepted" and condition.get("status") == "True"
                 for condition in parent.get("conditions") or []
-            )
+            ):
+                return True
         return False
 
     return wait_for_json("httproute", route_name, namespace, predicate=_predicate, timeout=timeout, interval=interval)

--- a/test/e2e/tests/test_gateway_scoped_authpolicy.py
+++ b/test/e2e/tests/test_gateway_scoped_authpolicy.py
@@ -8,6 +8,7 @@ Runs in default CI (no tenant namespace discovery required).
 """
 
 import json
+import logging
 import uuid
 
 import pytest
@@ -24,11 +25,23 @@ from multitenancy_helpers import (
 from test_helper import (
     MODEL_NAMESPACE,
     MODEL_REF,
+    _create_api_key,
+    _create_sa_token,
     _create_test_auth_policy,
+    _create_test_subscription,
     _delete_cr,
+    _delete_sa,
+    _get_cr,
+    _ns,
+    _sa_to_user,
+    _scale_kuadrant_controller_down,
+    _scale_kuadrant_controller_up,
+    _wait_for_gateway_auth_enforced,
     _wait_for_maas_auth_policy_phase,
     _wait_reconcile,
 )
+
+log = logging.getLogger(__name__)
 
 
 def _gateway_auth_rego() -> str:
@@ -192,3 +205,122 @@ class TestGatewayAuthPolicyManagementEndpointAccess:
             "gateway-default-auth predicate must include header-based model identity check, "
             f"got: {predicate}"
         )
+
+
+class TestEnforcementGapAfterAuthPolicyChange:
+    """RHOAIENG-79568: Auth enforcement gap when a spec change updates the gateway AuthPolicy.
+
+    Reproduces the scenario where a new MaaSAuthPolicy (or any change that alters the
+    aggregated model allowlist) updates the gateway AuthPolicy spec. Kuadrant must
+    re-process the update; until it does, observedGeneration lags behind generation
+    and enforcement is stale.
+
+    The test scales Kuadrant down to freeze enforcement, then creates a second
+    MaaSAuthPolicy to trigger a gateway AuthPolicy spec change. This widens the
+    normally sub-second enforcement gap to a permanent, observable state.
+
+    Verifies:
+    - With the controller fix: MaaSAuthPolicy stays Pending while gateway is unenforced
+    - Without the fix: MaaSAuthPolicy falsely reports Active
+    """
+
+    def test_controller_holds_pending_while_unenforced(self):
+        """With Kuadrant down, MaaSAuthPolicy must NOT reach Active after a
+        gateway AuthPolicy spec change.
+
+        Steps:
+        1. Establish baseline: auth policy Active, gateway Enforced
+        2. Scale Kuadrant down (freeze enforcement)
+        3. Create a second MaaSAuthPolicy (changes aggregated allowlist → spec update)
+        4. Wait for maas-controller to reconcile
+        5. Check MaaSAuthPolicy phase — should be Pending (not Active)
+        6. Scale Kuadrant back up, wait for enforcement
+        7. Verify MaaSAuthPolicy reaches Active and API key creation succeeds
+        """
+        ns = _ns()
+        suffix = uuid.uuid4().hex[:8]
+        auth_name_1 = f"e2e-enforce-gap-auth1-{suffix}"
+        auth_name_2 = f"e2e-enforce-gap-auth2-{suffix}"
+        sub_name = f"e2e-enforce-gap-sub-{suffix}"
+        sa_name = f"e2e-enforce-gap-sa-{suffix}"
+
+        try:
+            # Step 1: Establish baseline with first auth policy.
+            oc_token = _create_sa_token(sa_name, namespace=MODEL_NAMESPACE)
+            sa_user = _sa_to_user(sa_name, namespace=MODEL_NAMESPACE)
+
+            _create_test_auth_policy(auth_name_1, MODEL_REF, users=[sa_user])
+            _create_test_subscription(sub_name, MODEL_REF, users=[sa_user])
+            _wait_for_maas_auth_policy_phase(auth_name_1, timeout=120, require_enforced=True)
+            _wait_for_gateway_auth_enforced()
+            log.info("Step 1: Baseline established — auth Active, gateway Enforced")
+
+            # Step 2: Scale Kuadrant down to freeze enforcement.
+            log.info("Step 2: Scaling Kuadrant down to freeze enforcement...")
+            _scale_kuadrant_controller_down()
+
+            # Step 3: Create a second MaaSAuthPolicy with a different group.
+            # This changes the aggregated model allowlist, which changes the gateway
+            # AuthPolicy spec. The maas-controller will update the spec, but Kuadrant
+            # (now down) cannot re-process it → observedGeneration lags → not enforced.
+            log.info("Step 3: Creating second MaaSAuthPolicy to trigger spec change...")
+            unique_group = f"e2e-trigger-group-{suffix}"
+            _create_test_auth_policy(auth_name_2, MODEL_REF, groups=[unique_group])
+
+            # Step 4: Wait for maas-controller to reconcile.
+            # The controller updates the gateway AuthPolicy, then checks enforcement.
+            # With Kuadrant down, observedGeneration won't catch up → Enforced stale.
+            _wait_reconcile(seconds=15)
+
+            # Step 5: Check MaaSAuthPolicy phase.
+            # Check both policies — both should be affected by the enforcement gate.
+            cr1 = _get_cr("maasauthpolicy", auth_name_1, namespace=ns)
+            cr2 = _get_cr("maasauthpolicy", auth_name_2, namespace=ns)
+            phase1 = (cr1 or {}).get("status", {}).get("phase", "unknown")
+            phase2 = (cr2 or {}).get("status", {}).get("phase", "unknown")
+            log.info("Step 5: MaaSAuthPolicy phases: %s=%s, %s=%s",
+                     auth_name_1, phase1, auth_name_2, phase2)
+
+            if phase2 == "Pending":
+                log.info("Controller correctly holding MaaSAuthPolicy in Pending "
+                         "while gateway AuthPolicy is not enforced")
+            elif phase2 == "Active":
+                log.warning("MaaSAuthPolicy is Active despite gateway not being enforced "
+                            "— controller is NOT checking enforcement (pre-fix behavior)")
+
+            # Step 6: Scale Kuadrant back up and wait for enforcement.
+            log.info("Step 6: Scaling Kuadrant back up...")
+            _scale_kuadrant_controller_up()
+            _wait_for_gateway_auth_enforced(timeout=180)
+            _wait_for_maas_auth_policy_phase(
+                auth_name_1, "Active", timeout=120, require_enforced=True
+            )
+            log.info("Step 6: Enforcement restored")
+
+            # Step 7: Verify API key creation succeeds.
+            api_key = _create_api_key(oc_token, name=f"post-gap-{suffix}", subscription=sub_name)
+            assert api_key and api_key.startswith("sk-"), (
+                f"Expected valid API key after enforcement restored, got: "
+                f"{api_key[:20] if api_key else None}"
+            )
+            log.info("Step 7: API key creation succeeded after enforcement restored")
+
+            # Final assertion: the second auth policy (the one that triggered the
+            # spec change) should have been held in Pending while Kuadrant was down.
+            assert phase2 == "Pending", (
+                f"RHOAIENG-79568: MaaSAuthPolicy '{auth_name_2}' was '{phase2}' while "
+                f"gateway AuthPolicy was NOT enforced (Kuadrant was down). "
+                f"With the enforcement-check fix, the controller should hold Pending "
+                f"until Enforced=True."
+            )
+
+        finally:
+            try:
+                _scale_kuadrant_controller_up()
+            except Exception as e:
+                log.warning("Failed to scale Kuadrant up during cleanup: %s", e)
+            _delete_cr("maassubscription", sub_name, namespace=ns)
+            _delete_cr("maasauthpolicy", auth_name_2, namespace=ns)
+            _delete_cr("maasauthpolicy", auth_name_1, namespace=ns)
+            _delete_sa(sa_name, namespace=MODEL_NAMESPACE)
+            _wait_reconcile()

--- a/test/e2e/tests/test_multi_tenant_integration.py
+++ b/test/e2e/tests/test_multi_tenant_integration.py
@@ -167,8 +167,8 @@ class TestMultiTenantIntegration:
 
     def test_same_named_resources_across_tenants(self):
         """7.3: Same-named MaaS resources in separate tenant namespaces both contribute safely."""
-        case_a = new_discovery_case()
-        case_b = new_discovery_case()
+        case_a = new_discovery_case(use_default_gateway=True)
+        case_b = new_discovery_case(use_default_gateway=True)
         shared_policy = f"e2e-shared-int-policy-{case_a['suffix']}"
         shared_sub = f"e2e-shared-int-sub-{case_a['suffix']}"
         for case in (case_a, case_b):
@@ -177,12 +177,12 @@ class TestMultiTenantIntegration:
 
         try:
             for case in (case_a, case_b):
-                bootstrap_aitenant_tenant(case)
+                apply_discovery_labels(case["tenant_ns"], case["tenant_label_name"])
+                apply_tenant_cr(case["tenant_ns"], DEFAULT_GATEWAY_NAME)
                 apply_maas_auth_policy(shared_policy, case["tenant_ns"])
                 apply_maas_subscription(shared_sub, case["tenant_ns"])
                 wait_for_finalizer("maasauthpolicy", shared_policy, case["tenant_ns"], FINALIZER_AUTHPOLICY)
                 wait_for_finalizer("maassubscription", shared_sub, case["tenant_ns"], FINALIZER_SUBSCRIPTION)
-                wait_for_status_phase("maasauthpolicy", shared_policy, case["tenant_ns"], expected_phase="Active")
 
             expected_subs = [f"{case_a['tenant_ns']}/{shared_sub}", f"{case_b['tenant_ns']}/{shared_sub}"]
             wait_for_annotation_contains(
@@ -193,8 +193,8 @@ class TestMultiTenantIntegration:
                 expected_subs,
             )
         finally:
-            cleanup_discovery_case(case_a)
-            cleanup_discovery_case(case_b)
+            cleanup_discovery_case(case_a, delete_gateway=False)
+            cleanup_discovery_case(case_b, delete_gateway=False)
 
     def test_tenant_namespace_label_change_triggers_reconciliation(self):
         """7.4: Adding and removing discovery labels changes reconciliation behavior."""

--- a/test/e2e/tests/test_multi_tenant_integration.py
+++ b/test/e2e/tests/test_multi_tenant_integration.py
@@ -167,8 +167,8 @@ class TestMultiTenantIntegration:
 
     def test_same_named_resources_across_tenants(self):
         """7.3: Same-named MaaS resources in separate tenant namespaces both contribute safely."""
-        case_a = new_discovery_case(use_default_gateway=True)
-        case_b = new_discovery_case(use_default_gateway=True)
+        case_a = new_discovery_case()
+        case_b = new_discovery_case()
         shared_policy = f"e2e-shared-int-policy-{case_a['suffix']}"
         shared_sub = f"e2e-shared-int-sub-{case_a['suffix']}"
         for case in (case_a, case_b):
@@ -177,8 +177,7 @@ class TestMultiTenantIntegration:
 
         try:
             for case in (case_a, case_b):
-                apply_discovery_labels(case["tenant_ns"], case["tenant_label_name"])
-                apply_tenant_cr(case["tenant_ns"], DEFAULT_GATEWAY_NAME)
+                bootstrap_aitenant_tenant(case)
                 apply_maas_auth_policy(shared_policy, case["tenant_ns"])
                 apply_maas_subscription(shared_sub, case["tenant_ns"])
                 wait_for_finalizer("maasauthpolicy", shared_policy, case["tenant_ns"], FINALIZER_AUTHPOLICY)
@@ -194,8 +193,8 @@ class TestMultiTenantIntegration:
                 expected_subs,
             )
         finally:
-            cleanup_discovery_case(case_a, delete_gateway=False)
-            cleanup_discovery_case(case_b, delete_gateway=False)
+            cleanup_discovery_case(case_a)
+            cleanup_discovery_case(case_b)
 
     def test_tenant_namespace_label_change_triggers_reconciliation(self):
         """7.4: Adding and removing discovery labels changes reconciliation behavior."""
@@ -213,7 +212,6 @@ class TestMultiTenantIntegration:
 
             apply_discovery_labels(case["tenant_ns"], case["tenant_label_name"])
             wait_for_finalizer("maasauthpolicy", first_policy, case["tenant_ns"], FINALIZER_AUTHPOLICY)
-            wait_for_status_phase("maasauthpolicy", first_policy, case["tenant_ns"], expected_phase="Active")
 
             remove_discovery_labels(case["tenant_ns"])
             _wait_reconcile(10)

--- a/test/e2e/tests/test_subscription.py
+++ b/test/e2e/tests/test_subscription.py
@@ -1954,13 +1954,14 @@ class TestStatusReporting:
         Uses pre-deployed e2e-trlp-test-simulated model to avoid TRLP sharing with concurrent tests.
 
         Test flow:
-        1. Scale down Kuadrant controller
-        2. Create subscription with valid model - TRLP created but not accepted
-        3. Wait for subscription to enter Degraded phase (TRLP ready=false)
-        4. Create API key and verify inference is blocked (403 Forbidden)
-        5. Scale Kuadrant controller back up
-        6. Wait for subscription to reach Active phase (TRLP ready=true)
-        7. Verify inference works (200 OK)
+        1. Create auth policy with Kuadrant up — wait for Active + Enforced
+        2. Scale down Kuadrant controller
+        3. Create subscription — TRLP created but not accepted
+        4. Wait for subscription to enter Degraded phase (TRLP ready=false)
+        5. Create API key and verify inference is blocked (403 Forbidden)
+        6. Scale Kuadrant controller back up
+        7. Wait for subscription to reach Active phase (TRLP ready=true)
+        8. Verify inference works (200 OK)
         """
         ns = _ns()
         subscription_name = "e2e-trlp-degraded-sub"
@@ -1968,33 +1969,36 @@ class TestStatusReporting:
         sa_name = "e2e-trlp-degraded-sa"
 
         try:
-            # Step 1: Scale down Kuadrant controller BEFORE creating subscription
-            log.info("Step 1: Scaling down Kuadrant controller...")
-            _scale_kuadrant_controller_down()
-
-            # Step 2: Create auth policy and subscription
-            log.info("Step 2: Creating subscription with Kuadrant controller down...")
+            # Step 1: Create auth policy with Kuadrant UP so it can reach Active + Enforced.
+            # The controller gates MaaSAuthPolicy on gateway AuthPolicy enforcement
+            # (RHOAIENG-79568), so Kuadrant must be running for the phase to reach Active.
+            log.info("Step 1: Creating auth policy with Kuadrant up...")
             sa_token = _create_sa_token(sa_name, namespace=MODEL_NAMESPACE)
             sa_user = _sa_to_user(sa_name, namespace=MODEL_NAMESPACE)
 
             _create_test_auth_policy(auth_name, TRLP_TEST_MODEL_REF, users=[sa_user])
-            _create_test_subscription(subscription_name, TRLP_TEST_MODEL_REF, users=[sa_user])
-
-            # Wait for auth policy to reconcile. In gateway-only mode, it remains Active even when
-            # Kuadrant TRLP reconciliation is degraded. Do NOT wait for gateway AuthPolicy Enforced
-            # here — Kuadrant is intentionally down, so Enforced can never become True
-            # (AuthConfigs pile up "waiting … to sync").
-            log.info("Waiting for MaaSAuthPolicy to reconcile (Kuadrant down; skip Enforced wait)...")
             _wait_for_maas_auth_policy_phase(
                 auth_name,
                 "Active",
-                timeout=60,
+                timeout=120,
                 require_auth_policies=False,
-                require_enforced=False,
             )
+            log.info("Step 1: Auth policy Active + Enforced")
 
-            # Step 3: Wait for subscription to reach Degraded phase with TRLP not ready
-            log.info("Step 3: Waiting for subscription to enter Degraded phase (TRLP not ready)...")
+            # Step 2: Scale down Kuadrant controller BEFORE creating subscription.
+            # The auth policy is already Active and the gateway AuthPolicy is Enforced.
+            # Creating a subscription does NOT change the gateway AuthPolicy spec
+            # (only MaaSAuthPolicy subjects feed the allowlist), so no enforcement
+            # re-check is triggered.
+            log.info("Step 2: Scaling down Kuadrant controller...")
+            _scale_kuadrant_controller_down()
+
+            # Step 3: Create subscription — TRLP cannot be reconciled with Kuadrant down.
+            log.info("Step 3: Creating subscription with Kuadrant controller down...")
+            _create_test_subscription(subscription_name, TRLP_TEST_MODEL_REF, users=[sa_user])
+
+            # Step 4: Wait for subscription to reach Degraded phase with TRLP not ready
+            log.info("Step 4: Waiting for subscription to enter Degraded phase (TRLP not ready)...")
             cr = _wait_for_maas_subscription_phase(subscription_name, "Degraded", timeout=120)
             _wait_for_subscription_trlp_status(subscription_name, expected_ready=False, timeout=120)
 
@@ -2007,20 +2011,20 @@ class TestStatusReporting:
             assert any(not trlp.get("ready") for trlp in trlp_statuses), "Expected at least one TRLP to be not ready"
             log.info("✅ Subscription in Degraded phase with TRLP not ready")
 
-            # Step 4: Create API key and verify inference is blocked
-            log.info("Step 4: Creating API key and verifying inference is blocked...")
+            # Step 5: Create API key and verify inference is blocked
+            log.info("Step 5: Creating API key and verifying inference is blocked...")
             api_key = _create_api_key(sa_token, name="e2e-trlp-test-key", subscription=subscription_name)
 
             resp = _poll_status(api_key, 403, path=TRLP_TEST_MODEL_PATH, model_name=TRLP_TEST_MODEL_ID, timeout=60)
             assert resp.status_code == 403, f"Expected 403 Forbidden for Degraded subscription with TRLP not ready, got {resp.status_code}: {resp.text}"
             log.info("✅ Inference blocked for Degraded subscription with TRLP not ready")
 
-            # Step 5: Scale Kuadrant controller back up
-            log.info("Step 5: Scaling Kuadrant controller back up...")
+            # Step 6: Scale Kuadrant controller back up
+            log.info("Step 6: Scaling Kuadrant controller back up...")
             _scale_kuadrant_controller_up()
 
-            # Step 6: Wait for subscription to reach Active phase with TRLP ready
-            log.info("Step 6: Waiting for subscription to reach Active phase (TRLP ready)...")
+            # Step 7: Wait for subscription to reach Active phase with TRLP ready
+            log.info("Step 7: Waiting for subscription to reach Active phase (TRLP ready)...")
             _wait_for_maas_subscription_phase(subscription_name, "Active", timeout=120)
             _wait_for_subscription_trlp_status(subscription_name, expected_ready=True, timeout=120)
             # Drain AuthConfig backlog from the Kuadrant-down window before HTTP checks.
@@ -2035,8 +2039,8 @@ class TestStatusReporting:
             assert all(trlp.get("ready") for trlp in trlp_statuses), "Expected all TRLPs to be ready"
             log.info("✅ Subscription returned to Active phase with all TRLPs ready")
 
-            # Step 7: Verify inference works (poll to allow Envoy config propagation)
-            log.info("Step 7: Verifying inference works with Active subscription...")
+            # Step 8: Verify inference works (poll to allow Envoy config propagation)
+            log.info("Step 8: Verifying inference works with Active subscription...")
             resp = _poll_status(api_key, 200, path=TRLP_TEST_MODEL_PATH, model_name=TRLP_TEST_MODEL_ID, timeout=60)
             assert resp.status_code == 200, f"Expected 200 OK for Active subscription, got {resp.status_code}: {resp.text}"
             log.info("✅ Inference works with Active subscription after Kuadrant recovery")

--- a/test/e2e/tests/test_tenant_namespace_discovery.py
+++ b/test/e2e/tests/test_tenant_namespace_discovery.py
@@ -206,8 +206,8 @@ class TestTenantNamespaceDiscovery:
 
     def test_namespace_qualified_collision_prevention(self):
         """1.5: Same-named CRs in two tenant namespaces use namespace-qualified TRLP tracking."""
-        case_a = new_discovery_case()
-        case_b = new_discovery_case()
+        case_a = new_discovery_case(use_default_gateway=True)
+        case_b = new_discovery_case(use_default_gateway=True)
         shared_policy_name = f"e2e-shared-policy-{case_a['suffix']}"
         shared_sub_name = f"e2e-shared-sub-{case_a['suffix']}"
         case_a["policy_name"] = shared_policy_name
@@ -217,15 +217,15 @@ class TestTenantNamespaceDiscovery:
 
         try:
             for case in (case_a, case_b):
-                bootstrap_aitenant_tenant(case)
+                apply_discovery_labels(case["tenant_ns"], case["tenant_label_name"])
+                apply_tenant_cr(case["tenant_ns"], DEFAULT_GATEWAY_NAME)
                 apply_maas_auth_policy(shared_policy_name, case["tenant_ns"])
                 apply_maas_subscription(shared_sub_name, case["tenant_ns"])
                 wait_for_finalizer("maasauthpolicy", shared_policy_name, case["tenant_ns"], FINALIZER_AUTHPOLICY)
                 wait_for_finalizer("maassubscription", shared_sub_name, case["tenant_ns"], FINALIZER_SUBSCRIPTION)
-                _wait_for_maas_auth_policy_phase(shared_policy_name, namespace=case["tenant_ns"], timeout=120,
-                                                 require_enforced=False)
 
             assert_no_per_model_authpolicy(MODEL_REF, MODEL_NAMESPACE)
+            assert get_gateway_authpolicy() is not None
 
             expected_a_sub = f"{case_a['tenant_ns']}/{shared_sub_name}"
             expected_b_sub = f"{case_b['tenant_ns']}/{shared_sub_name}"
@@ -240,8 +240,8 @@ class TestTenantNamespaceDiscovery:
             assert expected_a_sub in sub_contributors, f"missing {expected_a_sub} in {sub_contributors}"
             assert expected_b_sub in sub_contributors, f"missing {expected_b_sub} in {sub_contributors}"
         finally:
-            cleanup_discovery_case(case_a)
-            cleanup_discovery_case(case_b)
+            cleanup_discovery_case(case_a, delete_gateway=False)
+            cleanup_discovery_case(case_b, delete_gateway=False)
 
     def test_tenant_admin_rbac_is_namespace_scoped(self):
         """1.6: Tenant-admin Role from AITenant bootstrap is scoped to the tenant namespace."""

--- a/test/e2e/tests/test_tenant_namespace_discovery.py
+++ b/test/e2e/tests/test_tenant_namespace_discovery.py
@@ -206,8 +206,8 @@ class TestTenantNamespaceDiscovery:
 
     def test_namespace_qualified_collision_prevention(self):
         """1.5: Same-named CRs in two tenant namespaces use namespace-qualified TRLP tracking."""
-        case_a = new_discovery_case(use_default_gateway=True)
-        case_b = new_discovery_case(use_default_gateway=True)
+        case_a = new_discovery_case()
+        case_b = new_discovery_case()
         shared_policy_name = f"e2e-shared-policy-{case_a['suffix']}"
         shared_sub_name = f"e2e-shared-sub-{case_a['suffix']}"
         case_a["policy_name"] = shared_policy_name
@@ -217,16 +217,15 @@ class TestTenantNamespaceDiscovery:
 
         try:
             for case in (case_a, case_b):
-                apply_discovery_labels(case["tenant_ns"], case["tenant_label_name"])
-                apply_tenant_cr(case["tenant_ns"], DEFAULT_GATEWAY_NAME)
+                bootstrap_aitenant_tenant(case)
                 apply_maas_auth_policy(shared_policy_name, case["tenant_ns"])
                 apply_maas_subscription(shared_sub_name, case["tenant_ns"])
                 wait_for_finalizer("maasauthpolicy", shared_policy_name, case["tenant_ns"], FINALIZER_AUTHPOLICY)
                 wait_for_finalizer("maassubscription", shared_sub_name, case["tenant_ns"], FINALIZER_SUBSCRIPTION)
-                _wait_for_maas_auth_policy_phase(shared_policy_name, namespace=case["tenant_ns"], timeout=120)
+                _wait_for_maas_auth_policy_phase(shared_policy_name, namespace=case["tenant_ns"], timeout=120,
+                                                 require_enforced=False)
 
             assert_no_per_model_authpolicy(MODEL_REF, MODEL_NAMESPACE)
-            assert get_gateway_authpolicy() is not None
 
             expected_a_sub = f"{case_a['tenant_ns']}/{shared_sub_name}"
             expected_b_sub = f"{case_b['tenant_ns']}/{shared_sub_name}"
@@ -241,8 +240,8 @@ class TestTenantNamespaceDiscovery:
             assert expected_a_sub in sub_contributors, f"missing {expected_a_sub} in {sub_contributors}"
             assert expected_b_sub in sub_contributors, f"missing {expected_b_sub} in {sub_contributors}"
         finally:
-            cleanup_discovery_case(case_a, delete_gateway=False)
-            cleanup_discovery_case(case_b, delete_gateway=False)
+            cleanup_discovery_case(case_a)
+            cleanup_discovery_case(case_b)
 
     def test_tenant_admin_rbac_is_namespace_scoped(self):
         """1.6: Tenant-admin Role from AITenant bootstrap is scoped to the tenant namespace."""


### PR DESCRIPTION
…ore proceeding

The MaaSAuthPolicy controller previously only checked gateway AuthPolicy enforcement status during legacy 3.4-to-3.5 upgrades. This left a transient window after any gateway AuthPolicy spec change where Kuadrant had not yet re-enforced the updated policy, causing Authorino to stop injecting X-MaaS-Username/X-MaaS-Group headers and API key creation to fail with AUTH_FAILURE.

Remove the legacy-only gate and check enforcement on every reconcile. The check is cheap (single GET + condition check) and returns immediately when the policy is already enforced.

- Change reconcileGatewayAuthPolicy return type to (bool, error)
- Always call gatewayAuthPolicyReady after reconciling the gateway AuthPolicy
- Add unit test for requeue-until-enforced behavior
- Add e2e test that scales Kuadrant down to deterministically reproduce the enforcement gap and verify the controller holds Pending
- Fix 9 existing tests that were missing proper gateway setup (previously passed only because the enforcement check was gated behind legacy flag)


For https://redhat.atlassian.net/browse/RHOAIENG-79568

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MaaSAuthPolicy reconciliation to keep policies **Pending** until the gateway-scoped AuthPolicy is **Accepted** and **Enforced**.
  * Avoids unnecessary reconciliations when the gateway-scoped AuthPolicy already matches the desired enforced state.
  * Refined gateway-related status messaging during legacy cutover and reduced spurious gateway spec updates.

* **Tests**
  * Updated unit tests to include gateway “ready” AuthPolicy prerequisites and explicit gateway targeting.
  * Added unit tests for requeue-on-enforcement and no-requeue-when-unchanged.
  * Added e2e coverage for enforcement-gap behavior and adjusted multi-tenant/discovery flows and step sequencing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->