### PR TITLE
docs: validate and fix multi-tenancy documentation accuracy

### DIFF
--- a/docs/content/concepts/auth-modes.md
+++ b/docs/content/concepts/auth-modes.md
@@ -58,7 +58,7 @@ spec:
 | `clientId` | OAuth2 client ID. Tokens must have `azp` claim matching this value. |
 | `ttl` | JWKS cache duration in seconds (default: 300, minimum: 30). |
 
-For unmanaged tenants (not backed by an AITenant), configure OIDC on the Tenant CR directly:
+For unmanaged tenants (legacy `Tenant` CR, not backed by an AITenant -- deprecated, will be removed in a future release):
 
 ```yaml
 apiVersion: maas.opendatahub.io/v1alpha1
@@ -108,9 +108,9 @@ For Mode 2 (standalone OIDC), the IdP must:
 
 MaaS does **not** perform OAuth2 client authentication (no `client_secret`). It validates bearer tokens only. Client authentication and secret management are the IdP's responsibility.
 
-## Field Alignment (Tenant vs AITenant)
+## Field Alignment (Legacy Tenant vs AITenant)
 
-Configuration fields align between Tenant CR and AITenant CR:
+Configuration fields align between the legacy Tenant CR and the current AITenant CR:
 
 | Field | Tenant CR path | AITenant CR path | Semantics |
 |-------|---------------|-------------------|-----------|
@@ -126,5 +126,5 @@ Configuration fields align between Tenant CR and AITenant CR:
 - [External OIDC Configuration](../advanced-administration/external-oidc.md) — JWKS cache TTL, monitoring, security controls
 - [API Key Authentication](api-key-authentication.md) — API key creation flow and architecture
 - [Authentication Internals](../architecture-internals/authentication-internals.md) — Gateway identity pipeline details
-- [Tenant CRD Reference](../reference/crds/tenant.md) — Full Tenant spec including OIDC fields
+- [MaasTenantConfig CRD Reference](../reference/crds/tenant.md) — Runtime tenant configuration (API keys, telemetry)
 - [AITenant CRD Reference](../reference/crds/ai-tenant.md) — AITenant spec including OIDC fields

--- a/docs/content/configuration-and-management/tenant-rbac.md
+++ b/docs/content/configuration-and-management/tenant-rbac.md
@@ -25,7 +25,7 @@ The tenant-admin Role in the tenant namespace grants:
 
 - `get`, `list`, `watch`, `create`, `update`, `patch`, and `delete` on `MaaSAuthPolicy`
 - `get`, `list`, `watch`, `create`, `update`, `patch`, and `delete` on `MaaSSubscription`
-- `get`, `update`, and `patch` on `Tenant/default-tenant`
+- `get`, `update`, and `patch` on `MaasTenantConfig/default-tenant`
 - `get`, `list`, and `watch` on `MaaSModelRef`
 
 The object-admin Role grants `get` on the specific `AITenant` object in the AITenant infrastructure namespace. Bind it when tenant administrators or dashboards need to read tenant bootstrap status.

--- a/docs/content/install/multi-tenant-setup.md
+++ b/docs/content/install/multi-tenant-setup.md
@@ -54,16 +54,6 @@ metadata:
 spec:
   gatewayClassName: openshift-default
   listeners:
-    - name: http
-      hostname: ${GATEWAY_HOSTNAME}
-      port: 80
-      protocol: HTTP
-      allowedRoutes:
-        namespaces:
-          from: Selector
-          selector:
-            matchLabels:
-              ${GATEWAY_ACCESS_LABEL}: "true"
     - name: https
       hostname: ${GATEWAY_HOSTNAME}
       port: 443
@@ -83,7 +73,12 @@ spec:
 EOF
 ```
 
-Create an OpenShift Route for external access:
+!!! note "Route auto-provisioning"
+    On OpenShift with `gatewayClassName: openshift-default`, the Gateway controller typically auto-provisions a Route for external access. Check whether a Route was created automatically before creating one manually:
+    ```bash
+    oc get route -n ${GATEWAY_NAMESPACE} -l gateway.networking.k8s.io/gateway-name=${TENANT_NAME}
+    ```
+    If no Route was auto-provisioned, create one manually:
 
 ```bash
 GATEWAY_SERVICE_NAME="${TENANT_NAME}-openshift-default"
@@ -120,7 +115,7 @@ oc get gateway ${TENANT_NAME} -n ${GATEWAY_NAMESPACE}
 ```
 
 !!! tip "Automated script"
