### PR TITLE
chore: fix flaky tests

### DIFF
--- a/test/e2e/tests/test_per_tenant_ipp_isolation.py
+++ b/test/e2e/tests/test_per_tenant_ipp_isolation.py
@@ -74,6 +74,8 @@ def _request_with_gateway_retry(method, url, retries=GATEWAY_PROPAGATION_RETRIES
             **kwargs,
         )
         retryable = (response.status_code == 403 and not response.text.strip()) or (
+            response.status_code == 403 and "Access denied" in response.text
+        ) or (
             response.status_code == 500 and "AUTH_FAILURE" in response.text
         )
         if retryable and attempt < retries:
@@ -175,7 +177,8 @@ def _post_hybrid_chat(
     model_name: str = MODEL_NAME,
 ) -> requests.Response:
     """Send hybrid BBR: model-specific URL path plus served model name in the body."""
-    return requests.post(
+    return _request_with_gateway_retry(
+        requests.post,
         f"{gateway_url.rstrip('/')}{model_path}/v1/chat/completions",
         headers={
             "Authorization": f"Bearer {api_key}",
@@ -186,8 +189,6 @@ def _post_hybrid_chat(
             "messages": [{"role": "user", "content": "ipp routing test"}],
             "max_tokens": 3,
         },
-        timeout=45,
-        verify=TLS_VERIFY,
     )
 
 

--- a/test/e2e/tests/test_subscription.py
+++ b/test/e2e/tests/test_subscription.py
@@ -2127,7 +2127,7 @@ class TestStatusReporting:
 
             # Create a temporary model
             _create_test_maas_model(model_name, llmis_name=MODEL_REF, namespace=MODEL_NAMESPACE)
-            _wait_reconcile()
+            _wait_for_maas_model_ready(model_name, namespace=MODEL_NAMESPACE)
 
             # Create auth policy and subscription for the model
             _create_test_auth_policy(auth_name, model_name, users=[sa_user])

--- a/test/e2e/tests/test_subscription.py
+++ b/test/e2e/tests/test_subscription.py
@@ -66,6 +66,7 @@ from test_helper import (
     TRLP_TEST_MODEL_REF,                                                                                                                                                              
     TRLP_TEST_MODEL_PATH,
     TRLP_TEST_MODEL_ID,
+    DISTINCT_MODEL_REF,
     UNCONFIGURED_MODEL_PATH,
     UNCONFIGURED_MODEL_REF,
     _apply_cr,
@@ -2125,14 +2126,17 @@ class TestStatusReporting:
             _create_sa_token(sa_name, namespace=MODEL_NAMESPACE)
             sa_user = _sa_to_user(sa_name, namespace=MODEL_NAMESPACE)
 
-            # Create a temporary model
-            _create_test_maas_model(model_name, llmis_name=MODEL_REF, namespace=MODEL_NAMESPACE)
-            _wait_for_maas_model_ready(model_name, namespace=MODEL_NAMESPACE)
+            # Create a temporary model backed by the distinct-tier LLMIS fixture.
+            # Do not reuse MODEL_REF (facebook-opt-125m-simulated): a second MaaSModelRef
+            # for that LLMIS stays Pending because the canonical ref already owns the route.
+            _create_test_maas_model(model_name, llmis_name=DISTINCT_MODEL_REF, namespace=MODEL_NAMESPACE)
 
-            # Create auth policy and subscription for the model
+            # Create auth policy and subscription for the model (governance pairing required
+            # before the MaaSModelRef can reach Ready).
             _create_test_auth_policy(auth_name, model_name, users=[sa_user])
             _create_test_subscription(subscription_name, model_name, users=[sa_user])
 
+            _wait_for_maas_model_ready(model_name, namespace=MODEL_NAMESPACE)
             _wait_for_maas_auth_policy_phase(auth_name)
             _wait_for_maas_subscription_phase(subscription_name)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
chore: fix flaky tests from PR https://github.com/opendatahub-io/models-as-a-service/pull/1333

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gateway request handling by retrying eligible access-denied responses.
  * Updated hybrid chat requests to use consistent gateway retry behavior.
  * Improved subscription status transition reliability by using an independent model setup and waiting for the referenced model to become ready.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->