### PR TITLE
feat: add MaxConcurrentReconciles for subscription and authpolicy controllers

### DIFF
--- a/docs/content/advanced-administration/controller-performance-tuning.md
+++ b/docs/content/advanced-administration/controller-performance-tuning.md
@@ -1,0 +1,51 @@
+# Controller Performance Tuning
+
+The maas-controller processes subscription and auth policy reconciliation within a single leader pod. By default, reconciliation is parallelized across 5 concurrent workers. This page describes how to tune concurrency for large-scale deployments.
+
+## `--max-concurrent-reconciles`
+
+Controls the number of concurrent reconciliation goroutines for the MaaSSubscription and MaaSAuthPolicy controllers. Other controllers (AITenant, MaaSModelRef, Tenant, Lifecycle) always use 1 to avoid conflicts on shared resources.
+
+| Parameter | Value |
+|---|---|
+| Flag | `--max-concurrent-reconciles` |
+| Default | 5 |
+| Range | 1–10 |
+| Applies to | MaaSSubscription, MaaSAuthPolicy controllers |
+
+## Benchmark Results
+
+Tested on RHOAI 3.5 cluster with 300 MaaSSubscriptions created simultaneously:
+
+| MaxConcurrentReconciles | Time to all Active | Speedup |
+|---|---|---|
+| 1 | 236s | baseline |
+| 5 (default) | 60s | 3.9x |
+| 10 | 67s | 3.5x |
+
+At default pod resource limits, values above 5 show diminishing returns due to API server contention.
+
+## Scaling Guidance
+
+| Deployment Size | Recommended Value | Resource Changes |
+|---|---|---|
+| Small (< 100 subscriptions) | 5 (default) | None |
+| Medium (100–500 subscriptions) | 5 | None |
+| Large (500+ subscriptions) | 5–10 | Increase controller CPU and memory |
+
+To increase the value beyond 5, update the controller deployment args and scale resources:
+
+```bash
+# Increase concurrency
+oc patch deploy maas-controller -n <controller-namespace> --type=json \
+  -p '[{"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--max-concurrent-reconciles=10"}]'
+
+# Scale resources to support higher concurrency
+oc patch deploy maas-controller -n <controller-namespace> --type=json \
+  -p '[{"op":"replace","path":"/spec/template/spec/containers/0/resources/limits/memory","value":"512Mi"},
+      {"op":"replace","path":"/spec/template/spec/containers/0/resources/limits/cpu","value":"1"}]'
+```
+
+## Leader Election
+
+The maas-controller uses Kubernetes leader election (`--leader-elect`). Only the leader pod runs reconcilers — additional replicas are standby for high-availability failover, not parallel processing. `MaxConcurrentReconciles` is the mechanism for parallelizing reconciliation within the single leader.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -99,6 +99,7 @@ nav:
       - Limitador Persistence: advanced-administration/limitador-persistence.md
       - Authorino Caching: configuration-and-management/authorino-caching.md
       - External OIDC: advanced-administration/external-oidc.md
+      - Controller Performance Tuning: advanced-administration/controller-performance-tuning.md
   - Observability:
     - Overview: observability/index.md
     - Setup: observability/setup.md

--- a/maas-controller/cmd/manager/main.go
+++ b/maas-controller/cmd/manager/main.go
@@ -953,13 +953,18 @@ func main() {
 		"How often to re-check controller-managed namespaces while the manager is running (recreate if deleted). "+
 			"Larger values reduce apiserver load; smaller values detect external deletions sooner.")
 	flag.IntVar(&maxConcurrentReconciles, "max-concurrent-reconciles", 5,
-		"Maximum number of concurrent reconciles for subscription and auth policy controllers.")
+		"Maximum number of concurrent reconciles for subscription and auth policy controllers (1-50).")
 	flag.BoolVar(&enableTenantNamespaceDiscovery, "enable-tenant-namespace-discovery", false,
 		"Discover AITenant-managed tenant namespaces labeled ai-gateway.opendatahub.io/tenant or maas.opendatahub.io/managed-by-aitenant=true and reconcile MaaS tenant CRs from them.")
 
 	opts := zap.Options{Development: false}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
