### PR TITLE
fix: set AUTH_SERVICE_TIMEOUT=2s during RHCL operator CSV patching

### DIFF
--- a/docs/content/install/platform-setup.md
+++ b/docs/content/install/platform-setup.md
@@ -409,7 +409,7 @@ Now install the Gateway API controller for your platform:
 
     #### High-concurrency authentication timeout
 
-    RHCL configures the Kuadrant WASM plugin with an authentication service timeout of `200ms` by default. Under high concurrent request load, this short timeout can appear as intermittent HTTP `500` or `503` responses from gateway policy evaluation even when the model backend is healthy. If you see timeout-related failures during concurrent inference, increase `AUTH_SERVICE_TIMEOUT` to `2s` (`2000ms`) on the RHCL operator Subscription (`spec.config.env`).
+    RHCL configures the Kuadrant WASM plugin with an authentication service timeout of `200ms` by default. Under high concurrent request load, this short timeout can appear as intermittent HTTP `500` or `503` responses from gateway policy evaluation even when the model backend is healthy. To override the default, set `AUTH_SERVICE_TIMEOUT` to `2s` (`2000ms`) on the RHCL operator Subscription (`spec.config.env`).
 
     Set the RHCL Subscription name and namespace for your installation before patching. The manual install example above uses `kuadrant-operator` in `kuadrant-system`; RHOAI-managed clusters commonly use `rhcl-operator` in `rh-connectivity-link`.
 

--- a/scripts/deployment-helpers.sh
+++ b/scripts/deployment-helpers.sh
@@ -365,7 +365,7 @@ patch_kuadrant_csv() {
   local namespace=$1
   local operator_prefix=$2
 
-  log_info "Patching $operator_prefix CSV (Gateway API, rate limit failure modes)..."
+  log_info "Patching $operator_prefix CSV (Gateway API, rate limit failure modes, auth service timeout)..."
 
   # Find the CSV
   local csv_name
@@ -386,12 +386,15 @@ patch_kuadrant_csv() {
   patch_csv_operator_container_env "$namespace" "$csv_name" "RATELIMIT_CHECK_SERVICE_FAILURE_MODE" "deny" && patched_any=true
   patch_csv_operator_container_env "$namespace" "$csv_name" "RATELIMIT_REPORT_SERVICE_FAILURE_MODE" "deny" && patched_any=true
 
+  # --- Auth service timeout (RHOAIENG-79789) ---
+  patch_csv_operator_container_env "$namespace" "$csv_name" "AUTH_SERVICE_TIMEOUT" "2s" && patched_any=true
+
   if [[ "$patched_any" != "true" ]]; then
-    log_debug "CSV already has all required operator env (Gateway + rate limit failure modes)"
+    log_debug "CSV already has all required operator env (Gateway + rate limit failure modes + auth timeout)"
     return 0
   fi
 
-  log_info "CSV patched (Gateway controller and/or rate limit failure modes)"
+  log_info "CSV patched (Gateway controller and/or rate limit failure modes and/or auth timeout)"
 
   # CRITICAL: Force delete the operator pod to pick up the new env var
   # OLM updates the deployment spec but doesn't always trigger a pod restart
@@ -419,10 +422,11 @@ patch_kuadrant_csv() {
 
     if echo "$pod_env" | grep '^ISTIO_GATEWAY_CONTROLLER_NAMES=' | grep -q 'openshift.io/gateway-controller/v1' \
       && echo "$pod_env" | grep -Fq 'RATELIMIT_CHECK_SERVICE_FAILURE_MODE=deny' \
-      && echo "$pod_env" | grep -Fq 'RATELIMIT_REPORT_SERVICE_FAILURE_MODE=deny'; then
-      log_info "Operator pod has required CSV env (ISTIO gateway controller + RATELIMIT_* failure modes)"
+      && echo "$pod_env" | grep -Fq 'RATELIMIT_REPORT_SERVICE_FAILURE_MODE=deny' \
+      && echo "$pod_env" | grep -Fq 'AUTH_SERVICE_TIMEOUT=2s'; then
+      log_info "Operator pod has required CSV env (ISTIO gateway controller + RATELIMIT_* failure modes + AUTH_SERVICE_TIMEOUT)"
     else
-      log_warn "Operator pod may not have correct env yet (ISTIO / RATELIMIT_* failure modes)"
+      log_warn "Operator pod may not have correct env yet (ISTIO / RATELIMIT_* failure modes / AUTH_SERVICE_TIMEOUT)"
     fi
 
     # Give the operator time to fully initialize with the new Gateway controller configuration

--- a/scripts/install-dependencies.sh
+++ b/scripts/install-dependencies.sh
@@ -160,7 +160,7 @@ EOF
 
         sleep 5
 
-        # Gateway API + fail-close rate limits (same as deploy.sh patch_kuadrant_csv)
+        # Gateway API + fail-close rate limits + auth timeout (same as deploy.sh patch_kuadrant_csv)
         echo "🚀 Patching Kuadrant operator CSV..."
         patch_kuadrant_csv "kuadrant-system" "kuadrant-operator"
 


### PR DESCRIPTION
## What

RHCL defaults the Kuadrant WASM `auth-service` timeout to `200ms`. Under load, Authorino cache misses push P95 auth latency above 200ms, causing the WASM plugin (`failureMode: deny`) to return HTTP 500 to clients.

## How

Add `AUTH_SERVICE_TIMEOUT=2s` to `patch_kuadrant_csv()` in `deployment-helpers.sh`, alongside the existing `RATELIMIT_*` env vars. Every MaaS install/deploy now sets a production-safe default automatically via the same CSV-patching mechanism already used for rate limit failure modes and gateway controller names.

### Changes
- **`scripts/deployment-helpers.sh`** -- add `AUTH_SERVICE_TIMEOUT=2s` patch, update pod verification to check the new env var, update log messages
- **`scripts/install-dependencies.sh`** -- update comment to mention auth timeout
- **`docs/content/install/platform-setup.md`** -- note the timeout is now set automatically; manual override instructions preserved for operators who need a different value or have pre-existing clusters

## Long-term

The upstream RHCL/Kuadrant default of 200ms for an auth call involving an external service lookup is too aggressive in general, not just for MaaS. A separate upstream issue should be filed to raise the default in the operator itself.

## Testing

- Verified `patch_kuadrant_csv` calls `patch_csv_operator_container_env` for `AUTH_SERVICE_TIMEOUT` in the same pattern as `RATELIMIT_*`
- Verification block confirms the env var is present in the running operator pod after restart

Resolves: [RHOAIENG-79789](https://redhat.atlassian.net/browse/RHOAIENG-79789)
Related: [PSAP-2733](https://issues.redhat.com/browse/PSAP-2733), [RHOAIENG-71638](https://redhat.atlassian.net/browse/RHOAIENG-71638), [RHOAIENG-71701](https://redhat.atlassian.net/browse/RHOAIENG-71701)

[RHOAIENG-79789]: https://redhat.atlassian.net/browse/RHOAIENG-79789?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the recommended authentication timeout setting for high-concurrency Gateway installations.
  * Added guidance to set the timeout to `2s` to help avoid intermittent `500`/`503` errors during policy checks.

* **Bug Fixes**
  * Updated installation automation to apply the longer authentication timeout by default.
  * Improved validation messages so setup checks now reflect the full required configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->