### PR TITLE
docs: center inference examples on body-based routing endpoints

### DIFF
--- a/docs/content/configuration-and-management/model-setup.md
+++ b/docs/content/configuration-and-management/model-setup.md
@@ -179,12 +179,15 @@ kubectl get maasmodelref <modelref-name> -n <namespace>
 **3. Test inference request:**
 
 ```bash
-# Get MODEL_URL from step 1 above (data[].url field)
-curl -sS -H "Authorization: Bearer $API_KEY" \
+# Use the body-based endpoint (recommended) with the model id from step 1
+curl -sS -H "Authorization: Bearer ${API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"model": "my-model", "messages": [{"role": "user", "content": "Hello"}]}' \
-  "${MODEL_URL}/v1/chat/completions"
+  "${HOST}/v1/chat/completions"
 ```
+
+!!! note "Legacy path-based endpoint"
+    You can also use the per-model `url` from step 1: `${MODEL_URL}/v1/chat/completions`. See [Inference - Path-Based Routing](../user-guide/inference.md#path-based-routing-legacy) for details.
 
 ---
 

--- a/docs/content/install/external-model-setup.md
+++ b/docs/content/install/external-model-setup.md
@@ -287,7 +287,7 @@ curl -sS "https://${GW_HOST}/v1/chat/completions" \
 # Bogus key - expect 403
 curl -sS -w "HTTP: %{http_code}\n" "https://${GW_HOST}/v1/chat/completions" \
   -H "Content-Type: application/json" \
-  -H "Authorization: Bearer bogus-key" \
+  -H "Authorization: Bearer sk-oai-FAKE-KEY" \
   -d '{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]}'
 
 # No auth - expect 401

--- a/docs/content/install/external-model-setup.md
+++ b/docs/content/install/external-model-setup.md
@@ -272,23 +272,26 @@ echo "MaaS API key: ${KEY:0:20}..."
 ### Run Inference
 
 ```bash
-curl -sS "https://${GW_HOST}/llm/gpt-4o/v1/chat/completions" \
+curl -sS "https://${GW_HOST}/v1/chat/completions" \
   -H "Content-Type: application/json" \
-  -H "Authorization: Bearer $KEY" \
+  -H "Authorization: Bearer ${KEY}" \
   -d '{"model":"gpt-4o","messages":[{"role":"user","content":"say hello"}]}'
 ```
+
+!!! note "Legacy path-based endpoint"
+    You can also use the path-based URL: `https://${GW_HOST}/llm/gpt-4o/v1/chat/completions`. Both routing modes are supported. See [Inference - Path-Based Routing](../user-guide/inference.md#path-based-routing-legacy) for details.
 
 ### Verify Auth Enforcement
 
 ```bash
-# Bogus key — expect 403
-curl -sS -w "HTTP: %{http_code}\n" "https://${GW_HOST}/llm/gpt-4o/v1/chat/completions" \
+# Bogus key - expect 403
+curl -sS -w "HTTP: %{http_code}\n" "https://${GW_HOST}/v1/chat/completions" \
   -H "Content-Type: application/json" \
-  -H "Authorization: Bearer sk-oai-FAKE-KEY" \
+  -H "Authorization: Bearer bogus-key" \
   -d '{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]}'
 
-# No auth — expect 401
-curl -sS -w "HTTP: %{http_code}\n" "https://${GW_HOST}/llm/gpt-4o/v1/chat/completions" \
+# No auth - expect 401
+curl -sS -w "HTTP: %{http_code}\n" "https://${GW_HOST}/v1/chat/completions" \
   -H "Content-Type: application/json" \
   -d '{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]}'
 ```

--- a/docs/content/install/validation.md
+++ b/docs/content/install/validation.md
@@ -70,11 +70,10 @@ Each API key is bound to one MaaSSubscription at creation time. `GET /v1/models`
 ```bash
 MODELS=$(curl -sS ${HOST}/maas-api/v1/models \
     -H "Content-Type: application/json" \
-    -H "Authorization: Bearer $API_KEY" | jq -r .) && \
+    -H "Authorization: Bearer ${API_KEY}" | jq -r .) && \
 echo $MODELS | jq . && \
-MODEL_NAME=$(echo $MODELS | jq -r '.data[0].id') && \
-MODEL_URL=$(echo $MODELS | jq -r '.data[0].url') && \
-echo "Model URL: $MODEL_URL"
+MODEL_NAME=$(echo $MODELS | jq -r '[.data[] | select(.ready==true)][0].id') && \
+echo "Model: $MODEL_NAME"
 ```
 
 ### 4. Test Model Inference Endpoint
@@ -89,7 +88,7 @@ curl -sS -H "Authorization: Bearer ${API_KEY}" \
 ```
 
 !!! note "Legacy path-based endpoint"
-    You can also use the per-model URL from step 3: `${MODEL_URL}/v1/chat/completions`. Both path-based and body-based endpoints are supported. See [Inference - Path-Based Routing](../user-guide/inference.md#path-based-routing-legacy) for details.
+    You can also use the per-model `url` from the model listing response (e.g. `${MODEL_URL}/v1/chat/completions`). Both path-based and body-based endpoints are supported. See [Inference - Path-Based Routing](../user-guide/inference.md#path-based-routing-legacy) for details.
 
 ### 6. Test Authorization Enforcement
 

--- a/docs/content/install/validation.md
+++ b/docs/content/install/validation.md
@@ -79,23 +79,26 @@ echo "Model URL: $MODEL_URL"
 
 ### 4. Test Model Inference Endpoint
 
-Send a request to the model’s OpenAI-compatible **chat completions** API (expect **200 OK**). This example uses **`POST /v1/chat/completions`** with a `messages` array. If your backend only implements **`/v1/completions`** (prompt-based) or another route, adjust the path and JSON body accordingly.
+Send a request to the OpenAI-compatible **chat completions** endpoint (expect **200 OK**). The gateway routes the request based on the `model` field in the body:
 
 ```bash
-curl -sS -H "Authorization: Bearer $API_KEY" \
+curl -sS -H "Authorization: Bearer ${API_KEY}" \
   -H "Content-Type: application/json" \
   -d "{\"model\": \"${MODEL_NAME}\", \"messages\": [{\"role\": \"user\", \"content\": \"Hello\"}], \"max_tokens\": 50}" \
-  "${MODEL_URL}/v1/chat/completions" | jq
+  "${HOST}/v1/chat/completions" | jq
 ```
+
+!!! note "Legacy path-based endpoint"
+    You can also use the per-model URL from step 3: `${MODEL_URL}/v1/chat/completions`. Both path-based and body-based endpoints are supported. See [Inference - Path-Based Routing](../user-guide/inference.md#path-based-routing-legacy) for details.
 
 ### 6. Test Authorization Enforcement
 
-Send a request to the model endpoint without a token (should get a 401 Unauthorized response):
+Send a request without a token (should get a 401 Unauthorized response):
 
 ```bash
 curl -sS -H "Content-Type: application/json" \
   -d "{\"model\": \"${MODEL_NAME}\", \"messages\": [{\"role\": \"user\", \"content\": \"Hello\"}], \"max_tokens\": 50}" \
-  "${MODEL_URL}/v1/chat/completions" -v
+  "${HOST}/v1/chat/completions" -v
 ```
 
 ### 7. Test Rate Limiting
@@ -105,10 +108,10 @@ Send multiple requests to trigger rate limit (should get 200 OK followed by 429 
 ```bash
 for i in {1..16}; do
   curl -sS -o /dev/null -w "%{http_code}\n" \
-    -H "Authorization: Bearer $API_KEY" \
+    -H "Authorization: Bearer ${API_KEY}" \
     -H "Content-Type: application/json" \
     -d "{\"model\": \"${MODEL_NAME}\", \"messages\": [{\"role\": \"user\", \"content\": \"Hello\"}], \"max_tokens\": 50}" \
-    "${MODEL_URL}/v1/chat/completions"
+    "${HOST}/v1/chat/completions"
 done
 ```
 

--- a/docs/content/install/validation.md
+++ b/docs/content/install/validation.md
@@ -72,7 +72,7 @@ MODELS=$(curl -sS ${HOST}/maas-api/v1/models \
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer ${API_KEY}" | jq -r .) && \
 echo $MODELS | jq . && \
-MODEL_NAME=$(echo $MODELS | jq -r '[.data[] | select(.ready==true)][0].id') && \
+MODEL_NAME=$(echo $MODELS | jq -re '[.data[] | select(.ready==true)][0].id') && \
 echo "Model: $MODEL_NAME"
 ```
 

--- a/docs/content/migration/tier-to-subscription.md
+++ b/docs/content/migration/tier-to-subscription.md
@@ -296,6 +296,9 @@ See [Migration Script](#migration-automation-script) section below for details.
 
 ### Phase 3: Validate New Configuration
 
+!!! note "Body-based routing"
+    The curl examples in this section use path-based URLs (e.g. `https://${HOST}/llm/my-model-name/v1/chat/completions`) for continuity with the migration context. For new integrations, use the body-based endpoint (`https://${HOST}/v1/chat/completions` with the model in the request body). See [Inference](../user-guide/inference.md) for details.
+
 Test each migrated model to ensure the new subscription model works correctly:
 
 ```bash

--- a/docs/content/migration/upgrade-to-3.4.md
+++ b/docs/content/migration/upgrade-to-3.4.md
@@ -562,6 +562,9 @@ kubectl get tokenratelimitpolicy -n llm
 
 ## Phase 6: Validation
 
+!!! note "Body-based routing"
+    The curl examples in this section use path-based URLs for continuity with the migration context. For new integrations, use the body-based endpoint (`https://${HOST}/v1/chat/completions` with the model in the request body). See [Inference](../user-guide/inference.md) for details.
+
 ### 6.1 Test Authorized Access
 
 ```bash

--- a/docs/content/user-guide/inference.md
+++ b/docs/content/user-guide/inference.md
@@ -12,14 +12,20 @@ This guide explains how to make inference requests to models through the MaaS pl
 
 MaaS provides an **OpenAI-compatible** inference endpoint. Send all requests to a single gateway URL and specify the model in the request body:
 
-```
+```text
 POST https://maas.<cluster-domain>/v1/chat/completions
 ```
 
 The gateway reads the `model` field from the JSON body and routes the request to the correct backend automatically. This is fully compatible with OpenAI SDKs and any client that speaks the OpenAI Chat Completions API.
 
+!!! note "Administrator prerequisite"
+    Body-based routing requires the Inference Payload Processing (IPP) component to be deployed. IPP reads the `model` field from the request body and sets the routing header for the gateway. Contact your administrator to confirm IPP is available on your cluster.
+
 !!! info "Legacy path-based endpoints"
     MaaS also supports **path-based endpoints** where the model is encoded in the URL path (e.g. `https://maas.<cluster-domain>/llm/my-model/v1/chat/completions`). These endpoints continue to work, but the body-based endpoint above is recommended for new integrations because it matches the standard OpenAI API contract and works with a single `base_url` for all models. See [Path-Based Routing (Legacy)](#path-based-routing-legacy) for details.
+
+!!! info "Multi-tenant deployments"
+    In a multi-tenant setup, non-default tenants use their own gateway URL (e.g. `https://<tenant-gateway>/v1/chat/completions`) with a tenant-scoped API key. See [Multi-Tenant Validation](../install/multi-tenant-validation.md) for details.
 
 ---
 
@@ -33,9 +39,10 @@ CLUSTER_DOMAIN=$(kubectl get ingresses.config.openshift.io cluster -o jsonpath='
 MAAS_API_URL="https://maas.${CLUSTER_DOMAIN}"
 API_KEY="sk-oai-..."  # Your API key
 
-# Get the first available model name
+# Get the first ready model name
 MODEL_NAME=$(curl -s "${MAAS_API_URL}/maas-api/v1/models" \
-    -H "Authorization: Bearer ${API_KEY}" | jq -r '.data[0].id')
+    -H "Authorization: Bearer ${API_KEY}" | \
+    jq -r '[.data[] | select(.ready==true)][0].id')
 
 # Make an inference request
 curl -sS \
@@ -54,6 +61,9 @@ curl -sS \
   "${MAAS_API_URL}/v1/chat/completions"
 ```
 
+!!! tip "Model ID format"
+    The `model` value must match the `id` returned by `/maas-api/v1/models`. For on-cluster models (LLMInferenceService), this is a publisher ID like `publishers/llm/models/facebook/opt-125m`. For external models, this is typically the model name (e.g. `gpt-4o`). Always use the `id` from the API response rather than constructing it manually.
+
 **Example response:**
 
 ```json
@@ -61,7 +71,7 @@ curl -sS \
   "id": "chatcmpl-123",
   "object": "chat.completion",
   "created": 1677652288,
-  "model": "llama-2-7b-chat",
+  "model": "publishers/llm/models/facebook/opt-125m",
   "choices": [
     {
       "index": 0,
@@ -106,12 +116,12 @@ curl -sS --no-buffer \
 
 **Example streaming response:**
 
-```
-data: {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1677652288,"model":"llama-2-7b-chat","choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null}]}
+```text
+data: {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1677652288,"model":"publishers/llm/models/facebook/opt-125m","choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null}]}
 
-data: {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1677652288,"model":"llama-2-7b-chat","choices":[{"index":0,"delta":{"content":"Once"},"finish_reason":null}]}
+data: {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1677652288,"model":"publishers/llm/models/facebook/opt-125m","choices":[{"index":0,"delta":{"content":"Once"},"finish_reason":null}]}
 
-data: {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1677652288,"model":"llama-2-7b-chat","choices":[{"index":0,"delta":{"content":" upon"},"finish_reason":null}]}
+data: {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1677652288,"model":"publishers/llm/models/facebook/opt-125m","choices":[{"index":0,"delta":{"content":" upon"},"finish_reason":null}]}
 
 data: [DONE]
 ```
@@ -126,7 +136,7 @@ Common parameters for chat completions:
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `model` | string | Yes | Model identifier from `/maas-api/v1/models` |
+| `model` | string | Yes | Model identifier (`id`) from `/maas-api/v1/models` |
 | `messages` | array | Yes | Array of message objects with `role` and `content` |
 | `max_tokens` | integer | No | Maximum tokens to generate (default varies by model) |
 | `temperature` | float | No | Sampling temperature (0-2, default 1.0). Higher = more random. |
@@ -184,7 +194,8 @@ MaaS also supports per-model URL endpoints where the model is identified by the 
 ```bash
 # Get the per-model URL
 MODEL_URL=$(curl -s "${MAAS_API_URL}/maas-api/v1/models" \
-    -H "Authorization: Bearer ${API_KEY}" | jq -r '.data[0].url')
+    -H "Authorization: Bearer ${API_KEY}" | \
+    jq -r '[.data[] | select(.ready==true)][0].url')
 
 # Make an inference request using the path-based URL
 curl -sS \
@@ -210,6 +221,7 @@ curl -sS \
 | **URL** | Single: `${MAAS_API_URL}/v1/chat/completions` | Per-model: `${MODEL_URL}/v1/chat/completions` |
 | **Model selection** | `model` field in request body | URL path determines the model |
 | **OpenAI SDK compatible** | Yes, single `base_url` for all models | Requires setting `base_url` per model |
+| **Requires IPP** | Yes | No |
 
 !!! tip
     The `model` value must match a model `id` returned by [`/maas-api/v1/models`](model-discovery.md). If the model name does not match, the request will be rejected.

--- a/docs/content/user-guide/inference.md
+++ b/docs/content/user-guide/inference.md
@@ -42,7 +42,8 @@ API_KEY="sk-oai-..."  # Your API key
 # Get the first ready model name
 MODEL_NAME=$(curl -s "${MAAS_API_URL}/maas-api/v1/models" \
     -H "Authorization: Bearer ${API_KEY}" | \
-    jq -r '[.data[] | select(.ready==true)][0].id')
+    jq -re '[.data[] | select(.ready==true)][0].id') || \
+    { echo "No ready models found"; exit 1; }
 
 # Make an inference request
 curl -sS \
@@ -195,7 +196,8 @@ MaaS also supports per-model URL endpoints where the model is identified by the 
 # Get the per-model URL
 MODEL_URL=$(curl -s "${MAAS_API_URL}/maas-api/v1/models" \
     -H "Authorization: Bearer ${API_KEY}" | \
-    jq -r '[.data[] | select(.ready==true)][0].url')
+    jq -re '[.data[] | select(.ready==true)][0].url') || \
+    { echo "No ready models found"; exit 1; }
 
 # Make an inference request using the path-based URL
 curl -sS \

--- a/docs/content/user-guide/inference.md
+++ b/docs/content/user-guide/inference.md
@@ -8,6 +8,21 @@ This guide explains how to make inference requests to models through the MaaS pl
 
 ---
 
+## Endpoint Overview
+
+MaaS provides an **OpenAI-compatible** inference endpoint. Send all requests to a single gateway URL and specify the model in the request body:
+
+```
+POST https://maas.<cluster-domain>/v1/chat/completions
+```
+
+The gateway reads the `model` field from the JSON body and routes the request to the correct backend automatically. This is fully compatible with OpenAI SDKs and any client that speaks the OpenAI Chat Completions API.
+
+!!! info "Legacy path-based endpoints"
+    MaaS also supports **path-based endpoints** where the model is encoded in the URL path (e.g. `https://maas.<cluster-domain>/llm/my-model/v1/chat/completions`). These endpoints continue to work, but the body-based endpoint above is recommended for new integrations because it matches the standard OpenAI API contract and works with a single `base_url` for all models. See [Path-Based Routing (Legacy)](#path-based-routing-legacy) for details.
+
+---
+
 ## Basic Chat Completion
 
 Make a simple chat completion request using your API key:
@@ -18,11 +33,9 @@ CLUSTER_DOMAIN=$(kubectl get ingresses.config.openshift.io cluster -o jsonpath='
 MAAS_API_URL="https://maas.${CLUSTER_DOMAIN}"
 API_KEY="sk-oai-..."  # Your API key
 
-# Get the first available model
-MODELS=$(curl -s "${MAAS_API_URL}/maas-api/v1/models" \
-    -H "Authorization: Bearer ${API_KEY}")
-MODEL_URL=$(echo $MODELS | jq -r '.data[0].url')
-MODEL_NAME=$(echo $MODELS | jq -r '.data[0].id')
+# Get the first available model name
+MODEL_NAME=$(curl -s "${MAAS_API_URL}/maas-api/v1/models" \
+    -H "Authorization: Bearer ${API_KEY}" | jq -r '.data[0].id')
 
 # Make an inference request
 curl -sS \
@@ -38,7 +51,7 @@ curl -sS \
         ],
         \"max_tokens\": 100
       }" \
-  "${MODEL_URL}/v1/chat/completions"
+  "${MAAS_API_URL}/v1/chat/completions"
 ```
 
 **Example response:**
@@ -88,7 +101,7 @@ curl -sS --no-buffer \
         \"max_tokens\": 200,
         \"stream\": true
       }" \
-  "${MODEL_URL}/v1/chat/completions"
+  "${MAAS_API_URL}/v1/chat/completions"
 ```
 
 **Example streaming response:**
@@ -159,23 +172,21 @@ curl -sS \
         ],
         \"max_tokens\": 100
       }" \
-  "${MODEL_URL}/v1/chat/completions"
+  "${MAAS_API_URL}/v1/chat/completions"
 ```
 
 ---
 
-## Unified Endpoint (Body-Based Routing)
+## Path-Based Routing (Legacy)
 
-The examples above use **per-model URLs** (path-based routing), where each model has its own endpoint such as `https://maas.example.com/llm/my-model/v1/chat/completions`.
-
-With **body-based routing** (BBR), you send all requests to a single endpoint and specify the model in the request body. The gateway reads the `model` field and routes the request to the correct backend automatically.
-
-!!! note "Administrator prerequisite"
-    Body-based routing requires the Inference Payload Processing (IPP) component to be deployed. Contact your administrator to confirm IPP is available on your cluster.
-
-### Basic BBR Request
+MaaS also supports per-model URL endpoints where the model is identified by the URL path rather than the request body. These endpoints are available at the `url` field returned by `/maas-api/v1/models`.
 
 ```bash
+# Get the per-model URL
+MODEL_URL=$(curl -s "${MAAS_API_URL}/maas-api/v1/models" \
+    -H "Authorization: Bearer ${API_KEY}" | jq -r '.data[0].url')
+
+# Make an inference request using the path-based URL
 curl -sS \
   -H "Authorization: Bearer ${API_KEY}" \
   -H "Content-Type: application/json" \
@@ -189,39 +200,16 @@ curl -sS \
         ],
         \"max_tokens\": 100
       }" \
-  "${MAAS_API_URL}/v1/chat/completions"
+  "${MODEL_URL}/v1/chat/completions"
 ```
 
-The only difference from path-based requests is the URL: `${MAAS_API_URL}/v1/chat/completions` instead of `${MODEL_URL}/v1/chat/completions`. The `model` field in the body determines which backend receives the request.
+### Comparison
 
-### Streaming with BBR
-
-```bash
-curl -sS --no-buffer \
-  -H "Authorization: Bearer ${API_KEY}" \
-  -H "Content-Type: application/json" \
-  -d "{
-        \"model\": \"${MODEL_NAME}\",
-        \"messages\": [
-          {
-            \"role\": \"user\",
-            \"content\": \"Tell me a short story\"
-          }
-        ],
-        \"max_tokens\": 200,
-        \"stream\": true
-      }" \
-  "${MAAS_API_URL}/v1/chat/completions"
-```
-
-### Path-Based vs Body-Based Routing
-
-| | Path-based | Body-based (BBR) |
+| | Body-based (recommended) | Path-based (legacy) |
 |---|---|---|
-| **URL** | Per-model: `${MODEL_URL}/v1/chat/completions` | Single: `${MAAS_API_URL}/v1/chat/completions` |
-| **Model selection** | URL path determines the model | `model` field in request body determines the model |
-| **OpenAI SDK compatible** | Requires setting `base_url` per model | Works with a single `base_url` for all models |
-| **Requires IPP** | No | Yes |
+| **URL** | Single: `${MAAS_API_URL}/v1/chat/completions` | Per-model: `${MODEL_URL}/v1/chat/completions` |
+| **Model selection** | `model` field in request body | URL path determines the model |
+| **OpenAI SDK compatible** | Yes, single `base_url` for all models | Requires setting `base_url` per model |
 
 !!! tip
     The `model` value must match a model `id` returned by [`/maas-api/v1/models`](model-discovery.md). If the model name does not match, the request will be rejected.
@@ -275,7 +263,7 @@ while [ $retry_count -lt $max_retries ]; do
     -H "Authorization: Bearer ${API_KEY}" \
     -H "Content-Type: application/json" \
     -d "{\"model\": \"${MODEL_NAME}\", \"messages\": [{\"role\": \"user\", \"content\": \"Hello\"}]}" \
-    "${MODEL_URL}/v1/chat/completions")
+    "${MAAS_API_URL}/v1/chat/completions")
   
   http_code=$(echo "$response" | tail -n1)
   body=$(echo "$response" | head -n-1)

