### PR TITLE
docs: document MaaSModelRef tenantRef field from PR #1250

### DIFF
--- a/docs/content/configuration-and-management/model-setup.md
+++ b/docs/content/configuration-and-management/model-setup.md
@@ -59,6 +59,9 @@ To enable MaaS policies for an LLMInferenceService:
 
 Without the gateway reference, the model uses the standard gateway and MaaS policies do not apply.
 
+!!! tip "Multi-tenant deployments"
+    For models that serve a non-default tenant, set `spec.tenantRef` on the MaaSModelRef to the AITenant name. This tells the controller to resolve the gateway from the named AITenant instead of using namespace-based inference. See [Multi-Tenant Setup — Configure Models](../install/multi-tenant-setup.md#5-configure-models).
+
 ---
 
 ## External Models

--- a/docs/content/install/multi-tenant-setup.md
+++ b/docs/content/install/multi-tenant-setup.md
@@ -227,6 +227,10 @@ Create the MaaSModelRef in the **model namespace** (co-located with the backend 
 TENANT_NS="ai-tenant-${TENANT_NAME}"
 MODEL_NS="llm"   # namespace where the LLMInferenceService runs
 
+# The model namespace must carry the tenant Gateway's access label
+# so the controller-generated HTTPRoute can attach.
+oc label namespace "${MODEL_NS}" "maas.opendatahub.io/gateway-access-${TENANT_NAME}=true" --overwrite
+
 # Create a MaaSModelRef in the model namespace.
 # tenantRef tells the controller to resolve the gateway from this AITenant
 # instead of using namespace-based inference (which defaults to the default tenant).
@@ -300,7 +304,7 @@ The AITenant admission webhook enforces two rules:
 
 ### Self-Bootstrap
 
-On startup, the controller automatically creates `AITenant/models-as-a-service` in the infrastructure namespace for the default tenant. This AITenant bootstraps the default tenant namespace and MaaSTenantConfig CR.
+On startup, the controller automatically creates `AITenant/models-as-a-service` in the infrastructure namespace for the default tenant. This AITenant bootstraps the default tenant namespace and `MaasTenantConfig` CR.
 
 ### Namespace Discovery
 

--- a/docs/content/install/multi-tenant-setup.md
+++ b/docs/content/install/multi-tenant-setup.md
@@ -226,25 +226,30 @@ See [Tenant RBAC](../configuration-and-management/tenant-rbac.md) for examples w
 
 ## 5. Configure Models
 
-Create MaaS resources in the tenant namespace to expose models:
+Create the MaaSModelRef in the **model namespace** (co-located with the backend resource) and use `tenantRef` to associate it with the tenant's gateway. MaaSAuthPolicy and MaaSSubscription must be created in the **tenant namespace** (where the MaasTenantConfig CR lives).
 
 ```bash
 TENANT_NS="ai-tenant-${TENANT_NAME}"
+MODEL_NS="llm"   # namespace where the LLMInferenceService runs
 
-# Create a MaaSModelRef
+# Create a MaaSModelRef in the model namespace.
+# tenantRef tells the controller to resolve the gateway from this AITenant
+# instead of using namespace-based inference (which defaults to the default tenant).
 cat <<EOF | oc apply -f -
 apiVersion: maas.opendatahub.io/v1alpha1
 kind: MaaSModelRef
 metadata:
   name: my-model
-  namespace: ${TENANT_NS}
+  namespace: ${MODEL_NS}
 spec:
   modelRef:
+    kind: LLMInferenceService
     name: my-llm-inference-service
-    namespace: llm
+  tenantRef: ${TENANT_NAME}
 EOF
 
-# Create a MaaSAuthPolicy
+# Create a MaaSAuthPolicy in the tenant namespace.
+# modelRefs point to the MaaSModelRef by name and namespace.
 cat <<EOF | oc apply -f -
 apiVersion: maas.opendatahub.io/v1alpha1
 kind: MaaSAuthPolicy
@@ -254,14 +259,14 @@ metadata:
 spec:
   modelRefs:
     - name: my-model
-      namespace: ${TENANT_NS}
+      namespace: ${MODEL_NS}
   subjects:
     groups:
       - name: system:authenticated
     users: []
 EOF
 
-# Create a MaaSSubscription
+# Create a MaaSSubscription in the tenant namespace.
 cat <<EOF | oc apply -f -
 apiVersion: maas.opendatahub.io/v1alpha1
 kind: MaaSSubscription
@@ -275,7 +280,7 @@ spec:
     users: []
   modelRefs:
     - name: my-model
-      namespace: ${TENANT_NS}
+      namespace: ${MODEL_NS}
       tokenRateLimits:
         - limit: 1000
           window: 1m
@@ -283,7 +288,10 @@ EOF
 ```
 
 !!! note
-    MaaSAuthPolicy and MaaSSubscription must be created in a namespace that contains a `Tenant` CR. The admission webhook rejects them otherwise.
+    MaaSAuthPolicy and MaaSSubscription must be created in a namespace that contains a `MaasTenantConfig` CR. The admission webhook rejects them otherwise.
+
+!!! tip "MaaSModelRef for the default tenant"
+    For models that belong to the default tenant, `tenantRef` can be omitted. The controller falls back to namespace-based gateway resolution. See [MaaSModelRef CRD Reference](../reference/crds/maas-model-ref.md#multi-tenant-models) for details.
 
 ## Webhook Validation
 

--- a/docs/content/reference/crds/maas-model-ref.md
+++ b/docs/content/reference/crds/maas-model-ref.md
@@ -12,6 +12,7 @@ Identifies an AI/ML model for the MaaS platform. The backend may be on-cluster (
 |-------|------|----------|-------------|
 | modelRef | ModelReference | Yes | Reference to the model backend (kind and name) |
 | endpointOverride | string | No | Optional override for the endpoint URL. See [Endpoint Override](#endpoint-override) below. |
+| tenantRef | string | No | Name of the AITenant this model belongs to. When omitted, the model is assigned to the default tenant. See [Multi-Tenant Models](#multi-tenant-models) below. |
 
 ### ModelReference
 
@@ -102,6 +103,34 @@ The override does not bypass backend validation. The controller still checks tha
 
 ---
 
+## Multi-Tenant Models
+
+By default, the controller resolves the gateway for a MaaSModelRef using namespace-based inference — it looks for a MaasTenantConfig in the model's namespace and uses the associated default-tenant gateway.
+
+In multi-tenant deployments, models often live in a shared namespace (e.g. `llm`) but need to route through a specific tenant's gateway. Set `spec.tenantRef` to the name of the AITenant. The controller looks up the AITenant in the AITenant namespace and uses its gateway directly.
+
+A validating webhook rejects `tenantRef` values that do not match an existing AITenant. The value must be a valid DNS-1123 label (max 253 characters).
+
+**Example:**
+```yaml
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: MaaSModelRef
+metadata:
+  name: granite-7b
+  namespace: llm
+spec:
+  modelRef:
+    kind: LLMInferenceService
+    name: granite-7b-instruct
+  tenantRef: red-team
+```
+
+The resolved tenant appears in `status.resolvedTenantRef`. When `tenantRef` is removed or left empty, the field is cleared and the controller reverts to namespace-based resolution.
+
+For step-by-step instructions, see [Multi-Tenant Setup — Configure Models](../../install/multi-tenant-setup.md#5-configure-models).
+
+---
+
 ## Status
 
 ### MaaSModelRefStatus
@@ -115,6 +144,7 @@ The override does not bypass backend validation. The controller still checks tha
 | httpRouteGatewayName | string | Name of the Gateway that the HTTPRoute references |
 | httpRouteGatewayNamespace | string | Namespace of the Gateway that the HTTPRoute references |
 | httpRouteHostnames | []string | Hostnames configured on the HTTPRoute |
+| resolvedTenantRef | string | Name of the AITenant the model was resolved to. Set from `spec.tenantRef` when provided; empty for default-tenant models. |
 | conditions | []Condition | Latest observations of the model's state |
 
 ---

--- a/docs/content/reference/crds/maas-model-ref.md
+++ b/docs/content/reference/crds/maas-model-ref.md
@@ -109,7 +109,7 @@ By default, the controller resolves the gateway for a MaaSModelRef using namespa
 
 In multi-tenant deployments, models often live in a shared namespace (e.g. `llm`) but need to route through a specific tenant's gateway. Set `spec.tenantRef` to the name of the AITenant. The controller looks up the AITenant in the AITenant namespace and uses its gateway directly.
 
-A validating webhook rejects `tenantRef` values that do not match an existing AITenant. The value must be a valid DNS-1123 label (max 253 characters).
+A validating webhook rejects `tenantRef` values that do not match an existing AITenant. The value must use lowercase alphanumeric characters and hyphens (matching the CRD pattern `^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`) and be no longer than 253 characters.
 
 **Example:**
 ```yaml
@@ -144,7 +144,7 @@ For step-by-step instructions, see [Multi-Tenant Setup — Configure Models](../
 | httpRouteGatewayName | string | Name of the Gateway that the HTTPRoute references |
 | httpRouteGatewayNamespace | string | Namespace of the Gateway that the HTTPRoute references |
 | httpRouteHostnames | []string | Hostnames configured on the HTTPRoute |
-| resolvedTenantRef | string | Name of the AITenant the model was resolved to. Set from `spec.tenantRef` when provided; empty for default-tenant models. |
+| resolvedTenantRef | string | The explicitly selected AITenant from `spec.tenantRef`; empty when `tenantRef` is omitted and namespace-based resolution is used. |
 | conditions | []Condition | Latest observations of the model's state |
 
 ---


### PR DESCRIPTION
Add tenantRef to the MaaSModelRef CRD reference (spec and status tables) with a new Multi-Tenant Models section. Update the multi-tenant setup guide to use the cross-namespace pattern with tenantRef and fix pre-existing modelRef bugs (missing kind, invalid namespace field). Add a cross-reference tip in the model setup guide.

Ref: https://redhat.atlassian.net/browse/RHOAIENG-79714

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for configuring model references in multi-tenant deployments.
  * Documented selecting a tenant explicitly for gateway resolution.
  * Clarified model, authentication policy, and subscription namespace references.
  * Added documentation for `tenantRef` and resolved tenant status information.
  * Clarified default-tenant behavior and self-bootstrap configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->