### PR TITLE
feat: add failed requests column and filter auth-failure rows from loki dashboards

### DIFF
--- a/deployment/components/observability/usage-logs/usage-logs-admin-dashboard.yaml
+++ b/deployment/components/observability/usage-logs/usage-logs-admin-dashboard.yaml
@@ -75,7 +75,7 @@ spec:
               name: usage-logs-all
             labelName: model
             matchers:
-              - '{service_name="models-as-a-service", model!="-"}'
+              - '{service_name="models-as-a-service", model!="-", subscription!="-"}'
     - kind: ListVariable
       spec:
         name: view_by
@@ -343,6 +343,13 @@ spec:
                 format:
                   unit: decimal
                   decimalPlaces: 0
+              - name: "value #4"
+                header: "Failed requests"
+                align: "right"
+                enableSorting: true
+                format:
+                  unit: decimal
+                  decimalPlaces: 0
         queries:
           - kind: TimeSeriesQuery
             spec:
@@ -356,8 +363,13 @@ spec:
                     sum by (user_id, model, subscription) (sum_over_time(
                     {service_name="models-as-a-service",
                     subscription=~"$subscription", model=~"$model", response_type="hit"}
-                    | user_id=~"$user"
+                    | user_id!="-" | user_id=~"$user"
                     | unwrap tokens_total [$__range]))
+                    or
+                    (sum by (user_id, model, subscription) (count_over_time(
+                    {service_name="models-as-a-service",
+                    subscription=~"$subscription", model=~"$model", response_type="error"}
+                    | user_id!="-" | user_id=~"$user" [$__range])) * 0)
           - kind: TimeSeriesQuery
             spec:
               plugin:
@@ -370,7 +382,12 @@ spec:
                     sum by (user_id, model, subscription) (count_over_time(
                     {service_name="models-as-a-service",
                     subscription=~"$subscription", model=~"$model", response_type="hit"}
-                    | user_id=~"$user" [$__range]))
+                    | user_id!="-" | user_id=~"$user" [$__range]))
+                    or
+                    (sum by (user_id, model, subscription) (count_over_time(
+                    {service_name="models-as-a-service",
+                    subscription=~"$subscription", model=~"$model", response_type="error"}
+                    | user_id!="-" | user_id=~"$user" [$__range])) * 0)
           - kind: TimeSeriesQuery
             spec:
               plugin:
@@ -383,12 +400,35 @@ spec:
                     sum by (user_id, model, subscription) (count_over_time(
                     {service_name="models-as-a-service",
                     subscription=~"$subscription", model=~"$model", response_type="rate_limit"}
-                    | user_id=~"$user" [$__range]))
+                    | user_id!="-" | user_id=~"$user" [$__range]))
                     or
                     (sum by (user_id, model, subscription) (count_over_time(
                     {service_name="models-as-a-service",
                     subscription=~"$subscription", model=~"$model", response_type="hit"}
-                    | user_id=~"$user" [$__range])) * 0)
+                    | user_id!="-" | user_id=~"$user" [$__range])) * 0)
+                    or
+                    (sum by (user_id, model, subscription) (count_over_time(
+                    {service_name="models-as-a-service",
+                    subscription=~"$subscription", model=~"$model", response_type="error"}
+                    | user_id!="-" | user_id=~"$user" [$__range])) * 0)
+          - kind: TimeSeriesQuery
+            spec:
+              plugin:
+                kind: LokiTimeSeriesQuery
+                spec:
+                  datasource:
+                    kind: LokiDatasource
+                    name: usage-logs-all
+                  query: >-
+                    sum by (user_id, model, subscription) (count_over_time(
+                    {service_name="models-as-a-service",
+                    subscription=~"$subscription", model=~"$model", response_type="error"}
+                    | user_id!="-" | user_id=~"$user" [$__range]))
+                    or
+                    (sum by (user_id, model, subscription) (count_over_time(
+                    {service_name="models-as-a-service",
+                    subscription=~"$subscription", model=~"$model", response_type="hit"}
+                    | user_id!="-" | user_id=~"$user" [$__range])) * 0)
 
   layouts:
     - kind: Grid

