### PR TITLE
[release-3.4] fix: add CEL has() guards to telemetry cost_center and organization_id labels

### DIFF
--- a/maas-controller/pkg/platform/tenantreconcile/postrender.go
+++ b/maas-controller/pkg/platform/tenantreconcile/postrender.go
@@ -315,10 +315,10 @@ func buildTelemetryLabels(log logr.Logger, config *maasv1alpha1.TenantTelemetryC
 	}
 	labels := map[string]any{
 		"subscription": "auth.identity.selected_subscription",
-		"cost_center":  "auth.identity.subscription_info.costCenter",
+		"cost_center":  `has(auth.identity.subscription_info.costCenter) ? auth.identity.subscription_info.costCenter : ""`,
 	}
 	if captureOrganization {
-		labels["organization_id"] = "auth.identity.subscription_info.organizationId"
+		labels["organization_id"] = `has(auth.identity.subscription_info.organizationId) ? auth.identity.subscription_info.organizationId : ""`
 	}
 	if captureUser {
 		log.Info("WARNING: User identity metrics enabled - ensure GDPR/privacy compliance", "field", "captureUser", "value", true)


### PR DESCRIPTION
## Summary

Cherry-pick of #1276 to `release-3.4` for 3.4.4 release.

Jira: [RHOAIENG-79318](https://redhat.atlassian.net/browse/RHOAIENG-79318)

`buildTelemetryLabels` unconditionally includes `cost_center` (`auth.identity.subscription_info.costCenter`) and conditionally includes `organization_id` (`auth.identity.subscription_info.organizationId`). When these fields are missing from the subscription response (common case), the wasm-shim crashes with `CelError::Resolve { NoSuchKey("costCenter") }` and drops the entire rate limit descriptor — `authorized_hits` stops incrementing and the MaaS monitoring dashboard shows all zeros.

Adds CEL `has()` guards so missing fields resolve to empty string instead of crashing.

## Validation

- Verified on RHOAI 3.4.2 cluster (Trevor Royer's): metrics showed up correctly with `has()` guards
- Verified on RHOAI 3.5 cluster: zero CEL errors, TelemetryPolicy Accepted+Enforced, all API calls working

## Test plan
- [x] Cherry-pick applies cleanly
- [x] Verified on 3.4.2 cluster
- [x] Verified on 3.5 cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RHOAIENG-79318]: https://redhat.atlassian.net/browse/RHOAIENG-79318?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