### PR TITLE
fix: close default tenant bootstrap race

### DIFF
--- a/maas-controller/cmd/manager/main.go
+++ b/maas-controller/cmd/manager/main.go
@@ -638,6 +638,10 @@ func markDefaultAITenantBootstrapped(ctx context.Context, c client.Client, ct *m
 	return nil
 }
 
+// clusterBootstrapPollInterval is how often ensureClusterBootstrapRunnable retries
+// creating the default AITenant after Config/default exists.
+const clusterBootstrapPollInterval = 2 * time.Second
+
 // ensureClusterBootstrapRunnable bootstraps the default AITenant once
 // Config/default is present (created by LifecycleReconciler). It does not set
 // owner references; LifecycleReconciler links Config to the default AITenant,
@@ -648,7 +652,7 @@ func ensureClusterBootstrapRunnable(mgr ctrl.Manager, tenantNamespace, aitenantN
 		log := ctrl.Log.WithName("setup").WithName("ensureClusterBootstrap")
 		c := mgr.GetClient()
 
-		ticker := time.NewTicker(30 * time.Second)
+		ticker := time.NewTicker(clusterBootstrapPollInterval)
 		defer ticker.Stop()
 
 		ensure := func() {

--- a/maas-controller/cmd/manager/main.go
+++ b/maas-controller/cmd/manager/main.go
@@ -638,10 +638,6 @@ func markDefaultAITenantBootstrapped(ctx context.Context, c client.Client, ct *m
 	return nil
 }
 
-// clusterBootstrapPollInterval is how often ensureClusterBootstrapRunnable retries
-// creating the default AITenant after Config/default exists.
-const clusterBootstrapPollInterval = 2 * time.Second
-
 // ensureClusterBootstrapRunnable bootstraps the default AITenant once
 // Config/default is present (created by LifecycleReconciler). It does not set
 // owner references; LifecycleReconciler links Config to the default AITenant,
@@ -652,7 +648,7 @@ func ensureClusterBootstrapRunnable(mgr ctrl.Manager, tenantNamespace, aitenantN
 		log := ctrl.Log.WithName("setup").WithName("ensureClusterBootstrap")
 		c := mgr.GetClient()
 
-		ticker := time.NewTicker(clusterBootstrapPollInterval)
+		ticker := time.NewTicker(30 * time.Second)
 		defer ticker.Stop()
 
 		ensure := func() {

--- a/maas-controller/pkg/controller/maas/aitenant_controller.go
+++ b/maas-controller/pkg/controller/maas/aitenant_controller.go
@@ -154,19 +154,69 @@ func (r *AITenantReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return ctrl.Result{RequeueAfter: time.Second}, nil
 	}
 
-	gatewayRef, err := r.validateTenantGateway(ctx, &aitenant)
+	gatewayRef := r.gatewayRefFor(&aitenant)
 	aitenant.Status.GatewayRef = gatewayRef
-	if err != nil {
+	if err := r.updateAITenantStatus(ctx, &aitenant, statusSnapshot); err != nil {
+		return ctrl.Result{}, err
+	}
+	statusSnapshot = aitenant.Status.DeepCopy()
+
+	var tenantConfigReady bool
+	ensureTenantResources := func() (ctrl.Result, bool, error) {
+		namespaceCreated, err := r.ensureTenantNamespace(ctx, &aitenant)
+		if err != nil {
+			setAITenantPhase(&aitenant, "Failed", "TenantNamespaceFailed", err.Error())
+			if err2 := r.updateAITenantStatus(ctx, &aitenant, statusSnapshot); err2 != nil {
+				return ctrl.Result{}, true, err2
+			}
+			return ctrl.Result{RequeueAfter: 30 * time.Second}, true, nil
+		}
+		if namespaceCreated {
+			setAITenantPhase(&aitenant, "Pending", "TenantNamespacePending", "waiting for tenant namespace to become available")
+			if err := r.updateAITenantStatus(ctx, &aitenant, statusSnapshot); err != nil {
+				return ctrl.Result{}, true, err
+			}
+			return ctrl.Result{RequeueAfter: time.Second}, true, nil
+		}
+
+		var namespacePending bool
+		tenantConfigReady, namespacePending, err = r.ensureTenantConfig(ctx, &aitenant)
+		if err != nil {
+			setAITenantPhase(&aitenant, "Failed", "TenantConfigReconcileFailed", err.Error())
+			if err2 := r.updateAITenantStatus(ctx, &aitenant, statusSnapshot); err2 != nil {
+				return ctrl.Result{}, true, err2
+			}
+			return ctrl.Result{RequeueAfter: 30 * time.Second}, true, nil
+		}
+		if namespacePending {
+			setAITenantPhase(&aitenant, "Pending", "TenantNamespacePending", "waiting for tenant namespace to accept tenant resources")
+			if err := r.updateAITenantStatus(ctx, &aitenant, statusSnapshot); err != nil {
+				return ctrl.Result{}, true, err
+			}
+			return ctrl.Result{RequeueAfter: time.Second}, true, nil
+		}
+
+		return ctrl.Result{}, false, nil
+	}
+
+	// The default namespace must be enabled before the Gateway becomes Ready so
+	// the UI is not blocked by the tenant-namespace admission check during normal
+	// bootstrap. Other AITenants keep the existing gateway-first provisioning
+	// order.
+	defaultTenantBootstrap := aitenant.Name == tenantreconcile.DefaultAITenantName
+	if defaultTenantBootstrap {
+		if res, done, err := ensureTenantResources(); err != nil || done {
+			return res, err
+		}
+	}
+
+	if err := r.validateTenantGateway(ctx, gatewayRef); err != nil {
 		setAITenantPhase(&aitenant, "Failed", "GatewayCheckFailed", err.Error())
 		if err2 := r.updateAITenantStatus(ctx, &aitenant, statusSnapshot); err2 != nil {
 			return ctrl.Result{}, err2
 		}
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 	}
-	if err := r.updateAITenantStatus(ctx, &aitenant, statusSnapshot); err != nil {
-		return ctrl.Result{}, err
-	}
-	statusSnapshot = aitenant.Status.DeepCopy()
 
 	if err := r.ensureGatewayClaim(ctx, &aitenant, gatewayRef); err != nil {
 		setAITenantPhase(&aitenant, "Failed", "GatewayClaimFailed", err.Error())
@@ -176,21 +226,10 @@ func (r *AITenantReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 	}
 
-	if err := r.ensureTenantNamespace(ctx, &aitenant); err != nil {
-		setAITenantPhase(&aitenant, "Failed", "TenantNamespaceFailed", err.Error())
-		if err2 := r.updateAITenantStatus(ctx, &aitenant, statusSnapshot); err2 != nil {
-			return ctrl.Result{}, err2
+	if !defaultTenantBootstrap {
+		if res, done, err := ensureTenantResources(); err != nil || done {
+			return res, err
 		}
-		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
-	}
-
-	tenantConfigReady, err := r.ensureTenantConfig(ctx, &aitenant)
-	if err != nil {
-		setAITenantPhase(&aitenant, "Failed", "TenantConfigReconcileFailed", err.Error())
-		if err2 := r.updateAITenantStatus(ctx, &aitenant, statusSnapshot); err2 != nil {
-			return ctrl.Result{}, err2
-		}
-		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 	}
 
 	if err := r.ensureTenantAdminRBAC(ctx, &aitenant); err != nil {
@@ -289,7 +328,7 @@ func (r *AITenantReconciler) tenantNamespaceName(aitenant *maasv1alpha1.AITenant
 	return tenantreconcile.TenantNamespaceForAITenant(aitenant.Name, r.TenantNamespace)
 }
 
-func (r *AITenantReconciler) ensureTenantNamespace(ctx context.Context, aitenant *maasv1alpha1.AITenant) error {
+func (r *AITenantReconciler) ensureTenantNamespace(ctx context.Context, aitenant *maasv1alpha1.AITenant) (bool, error) {
 	name := r.tenantNamespaceName(aitenant)
 	var ns corev1.Namespace
 	err := r.get(ctx, client.ObjectKey{Name: name}, &ns)
@@ -304,54 +343,53 @@ func (r *AITenantReconciler) ensureTenantNamespace(ctx context.Context, aitenant
 		setMapValue(&toCreate.Annotations, aitenantCreatedAnnotation, "true")
 		if createErr := r.Create(ctx, toCreate); createErr != nil {
 			if !isAlreadyExistsError(createErr) {
-				return fmt.Errorf("create tenant namespace %q: %w", name, createErr)
+				return false, fmt.Errorf("create tenant namespace %q: %w", name, createErr)
 			}
 			if err := r.get(ctx, client.ObjectKey{Name: name}, &ns); err != nil {
-				return fmt.Errorf("get tenant namespace %q after create conflict: %w", name, err)
+				return false, fmt.Errorf("get tenant namespace %q after create conflict: %w", name, err)
 			}
 			err = nil
 		} else {
-			return nil
+			return true, nil
 		}
 	}
 	if err != nil {
-		return fmt.Errorf("get tenant namespace %q: %w", name, err)
+		return false, fmt.Errorf("get tenant namespace %q: %w", name, err)
 	}
 	if ns.Status.Phase == corev1.NamespaceTerminating {
-		return fmt.Errorf("tenant namespace %q is terminating", name)
+		return false, fmt.Errorf("tenant namespace %q is terminating", name)
 	}
 	if hasAITenantOwnerAnnotations(&ns) && !ownedByAITenant(&ns, aitenant) {
-		return fmt.Errorf("tenant namespace %q is managed by another AITenant", name)
+		return false, fmt.Errorf("tenant namespace %q is managed by another AITenant", name)
 	}
 	base := ns.DeepCopy()
 	applyAITenantMetadata(&ns, aitenant, name)
 	if equality.Semantic.DeepEqual(base, &ns) {
-		return nil
+		return false, nil
 	}
 	if err := r.Patch(ctx, &ns, client.MergeFrom(base)); err != nil {
-		return fmt.Errorf("patch tenant namespace %q: %w", name, err)
+		return false, fmt.Errorf("patch tenant namespace %q: %w", name, err)
 	}
-	return nil
+	return false, nil
 }
 
-func (r *AITenantReconciler) validateTenantGateway(ctx context.Context, aitenant *maasv1alpha1.AITenant) (maasv1alpha1.TenantGatewayRef, error) {
-	ref := r.gatewayRefFor(aitenant)
+func (r *AITenantReconciler) validateTenantGateway(ctx context.Context, ref maasv1alpha1.TenantGatewayRef) error {
 	if ref.Namespace == "" {
-		return ref, errors.New("gateway namespace is required; set --gateway-namespace")
+		return errors.New("gateway namespace is required; set --gateway-namespace")
 	}
 	if ref.Name == "" {
-		return ref, errors.New("spec.gateway.name is required when AITenant name is empty")
+		return errors.New("spec.gateway.name is required when AITenant name is empty")
 	}
 
 	var gateway gatewayapiv1.Gateway
 	key := client.ObjectKey{Namespace: ref.Namespace, Name: ref.Name}
 	if err := r.get(ctx, key, &gateway); err != nil {
 		if isNotFoundError(err) {
-			return ref, fmt.Errorf("gateway %s/%s not found: the Gateway must be created by a network or cluster administrator before AITenant can be provisioned", key.Namespace, key.Name)
+			return fmt.Errorf("gateway %s/%s not found: the Gateway must be created by a network or cluster administrator before AITenant can be provisioned", key.Namespace, key.Name)
 		}
-		return ref, fmt.Errorf("get Gateway %s/%s: %w", key.Namespace, key.Name, err)
+		return fmt.Errorf("get Gateway %s/%s: %w", key.Namespace, key.Name, err)
 	}
-	return ref, nil
+	return nil
 }
 
 func (r *AITenantReconciler) gatewayRefFor(aitenant *maasv1alpha1.AITenant) maasv1alpha1.TenantGatewayRef {
@@ -410,7 +448,7 @@ func (r *AITenantReconciler) legacyGatewayNameIsSharedDefault(aitenant *maasv1al
 	return aitenant.Name != tenantreconcile.DefaultAITenantName && gatewayName == defaultGatewayName
 }
 
-func (r *AITenantReconciler) ensureTenantConfig(ctx context.Context, aitenant *maasv1alpha1.AITenant) (bool, error) {
+func (r *AITenantReconciler) ensureTenantConfig(ctx context.Context, aitenant *maasv1alpha1.AITenant) (bool, bool, error) {
 	tenantNamespace := r.tenantNamespaceName(aitenant)
 
 	config := &maasv1alpha1.MaasTenantConfig{
@@ -437,18 +475,21 @@ func (r *AITenantReconciler) ensureTenantConfig(ctx context.Context, aitenant *m
 		}
 		return nil
 	}); err != nil {
-		return false, err
+		if isNamespaceMissingError(err) {
+			return false, true, nil
+		}
+		return false, false, err
 	}
 	if err := r.markLegacyTenantDeprecated(ctx, tenantNamespace); err != nil {
-		return false, err
+		return false, false, err
 	}
 	if err := r.get(ctx, client.ObjectKeyFromObject(config), config); err != nil {
-		return false, fmt.Errorf("get MaasTenantConfig %s/%s readiness: %w", config.Namespace, config.Name, err)
+		return false, false, fmt.Errorf("get MaasTenantConfig %s/%s readiness: %w", config.Namespace, config.Name, err)
 	}
 	ready := apimeta.FindStatusCondition(config.Status.Conditions, tenantreconcile.ReadyConditionType)
 	return ready != nil &&
 		ready.Status == metav1.ConditionTrue &&
-		ready.ObservedGeneration == config.Generation, nil
+		ready.ObservedGeneration == config.Generation, false, nil
 }
 
 func (r *AITenantReconciler) copyLegacyTenantConfig(ctx context.Context, config *maasv1alpha1.MaasTenantConfig) error {
@@ -1406,6 +1447,25 @@ func isAlreadyExistsError(err error) bool {
 		return true
 	}
 	return hasAPIStatusReason(err, metav1.StatusReasonAlreadyExists)
+}
+
+func isNamespaceMissingError(err error) bool {
+	var statusErr *apierrors.StatusError
+	if !errors.As(err, &statusErr) {
+		return false
+	}
+	if statusErr.Status().Reason != metav1.StatusReasonNotFound {
+		return false
+	}
+	details := statusErr.Status().Details
+	if details != nil {
+		kind := strings.ToLower(details.Kind)
+		if kind == "namespace" || kind == "namespaces" {
+			return true
+		}
+	}
+	msg := strings.ToLower(statusErr.Status().Message)
+	return strings.HasPrefix(msg, "namespaces ") && strings.Contains(msg, "not found")
 }
 
 func hasAPIStatusReason(err error, reason metav1.StatusReason) bool {

--- a/maas-controller/pkg/controller/maas/aitenant_controller_test.go
+++ b/maas-controller/pkg/controller/maas/aitenant_controller_test.go
@@ -90,8 +90,18 @@ func reconcileAITenantTwice(t *testing.T, r *AITenantReconciler, key types.Names
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(res.RequeueAfter).To(Equal(time.Second))
 
-	_, err = r.Reconcile(ctx, ctrl.Request{NamespacedName: key})
-	g.Expect(err).NotTo(HaveOccurred())
+	// Finalizer convergence and tenant namespace creation can each requeue for
+	// one second before MaasTenantConfig is created.
+	converged := false
+	for i := 0; i < 3; i++ {
+		res, err = r.Reconcile(ctx, ctrl.Request{NamespacedName: key})
+		g.Expect(err).NotTo(HaveOccurred())
+		if res.RequeueAfter != time.Second {
+			converged = true
+			break
+		}
+	}
+	g.Expect(converged).To(BeTrue(), "AITenant bootstrap did not converge after expected one-second requeues")
 }
 
 func reconcileAITenantToActive(t *testing.T, r *AITenantReconciler, key types.NamespacedName) {
@@ -269,13 +279,13 @@ func TestAITenantReconcile_PersistsGatewayStatusBeforeTenantCreate(t *testing.T)
 	reconcileAITenantToActive(t, r, key)
 }
 
-func TestAITenantReconcile_MissingGatewaySetsFailedStatus(t *testing.T) {
+func TestAITenantReconcile_DefaultTenantCreatesConfigBeforeGatewayReady(t *testing.T) {
 	g := NewWithT(t)
 	s := aitenantTestScheme(t)
 
 	aitenant := &maasv1alpha1.AITenant{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "team-missing-gw",
+			Name:      tenantreconcile.DefaultAITenantName,
 			Namespace: tenantreconcile.DefaultAITenantNamespace,
 		},
 		Spec: maasv1alpha1.AITenantSpec{},
@@ -301,6 +311,10 @@ func TestAITenantReconcile_MissingGatewaySetsFailedStatus(t *testing.T) {
 
 	res, err = r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
 	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(res.RequeueAfter).To(Equal(time.Second))
+
+	res, err = r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
+	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(res.RequeueAfter).To(Equal(30 * time.Second))
 
 	var updated maasv1alpha1.AITenant
@@ -308,7 +322,7 @@ func TestAITenantReconcile_MissingGatewaySetsFailedStatus(t *testing.T) {
 	g.Expect(updated.Status.Phase).To(Equal("Failed"))
 	g.Expect(updated.Status.GatewayRef).To(Equal(maasv1alpha1.TenantGatewayRef{
 		Namespace: "openshift-ingress",
-		Name:      "team-missing-gw",
+		Name:      tenantreconcile.DefaultAITenantName,
 	}))
 	ready := apimeta.FindStatusCondition(updated.Status.Conditions, maasv1alpha1.AITenantConditionReady)
 	g.Expect(ready).NotTo(BeNil())
@@ -316,12 +330,121 @@ func TestAITenantReconcile_MissingGatewaySetsFailedStatus(t *testing.T) {
 	g.Expect(ready.Message).To(ContainSubstring("must be created by a network or cluster administrator"))
 
 	var tenant maasv1alpha1.MaasTenantConfig
-	err = cl.Get(context.Background(), client.ObjectKey{Name: maasv1alpha1.MaasTenantConfigInstanceName, Namespace: "ai-tenant-team-missing-gw"}, &tenant)
-	g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+	g.Expect(cl.Get(context.Background(), client.ObjectKey{
+		Name:      maasv1alpha1.MaasTenantConfigInstanceName,
+		Namespace: "models-as-a-service",
+	}, &tenant)).To(Succeed())
+	g.Expect(tenant.Labels).To(HaveKeyWithValue(aitenantManagedLabel, "true"))
+	g.Expect(tenant.Annotations).To(HaveKeyWithValue(aitenantNameAnnotation, tenantreconcile.DefaultAITenantName))
 
 	var ns corev1.Namespace
-	err = cl.Get(context.Background(), client.ObjectKey{Name: "ai-tenant-team-missing-gw"}, &ns)
+	g.Expect(cl.Get(context.Background(), client.ObjectKey{Name: "models-as-a-service"}, &ns)).To(Succeed())
+}
+
+func TestAITenantReconcile_CustomTenantWaitsForGatewayBeforeCreatingResources(t *testing.T) {
+	g := NewWithT(t)
+	s := aitenantTestScheme(t)
+
+	aitenant := &maasv1alpha1.AITenant{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "team-missing-gw",
+			Namespace: tenantreconcile.DefaultAITenantNamespace,
+		},
+	}
+	cl := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(&maasv1alpha1.AITenant{}).
+		WithObjects(aitenant).
+		Build()
+	r := &AITenantReconciler{
+		Client:           cl,
+		Scheme:           s,
+		APIReader:        cl,
+		AppNamespace:     "opendatahub",
+		TenantNamespace:  "models-as-a-service",
+		GatewayNamespace: "openshift-ingress",
+	}
+	key := types.NamespacedName{Name: aitenant.Name, Namespace: aitenant.Namespace}
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(res.RequeueAfter).To(Equal(time.Second))
+
+	res, err = r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(res.RequeueAfter).To(Equal(30 * time.Second))
+
+	err = cl.Get(context.Background(), client.ObjectKey{
+		Name:      maasv1alpha1.MaasTenantConfigInstanceName,
+		Namespace: "ai-tenant-team-missing-gw",
+	}, &maasv1alpha1.MaasTenantConfig{})
 	g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+	err = cl.Get(context.Background(), client.ObjectKey{Name: "ai-tenant-team-missing-gw"}, &corev1.Namespace{})
+	g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+}
+
+func TestAITenantReconcile_RetriesTenantConfigAfterNamespaceNotFound(t *testing.T) {
+	g := NewWithT(t)
+	s := aitenantTestScheme(t)
+
+	aitenant := &maasv1alpha1.AITenant{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "team-retry",
+			Namespace:  tenantreconcile.DefaultAITenantNamespace,
+			Finalizers: []string{aitenantFinalizer},
+		},
+	}
+	tenantNamespace := "ai-tenant-team-retry"
+	namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: tenantNamespace}}
+	gateway := existingAITenantGateway(aitenant.Name)
+
+	namespaceNotFound := true
+	cl := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(&maasv1alpha1.AITenant{}).
+		WithObjects(aitenant, namespace, gateway).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+				if _, ok := obj.(*maasv1alpha1.MaasTenantConfig); ok && namespaceNotFound {
+					namespaceNotFound = false
+					return apierrors.NewNotFound(schema.GroupResource{Resource: "namespaces"}, obj.GetNamespace())
+				}
+				return c.Create(ctx, obj, opts...)
+			},
+		}).
+		Build()
+	r := &AITenantReconciler{
+		Client:           cl,
+		Scheme:           s,
+		APIReader:        cl,
+		AppNamespace:     "opendatahub",
+		TenantNamespace:  "models-as-a-service",
+		GatewayNamespace: "openshift-ingress",
+	}
+	key := types.NamespacedName{Name: aitenant.Name, Namespace: aitenant.Namespace}
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(res.RequeueAfter).To(Equal(time.Second))
+	err = cl.Get(context.Background(), client.ObjectKey{
+		Name:      maasv1alpha1.MaasTenantConfigInstanceName,
+		Namespace: tenantNamespace,
+	}, &maasv1alpha1.MaasTenantConfig{})
+	g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+
+	var pending maasv1alpha1.AITenant
+	g.Expect(cl.Get(context.Background(), key, &pending)).To(Succeed())
+	ready := apimeta.FindStatusCondition(pending.Status.Conditions, maasv1alpha1.AITenantConditionReady)
+	g.Expect(ready).NotTo(BeNil())
+	g.Expect(ready.Reason).To(Equal("TenantNamespacePending"))
+
+	res, err = r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(res.RequeueAfter).To(Equal(30 * time.Second))
+	g.Expect(cl.Get(context.Background(), client.ObjectKey{
+		Name:      maasv1alpha1.MaasTenantConfigInstanceName,
+		Namespace: tenantNamespace,
+	}, &maasv1alpha1.MaasTenantConfig{})).To(Succeed())
 }
 
 func TestAITenantReconcile_ExplicitGatewayNameResolvesExistingGateway(t *testing.T) {


### PR DESCRIPTION
## Description

Fixes [RHOAIENG-79720](https://redhat.atlassian.net/browse/RHOAIENG-79720).

The default MaaS tenant bootstrap previously waited for the full `AITenant` gateway validation path before creating `MaasTenantConfig/default-tenant`. During that window, the UI could attempt to create a `MaaSAuthPolicy` or `MaaSSubscription` and be rejected by the tenant-namespace admission webhook.

This change:

- reduces the default `AITenant` bootstrap retry interval from 30 seconds to 2 seconds;
- creates or adopts the default tenant namespace and `MaasTenantConfig` before gateway readiness, with the expected AITenant ownership metadata;
- retries after one second when the API server temporarily reports that a newly created namespace is not yet available for namespaced resources;
- preserves gateway-first provisioning for non-default AITenants.

This PR does not make the default tenant mandatory. The existing bootstrap annotation and intentional default-tenant deletion behavior are unchanged: deleting the default `AITenant` still removes its tenant configuration without automatically recreating it.

## How Has This Been Tested?

Run from `maas-controller/`:

```bash
go test ./...
go test -race ./pkg/controller/maas ./cmd/manager
./bin/tools/golangci-lint run --new-from-rev=HEAD
```

The tests cover:

- creation of the default `MaasTenantConfig` before gateway readiness;
- preservation of gateway-first behavior for custom AITenants;
- retry and recovery after a transient namespace-not-found response;
- existing default-tenant deletion behavior.

No manual OpenShift cluster testing has been performed yet.

## Risk analysis

- **Risk rating:** 2
- **Why:** This changes controller bootstrap ordering and retry timing, but the behavior is limited to default-tenant initialization and transient namespace handling. Unit and race tests cover the changed paths, while the Prow smoke flow exercises full deployment plus subscription and authorization-policy creation. There are no API, CRD, RBAC, or manifest changes.

## Merge criteria:

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


[RHOAIENG-79720]: https://redhat.atlassian.net/browse/RHOAIENG-79720?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Default tenant resources can now be created before the gateway is fully ready.
  * Tenant setup reports a distinct pending status when the namespace is not yet available.
* **Bug Fixes**
  * Improved tenant provisioning retries when namespaces or configuration resources are temporarily unavailable.
  * Tenant configuration readiness now verifies that the latest configuration was observed.
  * Cluster bootstrap retries more frequently, reducing delays when creating the default tenant.
  * Custom tenants continue waiting for gateway readiness before resource creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->