--- a/deployment/components/observability/usage-logs/usage-logs-dashboard.yaml
+++ b/deployment/components/observability/usage-logs/usage-logs-dashboard.yaml
@@ -56,7 +56,7 @@ spec:
               name: usage-logs-multi-tenancy
             labelName: model
             matchers:
-              - '{service_name="models-as-a-service", model!="-"}'
+              - '{service_name="models-as-a-service", model!="-", subscription!="-"}'
     - kind: ListVariable
       spec:
         name: view_by
@@ -293,6 +293,13 @@ spec:
                 format:
                   unit: decimal
                   decimalPlaces: 0
+              - name: "value #4"
+                header: "Failed requests"
+                align: "right"
+                enableSorting: true
+                format:
+                  unit: decimal
+                  decimalPlaces: 0
         queries:
           - kind: TimeSeriesQuery
             spec:
@@ -305,8 +312,15 @@ spec:
                   query: >-
                     sum by (model, subscription, key_name) (sum_over_time(
                     {service_name="models-as-a-service",
-                    subscription=~"$subscription", model=~"$model", response_type="hit"}
+                    subscription=~"$subscription", subscription!="-",
+                    model=~"$model", response_type="hit"}
                     | unwrap tokens_total [$__range]))
+                    or
+                    (sum by (model, subscription, key_name) (count_over_time(
+                    {service_name="models-as-a-service",
+                    subscription=~"$subscription", subscription!="-",
+                    model=~"$model", response_type="error"}
+                    [$__range])) * 0)
           - kind: TimeSeriesQuery
             spec:
               plugin:
@@ -318,25 +332,60 @@ spec:
                   query: >-
                     sum by (model, subscription, key_name) (count_over_time(
                     {service_name="models-as-a-service",
-                    subscription=~"$subscription", model=~"$model", response_type="hit"}
-                    [$__range]))
-          - kind: TimeSeriesQuery
-            spec:
-              plugin:
-                kind: LokiTimeSeriesQuery
-                spec:
-                  datasource:
-                    kind: LokiDatasource
-                    name: usage-logs-multi-tenancy
-                  query: >-
-                    sum by (model, subscription, key_name) (count_over_time(
-                    {service_name="models-as-a-service",
-                    subscription=~"$subscription", model=~"$model", response_type="rate_limit"}
+                    subscription=~"$subscription", subscription!="-",
+                    model=~"$model", response_type="hit"}
                     [$__range]))
                     or
                     (sum by (model, subscription, key_name) (count_over_time(
                     {service_name="models-as-a-service",
-                    subscription=~"$subscription", model=~"$model", response_type="hit"}
+                    subscription=~"$subscription", subscription!="-",
+                    model=~"$model", response_type="error"}
+                    [$__range])) * 0)
+          - kind: TimeSeriesQuery
+            spec:
+              plugin:
+                kind: LokiTimeSeriesQuery
+                spec:
+                  datasource:
+                    kind: LokiDatasource
+                    name: usage-logs-multi-tenancy
+                  query: >-
+                    sum by (model, subscription, key_name) (count_over_time(
+                    {service_name="models-as-a-service",
+                    subscription=~"$subscription", subscription!="-",
+                    model=~"$model", response_type="rate_limit"}
+                    [$__range]))
+                    or
+                    (sum by (model, subscription, key_name) (count_over_time(
+                    {service_name="models-as-a-service",
+                    subscription=~"$subscription", subscription!="-",
+                    model=~"$model", response_type="hit"}
+                    [$__range])) * 0)
+                    or
+                    (sum by (model, subscription, key_name) (count_over_time(
+                    {service_name="models-as-a-service",
+                    subscription=~"$subscription", subscription!="-",
+                    model=~"$model", response_type="error"}
+                    [$__range])) * 0)
+          - kind: TimeSeriesQuery
+            spec:
+              plugin:
+                kind: LokiTimeSeriesQuery
+                spec:
+                  datasource:
+                    kind: LokiDatasource
+                    name: usage-logs-multi-tenancy
+                  query: >-
+                    sum by (model, subscription, key_name) (count_over_time(
+                    {service_name="models-as-a-service",
+                    subscription=~"$subscription", subscription!="-",
+                    model=~"$model", response_type="error"}
+                    [$__range]))
+                    or
+                    (sum by (model, subscription, key_name) (count_over_time(
+                    {service_name="models-as-a-service",
+                    subscription=~"$subscription", subscription!="-",
+                    model=~"$model", response_type="hit"}
                     [$__range])) * 0)
 
   layouts:


