### PR TITLE
fix(RHOAIENG-78601): set MAAS_PLATFORM_MANIFESTS in xKS overlay

### DIFF
--- a/deployment/base/maas-controller/overlays/xks/kustomization.yaml
+++ b/deployment/base/maas-controller/overlays/xks/kustomization.yaml
@@ -77,6 +77,17 @@ patches:
         path: /metadata/annotations/cert-manager.io~1inject-ca-from
         value: "$(NAMESPACE)/maas-controller-webhook-server"
 
+  # Set platform manifests path so maas-controller uses xKS tenant overlay
+  - target:
+      kind: Deployment
+      name: maas-controller
+    patch: |
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: MAAS_PLATFORM_MANIFESTS
+          value: /maas-api/deploy/overlays/xks
+
 vars:
   - name: NAMESPACE
     objref:


### PR DESCRIPTION
## Summary

- Adds a kustomize patch in the xKS overlay to inject `MAAS_PLATFORM_MANIFESTS=/maas-api/deploy/overlays/xks` into the maas-controller deployment
- This explicitly tells the controller to use the xKS tenant manifests (cert-manager TLS, no OCP service-serving-certs) instead of relying solely on runtime platform detection
- Once synced to `ai-gateway-operator`, supersedes https://github.com/opendatahub-io/ai-gateway-operator/pull/79

## Why

PR #1263 added `ManifestPathForPlatform()` with runtime detection as fallback, but explicit configuration via env var is more reliable and follows the existing pattern in this overlay (`INFRA_NAMESPACE`, `GATEWAY_NAMESPACE`).

## Test plan

- [x] `kustomize build deployment/base/maas-controller/overlays/xks` renders correctly with the new env var
- [x] Validated on AKS cluster — maas-controller picks up the env var and deploys maas-api with xKS overlay

Fixes: https://issues.redhat.com/browse/RHOAIENG-78601

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary of changes

* **Enhancements**
  * Updated the xKS deployment configuration to include the `MAAS_PLATFORM_MANIFESTS` environment variable, pointing to `/maas-api/deploy/overlays/xks`.
  * Improves consistency for how platform manifests are provided and applied in xKS environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->