### PR TITLE
fix(RHOAIENG-76060): use groups_str path for captureGroup telemetry label

### DIFF
--- a/maas-controller/pkg/platform/tenantreconcile/postrender.go
+++ b/maas-controller/pkg/platform/tenantreconcile/postrender.go
@@ -374,7 +374,7 @@ func buildTelemetryLabels(log logr.Logger, config *maasv1alpha1.TenantTelemetryC
 		labels["user"] = "auth.identity.userid"
 	}
 	if captureGroup {
-		labels["group"] = "auth.identity.group"
+		labels["group"] = "auth.identity.groups_str"
 	}
 	if captureModelUsage {
 		labels["model"] = "responseBodyJSON(\"/model\")"

--- a/maas-controller/pkg/platform/tenantreconcile/postrender_test.go
+++ b/maas-controller/pkg/platform/tenantreconcile/postrender_test.go
@@ -1,0 +1,114 @@
+package tenantreconcile
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+
+	maasv1alpha1 "github.com/opendatahub-io/models-as-a-service/maas-controller/api/maas/v1alpha1"
+)
+
+func boolPtr(b bool) *bool { return &b }
+
+func TestBuildTelemetryLabels(t *testing.T) {
+	tests := []struct {
+		name           string
+		config         *maasv1alpha1.TenantTelemetryConfig
+		expectedLabels map[string]any
+		absentKeys     []string
+	}{
+		{
+			name:   "nil config uses defaults",
+			config: nil,
+			expectedLabels: map[string]any{
+				"subscription":    "auth.identity.selected_subscription",
+				"cost_center":     "auth.identity.subscription_info.costCenter",
+				"organization_id": "auth.identity.subscription_info.organizationId",
+				"model":           "responseBodyJSON(\"/model\")",
+			},
+			absentKeys: []string{"user", "group"},
+		},
+		{
+			name: "captureGroup true emits groups_str path",
+			config: &maasv1alpha1.TenantTelemetryConfig{
+				Metrics: &maasv1alpha1.TenantMetricsConfig{
+					CaptureGroup: boolPtr(true),
+				},
+			},
+			expectedLabels: map[string]any{
+				"group": "auth.identity.groups_str",
+			},
+		},
+		{
+			name: "captureGroup false omits group label",
+			config: &maasv1alpha1.TenantTelemetryConfig{
+				Metrics: &maasv1alpha1.TenantMetricsConfig{
+					CaptureGroup: boolPtr(false),
+				},
+			},
+			absentKeys: []string{"group"},
+		},
+		{
+			name: "captureUser true emits userid path",
+			config: &maasv1alpha1.TenantTelemetryConfig{
+				Metrics: &maasv1alpha1.TenantMetricsConfig{
+					CaptureUser: boolPtr(true),
+				},
+			},
+			expectedLabels: map[string]any{
+				"user": "auth.identity.userid",
+			},
+		},
+		{
+			name: "captureOrganization false omits organization_id",
+			config: &maasv1alpha1.TenantTelemetryConfig{
+				Metrics: &maasv1alpha1.TenantMetricsConfig{
+					CaptureOrganization: boolPtr(false),
+				},
+			},
+			absentKeys: []string{"organization_id"},
+		},
+		{
+			name: "captureModelUsage false omits model",
+			config: &maasv1alpha1.TenantTelemetryConfig{
+				Metrics: &maasv1alpha1.TenantMetricsConfig{
+					CaptureModelUsage: boolPtr(false),
+				},
+			},
+			absentKeys: []string{"model"},
+		},
+		{
+			name: "all flags enabled",
+			config: &maasv1alpha1.TenantTelemetryConfig{
+				Metrics: &maasv1alpha1.TenantMetricsConfig{
+					CaptureGroup:        boolPtr(true),
+					CaptureUser:         boolPtr(true),
+					CaptureOrganization: boolPtr(true),
+					CaptureModelUsage:   boolPtr(true),
+				},
+			},
+			expectedLabels: map[string]any{
+				"subscription":    "auth.identity.selected_subscription",
+				"cost_center":     "auth.identity.subscription_info.costCenter",
+				"organization_id": "auth.identity.subscription_info.organizationId",
+				"user":            "auth.identity.userid",
+				"group":           "auth.identity.groups_str",
+				"model":           "responseBodyJSON(\"/model\")",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			labels := buildTelemetryLabels(logr.Discard(), tt.config)
+
+			for k, v := range tt.expectedLabels {
+				assert.Equal(t, v, labels[k], "label %q", k)
+			}
+			for _, k := range tt.absentKeys {
+				assert.NotContains(t, labels, k, "label %q should be absent", k)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- **Bug**: When `captureGroup: true` is set on the `Tenant`/`MaasTenantConfig`, the controller generated a `TelemetryPolicy` with `"group": "auth.identity.group"`. That key does not exist in the AuthPolicy identity filter, causing the Kuadrant WASM plugin to emit `CelError::Resolve { NoSuchKey("group") }` in gateway logs on every request.
- **Fix**: Change the selector to `"auth.identity.groups_str"` — the comma-joined string property defined in the AuthPolicy response filter that is explicitly designed for telemetry use.
- **Test**: Add `TestBuildTelemetryLabels` covering all five capture flags, including a regression case that pins `captureGroup: true` → `"auth.identity.groups_str"`.

## Root cause

`buildTelemetryLabels` in `postrender.go` emitted `"auth.identity.group"` (singular, non-existent) instead of `"auth.identity.groups_str"` (the actual property defined in the AuthPolicy `filters.identity.json.properties` block at `maasauthpolicy_controller.go:1147`). All other capture flags (`captureUser`, `captureOrganization`, `captureModelUsage`) correctly reference real property paths; `captureGroup` was the only one with the wrong key.

## Cluster verification

Reproduced on a fresh ROSA 4.21 cluster with Kuadrant v1.4.2:

**Before fix** — unpatched `odh-stable` controller generated:
```json
"group": "auth.identity.group"
```

**After fix** — patched controller regenerated:
```json
"group": "auth.identity.groups_str"
```

Gateway logs confirmed no `NoSuchKey` errors after the fix.

## Risk analysis

**Risk rating: 1**

**Why**: Documentation-adjacent runtime fix — one string literal changed in the TelemetryPolicy label map. No control-flow changes, no new dependencies. The only observable effect is that the `group` metric label now resolves correctly instead of failing with a CEL error. Existing behaviour for all other telemetry flags is unchanged. Unit tests cover all flag combinations.

For https://redhat.atlassian.net/browse/RHOAIENG-76060

## Merge criteria

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved telemetry label generation so group information is captured consistently when group tracking is enabled.

- **Tests**
  - Added unit tests covering default telemetry labels and conditional inclusion of group, user, organization ID, and model labels based on configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->