### PR TITLE
test: read workloadSelector instead of targetRefs in E2E envoyfilter helper

### DIFF
--- a/test/e2e/tests/multitenancy_helpers.py
+++ b/test/e2e/tests/multitenancy_helpers.py
@@ -1078,10 +1078,8 @@ def envoyfilter_target_gateway(name: str, namespace: str = GATEWAY_NAMESPACE) ->
     if not envoyfilter:
         return ""
     spec = envoyfilter.get("spec") or {}
-    target_refs = spec.get("targetRefs") or []
-    if target_refs:
-        return target_refs[0].get("name") or ""
-    return (spec.get("targetRef") or {}).get("name") or ""
+    labels = (spec.get("workloadSelector") or {}).get("labels") or {}
+    return labels.get("gateway.networking.k8s.io/gateway-name") or ""
 
 
 def envoyfilter_grpc_cluster_names(envoyfilter: dict) -> list[str]:

--- a/test/e2e/tests/test_per_tenant_ipp_isolation.py
+++ b/test/e2e/tests/test_per_tenant_ipp_isolation.py
@@ -223,7 +223,7 @@ class TestPerTenantIPPInfrastructure:
                 f"{names['processing_deployment']} TENANT_NAMESPACE mismatch: {env!r}"
             )
 
-    def test_per_tenant_envoyfilter_target_ref_isolated(self, ipp_tenant_cases):
+    def test_per_tenant_envoyfilter_workload_selector_isolated(self, ipp_tenant_cases):
         for case in ipp_tenant_cases:
             names = per_tenant_ipp_names(case["tenant_label_name"])
             target = envoyfilter_target_gateway(names["envoyfilter"], GATEWAY_NAMESPACE)


### PR DESCRIPTION
 read workloadSelector instead of targetRefs in E2E envoyfilter


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated per-tenant EnvoyFilter isolation coverage to identify target gateways using workload selector labels.
  * Renamed the isolation test to reflect workload selector behavior while preserving existing assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->