### PR TITLE
feat: add passthrough-profile-picker to default IPP config

### DIFF
--- a/deployment/base/payload-processing/manager/plugins-configmap.yaml
+++ b/deployment/base/payload-processing/manager/plugins-configmap.yaml
@@ -35,19 +35,24 @@ data:
     - type: model-provider-resolver
     - type: api-translation
     - type: apikey-injection
+    - type: passthrough-profile-picker
+      name: passthrough-profile-picker
+    preProcessing:
+      plugins:
+      - pluginRef: maas-headers-guard
+      - pluginRef: stream-usage-enforcer
+      - pluginRef: model-provider-resolver
+    profilePicker:
+      pluginRef: passthrough-profile-picker
     profiles:
-    - name: default
+    - name: translation
       plugins:
         request:
-        - pluginRef: maas-headers-guard
-        - pluginRef: stream-usage-enforcer
-        - pluginRef: model-provider-resolver
         - pluginRef: api-translation
         - pluginRef: apikey-injection
-        # Response api-translation is off by default so SSE streaming for
-        # internal/OpenAI-compatible models is not held by a response processor.
-        # Re-enable for providers that need response rewrite (e.g. Anthropic):
-        #   response:
-        #   - pluginRef: api-translation
-        # See docs/content/install/external-model-setup.md (IPP response translation).
-        response: []
+        response:
+        - pluginRef: api-translation
+    - name: passthrough
+      plugins:
+        request:
+        - pluginRef: apikey-injection


### PR DESCRIPTION
## Summary

Updates the default IPP config to use two profiles with a `passthrough-profile-picker`, eliminating unnecessary response buffering for passthrough and internal model requests.

## Motivation

Today all responses are buffered when `api-translation` is in the profile — even passthrough requests (same format in/out) and internal models that don't need translation. The client sees no tokens until the full response is complete.

With the two-profile config, the picker selects:
- **translation** profile → buffers response for cross-format translation
- **passthrough** profile → streams response chunks directly in real-time

## Config changes

**Before** (single profile, all plugins in request, response always buffered):
```yaml
profiles:
- name: default
  plugins:
    request: [maas-headers-guard, stream-usage-enforcer, model-provider-resolver, api-translation, apikey-injection]
    response: [api-translation]
```

**After** (two profiles, shared plugins in preProcessing, picker selects):
```yaml
preProcessing:
  plugins:
  - pluginRef: maas-headers-guard
  - pluginRef: stream-usage-enforcer
  - pluginRef: model-provider-resolver
profilePicker:
  pluginRef: passthrough-profile-picker
profiles:
- name: translation
  plugins:
    request: [api-translation, apikey-injection]
    response: [api-translation]
- name: passthrough
  plugins:
    request: [apikey-injection]
```

## Dependency

Requires IPP PR: opendatahub-io/ai-gateway-payload-processing#428 (the `passthrough-profile-picker` plugin)

## Risk analysis

- **Risk rating**: 2
- **Why**: Config-only change to a static YAML file. No Go code modified. The picker plugin is registered in IPP — if the plugin type is not found (e.g., older IPP image), the framework will error on startup with a clear message. Validated with `validate-manifests.sh`.

## Test plan

- [x] `validate-manifests.sh` passes
- [x] Tested on live cluster (isequeir-test): translation profile selected for openai→messages, passthrough profile selected for messages→messages, confirmed buffering vs streaming via logs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added profile-based payload processing with selectable translation and passthrough modes.
  * Added preprocessing for request headers, stream usage, and model provider resolution.
  * Added API translation and API key injection support for translation workflows.
* **Improvements**
  * Enabled dynamic profile selection for incoming requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->