+
+	if maxConcurrentReconciles < 1 || maxConcurrentReconciles > 50 {
+		setupLog.Error(nil, "invalid --max-concurrent-reconciles, must be 1-50", "value", maxConcurrentReconciles)
+		os.Exit(1)
+	}
 
 	// Allow empty monitoring-namespace to disable observability features (e.g. on xKS
 	// where the monitoring namespace may not exist). Non-empty values must be valid.

--- a/maas-controller/cmd/manager/main.go
+++ b/maas-controller/cmd/manager/main.go
@@ -847,7 +847,7 @@ func resolveInfraNamespace(infraNs, controllerNs string) string {
 // deriveInfraNamespace maps controller namespace to infrastructure namespace.
 // This implements namespace separation: controller runs in one namespace, infrastructure services in another.
 func clampConcurrentReconciles(v int) int {
-	const minConcurrent, maxConcurrent = 1, 5
+	const minConcurrent, maxConcurrent = 1, 10
 	if v < minConcurrent {
 		setupLog.Info("clamping --max-concurrent-reconciles to minimum", "requested", v, "using", minConcurrent)
 		return minConcurrent
@@ -966,7 +966,7 @@ func main() {
 		"How often to re-check controller-managed namespaces while the manager is running (recreate if deleted). "+
 			"Larger values reduce apiserver load; smaller values detect external deletions sooner.")
 	flag.IntVar(&maxConcurrentReconciles, "max-concurrent-reconciles", 5,
-		"Maximum number of concurrent reconciles for subscription and auth policy controllers (1-5).")
+		"Maximum number of concurrent reconciles for subscription and auth policy controllers (1-10). Values above 5 may require increased CPU/memory on the controller pod.")
 	flag.BoolVar(&enableTenantNamespaceDiscovery, "enable-tenant-namespace-discovery", false,
 		"Discover AITenant-managed tenant namespaces labeled ai-gateway.opendatahub.io/tenant or maas.opendatahub.io/managed-by-aitenant=true and reconcile MaaS tenant CRs from them.")
 

--- a/maas-controller/cmd/manager/main.go
+++ b/maas-controller/cmd/manager/main.go
@@ -927,6 +927,7 @@ func main() {
 	var authzCacheTTL int64
 	var subscriptionNamespaceMaintainInterval time.Duration
 	var enableTenantNamespaceDiscovery bool
+	var maxConcurrentReconciles int
 	var observabilityManifestsPath string
 	var monitoringNamespace string
 	var usageLogsManifestPath string
@@ -951,6 +952,8 @@ func main() {
 	flag.DurationVar(&subscriptionNamespaceMaintainInterval, "subscription-namespace-maintain-interval", 30*time.Second,
 		"How often to re-check controller-managed namespaces while the manager is running (recreate if deleted). "+
 			"Larger values reduce apiserver load; smaller values detect external deletions sooner.")
+	flag.IntVar(&maxConcurrentReconciles, "max-concurrent-reconciles", 5,
+		"Maximum number of concurrent reconciles for subscription and auth policy controllers.")
 	flag.BoolVar(&enableTenantNamespaceDiscovery, "enable-tenant-namespace-discovery", false,
 		"Discover AITenant-managed tenant namespaces labeled ai-gateway.opendatahub.io/tenant or maas.opendatahub.io/managed-by-aitenant=true and reconcile MaaS tenant CRs from them.")
 
@@ -1136,6 +1139,7 @@ func main() {
 		MetadataCacheTTL:                metadataCacheTTL,
 		AuthzCacheTTL:                   authzCacheTTL,
 		TenantNamespaceDiscoveryEnabled: enableTenantNamespaceDiscovery,
+		MaxConcurrentReconciles:         maxConcurrentReconciles,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "MaaSAuthPolicy")
 		os.Exit(1)
@@ -1147,6 +1151,7 @@ func main() {
 		TenantNamespaceDiscoveryEnabled: enableTenantNamespaceDiscovery,
 		GatewayName:                     gatewayName,
 		GatewayNamespace:                gatewayNamespace,
+		MaxConcurrentReconciles:         maxConcurrentReconciles,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "MaaSSubscription")
 		os.Exit(1)

--- a/maas-controller/cmd/manager/main.go
+++ b/maas-controller/cmd/manager/main.go
@@ -847,7 +847,7 @@ func resolveInfraNamespace(infraNs, controllerNs string) string {
 // deriveInfraNamespace maps controller namespace to infrastructure namespace.
 // This implements namespace separation: controller runs in one namespace, infrastructure services in another.
 func clampConcurrentReconciles(v int) int {
-	const minConcurrent, maxConcurrent = 1, 50
+	const minConcurrent, maxConcurrent = 1, 5
 	if v < minConcurrent {
 		setupLog.Info("clamping --max-concurrent-reconciles to minimum", "requested", v, "using", minConcurrent)
 		return minConcurrent
@@ -966,7 +966,7 @@ func main() {
 		"How often to re-check controller-managed namespaces while the manager is running (recreate if deleted). "+
 			"Larger values reduce apiserver load; smaller values detect external deletions sooner.")
 	flag.IntVar(&maxConcurrentReconciles, "max-concurrent-reconciles", 5,
-		"Maximum number of concurrent reconciles for subscription and auth policy controllers (1-50).")
+		"Maximum number of concurrent reconciles for subscription and auth policy controllers (1-5).")
 	flag.BoolVar(&enableTenantNamespaceDiscovery, "enable-tenant-namespace-discovery", false,
 		"Discover AITenant-managed tenant namespaces labeled ai-gateway.opendatahub.io/tenant or maas.opendatahub.io/managed-by-aitenant=true and reconcile MaaS tenant CRs from them.")
 

--- a/maas-controller/cmd/manager/main.go
+++ b/maas-controller/cmd/manager/main.go
@@ -846,6 +846,19 @@ func resolveInfraNamespace(infraNs, controllerNs string) string {
 
 // deriveInfraNamespace maps controller namespace to infrastructure namespace.
 // This implements namespace separation: controller runs in one namespace, infrastructure services in another.
+func clampConcurrentReconciles(v int) int {
+	const minConcurrent, maxConcurrent = 1, 50
+	if v < minConcurrent {
+		setupLog.Info("clamping --max-concurrent-reconciles to minimum", "requested", v, "using", minConcurrent)
+		return minConcurrent
+	}
+	if v > maxConcurrent {
+		setupLog.Info("clamping --max-concurrent-reconciles to maximum", "requested", v, "using", maxConcurrent)
+		return maxConcurrent
+	}
+	return v
+}
+
 func deriveInfraNamespace(controllerNs string) string {
 	switch controllerNs {
 	case "redhat-ods-applications":
@@ -961,10 +974,7 @@ func main() {
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
 
-	if maxConcurrentReconciles < 1 || maxConcurrentReconciles > 50 {
-		setupLog.Error(nil, "invalid --max-concurrent-reconciles, must be 1-50", "value", maxConcurrentReconciles)
-		os.Exit(1)
-	}
+	maxConcurrentReconciles = clampConcurrentReconciles(maxConcurrentReconciles)
 
 	// Allow empty monitoring-namespace to disable observability features (e.g. on xKS
 	// where the monitoring namespace may not exist). Non-empty values must be valid.

--- a/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
@@ -41,6 +41,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -87,6 +88,9 @@ type MaaSAuthPolicyReconciler struct {
 
 	// Recorder emits Kubernetes events for conflict detection warnings.
 	Recorder record.EventRecorder
+	// MaxConcurrentReconciles is the maximum number of concurrent Reconciles which can be run.
+	// Defaults to 1 if not set.
+	MaxConcurrentReconciles int
 }
 
 // oidcConfig holds resolved OIDC configuration from AITenant or a legacy Tenant CR.
@@ -2012,6 +2016,7 @@ func (r *MaaSAuthPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	})
 
 	b := ctrl.NewControllerManagedBy(mgr).
+		WithOptions(controller.Options{MaxConcurrentReconciles: max(1, r.MaxConcurrentReconciles)}).
 		For(&maasv1alpha1.MaaSAuthPolicy{}, builder.WithPredicates(predicate.Or(
 			predicate.GenerationChangedPredicate{},
 			predicate.Funcs{UpdateFunc: deletionTimestampSet},

--- a/maas-controller/pkg/controller/maas/maassubscription_controller.go
+++ b/maas-controller/pkg/controller/maas/maassubscription_controller.go
@@ -40,6 +40,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -67,6 +68,9 @@ type MaaSSubscriptionReconciler struct {
 	// Tenant does not yet carry spec.gatewayRef.
 	GatewayName      string
 	GatewayNamespace string
+	// MaxConcurrentReconciles is the maximum number of concurrent Reconciles which can be run.
+	// Defaults to 1 if not set.
+	MaxConcurrentReconciles int
 }
 
 //+kubebuilder:rbac:groups=maas.opendatahub.io,resources=maassubscriptions,verbs=get;list;watch;create;update;patch;delete
@@ -1068,6 +1072,7 @@ func (r *MaaSSubscriptionReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 
 	b := ctrl.NewControllerManagedBy(mgr).
+		WithOptions(controller.Options{MaxConcurrentReconciles: max(1, r.MaxConcurrentReconciles)}).
 		For(&maasv1alpha1.MaaSSubscription{}, builder.WithPredicates(predicate.Or(
 			predicate.GenerationChangedPredicate{},
 			predicate.Funcs{UpdateFunc: deletionTimestampSet},


### PR DESCRIPTION
## Summary

Jira: [RHOAIENG-76581](https://redhat.atlassian.net/browse/RHOAIENG-76581)

Adds `--max-concurrent-reconciles` flag (default 5, max 10) to the maas-controller. This parallelizes subscription and auth policy reconciliation within the single leader pod, addressing the Jira's acceptance criteria:
- "So that subscription reconciliation is not serialized through a single controller pod"
- "Given batch subscription creation, When configured, Then time-to-Active improves vs single-replica baseline"

### Why not replicas?

PR #1220 (closed) tried to solve this with extra controller replicas, but `--leader-elect` means only the leader reconciles — extra replicas are standby for HA failover. `MaxConcurrentReconciles` is the controller-runtime mechanism for parallel reconciliation within a single leader.

### What changes

- `--max-concurrent-reconciles` flag in `main.go` (default: 5, range: 1-10)
- `MaaSSubscriptionReconciler` and `MaaSAuthPolicyReconciler` use `WithOptions(controller.Options{MaxConcurrentReconciles: N})`
- Other controllers (AITenant, MaaSModelRef, Tenant, Lifecycle) remain at default 1 — they manage shared resources where concurrency could cause conflicts
- Input clamped via `clampConcurrentReconciles` to keep `main()` cyclomatic complexity under gocyclo threshold

### Benchmark results (300 subscriptions)

| MaxConcurrentReconciles | 300 subs → all Active | Speedup |
|---|---|---|
| 1 (current main) | 236s | baseline |
| 5 (PR default) | 60s | 3.9x |
| 10 | 67s | 3.5x |

MCR=10 is slower than 5 at default resource limits — more concurrent reconcilers cause API server contention. Values above 5 may require increased CPU/memory on the controller pod.

### Tuning guidance

| Subscriptions | Recommended MCR | Notes |
|---|---|---|
| < 100 | 5 (default) | No resource changes needed |
| 100-500 | 5 | Works within default pod limits |
| 500+ | 5-10 | Increase controller CPU/memory alongside MCR |

## Test plan
- [x] Unit tests pass
- [x] On cluster: 300 subscriptions all Active in 60s (vs 236s on old image)
- [x] Benchmarked MCR=5 vs MCR=10 — 5 is optimal at default resource limits
- [x] Auth works with MCR=5 (200/401 correct)
- [x] `--max-concurrent-reconciles` flag accepted, clamped to 1-10

## Risk analysis
- **Risk rating**: 2
- **Why**: `MaxConcurrentReconciles` is a standard controller-runtime feature. The reconcilers are goroutine-safe (informer caches + server-side apply, no shared mutable state). Default of 5 is conservative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RHOAIENG-76581]: https://redhat.atlassian.net/browse/RHOAIENG-76581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable controller reconciliation concurrency through the `--max-concurrent-reconciles` option.
  - Supported concurrency range is now 1–10, improving performance tuning for authentication policy and subscription processing.
  - Gateway authentication policies now avoid unnecessary updates when no meaningful changes are detected.

- **Documentation**
  - Added an Administration Guide page covering performance tuning, scaling recommendations, deployment configuration, and leader-election considerations.
  - Added the new page to the Advanced Administration navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->