### PR TITLE
fix: remove remaining from: All in Gateway manifests, samples, and docs

### DIFF
--- a/deployment/base/networking/odh/odh-gateway-api.yaml
+++ b/deployment/base/networking/odh/odh-gateway-api.yaml
@@ -20,4 +20,4 @@ spec:
     protocol: HTTP
     allowedRoutes:
       namespaces:
-        from: All
+        from: Same

--- a/docs/content/configuration-and-management/gateway-patterns.md
+++ b/docs/content/configuration-and-management/gateway-patterns.md
@@ -153,7 +153,7 @@ spec:
       protocol: HTTPS
       allowedRoutes:
         namespaces:
-          from: All
+          from: Same
       tls:
         certificateRefs:
           - group: ""

--- a/docs/samples/gateway-patterns/clusterip-route-reencrypt/gateway.yaml
+++ b/docs/samples/gateway-patterns/clusterip-route-reencrypt/gateway.yaml
@@ -22,7 +22,7 @@ spec:
       protocol: HTTPS
       allowedRoutes:
         namespaces:
-          from: All
+          from: Same
       tls:
         certificateRefs:
           - group: ""

--- a/test/e2e/scripts/local-deploy.sh
+++ b/test/e2e/scripts/local-deploy.sh
@@ -994,7 +994,7 @@ spec:
     protocol: HTTP
     allowedRoutes:
       namespaces:
-        from: All
+        from: Same
 EOF
 
   echo "  Waiting for Gateway to be programmed..."


### PR DESCRIPTION
## Summary

Removes remaining insecure `allowedRoutes: namespaces: from: All` from Gateway manifests, samples, and documentation that were missed by PR #1255.

**Files changed:**
- `deployment/base/networking/odh/odh-gateway-api.yaml` — ODH gateway manifest
- `docs/samples/gateway-patterns/clusterip-route-reencrypt/gateway.yaml` — sample Gateway
- `docs/content/configuration-and-management/gateway-patterns.md` — doc example
- `test/e2e/scripts/local-deploy.sh` — e2e test script

All changed from `from: All` to `from: Same` (secure default).

References:
- [Gateway API Security: Avoiding Hostname/Domain Hijacking](https://gateway-api.sigs.k8s.io/docs/concepts/security/#avoiding-hostnamedomain-hijacking)
- Follow-up to PR #1255

## Test plan
- [x] `grep -rn "from: All" --include="*.yaml" --include="*.sh" --include="*.md"` returns only comments/references, no actual configs
- [ ] Kustomize manifests validate
- [ ] E2e tests pass with `from: Same`

## Risk analysis
- **Risk rating**: 1
- **Why**: Four string replacements in manifests, samples, and docs. `from: Same` is more restrictive than `from: All` — existing HTTPRoutes in the same namespace continue to work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Restricted Gateway route attachment to routes in the same namespace.
  * Prevented routes from other namespaces from being accepted by default.

* **Documentation**
  * Updated Gateway configuration guidance and examples to reflect namespace-local routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->