### PR TITLE
fix: apply payload-processing envoyfilter after kuadrant on tenant gateways

### DIFF
--- a/deployment/base/payload-processing/manager/envoy-filter.yaml
+++ b/deployment/base/payload-processing/manager/envoy-filter.yaml
@@ -4,6 +4,16 @@ metadata:
   name: payload-processing
   namespace: openshift-ingress
 spec:
+  # Must run AFTER Kuadrant's EnvoyFilter (default priority 0), which INSERT_BEFOREs
+  # envoy.filters.http.wasm relative to the router. Without a positive priority, istiod
+  # applies this resource first (same priority 0, older creationTimestamp) and the RHCL
+  # wasm anchors miss — ext_proc never enters the gateway filter chain (404 NR on
+  # body-routed /v1/*). Multi-tenant gateways are especially affected: their
+  # payload-processing-* EFs are often created before Kuadrant's per-gateway EF.
+  # ODH WasmPlugin anchors are unaffected: WasmPlugin is in the base chain before
+  # any EnvoyFilter patches.
+  # See: https://istio.io/latest/docs/reference/config/networking/envoy-filter/#EnvoyFilter
+  priority: 10
   targetRefs:
     - group: gateway.networking.k8s.io
       kind: Gateway
@@ -70,6 +80,7 @@ spec:
             message_timeout: 300s
     # RHCL 1.4 injects auth via envoy.filters.http.wasm (no WasmPlugin CR). Only one anchor
     # pair matches per cluster: WasmPlugin on ODH/community Kuadrant, wasm filter on RHCL 1.4.
+    # These patches require priority > Kuadrant's EF (see spec.priority above).
     - applyTo: HTTP_FILTER
       match:
         context: GATEWAY

