### PR TITLE
fix: prune dead RBAC grants from maas-api ClusterRole

### DIFF
--- a/deployment/base/maas-api/rbac/clusterrole.yaml
+++ b/deployment/base/maas-api/rbac/clusterrole.yaml
@@ -9,17 +9,15 @@ rules:
   resourceNames: ["maas-db-config"]
   verbs: ["get"]
 
-# SA token provider resources
+# Namespace read access
 - apiGroups: [""]
   resources: ["namespaces"]
-  verbs: ["get", "list", "watch", "create"]
+  verbs: ["get", "list", "watch"]
+
+# ServiceAccount read access (informer)
 - apiGroups: [""]
   resources: ["serviceaccounts"]
-  verbs: ["get", "list", "watch", "create", "delete"]
-- apiGroups: [""]
-  # Needed for TokenRequest API
-  resources: ["serviceaccounts/token"]
-  verbs: ["create"]
+  verbs: ["get", "list", "watch"]
 
 # Token review for authentication
 - apiGroups: ["authentication.k8s.io"]
@@ -31,27 +29,19 @@ rules:
   resources: ["subjectaccessreviews"]
   verbs: ["create"]
 
-
 # MaaS CRs for the models endpoint and subscription selector (cached via informer)
 - apiGroups: ["maas.opendatahub.io"]
   resources: ["maasauthpolicies", "maasmodelrefs", "maassubscriptions"]
   verbs: ["get", "list", "watch"]
 
-# HTTPRoutes (for future use, e.g. listing or resolving model routes)
-- apiGroups: ["gateway.networking.k8s.io"]
-  resources: ["httproutes"]
-  verbs: ["get", "list", "watch"]
-
 # Gateways for /v1/tenants endpoint (gateway discovery)
-# Only 'get' needed - code uses .Get(gatewayName) not .List()
-# External hostname comes from Gateway status (status.addresses or listener.hostname)
 - apiGroups: ["gateway.networking.k8s.io"]
   resources: ["gateways"]
   verbs: ["get"]
 
-# Metrics and monitoring
+# Services for gateway internal hostname resolution (ResolveGatewayInternalHost)
 - apiGroups: [""]
-  resources: ["pods", "services", "endpoints"]
+  resources: ["services"]
   verbs: ["get", "list", "watch"]
 
 # OpenShift cluster TLS security profile (for honoring cluster-wide TLS policy)


### PR DESCRIPTION
## Summary

Fixes: [RHOAIENG-69233](https://redhat.atlassian.net/browse/RHOAIENG-69233)

Prune dead cluster-wide RBAC grants from the maas-api ClusterRole flagged by Glasswing EMBARGO-002 (CWE-269, CWE-732).

### Removed (dead — zero production code usage):

| Rule | Change | Verification |
|------|--------|-------------|
| `namespaces` | remove `create` | No `Namespace.Create()` in maas-api codebase |
| `serviceaccounts` | remove `create`, `delete` | Code only reads SAs via informer, never creates/deletes |
| `serviceaccounts/token` | remove entire rule | Dead from pre-opaque-key architecture. `tokenreviews` (kept) is the rule used for auth |
| `httproutes` | remove entire rule | Comment said "for future use" — not implemented |
| `pods`, `endpoints` | remove | Only `services` is used (by `ResolveGatewayInternalHost`) |

### Retained (verified used):

- `secrets` (resourceNames: maas-db-config, get) — `LoadDatabaseURL()`
- `namespaces` (get, list, watch) — informer
- `serviceaccounts` (get, list, watch) — informer
- `tokenreviews` (create) — `tenant_auth_middleware.go:44`
- `subjectaccessreviews` (create) — `sar_admin_checker.go:58`
- `maas CRs` (get, list, watch) — informer cache
- `gateways` (get) — `/v1/tenants` endpoint
- `services` (get, list, watch) — `ResolveGatewayInternalHost`
- `apiservers` (get, list, watch) — TLS profile

### maas-controller ClusterRole — audited, no changes

Per Jamie and Marius: maas-controller needs cluster-wide permissions for multi-namespace reconciliation. `secrets` read is locked by API-server escalation validation (SSA-applying ClusterRoles). `clusterroles/clusterrolebindings` write is used by kustomize SSA and orphan cleanup. Retained with justification.

## Test plan
- [ ] maas-api pod starts without permission errors
- [ ] `/v1/tenants` endpoint works (gateways get + services list)
- [ ] `/v1/models` endpoint works (maas CRs read)
- [ ] Bearer token auth works (tokenreviews create)
- [ ] Admin check works (SAR create)
- [ ] No RBAC denied errors in maas-api logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RHOAIENG-69233]: https://redhat.atlassian.net/browse/RHOAIENG-69233?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