--- a/docs/content/user-guide/model-discovery.md
+++ b/docs/content/user-guide/model-discovery.md
@@ -119,7 +119,7 @@ Use the model `id` with the gateway's body-based endpoint:
 ```bash
 MODEL_NAME=$(curl -s "${MAAS_API_URL}/maas-api/v1/models" \
     -H "Authorization: Bearer ${API_KEY}" | \
-    jq -r '.data[] | select(.id=="llama-2-7b-chat") | .id')
+    jq -r '[.data[] | select(.ready==true)][0].id')
 
 curl -sS \
   -H "Authorization: Bearer ${API_KEY}" \
@@ -127,6 +127,9 @@ curl -sS \
   -d "{\"model\": \"${MODEL_NAME}\", \"messages\": [{\"role\": \"user\", \"content\": \"Hello\"}]}" \
   "${MAAS_API_URL}/v1/chat/completions"
 ```
+
+!!! tip "Model ID format"
+    For on-cluster models (LLMInferenceService), the `id` is a publisher ID like `publishers/llm/models/facebook/opt-125m`. For external models, it is typically the model name (e.g. `gpt-4o`). Always use the `id` from the API response.
 
 See [Inference](inference.md) for full examples including streaming and multi-turn conversations.
 
@@ -137,7 +140,7 @@ The `url` field provides a per-model endpoint for path-based routing:
 ```bash
 MODEL_URL=$(curl -s "${MAAS_API_URL}/maas-api/v1/models" \
     -H "Authorization: Bearer ${API_KEY}" | \
-    jq -r '.data[] | select(.id=="llama-2-7b-chat") | .url')
+    jq -r '[.data[] | select(.ready==true)][0].url')
 
 echo "Model URL: ${MODEL_URL}"
 ```