-    The `scripts/create-ai-tenant.sh` script automates Gateway, Route, and AITenant creation.
+    The `scripts/create-ai-tenant.sh` script automates Gateway and AITenant creation.
     For multi-tenant deployments use the per-gateway label selector and label namespaces manually:
     ```bash
     NAMESPACE_SELECTOR_LABELS="maas.opendatahub.io/gateway-access-red-team=true" \
@@ -198,10 +193,10 @@ Expected labels:
 - `ai-gateway.opendatahub.io/tenant=<tenant-name>`
 - `maas.opendatahub.io/managed-by-aitenant=true`
 
-Verify the Tenant CR exists:
+Verify the MaasTenantConfig CR exists:
 
 ```bash
-oc get tenant default-tenant -n ai-tenant-${TENANT_NAME}
+oc get maastenantconfig default-tenant -n ai-tenant-${TENANT_NAME}
 ```
 
 Verify the maas-api deployment is running in the infrastructure namespace:
@@ -283,7 +278,7 @@ EOF
 ```
 
 !!! note
-    MaaSAuthPolicy and MaaSSubscription must be created in a namespace that contains a `Tenant` CR. The admission webhook rejects them otherwise.
+    MaaSAuthPolicy and MaaSSubscription must be created in a namespace that contains a `MaasTenantConfig` CR. The admission webhook rejects them otherwise.
 
 ## Webhook Validation
 
@@ -331,7 +326,7 @@ The controller finalizer cleans up:
     User-created RoleBindings are **not** deleted. Remove them manually before or after deleting the AITenant. Stale RoleBindings that reference recreated Roles can re-enable access.
 
 !!! tip "Automated cleanup"
-    Use the `scripts/delete-ai-tenant.sh` script for full cleanup including Gateway and Route:
+    Use the `scripts/delete-ai-tenant.sh` script for full cleanup including Gateway:
     ```bash
     ./scripts/delete-ai-tenant.sh red-team
     ```
@@ -344,7 +339,7 @@ The controller finalizer cleans up:
 ## See Also
 
 - [AITenant CRD Reference](../reference/crds/ai-tenant.md)
-- [Tenant CRD Reference](../reference/crds/tenant.md)
+- [MaasTenantConfig CRD Reference](../reference/crds/tenant.md)
 - [Tenant RBAC](../configuration-and-management/tenant-rbac.md)
 - [Multi-Tenant Validation](multi-tenant-validation.md)
 - [API Reference](../reference/api-reference.md)

--- a/docs/content/install/multi-tenant-validation.md
+++ b/docs/content/install/multi-tenant-validation.md
@@ -27,10 +27,10 @@ Expected labels:
 - `ai-gateway.opendatahub.io/tenant: <tenant-name>`
 - `maas.opendatahub.io/managed-by-aitenant: "true"`
 
-Verify the Tenant CR:
+Verify the MaasTenantConfig CR:
 
 ```bash
-oc get tenant default-tenant -n ${TENANT_NS} -o yaml
+oc get maastenantconfig default-tenant -n ${TENANT_NS} -o yaml
 ```
 
 Expected: `status.phase` is `Active`.
@@ -122,8 +122,8 @@ Each tenant's maas-api instance serves only its own tenant's data. API keys are 
 echo "=== AITenant ==="
 oc get aitenant ${TENANT_NAME} -n ai-tenants
 
-echo "=== Tenant CR ==="
-oc get tenant default-tenant -n ${TENANT_NS}
+echo "=== MaasTenantConfig CR ==="
+oc get maastenantconfig default-tenant -n ${TENANT_NS}
 
 echo "=== maas-api ==="
 oc get deployment maas-api-${TENANT_NAME} -n ${INFRA_NS}
@@ -175,7 +175,7 @@ gateway openshift-ingress/red-team is already in use by AITenant ai-tenants/othe
 
 ### MaaSSubscription rejected
 