### PR DESCRIPTION
## Summary

Add a **Failed requests** column to the usage breakdown table on both Loki dashboards and filter out auth-failure noise (401/403 with unresolved identity) from dropdowns and table.

## Changes

### Failed requests column (Q4)

Both dashboards gain a fourth table query counting `response_type="error"` entries. The column shows how many requests failed per user/model/subscription combination — errors that occurred **after** successful authentication (e.g. 404 model-not-found, 500 backend error).

### Auth-failure filtering

When authentication fails (401 invalid token, 403 subscription mismatch), the WASM shim is atomic — **no** identity fields are written to FILTER_STATE. These entries have `user_id="-"` and `subscription="-"` with garbage model names (client-provided, never routed).

| Where | Filter | Mechanism |
|-------|--------|-----------|
| Model dropdown (both) | `subscription!="-"` added to matcher | Stream label (proxy for unresolved identity) |
| Admin table Q1–Q4 | `\| user_id!="-"` | Structured metadata pipeline filter |
| User table Q1–Q4 | `subscription!="-"` in stream selector | Stream label (no `user_id` column — proxy handles user scoping) |

Subscription dropdown already had `subscription!="-"` — no change needed.

### Cross-zero-padding

All four table queries use `or (other_query * 0)` to ensure every label combo appears in every query with value `0` instead of empty. This is required for `MergeSeries` to join correctly — without it, error-only combinations produce empty cells that sort before numbers in descending order.

| Query | Zero-padded with |
|-------|------------------|
| Q1 (Tokens used) | `or (error * 0)` |
| Q2 (Successful requests) | `or (error * 0)` |
| Q3 (Rate limited requests) | `or (hit * 0) or (error * 0)` |
| Q4 (Failed requests) | `or (hit * 0)` |

## Testing

Verified on `amit.dev` cluster against live Loki data:
- All 4 queries return identical label sets (20 combos each) — confirmed via direct Loki API
- Auth-failure rows (`GARBAGE-401-MODEL`, `WRONG-MODEL-NAME-403`, etc.) excluded from table
- Hit-only combos show `0` in Failed column; error-only combos show `0` in Tokens/Successful/Rate limited
- Descending sort on Tokens places real values first (no empty-before-numbers issue)
- Dropdowns exclude models that only appear in auth-failure logs

## Risk analysis

- **Risk rating**: 2
- **Why**: LogQL query changes only — no controller, Go, or infrastructure changes. Dashboard YAML modifications are straightforward stream selector and pipeline filter additions. Cross-zero-padding pattern is well-understood (`or (query * 0)` is standard LogQL). Verified end-to-end on live cluster. Risk is moderate because the queries are more complex and dashboard rendering depends on Perses `MergeSeries` behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **Failed requests** column to the Usage breakdown dashboard table.
  * Preserved dashboard rows with zero values when certain response types have no matching data.

* **Bug Fixes**
  * Updated model selections to exclude error responses.
  * Excluded unassigned subscriptions from total request, success-rate, and usage breakdown metrics.
  * Improved consistency of usage queries and zero-valued fallback results for tokens, successful requests, rate-limited requests, and failed requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->