--- a/docs/content/user-guide/model-discovery.md
+++ b/docs/content/user-guide/model-discovery.md
@@ -83,7 +83,7 @@ Each model in the `data` array contains:
 |-------|-------------|
 | `id` | Model identifier used in inference requests |
 | `kind` | Backend type: `LLMInferenceService` or `ExternalModel` |
-| `url` | Full endpoint URL for the model |
+| `url` | Path-based endpoint URL for the model (legacy). For body-based routing, use the gateway base URL with `/v1/chat/completions` instead (see [Inference](inference.md)). |
 | `ready` | Whether the model is currently available (`true`/`false`) |
 | `modelDetails.displayName` | Human-friendly model name |
 | `modelDetails.description` | Model description |
@@ -112,9 +112,27 @@ If a model doesn't appear in the list, check:
 
 ## Using Model Information
 
-### Get the Model URL
+### Make an Inference Request
 
-Extract the URL for a specific model:
+Use the model `id` with the gateway's body-based endpoint:
+
+```bash
+MODEL_NAME=$(curl -s "${MAAS_API_URL}/maas-api/v1/models" \
+    -H "Authorization: Bearer ${API_KEY}" | \
+    jq -r '.data[] | select(.id=="llama-2-7b-chat") | .id')
+
+curl -sS \
+  -H "Authorization: Bearer ${API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d "{\"model\": \"${MODEL_NAME}\", \"messages\": [{\"role\": \"user\", \"content\": \"Hello\"}]}" \
+  "${MAAS_API_URL}/v1/chat/completions"
+```
+
+See [Inference](inference.md) for full examples including streaming and multi-turn conversations.
+
+### Get the Path-Based Model URL (Legacy)
+
+The `url` field provides a per-model endpoint for path-based routing:
 
 ```bash
 MODEL_URL=$(curl -s "${MAAS_API_URL}/maas-api/v1/models" \
@@ -123,6 +141,8 @@ MODEL_URL=$(curl -s "${MAAS_API_URL}/maas-api/v1/models" \
 
 echo "Model URL: ${MODEL_URL}"
 ```
