### PR TITLE
fix: add seccompProfile to tenant API key revocation Job

### DIFF
--- a/maas-controller/pkg/controller/maas/aitenant_controller.go
+++ b/maas-controller/pkg/controller/maas/aitenant_controller.go
@@ -989,6 +989,9 @@ func tenantAPIKeyRevocationJob(aitenant *maasv1alpha1.AITenant, namespace string
 					RestartPolicy:                corev1.RestartPolicyOnFailure,
 					SecurityContext: &corev1.PodSecurityContext{
 						RunAsNonRoot: boolPtr(true),
+						SeccompProfile: &corev1.SeccompProfile{
+							Type: corev1.SeccompProfileTypeRuntimeDefault,
+						},
 					},
 					Volumes: []corev1.Volume{
 						{
@@ -1045,6 +1048,9 @@ func tenantAPIKeyRevocationJob(aitenant *maasv1alpha1.AITenant, namespace string
 								RunAsNonRoot:             boolPtr(true),
 								Capabilities: &corev1.Capabilities{
 									Drop: []corev1.Capability{"ALL"},
+								},
+								SeccompProfile: &corev1.SeccompProfile{
+									Type: corev1.SeccompProfileTypeRuntimeDefault,
 								},
 							},
 						},


### PR DESCRIPTION
## Summary

Add `seccompProfile: {type: RuntimeDefault}` at both pod and container level for the `tenantAPIKeyRevocationJob` created in `aitenant_controller.go`.

This was the only workload in the repo missing the seccomp profile, flagged by Glasswing as **FIND-Missing-Seccomp** (CVSS 2.5, CWE-1188, CIS 5.7.2).

All other deployments (`maas-api`, `maas-controller`, `payload-processing`, `cronjob-cleanup`, `tenancy-proxy`) already have `seccompProfile: RuntimeDefault`.

## Test plan
- [ ] Unit tests pass
- [ ] Verify the revocation Job pod spec includes `seccompProfile` at both levels

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Enhancements**
  * Added default seccomp security profiles to API-key revocation Jobs, strengthening pod and container runtime protection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->