### PR TITLE
fix(xKS): exclude PodMonitor and monitoring NetworkPolicy from xKS overlay

### DIFF
--- a/maas-api/deploy/overlays/xks/kustomization.yaml
+++ b/maas-api/deploy/overlays/xks/kustomization.yaml
@@ -47,3 +47,26 @@ patches:
     patch: |
       - op: remove
         path: /metadata/annotations/service.beta.openshift.io~1inject-cabundle
+
+  # Exclude monitoring resources on xKS (PodMonitor CRD requires Prometheus Operator,
+  # NetworkPolicy references OCP-specific redhat-ods-monitoring namespace)
+  - target:
+      group: monitoring.coreos.com
+      version: v1
+      kind: PodMonitor
+      name: maas-api-metrics
+    patch: |
+      $patch: delete
+      apiVersion: monitoring.coreos.com/v1
+      kind: PodMonitor
+      metadata:
+        name: maas-api-metrics
+  - target:
+      kind: NetworkPolicy
+      name: maas-api-allow-monitoring
+    patch: |
+      $patch: delete
+      apiVersion: networking.k8s.io/v1
+      kind: NetworkPolicy
+      metadata:
+        name: maas-api-allow-monitoring


### PR DESCRIPTION
## Summary

- Excludes `PodMonitor` (monitoring.coreos.com/v1) and `maas-api-allow-monitoring` NetworkPolicy from the maas-api xKS platform overlay
- On xKS clusters (AKS/EKS/GKE), the Prometheus Operator CRD is not available, causing `MaaSTenantConfig` reconciliation to fail with: `no matches for kind "PodMonitor" in version "monitoring.coreos.com/v1"`
- The monitoring NetworkPolicy also references the OCP-specific `redhat-ods-monitoring` namespace

## Root Cause

The xKS overlay at `maas-api/deploy/overlays/xks/` references `deployment/base/maas-api/overlays/tls` → `../../default` → `../monitoring/podmonitor.yaml`. The `default` base unconditionally includes monitoring resources.

The maas-controller's own xKS overlay already correctly excludes monitoring:
```
# monitoring is excluded on xKS (OpenShift-specific ServiceMonitor/PodMonitor)
```

But the platform manifests rendered at runtime for maas-api did not have this exclusion.

## Fix

Add kustomize `$patch: delete` patches to remove both monitoring resources from the xKS overlay output, matching the existing pattern.

## Verification

```bash
# xKS: no PodMonitor
kubectl kustomize maas-api/deploy/overlays/xks | grep "kind: PodMonitor"
# (no output)

# ODH: PodMonitor still present
kubectl kustomize maas-api/deploy/overlays/odh | grep "kind: PodMonitor"
# kind: PodMonitor
```

## Test plan

- [x] `kubectl kustomize maas-api/deploy/overlays/xks` renders without PodMonitor
- [x] `kubectl kustomize maas-api/deploy/overlays/odh` still includes PodMonitor
- [ ] Deploy on fresh AKS cluster — MaaSTenantConfig reaches `Active` without PodMonitor CRD installed


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the xKS deployment configuration to remove obsolete monitoring resources.
  * Prevented unnecessary metrics monitoring and monitoring network access in xKS environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->