+
+See [Inference - Path-Based Routing](inference.md#path-based-routing-legacy) for details.
 
 ### Check Model Readiness
 

--- a/docs/content/user-guide/model-discovery.md
+++ b/docs/content/user-guide/model-discovery.md
@@ -119,7 +119,8 @@ Use the model `id` with the gateway's body-based endpoint:
 ```bash
 MODEL_NAME=$(curl -s "${MAAS_API_URL}/maas-api/v1/models" \
     -H "Authorization: Bearer ${API_KEY}" | \
-    jq -r '[.data[] | select(.ready==true)][0].id')
+    jq -re '[.data[] | select(.ready==true)][0].id') || \
+    { echo "No ready models found"; exit 1; }
 
 curl -sS \
   -H "Authorization: Bearer ${API_KEY}" \
@@ -140,7 +141,8 @@ The `url` field provides a per-model endpoint for path-based routing:
 ```bash
 MODEL_URL=$(curl -s "${MAAS_API_URL}/maas-api/v1/models" \
     -H "Authorization: Bearer ${API_KEY}" | \
-    jq -r '[.data[] | select(.ready==true)][0].url')
+    jq -re '[.data[] | select(.ready==true)][0].url') || \
+    { echo "No ready models found"; exit 1; }
 
 echo "Model URL: ${MODEL_URL}"
 ```


### PR DESCRIPTION
## Summary

Validates and updates upstream Body-Based Routing documentation per RHOAIENG-79713. All primary inference examples now use the OpenAI-compatible body-based endpoint (`POST /v1/chat/completions` with model in the request body) instead of path-based per-model URLs.

## Changes across 7 files

- **inference.md**: Restructured to lead with body-based endpoint as the primary teaching path. Moved path-based routing to a dedicated "Path-Based Routing (Legacy)" section with a comparison table. All examples (basic, streaming, multi-turn, rate limit retry) now use `${MAAS_API_URL}/v1/chat/completions`.
- **validation.md**: Test steps (inference, auth enforcement, rate limiting) use body-based endpoint as primary, with a note that path-based still works.
- **model-setup.md**: Verification section uses body-based endpoint with a legacy note.
- **model-discovery.md**: Clarified `url` field as path-based (legacy). Added a body-based inference example in "Using Model Information". Renamed "Get the Model URL" to "Get the Path-Based Model URL (Legacy)".
- **external-model-setup.md**: Validation curl commands (Run Inference, Verify Auth Enforcement) use body-based endpoint.
- **tier-to-subscription.md**, **upgrade-to-3.4.md**: Added informational admonition notes explaining that path-based URLs are used for migration context continuity, with a link to the updated Inference guide.

All files include a note that legacy path-based endpoints still work, linking to the Path-Based Routing (Legacy) section in inference.md.

## What is NOT changed

- No code changes, no API changes
- Migration docs keep their path-based examples (contextually appropriate) with a note
- The `/maas-api/v1/models` response format is unchanged (`url` field still returns path-based URLs)
- No new doc files created (updates only, per doc policy)

## Risk analysis

- **Risk rating**: 0
- **Why**: Documentation-only changes with no runtime impact. All changes are to markdown files under `docs/content/`. No Go code, scripts, manifests, or CI logic is affected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated inference guidance to recommend a unified OpenAI-compatible endpoint with the model specified in the request body.
  * Refreshed setup, validation, migration, and upgrade examples to use body-based routing.
  * Clarified path-based routing as a supported legacy option.
  * Updated model discovery guidance and examples to distinguish current and legacy endpoint formats.
  * Revised authentication, authorization, rate-limit, streaming, retry, and multi-turn examples accordingly.
  * Added guidance on selecting ready models and using their identifiers for requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->