-MaaSSubscription and MaaSAuthPolicy must be created in a namespace that contains a `Tenant` CR. Wait for the AITenant controller to create the Tenant CR before creating these resources.
+MaaSSubscription and MaaSAuthPolicy must be created in a namespace that contains a `MaasTenantConfig` CR. Wait for the AITenant controller to create the MaasTenantConfig before creating these resources.
 
 ## See Also
 

--- a/scripts/delete-ai-tenant.sh
+++ b/scripts/delete-ai-tenant.sh
@@ -34,6 +34,7 @@ echo "  Deleting Gateway..."
 kubectl delete gateway "$TENANT_NAME" -n "$GATEWAY_NAMESPACE" --ignore-not-found=true
 
 echo "  Deleting Route..."
+kubectl delete route "${TENANT_NAME}-gateway" -n "$GATEWAY_NAMESPACE" --ignore-not-found=true
 kubectl delete route "${TENANT_NAME}-route" -n "$GATEWAY_NAMESPACE" --ignore-not-found=true
 
 echo "  Deleting Gateway options ConfigMap..."


### PR DESCRIPTION
## Summary

Validate upstream MaaS Multi-Tenancy documentation for accuracy against current shipped behavior (Phase 2 / AITenant + MaasTenantConfig). Fix stale references to the legacy `Tenant` CRD, align script descriptions with actual script behavior, and correct Gateway listener configuration.

## Changes

### Stale `Tenant` -> `MaasTenantConfig` references
- `oc get tenant` -> `oc get maastenantconfig` in multi-tenant-setup.md and multi-tenant-validation.md
- `Tenant` CR -> `MaasTenantConfig` CR in webhook admission notes
- `Tenant/default-tenant` -> `MaasTenantConfig/default-tenant` in tenant-admin Role permissions (tenant-rbac.md)
- Verified against controller code: `aitenant_controller.go:563` confirms the tenant-admin Role grants access to `maastenantconfigs`, not `tenants`

### Gateway / Route discrepancies
- Removed HTTP listener from Gateway example (HTTPS-only matches `scripts/create-ai-tenant.sh`)
- Added Route auto-provisioning note (OpenShift `gatewayClassName: openshift-default` may auto-create Routes)
- Fixed script tips: removed "Route" from descriptions since neither create nor delete scripts manage Routes via Gateway API
- `scripts/delete-ai-tenant.sh`: added cleanup of `${TENANT_NAME}-gateway` Route name (the name used in docs) alongside existing `${TENANT_NAME}-route`

### Legacy Tenant deprecation clarity
- Marked legacy `Tenant` CR as deprecated in auth-modes.md
- Renamed "Field Alignment (Tenant vs AITenant)" to "Field Alignment (Legacy Tenant vs AITenant)"
- Updated "Tenant CRD Reference" links to "MaasTenantConfig CRD Reference"

## Validation

Validated on a live ROSA HCP cluster (ODH nightly with AITenant support):

| Step | Result |
|------|--------|
| `oc get aitenant models-as-a-service -n ai-tenants` | Ready=True |
| Create Gateway for `red-team` tenant | Programmed=True |
| Create `AITenant/red-team` | Ready=True |
| `oc get maastenantconfig default-tenant -n ai-tenant-red-team` | Ready=True, Reason=Reconciled |
| Namespace labels | `ai-gateway.opendatahub.io/tenant=red-team`, `maas.opendatahub.io/managed-by-aitenant=true` |
| `maas-api-red-team` deployment | 1/1 Ready in infra namespace |

## Risk analysis

- **Risk rating**: 1
- **Why**: Documentation-only changes plus a minor script fix (adding one `kubectl delete route` line with `--ignore-not-found`). No Go code, no CRD, no controller behavior changes. All corrections verified against source code and a live cluster.

Ref: [RHOAIENG-79714](https://redhat.atlassian.net/browse/RHOAIENG-79714)

[RHOAIENG-79714]: https://redhat.atlassian.net/browse/RHOAIENG-79714?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated authentication and multi-tenant guides to use `MaasTenantConfig` terminology and validation steps.
  - Clarified legacy tenant configuration, RBAC permissions, troubleshooting guidance, and referenced resources.
  - Improved Gateway setup instructions, including OpenShift Route handling and tenant cleanup guidance.

- **Bug Fixes**
  - Enhanced tenant deletion automation to remove an additional Gateway-related Route during cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->