--- a/maas-controller/pkg/controller/maas/tenant_reconcile.go
+++ b/maas-controller/pkg/controller/maas/tenant_reconcile.go
@@ -386,7 +386,7 @@ func (r *TenantReconciler) setFinalStatus(ctx context.Context, tenant *maasv1alp
 	if apimeta.IsStatusConditionTrue(tenant.Status.Conditions, tenantreconcile.ConditionTypeDegraded) {
 		tenant.Status.Phase = "Degraded"
 	}
-	setDeploymentsAvailableCondition(tenant, true, "DeploymentsReady", "maas-api deployment is available")
+	setDeploymentsAvailableCondition(tenant, true, "DeploymentsReady", "maas-api deployment and payload-processing EnvoyFilter are available")
 	apimeta.SetStatusCondition(&tenant.Status.Conditions, metav1.Condition{
 		Type:               tenantreconcile.ReadyConditionType,
 		Status:             metav1.ConditionTrue,

--- a/maas-controller/pkg/platform/tenantreconcile/constants.go
+++ b/maas-controller/pkg/platform/tenantreconcile/constants.go
@@ -86,6 +86,9 @@ const (
 	PayloadPreProcessingName                      = "payload-pre-processing"
 	PayloadProcessingPluginsConfigMapName         = "payload-processing-plugins"
 	PayloadProcessingReaderClusterRoleBindingName = "payload-processing-reader"
+	// PayloadProcessingEnvoyFilterPriority runs after Kuadrant's default-priority (0)
+	// EnvoyFilter so RHCL's envoy.filters.http.wasm anchor exists when we INSERT_*.
+	PayloadProcessingEnvoyFilterPriority int64 = 10
 
 	// LabelTenantInstance distinguishes pods when multiple IPP stacks share a gateway namespace.
 	LabelTenantInstance = "maas.opendatahub.io/tenant-instance"

--- a/maas-controller/pkg/platform/tenantreconcile/params.go
+++ b/maas-controller/pkg/platform/tenantreconcile/params.go
@@ -646,6 +646,14 @@ func grpcClusterName(service, namespace string, port int) string {
 func patchPayloadProcessingEnvoyFilter(log logr.Logger, r *unstructured.Unstructured, params PlatformParams) error {
 	r.SetNamespace(params.GatewayNamespace)
 
+	// Ensure we patch after Kuadrant's wasm INSERT (priority 0). Without this,
+	// RHCL subFilter matches on envoy.filters.http.wasm never fire — especially
+	// on secondary tenant gateways whose payload-processing EF is often created
+	// before Kuadrant's per-gateway EF (same priority 0 → creationTimestamp order).
+	if err := unstructured.SetNestedField(r.Object, PayloadProcessingEnvoyFilterPriority, "spec", "priority"); err != nil {
+		return fmt.Errorf("write EnvoyFilter priority: %w", err)
+	}
+
 	targetRefs, found, err := unstructured.NestedSlice(r.Object, "spec", "targetRefs")
 	if err != nil {
 		return fmt.Errorf("read EnvoyFilter targetRefs: %w", err)

--- a/maas-controller/pkg/platform/tenantreconcile/params_test.go
+++ b/maas-controller/pkg/platform/tenantreconcile/params_test.go
@@ -313,6 +313,10 @@ func TestApplyPlatformParamsWithRenderedOverlay(t *testing.T) {
 
 	payloadEnvoyFilter := requireResource(t, resources, GVKEnvoyFilter, PayloadProcessingEnvoyFilterName(tenantID))
 	assert.Equal(t, params.GatewayNamespace, payloadEnvoyFilter.GetNamespace())
+	priority, found, err := unstructured.NestedInt64(payloadEnvoyFilter.Object, "spec", "priority")
+	require.NoError(t, err)
+	require.True(t, found, "EnvoyFilter spec.priority must be set so RHCL wasm anchors apply after Kuadrant")
+	assert.Equal(t, PayloadProcessingEnvoyFilterPriority, priority)
 	targetRefs, found, err := unstructured.NestedSlice(payloadEnvoyFilter.Object, "spec", "targetRefs")
 	require.NoError(t, err)
 	require.True(t, found)

--- a/maas-controller/pkg/platform/tenantreconcile/pipeline.go
+++ b/maas-controller/pkg/platform/tenantreconcile/pipeline.go
@@ -5,11 +5,13 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"strconv"
 
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation"
@@ -104,6 +106,13 @@ func RunPlatform(
 	ready, detail, err := MaasAPIDeploymentReady(ctx, c, appNs, tenantID)
 	if err != nil {
 		return nil, fmt.Errorf("deployment status: %w", err)
+	}
+	if !ready {
+		return &RunResult{DeploymentPending: true, Detail: detail, Warnings: params.Warnings}, nil
+	}
+	ready, detail, err = PayloadProcessingEnvoyFilterReady(ctx, c, params.GatewayNamespace, params.GatewayName, tenantID)
+	if err != nil {
+		return nil, fmt.Errorf("payload-processing EnvoyFilter status: %w", err)
 	}
 	if !ready {
 		return &RunResult{DeploymentPending: true, Detail: detail, Warnings: params.Warnings}, nil
@@ -210,6 +219,59 @@ func MaasAPIDeploymentReady(ctx context.Context, c client.Client, appNamespace, 
 	}
 	if dep.Status.AvailableReplicas < desired {
 		return false, fmt.Sprintf("available replicas %d/%d", dep.Status.AvailableReplicas, desired), nil
+	}
+	return true, "", nil
+}
+
+// PayloadProcessingEnvoyFilterReady verifies the per-tenant gateway EnvoyFilter that
+// wires ext_proc is present with a priority high enough to run after Kuadrant's wasm
+// insert. Without that, RHCL body-routed inference returns 404 NR on that gateway.
+//
+// This is a config-shape check (not a live config_dump). Use
+// scripts/check-payload-ext-proc-filters.sh to confirm filters are in the proxy.
+func PayloadProcessingEnvoyFilterReady(ctx context.Context, c client.Client, gatewayNamespace, gatewayName, tenantID string) (ready bool, detail string, err error) {
+	efName := PayloadProcessingEnvoyFilterName(tenantID)
+	ef := &unstructured.Unstructured{}
+	ef.SetGroupVersionKind(GVKEnvoyFilter)
+	key := types.NamespacedName{Namespace: gatewayNamespace, Name: efName}
+	if err := c.Get(ctx, key, ef); err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, fmt.Sprintf(
+				"EnvoyFilter %s/%s not found — ext_proc will not run; body-routed /v1/* returns 404 NR",
+				gatewayNamespace, efName), nil
+		}
+		return false, "", err
+	}
+
+	priority, found, err := unstructured.NestedInt64(ef.Object, "spec", "priority")
+	if err != nil {
+		return false, "", fmt.Errorf("read EnvoyFilter priority: %w", err)
+	}
+	if !found || priority < PayloadProcessingEnvoyFilterPriority {
+		shown := "missing"
+		if found {
+			shown = strconv.FormatInt(priority, 10)
+		}
+		return false, fmt.Sprintf(
+			"EnvoyFilter %s/%s spec.priority=%s; need >= %d so HTTP_FILTER inserts apply after Kuadrant wasm (otherwise body-routed /v1/* returns 404 NR)",
+			gatewayNamespace, efName, shown, PayloadProcessingEnvoyFilterPriority), nil
+	}
+
+	targetRefs, found, err := unstructured.NestedSlice(ef.Object, "spec", "targetRefs")
+	if err != nil {
+		return false, "", fmt.Errorf("read EnvoyFilter targetRefs: %w", err)
+	}
+	if !found || len(targetRefs) == 0 {
+		return false, fmt.Sprintf("EnvoyFilter %s/%s has no targetRefs", gatewayNamespace, efName), nil
+	}
+	ref, ok := targetRefs[0].(map[string]any)
+	if !ok {
+		return false, fmt.Sprintf("EnvoyFilter %s/%s targetRefs[0] is not an object", gatewayNamespace, efName), nil
+	}
+	if name, _ := ref["name"].(string); name != gatewayName {
+		return false, fmt.Sprintf(
+			"EnvoyFilter %s/%s targetRefs[0].name=%q; expected gateway %q",
+			gatewayNamespace, efName, name, gatewayName), nil
 	}
 	return true, "", nil
 }

--- a/maas-controller/pkg/platform/tenantreconcile/pipeline_test.go
+++ b/maas-controller/pkg/platform/tenantreconcile/pipeline_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -64,4 +65,91 @@ func TestSyncMaaSParametersConfigMap_UpdatesValue(t *testing.T) {
 	var updated corev1.ConfigMap
 	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: maasParametersConfigMapName, Namespace: "test-ns"}, &updated))
 	assert.Equal(t, "365", updated.Data["api-key-max-expiration-days"])
+}
+
+func payloadProcessingEnvoyFilter(ns, efName, gatewayName string, priority *int64) *unstructured.Unstructured {
+	ef := &unstructured.Unstructured{}
+	ef.SetGroupVersionKind(GVKEnvoyFilter)
+	ef.SetNamespace(ns)
+	ef.SetName(efName)
+	spec := map[string]any{
+		"targetRefs": []any{
+			map[string]any{
+				"group": "gateway.networking.k8s.io",
+				"kind":  "Gateway",
+				"name":  gatewayName,
+			},
+		},
+	}
+	if priority != nil {
+		spec["priority"] = *priority
+	}
+	ef.Object["spec"] = spec
+	return ef
+}
+
+func TestPayloadProcessingEnvoyFilterReady(t *testing.T) {
+	const (
+		gwNS     = "openshift-ingress"
+		gwName   = "partner"
+		tenantID = "partner"
+	)
+	efName := PayloadProcessingEnvoyFilterName(tenantID)
+	prioOK := PayloadProcessingEnvoyFilterPriority
+	prioLow := int64(0)
+
+	t.Run("missing EnvoyFilter", func(t *testing.T) {
+		c := fake.NewClientBuilder().Build()
+		ready, detail, err := PayloadProcessingEnvoyFilterReady(context.Background(), c, gwNS, gwName, tenantID)
+		require.NoError(t, err)
+		assert.False(t, ready)
+		assert.Contains(t, detail, "not found")
+		assert.Contains(t, detail, efName)
+		assert.Contains(t, detail, "404 NR")
+	})
+
+	t.Run("missing priority", func(t *testing.T) {
+		c := fake.NewClientBuilder().WithObjects(payloadProcessingEnvoyFilter(gwNS, efName, gwName, nil)).Build()
+		ready, detail, err := PayloadProcessingEnvoyFilterReady(context.Background(), c, gwNS, gwName, tenantID)
+		require.NoError(t, err)
+		assert.False(t, ready)
+		assert.Contains(t, detail, "priority=missing")
+		assert.Contains(t, detail, "404 NR")
+	})
+
+	t.Run("priority too low", func(t *testing.T) {
+		c := fake.NewClientBuilder().WithObjects(payloadProcessingEnvoyFilter(gwNS, efName, gwName, &prioLow)).Build()
+		ready, detail, err := PayloadProcessingEnvoyFilterReady(context.Background(), c, gwNS, gwName, tenantID)
+		require.NoError(t, err)
+		assert.False(t, ready)
+		assert.Contains(t, detail, "priority=0")
+	})
+
+	t.Run("wrong gateway targetRef", func(t *testing.T) {
+		c := fake.NewClientBuilder().WithObjects(payloadProcessingEnvoyFilter(gwNS, efName, "other-gw", &prioOK)).Build()
+		ready, detail, err := PayloadProcessingEnvoyFilterReady(context.Background(), c, gwNS, gwName, tenantID)
+		require.NoError(t, err)
+		assert.False(t, ready)
+		assert.Contains(t, detail, "targetRefs[0].name")
+	})
+
+	t.Run("ignores default-tenant EnvoyFilter name for secondary tenants", func(t *testing.T) {
+		// Secondary tenants must look up payload-processing-<id>, not payload-processing.
+		c := fake.NewClientBuilder().WithObjects(
+			payloadProcessingEnvoyFilter(gwNS, PayloadProcessingName, gwName, &prioOK),
+		).Build()
+		ready, detail, err := PayloadProcessingEnvoyFilterReady(context.Background(), c, gwNS, gwName, tenantID)
+		require.NoError(t, err)
+		assert.False(t, ready)
+		assert.Contains(t, detail, efName)
+		assert.Contains(t, detail, "not found")
+	})
+
+	t.Run("ready", func(t *testing.T) {
+		c := fake.NewClientBuilder().WithObjects(payloadProcessingEnvoyFilter(gwNS, efName, gwName, &prioOK)).Build()
+		ready, detail, err := PayloadProcessingEnvoyFilterReady(context.Background(), c, gwNS, gwName, tenantID)
+		require.NoError(t, err)
+		assert.True(t, ready)
+		assert.Empty(t, detail)
+	})
 }

--- a/scripts/check-payload-ext-proc-filters.sh
+++ b/scripts/check-payload-ext-proc-filters.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# Check that payload-processing EnvoyFilter is shaped correctly AND that
+# ext_proc filters are present in the live gateway Envoy config.
+#
+# Catches the RHCL failure mode where EnvoyFilter YAML exists but HTTP_FILTER
+# inserts never match (e.g. missing positive priority) → 404 NR on body-routed /v1/*.
+#
+# Usage:
+#   ./scripts/check-payload-ext-proc-filters.sh
+#   GATEWAY_NAMESPACE=openshift-ingress GATEWAY_NAME=maas-default-gateway ./scripts/check-payload-ext-proc-filters.sh
+#   GATEWAY_NAME=partner EF_NAME=payload-processing-partner ./scripts/check-payload-ext-proc-filters.sh
+#
+# Requires: oc/kubectl, python3, curl (for local port-forward to Envoy admin)
+
+set -euo pipefail
+
+GATEWAY_NAMESPACE="${GATEWAY_NAMESPACE:-openshift-ingress}"
+GATEWAY_NAME="${GATEWAY_NAME:-maas-default-gateway}"
+EF_NAME="${EF_NAME:-payload-processing}"
+MIN_PRIORITY="${MIN_PRIORITY:-10}"
+REQUIRED_FILTERS=(
+  "envoy.filters.http.ext_proc.ipp-pre"
+  "envoy.filters.http.ext_proc.ipp"
+)
+
+KUBECTL="${KUBECTL:-}"
+if [[ -z "$KUBECTL" ]]; then
+  if command -v oc >/dev/null 2>&1; then
+    KUBECTL=oc
+  else
+    KUBECTL=kubectl
+  fi
+fi
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+ok() { echo "OK: $*"; }
+
+echo "== EnvoyFilter ${GATEWAY_NAMESPACE}/${EF_NAME} =="
+if ! "$KUBECTL" get envoyfilter "$EF_NAME" -n "$GATEWAY_NAMESPACE" >/dev/null 2>&1; then
+  fail "EnvoyFilter not found — ext_proc cannot run (body-routed /v1/* → 404 NR)"
+fi
+
+priority="$("$KUBECTL" get envoyfilter "$EF_NAME" -n "$GATEWAY_NAMESPACE" -o jsonpath='{.spec.priority}' 2>/dev/null || true)"
+if [[ -z "$priority" ]]; then
+  fail "spec.priority is missing; need >= ${MIN_PRIORITY} so inserts apply after Kuadrant wasm"
+fi
+if (( priority < MIN_PRIORITY )); then
+  fail "spec.priority=${priority}; need >= ${MIN_PRIORITY}"
+fi
+ok "spec.priority=${priority}"
+
+target="$("$KUBECTL" get envoyfilter "$EF_NAME" -n "$GATEWAY_NAMESPACE" -o jsonpath='{.spec.targetRefs[0].name}' 2>/dev/null || true)"
+[[ "$target" == "$GATEWAY_NAME" ]] || fail "targetRefs[0].name=${target:-empty}; expected ${GATEWAY_NAME}"
+ok "targetRefs → Gateway/${GATEWAY_NAME}"
+
+echo "== Live gateway http_filters =="
+pod="$("$KUBECTL" get pods -n "$GATEWAY_NAMESPACE" \
+  -l "gateway.networking.k8s.io/gateway-name=${GATEWAY_NAME}" \
+  -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)"
+[[ -n "$pod" ]] || fail "no Running pod for Gateway/${GATEWAY_NAME} in ${GATEWAY_NAMESPACE}"
+
+local_port=15000
+pf_log="$(mktemp)"
+dump="$(mktemp)"
+cleanup() {
+  kill "$pf_pid" 2>/dev/null || true
+  wait "$pf_pid" 2>/dev/null || true
+  rm -f "$pf_log" "$dump"
+}
+trap cleanup EXIT
+
+"$KUBECTL" port-forward -n "$GATEWAY_NAMESPACE" "pod/${pod}" "${local_port}:15000" >"$pf_log" 2>&1 &
+pf_pid=$!
+
+# Wait for admin port
+for _ in $(seq 1 30); do
+  if curl -fsS "http://127.0.0.1:${local_port}/ready" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 0.2
+done
+curl -fsS "http://127.0.0.1:${local_port}/config_dump?resource=dynamic_listeners" -o "$dump" \
+  || fail "could not fetch Envoy config_dump from ${pod} (see ${pf_log})"
+
+python3 - "$dump" "${REQUIRED_FILTERS[@]}" <<'PY'
+import json, sys
+path = sys.argv[1]
+required = sys.argv[2:]
+with open(path) as f:
+    data = json.load(f)
+
+chains = []
+
+def walk(o):
+    if isinstance(o, dict):
+        if "http_filters" in o:
+            names = [f.get("name", "") for f in o["http_filters"]]
+            chains.append(names)
+        for v in o.values():
+            walk(v)
+    elif isinstance(o, list):
+        for v in o:
+            walk(v)
+
+walk(data)
+if not chains:
+    print("FAIL: no http_filters found in config_dump", file=sys.stderr)
+    sys.exit(1)
+
+# Prefer a chain that already has kuadrant wasm / wasmplugin (auth-bearing listener)
+def score(names):
+    s = 0
+    joined = " ".join(names)
+    if "envoy.filters.http.wasm" in joined or "wasmplugin" in joined:
+        s += 10
+    if "envoy.filters.http.router" in names:
+        s += 1
+    return s
+
+chains.sort(key=score, reverse=True)
+names = chains[0]
+print("filter chain:")
+for n in names:
+    print(f"  - {n}")
+
+missing = [r for r in required if r not in names]
+if missing:
+    print("FAIL: missing required ext_proc filters:", ", ".join(missing), file=sys.stderr)
+    print("hint: EnvoyFilter inserts may not be matching (check priority / auth anchor).", file=sys.stderr)
+    sys.exit(1)
+
+# Ordering: ipp-pre before auth (wasm|wasmplugin), ipp after auth, before router
+def idx(exact):
+    try:
+        return names.index(exact)
+    except ValueError:
+        return -1
+
+def idx_substr(substr):
+    for i, n in enumerate(names):
+        if substr in n:
+            return i
+    return -1
+
+pre = idx("envoy.filters.http.ext_proc.ipp-pre")
+ipp = idx("envoy.filters.http.ext_proc.ipp")
+auth = idx("envoy.filters.http.wasm")
+if auth < 0:
+    auth = idx_substr("wasmplugin")
+router = idx("envoy.filters.http.router")
+
+if pre < 0 or ipp < 0 or router < 0:
+    print("FAIL: unexpected filter names", file=sys.stderr)
+    sys.exit(1)
+if auth >= 0 and not (pre < auth < ipp < router):
+    print(f"FAIL: bad order pre={pre} auth={auth} ipp={ipp} router={router}", file=sys.stderr)
+    print("expected: ipp-pre → auth → ipp → router", file=sys.stderr)
+    sys.exit(1)
+if auth < 0 and not (pre < ipp < router):
+    print(f"FAIL: bad order pre={pre} ipp={ipp} router={router}", file=sys.stderr)
+    sys.exit(1)
+
+print("OK: ext_proc filters present with correct relative order")
+PY
+
+echo "All checks passed."


### PR DESCRIPTION
## Summary
- Set `EnvoyFilter/payload-processing*` `spec.priority: 10` so RHCL Kuadrant `envoy.filters.http.wasm` exists before IPP `INSERT_BEFORE`/`INSERT_AFTER` patches run.
- Without this, istiod applies the payload EF at default priority 0; when that EF is created *before* Kuadrant's per-gateway EF (common for partner/oidc tenants), wasm anchors miss, `ext_proc.ipp-pre`/`ipp` never enter the chain, and body-only `/v1/chat/completions` returns gateway **404**.
- Ready-check looks up the **per-tenant** EnvoyFilter name (`payload-processing-<tenantID>`) and verifies priority + `targetRefs`.
- Add `scripts/check-payload-ext-proc-filters.sh` for live config_dump verification.

Related: supersedes the approach in #1239 with a tenant-aware ready check (that PR looked up only the default `payload-processing` name, which broke secondary AITenant readiness).

## Test plan
- [x] `go test ./pkg/platform/tenantreconcile/ -count=1`
- [x] `./scripts/ci/validate-manifests.sh`
- [x] On RHCL multi-tenant cluster: partner/oidc/default EnvoyFilters get `priority: 10` after reconcile
- [x] `GATEWAY_NAME=partner EF_NAME=payload-processing-partner ./scripts/check-payload-ext-proc-filters.sh` → `ipp-pre → wasm → ipp → router`
- [x] Partner body-only `POST /v1/chat/completions` returns **200**; `payload-pre-processing-partner` logs `LLMISvc BBR: rewrote body model field`

## Risk analysis
- **Risk rating**: 4
- **Why**: Changes gateway HTTP filter-chain ordering for every MaaS gateway (default + tenants). Not covered by default Prow smoke path for multi-tenant partner/oidc BBR; validated manually on RHCL. Wrong priority could regress body routing or race with Kuadrant.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gateway filter ordering to ensure payload processing runs correctly alongside authentication and routing filters.
  * Tenant readiness now waits for the required payload-processing gateway configuration, with clearer status details when it is missing or invalid.

* **Validation**
  * Added checks to verify filter priority, gateway targeting, and runtime filter ordering.
  * Added a diagnostic script to validate live gateway configuration and filter placement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->