### PR TITLE
feat(api-keys): add subscription-scoped bulk revoke and dry-run mode

### DIFF
--- a/docs/content/configuration-and-management/api-key-administration.md
+++ b/docs/content/configuration-and-management/api-key-administration.md
@@ -4,7 +4,7 @@ This guide covers administrative operations for managing API keys across the Maa
 
 ## Bulk Key Revocation
 
-Platform administrators can revoke API keys for any user, which is useful for security incidents or offboarding.
+Platform administrators can bulk revoke API keys by **user**, by **subscription**, or both. A **dry-run** mode is available to preview how many keys would be revoked before committing.
 
 ### Revoking All Keys for a User
 
@@ -19,13 +19,89 @@ curl -sS -X POST "${MAAS_API_URL}/maas-api/v1/api-keys/bulk-revoke" \
 
 This updates the status of all API keys belonging to the specified user to `revoked` in the database. The next validation request for any of those keys will reject them. Authorino may cache validation results briefly; revocation is effective as soon as the cache expires.
 
+### Revoking All Keys for a Subscription
+
+Revoke every active API key bound to a specific MaaSSubscription. This is useful when decommissioning a subscription or rotating all credentials for a particular access tier:
+
+```bash
+curl -sS -X POST "${MAAS_API_URL}/maas-api/v1/api-keys/bulk-revoke" \
+  -H "Authorization: Bearer $(oc whoami -t)" \
+  -H "Content-Type: application/json" \
+  -d '{"subscription": "premium-simulator-subscription"}'
+```
+
+### Combined Scope (User + Subscription)
+
+Revoke only a specific user's keys that are bound to a particular subscription:
+
+```bash
+curl -sS -X POST "${MAAS_API_URL}/maas-api/v1/api-keys/bulk-revoke" \
+  -H "Authorization: Bearer $(oc whoami -t)" \
+  -H "Content-Type: application/json" \
+  -d '{"username": "alice", "subscription": "simulator-subscription"}'
+```
+
+### Dry-Run Mode
+
+Preview how many keys would be revoked without actually revoking them. The response returns only the count — no key IDs are exposed. Set `dryRun: true` with any scope (username, subscription, or both).
+
+**Dry-run by subscription:**
+
+```bash
+curl -sS -X POST "${MAAS_API_URL}/maas-api/v1/api-keys/bulk-revoke" \
+  -H "Authorization: Bearer $(oc whoami -t)" \
+  -H "Content-Type: application/json" \
+  -d '{"subscription": "simulator-subscription", "dryRun": true}'
+```
+
+**Dry-run by username:**
+
+```bash
+curl -sS -X POST "${MAAS_API_URL}/maas-api/v1/api-keys/bulk-revoke" \
+  -H "Authorization: Bearer $(oc whoami -t)" \
+  -H "Content-Type: application/json" \
+  -d '{"username": "alice", "dryRun": true}'
+```
+
+**Dry-run with combined scope:**
+
+```bash
+curl -sS -X POST "${MAAS_API_URL}/maas-api/v1/api-keys/bulk-revoke" \
+  -H "Authorization: Bearer $(oc whoami -t)" \
+  -H "Content-Type: application/json" \
+  -d '{"username": "alice", "subscription": "simulator-subscription", "dryRun": true}'
+```
+
+**Response (same structure for all dry-run scopes):**
+
+```json
+{
+  "revokedCount": 12,
+  "message": "Dry run: 12 active key(s) would be revoked for subscription simulator-subscription",
+  "dryRun": true
+}
+```
+
+### Request Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `username` | Optional (at least one of `username` or `subscription` must be provided) | Target user whose keys should be revoked. Regular users can only specify their own username; specifying another user requires admin privileges. |
+| `subscription` | Optional (at least one of `username` or `subscription` must be provided) | MaaSSubscription name whose bound keys should be revoked. Admin-only. |
+| `dryRun` | Optional | When `true`, returns the count of keys that would be revoked without performing any mutation. Default: `false`. |
+
+### Authorization
+
 !!! warning "Administrative privilege required"
-    Only administrators with appropriate permissions can revoke other users' keys. Regular users can only revoke their own keys via `DELETE /v1/api-keys/{id}`.
+    Subscription-scoped and cross-user revocation require admin privileges. Regular users can only revoke their own keys via `DELETE /v1/api-keys/{id}` or bulk revoke with their own username.
 
 ### Use Cases
 
 - **Security incident response**: Immediately cut off access for a compromised account
 - **User offboarding**: Revoke all keys when a user leaves the organization
+- **Subscription decommission**: Revoke all keys bound to a subscription before removing it
+- **Access tier migration**: Revoke keys for an old subscription after migrating users to a new one
+- **Impact assessment**: Use dry-run to preview the blast radius before executing a bulk revoke
 - **Policy enforcement**: Revoke keys that violate usage policies
 
 ---

--- a/docs/content/release-notes/index.md
+++ b/docs/content/release-notes/index.md
@@ -88,6 +88,14 @@ For dependency version requirements (OCP, Kuadrant/RHCL, Gateway API), see [Vers
 - GitHub Actions pinned to immutable commit SHAs.
 - `govulncheck` added for maas-api and maas-controller.
 
+**Bulk API key revocation enhancements**
+
+- Subscription-scoped bulk revoke: administrators can revoke all API keys bound to a specific `MaaSSubscription` in a single call.
+- Combined scope: revoke keys for a specific user within a specific subscription.
+- Dry-run mode (`dryRun: true`): preview how many keys would be revoked without mutating any data.
+- Structured audit records emitted for every actual bulk revoke operation (action, actor, scope, count, tenant).
+- See [API Key Administration](../configuration-and-management/api-key-administration.md) for usage examples.
+
 **Additional features**
 
 - OpenShift cluster TLS profiles honored for gateway and controller TLS configuration.

--- a/docs/content/user-guide/api-key-management.md
+++ b/docs/content/user-guide/api-key-management.md
@@ -263,7 +263,7 @@ curl -sS -X POST "${MAAS_API_URL}/maas-api/v1/api-keys/bulk-revoke" \
 - Rotating all credentials as part of security policy
 
 !!! note "Administrator bulk revocation"
-    Administrators can revoke keys for any user. See [API Key Administration](../configuration-and-management/api-key-administration.md#bulk-key-revocation).
+    Administrators can revoke keys for any user or for an entire subscription. See [API Key Administration](../configuration-and-management/api-key-administration.md#bulk-key-revocation) for subscription-scoped revocation, dry-run mode, and combined user+subscription scope.
 
 ---
 

--- a/maas-api/internal/api_keys/handler.go
+++ b/maas-api/internal/api_keys/handler.go
@@ -606,11 +606,23 @@ func (h *Handler) RevokeTenantAPIKeys(c *gin.Context) {
 }
 
 // BulkRevokeAPIKeys handles POST /v1/api-keys/bulk-revoke
-// Revokes all active API keys for a specific user.
+// Revokes all active API keys matching the scope: by username, subscription, or both.
+// Supports dryRun=true to preview how many keys would be revoked without mutating.
+// Subscription-scoped revocation is admin-only.
 func (h *Handler) BulkRevokeAPIKeys(c *gin.Context) {
 	var req BulkRevokeRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	req.Username = strings.TrimSpace(req.Username)
+	req.Subscription = strings.TrimSpace(req.Subscription)
+
+	if req.Username == "" && req.Subscription == "" {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "at least one of username or subscription is required",
+		})
 		return
 	}
 
@@ -619,8 +631,11 @@ func (h *Handler) BulkRevokeAPIKeys(c *gin.Context) {
 		return
 	}
 
-	// Authorization: users can revoke own keys, admins can revoke any user's keys
-	if req.Username != user.Username {
+	// Authorization rules:
+	// - Subscription-scoped revocation always requires admin
+	// - Username-scoped: users can revoke own keys, admins can revoke any user's keys
+	needsAdmin := req.Subscription != "" || (req.Username != "" && req.Username != user.Username)
+	if needsAdmin {
 		isAdmin, adminErr := h.isAdmin(c.Request.Context(), user)
 		if adminErr != nil {
 			h.logger.Error("Failed to check admin status", "error", adminErr)
@@ -631,20 +646,47 @@ func (h *Handler) BulkRevokeAPIKeys(c *gin.Context) {
 			h.logger.Warn("Unauthorized bulk revoke attempt",
 				"requestingUser", logger.RedactValue(user.Username),
 				"targetUser", logger.RedactValue(req.Username),
+				"targetSubscription", logger.RedactValue(req.Subscription),
 			)
 			c.JSON(http.StatusForbidden, gin.H{
-				"error": "Access denied: you can only bulk revoke your own API keys",
+				"error": "Access denied: admin privileges required for this bulk revoke operation",
 			})
 			return
 		}
 	}
 
+	scopeDesc := h.bulkRevokeScopeDescription(req)
+	logScope := h.bulkRevokeLogScope(req)
+
+	// Dry-run: return count of keys that would be revoked without mutating
+	if req.DryRun {
+		count, err := h.service.BulkRevokeAPIKeys(c.Request.Context(), req.Username, req.Subscription, user.Tenant, true)
+		if err != nil {
+			h.logger.Error("Dry-run bulk revoke failed", "error", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to perform dry-run"})
+			return
+		}
+
+		h.reqLogger(c).Info("Dry-run bulk revoke",
+			"count", count,
+			"scope", logScope,
+			"actor", logger.RedactValue(user.Username),
+		)
+
+		c.JSON(http.StatusOK, BulkRevokeResponse{
+			RevokedCount: count,
+			Message:      fmt.Sprintf("Dry run: %d active key(s) would be revoked for %s", count, scopeDesc),
+			DryRun:       true,
+		})
+		return
+	}
+
 	// Perform bulk revocation (scoped to caller's tenant)
-	count, err := h.service.BulkRevokeAPIKeys(c.Request.Context(), req.Username, user.Tenant)
+	count, err := h.service.BulkRevokeAPIKeys(c.Request.Context(), req.Username, req.Subscription, user.Tenant, false)
 	if err != nil {
 		h.logger.Error("Failed to bulk revoke API keys",
 			"error", err,
-			"targetUser", logger.RedactValue(req.Username),
+			"scope", logScope,
 			"requestingUser", logger.RedactValue(user.Username),
 		)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to revoke API keys"})
@@ -653,14 +695,54 @@ func (h *Handler) BulkRevokeAPIKeys(c *gin.Context) {
 
 	h.reqLogger(c).Info("Bulk revoked API keys",
 		"count", count,
-		"targetUser", logger.RedactValue(req.Username),
+		"scope", logScope,
 		"revokedBy", logger.RedactValue(user.Username),
 	)
 
-	response := BulkRevokeResponse{
-		RevokedCount: count,
-		Message:      fmt.Sprintf("Successfully revoked %d active API key(s) for user %s", count, req.Username),
-	}
+	h.emitBulkRevokeAudit(c, user, req, count)
 
-	c.JSON(http.StatusOK, response)
+	c.JSON(http.StatusOK, BulkRevokeResponse{
+		RevokedCount: count,
+		Message:      fmt.Sprintf("Successfully revoked %d active API key(s) for %s", count, scopeDesc),
+	})
+}
+
+// bulkRevokeScopeDescription returns a human-readable description for HTTP responses.
+func (h *Handler) bulkRevokeScopeDescription(req BulkRevokeRequest) string {
+	switch {
+	case req.Username != "" && req.Subscription != "":
+		return fmt.Sprintf("user %s in subscription %s", req.Username, req.Subscription)
+	case req.Subscription != "":
+		return fmt.Sprintf("subscription %s", req.Subscription)
+	default:
+		return fmt.Sprintf("user %s", req.Username)
+	}
+}
+
+// bulkRevokeLogScope returns a redacted scope description safe for logging (CWE-532).
+func (h *Handler) bulkRevokeLogScope(req BulkRevokeRequest) string {
+	switch {
+	case req.Username != "" && req.Subscription != "":
+		return fmt.Sprintf("user %s in subscription %s", logger.RedactValue(req.Username), logger.RedactValue(req.Subscription))
+	case req.Subscription != "":
+		return fmt.Sprintf("subscription %s", logger.RedactValue(req.Subscription))
+	default:
+		return fmt.Sprintf("user %s", logger.RedactValue(req.Username))
+	}
+}
+
+// emitBulkRevokeAudit writes a structured audit record for actual bulk revoke
+// operations. Not called for dry-runs — dry-runs are read-only previews and
+// should not produce audit records.
+// Fields follow a stable schema so log aggregators (Splunk, ELK, CloudWatch)
+// can index them without custom parsing.
+func (h *Handler) emitBulkRevokeAudit(c *gin.Context, user *token.UserContext, req BulkRevokeRequest, count int) {
+	h.reqLogger(c).Info("AUDIT bulk-revoke",
+		"audit.action", "bulk-revoke",
+		"audit.actor", logger.RedactValue(user.Username),
+		"audit.tenant", user.Tenant,
+		"audit.targetUser", logger.RedactValue(req.Username),
+		"audit.targetSubscription", logger.RedactValue(req.Subscription),
+		"audit.revokedCount", count,
+	)
 }

--- a/maas-api/internal/api_keys/handler_test.go
+++ b/maas-api/internal/api_keys/handler_test.go
@@ -2214,6 +2214,179 @@ func TestBulkRevokeAPIKeys_TenantIsolation(t *testing.T) {
 	assert.Equal(t, StatusActive, key.Status, "tenant-b key 2 should remain active")
 }
 
+func TestBulkRevokeAPIKeys_BySubscription(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	store := NewMockStore()
+	cfg := &config.Config{}
+	service := NewServiceWithLogger(store, cfg, fixedSubSelector{}, logger.Development())
+	handler := NewHandler(logger.Development(), service, newMockAdminChecker(), nil)
+
+	ctx := context.Background()
+
+	require.NoError(t, store.AddKey(ctx, "alice", "sub-a-key-1", "h1", "Key 1", "", nil, "sub-alpha", "test-tenant", nil, false))
+	require.NoError(t, store.AddKey(ctx, "bob", "sub-a-key-2", "h2", "Key 2", "", nil, "sub-alpha", "test-tenant", nil, false))
+	require.NoError(t, store.AddKey(ctx, "alice", "sub-b-key-1", "h3", "Key 3", "", nil, "sub-beta", "test-tenant", nil, false))
+
+	t.Run("AdminCanRevokeBySubscription", func(t *testing.T) {
+		adminUser := &token.UserContext{
+			Username: "admin",
+			Groups:   []string{"admin-users", "system:authenticated"},
+			Tenant:   "test-tenant",
+		}
+
+		body := `{"subscription": "sub-alpha"}`
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest(http.MethodPost, "/v1/api-keys/bulk-revoke", nil)
+		c.Request.Header.Set("Content-Type", "application/json")
+		c.Request.Body = io.NopCloser(strings.NewReader(body))
+		c.Set("user", adminUser)
+
+		//nolint:contextcheck // gin handler receives context via *gin.Context
+		handler.BulkRevokeAPIKeys(c)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		var response BulkRevokeResponse
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		require.NoError(t, err)
+		assert.Equal(t, 2, response.RevokedCount, "should revoke both sub-alpha keys")
+
+		key, err := store.Get(ctx, "sub-b-key-1")
+		require.NoError(t, err)
+		assert.Equal(t, StatusActive, key.Status, "sub-beta key should remain active")
+	})
+
+	t.Run("NonAdminCannotRevokeBySubscription", func(t *testing.T) {
+		regularUser := &token.UserContext{
+			Username: "alice",
+			Groups:   []string{"system:authenticated"},
+			Tenant:   "test-tenant",
+		}
+
+		body := `{"subscription": "sub-beta"}`
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest(http.MethodPost, "/v1/api-keys/bulk-revoke", nil)
+		c.Request.Header.Set("Content-Type", "application/json")
+		c.Request.Body = io.NopCloser(strings.NewReader(body))
+		c.Set("user", regularUser)
+
+		handler.BulkRevokeAPIKeys(c)
+
+		assert.Equal(t, http.StatusForbidden, w.Code)
+	})
+
+	t.Run("AdminCanRevokeByUserAndSubscription", func(t *testing.T) {
+		store2 := NewMockStore()
+		service2 := NewServiceWithLogger(store2, cfg, fixedSubSelector{}, logger.Development())
+		handler2 := NewHandler(logger.Development(), service2, newMockAdminChecker(), nil)
+
+		require.NoError(t, store2.AddKey(ctx, "alice", "combo-1", "ch1", "K1", "", nil, "sub-x", "test-tenant", nil, false))
+		require.NoError(t, store2.AddKey(ctx, "alice", "combo-2", "ch2", "K2", "", nil, "sub-y", "test-tenant", nil, false))
+		require.NoError(t, store2.AddKey(ctx, "bob", "combo-3", "ch3", "K3", "", nil, "sub-x", "test-tenant", nil, false))
+
+		adminUser := &token.UserContext{
+			Username: "admin",
+			Groups:   []string{"admin-users", "system:authenticated"},
+			Tenant:   "test-tenant",
+		}
+
+		body := `{"username": "alice", "subscription": "sub-x"}`
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest(http.MethodPost, "/v1/api-keys/bulk-revoke", nil)
+		c.Request.Header.Set("Content-Type", "application/json")
+		c.Request.Body = io.NopCloser(strings.NewReader(body))
+		c.Set("user", adminUser)
+
+		//nolint:contextcheck // gin handler receives context via *gin.Context
+		handler2.BulkRevokeAPIKeys(c)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		var response BulkRevokeResponse
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		require.NoError(t, err)
+		assert.Equal(t, 1, response.RevokedCount, "should only revoke alice's sub-x key")
+
+		key, _ := store2.Get(ctx, "combo-2")
+		assert.Equal(t, StatusActive, key.Status, "alice sub-y key should remain active")
+		key, _ = store2.Get(ctx, "combo-3")
+		assert.Equal(t, StatusActive, key.Status, "bob sub-x key should remain active")
+	})
+}
+
+func TestBulkRevokeAPIKeys_DryRun(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	store := NewMockStore()
+	cfg := &config.Config{}
+	service := NewServiceWithLogger(store, cfg, fixedSubSelector{}, logger.Development())
+	handler := NewHandler(logger.Development(), service, newMockAdminChecker(), nil)
+
+	ctx := context.Background()
+
+	require.NoError(t, store.AddKey(ctx, "alice", "dr-key-1", "dh1", "DK1", "", nil, "sub-a", "test-tenant", nil, false))
+	require.NoError(t, store.AddKey(ctx, "alice", "dr-key-2", "dh2", "DK2", "", nil, "sub-a", "test-tenant", nil, false))
+	require.NoError(t, store.AddKey(ctx, "alice", "dr-key-3", "dh3", "DK3", "", nil, "sub-b", "test-tenant", nil, false))
+
+	t.Run("DryRunDoesNotMutate", func(t *testing.T) {
+		adminUser := &token.UserContext{
+			Username: "admin",
+			Groups:   []string{"admin-users", "system:authenticated"},
+			Tenant:   "test-tenant",
+		}
+
+		body := `{"username": "alice", "dryRun": true}`
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest(http.MethodPost, "/v1/api-keys/bulk-revoke", nil)
+		c.Request.Header.Set("Content-Type", "application/json")
+		c.Request.Body = io.NopCloser(strings.NewReader(body))
+		c.Set("user", adminUser)
+
+		//nolint:contextcheck // gin handler receives context via *gin.Context
+		handler.BulkRevokeAPIKeys(c)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		var response BulkRevokeResponse
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		require.NoError(t, err)
+		assert.Equal(t, 3, response.RevokedCount, "dry run should report 3 keys")
+		assert.True(t, response.DryRun, "should indicate dry run")
+
+		// Verify keys are still active
+		for _, id := range []string{"dr-key-1", "dr-key-2", "dr-key-3"} {
+			key, err := store.Get(ctx, id)
+			require.NoError(t, err)
+			assert.Equal(t, StatusActive, key.Status, "key %s should remain active after dry run", id)
+		}
+	})
+
+	t.Run("DryRunBySubscription", func(t *testing.T) {
+		adminUser := &token.UserContext{
+			Username: "admin",
+			Groups:   []string{"admin-users", "system:authenticated"},
+			Tenant:   "test-tenant",
+		}
+
+		body := `{"subscription": "sub-a", "dryRun": true}`
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest(http.MethodPost, "/v1/api-keys/bulk-revoke", nil)
+		c.Request.Header.Set("Content-Type", "application/json")
+		c.Request.Body = io.NopCloser(strings.NewReader(body))
+		c.Set("user", adminUser)
+
+		handler.BulkRevokeAPIKeys(c)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		var response BulkRevokeResponse
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		require.NoError(t, err)
+		assert.Equal(t, 2, response.RevokedCount, "dry run should find 2 sub-a keys")
+		assert.True(t, response.DryRun)
+	})
+}
+
 // TestSearchAPIKeys_AdminCrossTenantIsolation verifies that admin privileges
 // do not bypass tenant isolation — an admin from tenant-B cannot see keys in tenant-A.
 func TestSearchAPIKeys_AdminCrossTenantIsolation(t *testing.T) {

--- a/maas-api/internal/api_keys/service.go
+++ b/maas-api/internal/api_keys/service.go
@@ -342,13 +342,14 @@ func (s *Service) Search(
 	return s.store.Search(ctx, username, tenant, filters, sort, pagination)
 }
 
-// BulkRevokeAPIKeys revokes all active keys for a user
-// Returns count of revoked keys.
-func (s *Service) BulkRevokeAPIKeys(ctx context.Context, username string, tenant string) (int, error) {
-	if username == "" {
-		return 0, errors.New("username is required")
+// BulkRevokeAPIKeys revokes all active keys matching the scope (username and/or subscription),
+// or performs a dry-run count when dryRun is true.
+// At least one of username or subscription must be provided.
+func (s *Service) BulkRevokeAPIKeys(ctx context.Context, username, subscription, tenant string, dryRun bool) (int, error) {
+	if username == "" && subscription == "" {
+		return 0, errors.New("at least one of username or subscription is required")
 	}
-	return s.store.InvalidateAll(ctx, username, tenant)
+	return s.store.BulkRevoke(ctx, username, subscription, tenant, dryRun)
 }
 
 // RevokeTenantAPIKeys revokes all active keys for a tenant.

--- a/maas-api/internal/api_keys/service_test.go
+++ b/maas-api/internal/api_keys/service_test.go
@@ -415,7 +415,7 @@ func TestBulkRevokeAPIKeys_TenantScopedCount(t *testing.T) {
 	}
 
 	// Bulk revoke only tenant-a keys
-	count, err := svc.BulkRevokeAPIKeys(ctx, "alice", "tenant-a")
+	count, err := svc.BulkRevokeAPIKeys(ctx, "alice", "", "tenant-a", false)
 	require.NoError(t, err)
 	assert.Equal(t, 3, count, "should revoke exactly the 3 keys in tenant-a")
 
@@ -632,7 +632,7 @@ func TestBulkRevokeAPIKeys(t *testing.T) {
 			require.NoError(t, store.AddKey(ctx, "alice", id, hash, "Key "+id, "", nil, "default-sub", "", nil, false))
 		}
 
-		count, err := svc.BulkRevokeAPIKeys(ctx, "alice", "")
+		count, err := svc.BulkRevokeAPIKeys(ctx, "alice", "", "", false)
 		require.NoError(t, err)
 		assert.Equal(t, 3, count)
 
@@ -650,7 +650,7 @@ func TestBulkRevokeAPIKeys(t *testing.T) {
 		ctx := context.Background()
 		svc, _ := createTestService(t)
 
-		count, err := svc.BulkRevokeAPIKeys(ctx, "nobody", "")
+		count, err := svc.BulkRevokeAPIKeys(ctx, "nobody", "", "", false)
 		require.NoError(t, err)
 		assert.Equal(t, 0, count)
 	})
@@ -664,24 +664,24 @@ func TestBulkRevokeAPIKeys(t *testing.T) {
 		_, hash := createTestAPIKey(t)
 		require.NoError(t, store.AddKey(ctx, "bob", "idem-key", hash, "Idempotent Key", "", nil, "default-sub", "", nil, false))
 
-		count, err := svc.BulkRevokeAPIKeys(ctx, "bob", "")
+		count, err := svc.BulkRevokeAPIKeys(ctx, "bob", "", "", false)
 		require.NoError(t, err)
 		assert.Equal(t, 1, count)
 
 		// Second call: no active keys left
-		count, err = svc.BulkRevokeAPIKeys(ctx, "bob", "")
+		count, err = svc.BulkRevokeAPIKeys(ctx, "bob", "", "", false)
 		require.NoError(t, err)
 		assert.Equal(t, 0, count)
 	})
 
-	// Verify that empty username is rejected with an error.
-	t.Run("EmptyUsername", func(t *testing.T) {
+	// Verify that empty username and subscription is rejected with an error.
+	t.Run("EmptyUsernameAndSubscription", func(t *testing.T) {
 		ctx := context.Background()
 		svc, _ := createTestService(t)
 
-		_, err := svc.BulkRevokeAPIKeys(ctx, "", "")
+		_, err := svc.BulkRevokeAPIKeys(ctx, "", "", "", false)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "username is required")
+		assert.Contains(t, err.Error(), "at least one of username or subscription is required")
 	})
 }
 
@@ -701,7 +701,7 @@ func TestBulkRevokeAPIKeys_ThenValidateAll(t *testing.T) {
 	}
 
 	// Bulk revoke all of carol's keys
-	count, err := svc.BulkRevokeAPIKeys(ctx, "carol", "")
+	count, err := svc.BulkRevokeAPIKeys(ctx, "carol", "", "", false)
 	require.NoError(t, err)
 	assert.Equal(t, 3, count)
 

--- a/maas-api/internal/api_keys/store_interface.go
+++ b/maas-api/internal/api_keys/store_interface.go
@@ -70,9 +70,13 @@ type MetadataStore interface {
 	// Returns ErrKeyNotFound if key doesn't exist, ErrInvalidKey if revoked or expired.
 	GetByHash(ctx context.Context, keyHash string) (*ApiKey, error)
 
-	// InvalidateAll marks all active tokens for a user within a tenant as revoked.
-	// Returns the count of keys that were revoked.
-	InvalidateAll(ctx context.Context, username string, tenant string) (int, error)
+	// BulkRevoke handles both actual revocation and dry-run counting in a single
+	// method. When dryRun is false, it marks all active, non-expired keys matching
+	// the scope as revoked in a single atomic UPDATE and returns the revoked count.
+	// When dryRun is true, it returns the count of keys that would be revoked
+	// without mutating any data. At least one of username or subscription must be
+	// non-empty.
+	BulkRevoke(ctx context.Context, username, subscription, tenant string, dryRun bool) (int, error)
 
 	// InvalidateTenant marks all active tokens within a tenant as revoked.
 	// Returns the count of keys that were revoked.

--- a/maas-api/internal/api_keys/store_mock.go
+++ b/maas-api/internal/api_keys/store_mock.go
@@ -429,18 +429,53 @@ func (m *MockStore) GetByHash(ctx context.Context, keyHash string) (*ApiKey, err
 	return nil, ErrKeyNotFound
 }
 
-func (m *MockStore) InvalidateAll(ctx context.Context, username string, tenant string) (int, error) {
+// bulkRevokeMatch returns true if the key matches the bulk revoke scope.
+// Keys with a past expiresAt are treated as expired even when the persisted
+// status is still "active", consistent with the Get/Search auto-expire logic.
+func bulkRevokeMatch(k *storedKey, username, subscription, tenant string) bool {
+	if k.metadata.Status != StatusActive || k.metadata.Tenant != tenant {
+		return false
+	}
+	if !k.expiresAt.IsZero() && k.expiresAt.Before(time.Now().UTC()) {
+		return false
+	}
+	if username != "" && k.username != username {
+		return false
+	}
+	if subscription != "" && k.metadata.Subscription != subscription {
+		return false
+	}
+	return true
+}
+
+func (m *MockStore) BulkRevoke(ctx context.Context, username, subscription, tenant string, dryRun bool) (int, error) {
+	if username == "" && subscription == "" {
+		return 0, errors.New("at least one of username or subscription is required")
+	}
+
+	if dryRun {
+		m.mu.RLock()
+		defer m.mu.RUnlock()
+
+		count := 0
+		for _, k := range m.keys {
+			if bulkRevokeMatch(k, username, subscription, tenant) {
+				count++
+			}
+		}
+		return count, nil
+	}
+
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	count := 0
 	for _, k := range m.keys {
-		if k.username == username && k.metadata.Tenant == tenant && k.metadata.Status == StatusActive {
+		if bulkRevokeMatch(k, username, subscription, tenant) {
 			k.metadata.Status = StatusRevoked
 			count++
 		}
 	}
-
 	return count, nil
 }
 

--- a/maas-api/internal/api_keys/store_postgres.go
+++ b/maas-api/internal/api_keys/store_postgres.go
@@ -447,15 +447,58 @@ func (s *PostgresStore) GetByHash(ctx context.Context, keyHash string) (*ApiKey,
 	return &k, nil
 }
 
-// InvalidateAll revokes all active keys for a user within this tenant.
-// Returns the count of keys that were revoked.
-func (s *PostgresStore) InvalidateAll(ctx context.Context, username string, tenant string) (int, error) {
-	// Use store's tenant for isolation (tenant parameter is for backward compatibility)
-	query := `UPDATE api_keys SET status = 'revoked' WHERE username = $1 AND tenant = $2 AND status = 'active'`
+// bulkRevokeWhereClause builds a parameterized WHERE clause for bulk revoke
+// operations. It dynamically adds username and/or subscription filters alongside
+// the mandatory tenant and status=active predicates.
+func (s *PostgresStore) bulkRevokeWhereClause(username, subscription string) (string, []any) {
+	conditions := []string{"tenant = $1", "status = 'active'", "(expires_at IS NULL OR expires_at > NOW())"}
+	args := []any{s.tenantName}
+	paramIdx := 2
 
-	result, err := s.db.ExecContext(ctx, query, username, s.tenantName)
+	if username != "" {
+		conditions = append(conditions, fmt.Sprintf("username = $%d", paramIdx))
+		args = append(args, username)
+		paramIdx++
+	}
+	if subscription != "" {
+		conditions = append(conditions, fmt.Sprintf("subscription = $%d", paramIdx))
+		args = append(args, subscription)
+	}
+
+	return strings.Join(conditions, " AND "), args
+}
+
+// BulkRevoke handles both actual revocation and dry-run counting. When dryRun
+// is false, it marks all active, non-expired keys matching the scope as revoked
+// in a single atomic UPDATE and returns the affected count. When dryRun is true,
+// it returns the count without mutating any data.
+func (s *PostgresStore) BulkRevoke(ctx context.Context, username, subscription, tenant string, dryRun bool) (int, error) {
+	if username == "" && subscription == "" {
+		return 0, errors.New("at least one of username or subscription is required")
+	}
+	if tenant != s.tenantName {
+		return 0, fmt.Errorf("%w: attempted to revoke keys for tenant %q but store is scoped to %q", ErrTenantMismatch, tenant, s.tenantName)
+	}
+
+	where, args := s.bulkRevokeWhereClause(username, subscription)
+
+	if dryRun {
+		//nolint:gosec // where clause uses static column names with parameterized $N placeholders
+		query := fmt.Sprintf("SELECT COUNT(*) FROM api_keys WHERE %s", where)
+
+		var count int
+		if err := s.db.QueryRowContext(ctx, query, args...).Scan(&count); err != nil {
+			return 0, fmt.Errorf("dry-run count query failed: %w", err)
+		}
+		return count, nil
+	}
+
+	//nolint:gosec // where clause uses static column names with parameterized $N placeholders
+	query := fmt.Sprintf("UPDATE api_keys SET status = 'revoked' WHERE %s", where)
+
+	result, err := s.db.ExecContext(ctx, query, args...)
 	if err != nil {
-		return 0, fmt.Errorf("failed to revoke keys: %w", err)
+		return 0, fmt.Errorf("failed to bulk revoke keys: %w", err)
 	}
 
 	rows, err := result.RowsAffected()
@@ -464,7 +507,11 @@ func (s *PostgresStore) InvalidateAll(ctx context.Context, username string, tena
 	}
 
 	count := int(rows)
-	s.logger.Info("Revoked all keys for user", "count", count, "user", logger.RedactValue(username))
+	s.logger.Info("Bulk revoked keys",
+		"count", count,
+		"user", logger.RedactValue(username),
+		"subscription", logger.RedactValue(subscription),
+	)
 	return count, nil
 }
 

--- a/maas-api/internal/api_keys/store_test.go
+++ b/maas-api/internal/api_keys/store_test.go
@@ -3,6 +3,7 @@ package api_keys_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -130,17 +131,15 @@ func TestAPIKeyOperations(t *testing.T) {
 	})
 }
 
-// TestInvalidateAll tests bulk revocation of all active keys for a given user.
-// InvalidateAll revokes all keys with status='active' for a username and returns the count.
-func TestInvalidateAll(t *testing.T) {
+// TestBulkRevoke tests bulk revocation of all active keys for a given scope.
+// BulkRevoke revokes all keys with status='active' matching the username and/or
+// subscription filter and returns the count.
+func TestBulkRevoke(t *testing.T) {
 	ctx := t.Context()
 	store := createTestStore(t)
 	defer store.Close()
 
-	// Verify that InvalidateAll revokes all active keys for the target user
-	// while leaving other users' keys untouched.
 	t.Run("BasicHappyPath", func(t *testing.T) {
-		// Add 3 keys for alice, 2 for bob
 		for i := range 3 {
 			id := "alice-key-" + string(rune('a'+i))
 			require.NoError(t, store.AddKey(ctx, "alice", id, "ahash"+id, "key-"+id, "", nil, "sub-1", "", nil, false))
@@ -150,11 +149,10 @@ func TestInvalidateAll(t *testing.T) {
 			require.NoError(t, store.AddKey(ctx, "bob", id, "bhash"+id, "key-"+id, "", nil, "sub-1", "", nil, false))
 		}
 
-		count, err := store.InvalidateAll(ctx, "alice", "")
+		count, err := store.BulkRevoke(ctx, "alice", "", "", false)
 		require.NoError(t, err)
 		assert.Equal(t, 3, count)
 
-		// Verify all of alice's keys are now revoked
 		for i := range 3 {
 			id := "alice-key-" + string(rune('a'+i))
 			key, err := store.Get(ctx, id)
@@ -162,7 +160,6 @@ func TestInvalidateAll(t *testing.T) {
 			assert.Equal(t, api_keys.StatusRevoked, key.Status, "alice's key %s should be revoked", id)
 		}
 
-		// Verify bob's keys are completely unaffected
 		for i := range 2 {
 			id := "bob-key-" + string(rune('a'+i))
 			key, err := store.Get(ctx, id)
@@ -171,15 +168,12 @@ func TestInvalidateAll(t *testing.T) {
 		}
 	})
 
-	// Verify that InvalidateAll for a user with no keys returns count=0 and no error.
 	t.Run("NoKeysForUser", func(t *testing.T) {
-		count, err := store.InvalidateAll(ctx, "nobody", "")
+		count, err := store.BulkRevoke(ctx, "nobody", "", "", false)
 		require.NoError(t, err)
 		assert.Equal(t, 0, count)
 	})
 
-	// Verify that InvalidateAll only counts keys transitioning from active to revoked.
-	// Pre-revoked keys should not be counted again.
 	t.Run("MixedStatuses", func(t *testing.T) {
 		s := createTestStore(t)
 		defer s.Close()
@@ -188,31 +182,60 @@ func TestInvalidateAll(t *testing.T) {
 		require.NoError(t, s.AddKey(ctx, "carol", "c2", "ch2", "k2", "", nil, "sub-1", "", nil, false))
 		require.NoError(t, s.AddKey(ctx, "carol", "c3", "ch3", "k3", "", nil, "sub-1", "", nil, false))
 
-		// Revoke one key manually first
 		require.NoError(t, s.Revoke(ctx, "c3"))
 
-		// InvalidateAll should only revoke the 2 remaining active keys
-		count, err := s.InvalidateAll(ctx, "carol", "")
+		count, err := s.BulkRevoke(ctx, "carol", "", "", false)
 		require.NoError(t, err)
 		assert.Equal(t, 2, count, "should only revoke active keys, not already-revoked ones")
 	})
 
-	// Verify that calling InvalidateAll twice is idempotent:
-	// the second call finds no active keys and returns count=0.
 	t.Run("IdempotentSecondCall", func(t *testing.T) {
 		s := createTestStore(t)
 		defer s.Close()
 
 		require.NoError(t, s.AddKey(ctx, "dan", "d1", "dh1", "k1", "", nil, "sub-1", "", nil, false))
 
-		count, err := s.InvalidateAll(ctx, "dan", "")
+		count, err := s.BulkRevoke(ctx, "dan", "", "", false)
 		require.NoError(t, err)
 		assert.Equal(t, 1, count)
 
-		// Second call should be a no-op
-		count, err = s.InvalidateAll(ctx, "dan", "")
+		count, err = s.BulkRevoke(ctx, "dan", "", "", false)
 		require.NoError(t, err)
 		assert.Equal(t, 0, count, "second call should find no active keys")
+	})
+
+	t.Run("BySubscription", func(t *testing.T) {
+		s := createTestStore(t)
+		defer s.Close()
+
+		require.NoError(t, s.AddKey(ctx, "alice", "sa-1", "sah1", "k1", "", nil, "sub-alpha", "", nil, false))
+		require.NoError(t, s.AddKey(ctx, "bob", "sa-2", "sah2", "k2", "", nil, "sub-alpha", "", nil, false))
+		require.NoError(t, s.AddKey(ctx, "alice", "sb-1", "sbh1", "k3", "", nil, "sub-beta", "", nil, false))
+
+		count, err := s.BulkRevoke(ctx, "", "sub-alpha", "", false)
+		require.NoError(t, err)
+		assert.Equal(t, 2, count)
+
+		key, _ := s.Get(ctx, "sb-1")
+		assert.Equal(t, api_keys.StatusActive, key.Status, "sub-beta key should remain active")
+	})
+
+	t.Run("ByUsernameAndSubscription", func(t *testing.T) {
+		s := createTestStore(t)
+		defer s.Close()
+
+		require.NoError(t, s.AddKey(ctx, "alice", "us-1", "ush1", "k1", "", nil, "sub-x", "", nil, false))
+		require.NoError(t, s.AddKey(ctx, "alice", "us-2", "ush2", "k2", "", nil, "sub-y", "", nil, false))
+		require.NoError(t, s.AddKey(ctx, "bob", "us-3", "ush3", "k3", "", nil, "sub-x", "", nil, false))
+
+		count, err := s.BulkRevoke(ctx, "alice", "sub-x", "", false)
+		require.NoError(t, err)
+		assert.Equal(t, 1, count)
+
+		key, _ := s.Get(ctx, "us-2")
+		assert.Equal(t, api_keys.StatusActive, key.Status, "alice sub-y key should remain active")
+		key, _ = s.Get(ctx, "us-3")
+		assert.Equal(t, api_keys.StatusActive, key.Status, "bob sub-x key should remain active")
 	})
 }
 
@@ -287,38 +310,68 @@ func TestSearchByTenant(t *testing.T) {
 	})
 }
 
-// TestInvalidateAll_TenantScoped verifies that InvalidateAll only revokes keys
+// TestBulkRevoke_TenantScoped verifies that BulkRevoke only revokes keys
 // within the specified tenant, leaving keys in other tenants active.
-func TestInvalidateAll_TenantScoped(t *testing.T) {
+func TestBulkRevoke_TenantScoped(t *testing.T) {
 	ctx := t.Context()
 	store := createTestStore(t)
 	defer store.Close()
 
-	// Add 2 keys for alice in tenant-a
 	require.NoError(t, store.AddKey(ctx, "alice", "ta-1", "tah1", "key-ta1", "", nil, "sub-1", "tenant-a", nil, false))
 	require.NoError(t, store.AddKey(ctx, "alice", "ta-2", "tah2", "key-ta2", "", nil, "sub-1", "tenant-a", nil, false))
-	// Add 2 keys for alice in tenant-b
 	require.NoError(t, store.AddKey(ctx, "alice", "tb-1", "tbh1", "key-tb1", "", nil, "sub-1", "tenant-b", nil, false))
 	require.NoError(t, store.AddKey(ctx, "alice", "tb-2", "tbh2", "key-tb2", "", nil, "sub-1", "tenant-b", nil, false))
 
-	// Invalidate only tenant-a keys
-	count, err := store.InvalidateAll(ctx, "alice", "tenant-a")
+	count, err := store.BulkRevoke(ctx, "alice", "", "tenant-a", false)
 	require.NoError(t, err)
 	assert.Equal(t, 2, count)
 
-	// Verify tenant-a keys are revoked
 	for _, id := range []string{"ta-1", "ta-2"} {
 		key, err := store.Get(ctx, id)
 		require.NoError(t, err)
 		assert.Equal(t, api_keys.StatusRevoked, key.Status, "tenant-a key %s should be revoked", id)
 	}
 
-	// Verify tenant-b keys are still active
 	for _, id := range []string{"tb-1", "tb-2"} {
 		key, err := store.Get(ctx, id)
 		require.NoError(t, err)
 		assert.Equal(t, api_keys.StatusActive, key.Status, "tenant-b key %s should remain active", id)
 	}
+}
+
+func TestBulkRevoke_ExcludesExpiredKeys(t *testing.T) {
+	ctx := t.Context()
+	store := createTestStore(t)
+	defer store.Close()
+
+	pastExpiry := time.Now().Add(-time.Hour)
+	futureExpiry := time.Now().Add(24 * time.Hour)
+
+	require.NoError(t, store.AddKey(ctx, "alice", "active-1", "ah1", "key-a1", "", nil, "sub-1", "tenant-a", &futureExpiry, false))
+	require.NoError(t, store.AddKey(ctx, "alice", "expired-1", "ah2", "key-a2", "", nil, "sub-1", "tenant-a", &pastExpiry, false))
+	require.NoError(t, store.AddKey(ctx, "alice", "permanent-1", "ah3", "key-a3", "", nil, "sub-1", "tenant-a", nil, false))
+
+	count, err := store.BulkRevoke(ctx, "alice", "", "tenant-a", true)
+	require.NoError(t, err)
+	assert.Equal(t, 2, count, "dry-run should count only active+permanent, not expired")
+
+	count, err = store.BulkRevoke(ctx, "alice", "", "tenant-a", false)
+	require.NoError(t, err)
+	assert.Equal(t, 2, count, "should revoke only active+permanent, not expired")
+}
+
+func TestBulkRevoke_EmptyScopeRejected(t *testing.T) {
+	ctx := t.Context()
+	store := createTestStore(t)
+	defer store.Close()
+
+	_, err := store.BulkRevoke(ctx, "", "", "tenant-a", false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "at least one of username or subscription is required")
+
+	_, err = store.BulkRevoke(ctx, "", "", "tenant-a", true)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "at least one of username or subscription is required")
 }
 
 func TestInvalidateTenant(t *testing.T) {

--- a/maas-api/internal/api_keys/types.go
+++ b/maas-api/internal/api_keys/types.go
@@ -147,14 +147,18 @@ type SearchAPIKeysResponse struct {
 // ============================================================
 
 // BulkRevokeRequest for POST /v1/api-keys/bulk-revoke.
+// At least one of Username or Subscription must be provided.
 type BulkRevokeRequest struct {
-	Username string `binding:"required" json:"username"`
+	Username     string `json:"username,omitempty"`
+	Subscription string `json:"subscription,omitempty"`
+	DryRun       bool   `json:"dryRun,omitempty"`
 }
 
 // BulkRevokeResponse returns count of revoked keys.
 type BulkRevokeResponse struct {
 	RevokedCount int    `json:"revokedCount"`
 	Message      string `json:"message"`
+	DryRun       bool   `json:"dryRun,omitempty"`
 }
 
 // TenantRevokeResponse returns count of revoked keys for tenant-wide cleanup.

--- a/maas-api/openapi3.yaml
+++ b/maas-api/openapi3.yaml
@@ -406,8 +406,18 @@ paths:
         post:
             tags:
                 - api-keys-v2
-            summary: Bulk revoke API keys for a user
-            description: Revokes all active API keys for a specific user. Regular users can only bulk revoke their own keys. Admins can bulk revoke any user's keys.
+            summary: Bulk revoke API keys by user and/or subscription
+            description: |
+                Revokes all active API keys matching the specified scope. At least one of
+                `username` or `subscription` must be provided.
+
+                **Authorization rules:**
+                - Regular users can bulk revoke their own keys (username = self).
+                - Subscription-scoped revocation requires admin privileges.
+                - Cross-user revocation requires admin privileges.
+
+                When `dryRun` is true, the response includes the count of keys that
+                would be revoked without performing any mutation.
             operationId: api-keys-v2#bulk-revoke
             requestBody:
                 required: true
@@ -415,21 +425,39 @@ paths:
                     application/json:
                         schema:
                             type: object
-                            required:
-                                - username
+                            anyOf:
+                                - required: [username]
+                                - required: [subscription]
                             properties:
                                 username:
                                     type: string
-                                    description: Username whose keys should be revoked
+                                    description: Username whose keys should be revoked.
+                                subscription:
+                                    type: string
+                                    description: Subscription name whose bound keys should be revoked. Admin-only.
+                                dryRun:
+                                    type: boolean
+                                    default: false
+                                    description: When true, returns the count of keys that would be revoked without performing any mutation.
                         examples:
                             revoke_own:
                                 summary: User revoking own keys
                                 value:
                                     username: "alice"
-                            admin_revoke:
-                                summary: Admin revoking user's keys
+                            admin_revoke_by_subscription:
+                                summary: Admin revoking all keys for a subscription
+                                value:
+                                    subscription: "premium-simulator-subscription"
+                            dry_run:
+                                summary: Dry-run preview (no mutation)
+                                value:
+                                    username: "alice"
+                                    dryRun: true
+                            combined_scope:
+                                summary: Admin revoking a user's keys in a specific subscription
                                 value:
                                     username: "bob"
+                                    subscription: "simulator-subscription"
             responses:
                 "200":
                     description: OK response.
@@ -440,15 +468,27 @@ paths:
                                 properties:
                                     revokedCount:
                                         type: integer
-                                        description: Number of keys that were revoked
+                                        description: Number of keys revoked (or that would be revoked in dry-run).
                                     message:
                                         type: string
-                                        description: Success message
-                            example:
-                                revokedCount: 5
-                                message: "Successfully revoked 5 active API key(s) for user alice"
+                                        description: Human-readable result message.
+                                    dryRun:
+                                        type: boolean
+                                        description: True when the request was a dry-run (no keys were mutated).
+                            examples:
+                                revoke_result:
+                                    summary: Successful revocation
+                                    value:
+                                        revokedCount: 5
+                                        message: "Successfully revoked 5 active API key(s) for user alice"
+                                dry_run_result:
+                                    summary: Dry-run result
+                                    value:
+                                        revokedCount: 3
+                                        message: "Dry run: 3 active key(s) would be revoked for subscription premium-simulator-subscription"
+                                        dryRun: true
                 "400":
-                    description: Bad Request. Invalid request.
+                    description: Bad Request. At least one of username or subscription is required.
                     content:
                         application/json:
                             schema:
@@ -456,15 +496,11 @@ paths:
                 "401":
                     description: Unauthorized response.
                 "403":
-                    description: Forbidden. User trying to revoke another user's keys.
+                    description: Forbidden. Admin privileges required for subscription-scoped or cross-user revocation.
                     content:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/ErrorResponse'
-                            example:
-                                error:
-                                    message: "Access denied: you can only bulk revoke your own API keys"
-                                    type: forbidden
     /v1/api-keys/config:
         get:
             tags:

--- a/test/e2e/tests/test_api_keys.py
+++ b/test/e2e/tests/test_api_keys.py
@@ -303,8 +303,8 @@ class TestAPIKeyBulkOperations:
         # Verify keys are revoked
         for key_id in key_ids:
             r_check = requests.get(f"{api_keys_base_url}/{key_id}", headers=headers, timeout=30, verify=TLS_VERIFY)
-            if r_check.status_code == 200:
-                assert r_check.json().get("status") == "revoked"
+            assert r_check.status_code == 200, f"Failed to fetch key {key_id}: {r_check.status_code}"
+            assert r_check.json().get("status") == "revoked"
 
     def test_bulk_revoke_other_user_forbidden(self, api_keys_base_url: str, headers: dict):
         """Test 9: Bulk revoke - non-admin cannot bulk revoke other user's keys."""
@@ -346,6 +346,263 @@ class TestAPIKeyBulkOperations:
         data = r_bulk.json()
         assert data.get("revokedCount") >= 1
         print(f"[bulk-revoke] Admin successfully revoked {data.get('revokedCount')} keys for user {username}")
+
+    def test_bulk_revoke_by_subscription(self, api_keys_base_url: str, headers: dict, admin_headers: dict):
+        """Admin can bulk revoke all keys bound to a subscription."""
+        if not admin_headers:
+            pytest.skip("ADMIN_OC_TOKEN not set")
+
+        sub_name = f"e2e-bulk-sub-{os.urandom(4).hex()}"
+        ns = _ns()
+        sa_name = f"e2e-bulk-sa-{os.urandom(4).hex()}"
+
+        key_ids = []
+        try:
+            oc_token = _create_sa_token(sa_name, namespace=MODEL_NAMESPACE)
+            sa_user = _sa_to_user(sa_name, namespace=MODEL_NAMESPACE)
+            sa_headers = {"Authorization": f"Bearer {oc_token}", "Content-Type": "application/json"}
+
+            _create_test_auth_policy(f"{sub_name}-auth", MODEL_REF, users=[sa_user])
+            _create_test_subscription(sub_name, MODEL_REF, users=[sa_user])
+            _wait_for_maas_subscription_phase(sub_name, namespace=ns)
+
+            for i in range(3):
+                r = _request_with_gateway_retry(
+                    requests.post,
+                    api_keys_base_url, headers=sa_headers,
+                    json={"name": f"sub-bulk-{i}", "subscription": sub_name},
+                    timeout=TIMEOUT, verify=TLS_VERIFY,
+                )
+                assert r.status_code in (200, 201), f"Failed to create key: {r.text}"
+                key_ids.append(r.json()["id"])
+
+            r_bulk = requests.post(
+                f"{api_keys_base_url}/bulk-revoke",
+                headers=admin_headers,
+                json={"subscription": sub_name},
+                timeout=30, verify=TLS_VERIFY,
+            )
+            assert r_bulk.status_code == 200
+            data = r_bulk.json()
+            assert data["revokedCount"] == 3, (
+                f"Expected exactly 3 revoked, got {data.get('revokedCount')}"
+            )
+            print(f"[bulk-revoke] Admin revoked {data['revokedCount']} keys for subscription {sub_name}")
+
+            for key_id in key_ids:
+                r_check = requests.get(f"{api_keys_base_url}/{key_id}", headers=admin_headers, timeout=30, verify=TLS_VERIFY)
+                assert r_check.status_code == 200, f"Failed to fetch key {key_id}: {r_check.status_code}"
+                assert r_check.json().get("status") == "revoked"
+
+        finally:
+            for kid in key_ids:
+                requests.delete(f"{api_keys_base_url}/{kid}", headers=sa_headers, timeout=TIMEOUT, verify=TLS_VERIFY)
+            _delete_cr("maassubscription", sub_name, namespace=ns)
+            _delete_cr("maasauthpolicy", f"{sub_name}-auth", namespace=ns)
+            _delete_sa(sa_name, namespace=MODEL_NAMESPACE)
+            _wait_for_gateway_auth_enforced()
+
+    def test_bulk_revoke_by_subscription_forbidden_for_non_admin(self, api_keys_base_url: str, headers: dict):
+        """Non-admin cannot bulk revoke by subscription (requires admin)."""
+        r_bulk = requests.post(
+            f"{api_keys_base_url}/bulk-revoke",
+            headers=headers,
+            json={"subscription": SIMULATOR_SUBSCRIPTION},
+            timeout=30,
+            verify=TLS_VERIFY,
+        )
+        assert r_bulk.status_code == 403, (
+            f"Expected 403 for non-admin subscription revoke, got {r_bulk.status_code}: {r_bulk.text}"
+        )
+        print("[bulk-revoke] Non-admin correctly got 403 for subscription-scoped revoke")
+
+    def test_bulk_revoke_dry_run(self, api_keys_base_url: str, headers: dict):
+        """Dry-run returns count without actually revoking."""
+        key_ids = []
+        for i in range(2):
+            r = requests.post(
+                api_keys_base_url, headers=headers,
+                json={"name": f"dry-run-{i}"},
+                timeout=30, verify=TLS_VERIFY,
+            )
+            assert r.status_code in (200, 201)
+            key_ids.append(r.json()["id"])
+
+        r_get = requests.get(f"{api_keys_base_url}/{key_ids[0]}", headers=headers, timeout=30, verify=TLS_VERIFY)
+        username = r_get.json().get("username") or r_get.json().get("owner")
+        assert username
+
+        r_dry = requests.post(
+            f"{api_keys_base_url}/bulk-revoke",
+            headers=headers,
+            json={"username": username, "dryRun": True},
+            timeout=30,
+            verify=TLS_VERIFY,
+        )
+        assert r_dry.status_code == 200
+        data = r_dry.json()
+        assert data.get("dryRun") is True, "Response should indicate dry-run"
+        assert data.get("revokedCount") >= 2, (
+            f"Expected at least 2 in dry-run, got {data.get('revokedCount')}"
+        )
+        assert "keyIds" not in data, "Dry-run should not expose key IDs"
+        print(f"[bulk-revoke] Dry-run reported {data.get('revokedCount')} keys would be revoked")
+
+        for key_id in key_ids:
+            r_check = requests.get(f"{api_keys_base_url}/{key_id}", headers=headers, timeout=30, verify=TLS_VERIFY)
+            assert r_check.status_code == 200
+            assert r_check.json().get("status") == "active", (
+                f"Key {key_id} should still be active after dry-run"
+            )
+        print("[bulk-revoke] Keys confirmed still active after dry-run")
+
+    def test_bulk_revoke_dry_run_by_subscription(self, api_keys_base_url: str, headers: dict, admin_headers: dict):
+        """Admin dry-run by subscription returns correct key count."""
+        if not admin_headers:
+            pytest.skip("ADMIN_OC_TOKEN not set")
+
+        sub_name = f"e2e-dry-sub-{os.urandom(4).hex()}"
+        ns = _ns()
+        sa_name = f"e2e-dry-sa-{os.urandom(4).hex()}"
+
+        key_ids = []
+        try:
+            oc_token = _create_sa_token(sa_name, namespace=MODEL_NAMESPACE)
+            sa_user = _sa_to_user(sa_name, namespace=MODEL_NAMESPACE)
+            sa_headers = {"Authorization": f"Bearer {oc_token}", "Content-Type": "application/json"}
+
+            _create_test_auth_policy(f"{sub_name}-auth", MODEL_REF, users=[sa_user])
+            _create_test_subscription(sub_name, MODEL_REF, users=[sa_user])
+            _wait_for_maas_subscription_phase(sub_name, namespace=ns)
+
+            for i in range(2):
+                r = _request_with_gateway_retry(
+                    requests.post,
+                    api_keys_base_url, headers=sa_headers,
+                    json={"name": f"dry-sub-{i}", "subscription": sub_name},
+                    timeout=TIMEOUT, verify=TLS_VERIFY,
+                )
+                assert r.status_code in (200, 201)
+                key_ids.append(r.json()["id"])
+
+            r_dry = requests.post(
+                f"{api_keys_base_url}/bulk-revoke",
+                headers=admin_headers,
+                json={"subscription": sub_name, "dryRun": True},
+                timeout=30, verify=TLS_VERIFY,
+            )
+            assert r_dry.status_code == 200
+            data = r_dry.json()
+            assert data.get("dryRun") is True
+            assert data["revokedCount"] == 2
+            assert "keyIds" not in data, "Dry-run should not expose key IDs"
+            print(f"[bulk-revoke] Admin dry-run by subscription: {data['revokedCount']} keys would be revoked")
+
+            for key_id in key_ids:
+                r_check = requests.get(f"{api_keys_base_url}/{key_id}", headers=sa_headers, timeout=30, verify=TLS_VERIFY)
+                assert r_check.status_code == 200, f"Failed to fetch key {key_id}: {r_check.status_code}"
+                assert r_check.json().get("status") == "active", "Key should remain active after dry-run"
+
+        finally:
+            for kid in key_ids:
+                requests.delete(f"{api_keys_base_url}/{kid}", headers=sa_headers, timeout=TIMEOUT, verify=TLS_VERIFY)
+            _delete_cr("maassubscription", sub_name, namespace=ns)
+            _delete_cr("maasauthpolicy", f"{sub_name}-auth", namespace=ns)
+            _delete_sa(sa_name, namespace=MODEL_NAMESPACE)
+            _wait_for_gateway_auth_enforced()
+
+    def test_bulk_revoke_combined_user_and_subscription(self, api_keys_base_url: str, headers: dict, admin_headers: dict):
+        """Admin can revoke keys for a specific user within a specific subscription.
+
+        Negative control: a second user's keys in the same subscription must remain active.
+        """
+        if not admin_headers:
+            pytest.skip("ADMIN_OC_TOKEN not set")
+
+        sub_name = f"e2e-combo-sub-{os.urandom(4).hex()}"
+        ns = _ns()
+        sa_name = f"e2e-combo-sa-{os.urandom(4).hex()}"
+        sa2_name = f"e2e-combo-sa2-{os.urandom(4).hex()}"
+
+        key_ids = []
+        key_ids_user2 = []
+        try:
+            oc_token = _create_sa_token(sa_name, namespace=MODEL_NAMESPACE)
+            sa_user = _sa_to_user(sa_name, namespace=MODEL_NAMESPACE)
+            sa_headers = {"Authorization": f"Bearer {oc_token}", "Content-Type": "application/json"}
+
+            oc_token2 = _create_sa_token(sa2_name, namespace=MODEL_NAMESPACE)
+            sa_user2 = _sa_to_user(sa2_name, namespace=MODEL_NAMESPACE)
+            sa2_headers = {"Authorization": f"Bearer {oc_token2}", "Content-Type": "application/json"}
+
+            _create_test_auth_policy(f"{sub_name}-auth", MODEL_REF, users=[sa_user, sa_user2])
+            _create_test_subscription(sub_name, MODEL_REF, users=[sa_user, sa_user2])
+            _wait_for_maas_subscription_phase(sub_name, namespace=ns)
+
+            for i in range(2):
+                r = _request_with_gateway_retry(
+                    requests.post,
+                    api_keys_base_url, headers=sa_headers,
+                    json={"name": f"combined-{i}", "subscription": sub_name},
+                    timeout=TIMEOUT, verify=TLS_VERIFY,
+                )
+                assert r.status_code in (200, 201)
+                key_ids.append(r.json()["id"])
+
+            r_u2 = _request_with_gateway_retry(
+                requests.post,
+                api_keys_base_url, headers=sa2_headers,
+                json={"name": "user2-key", "subscription": sub_name},
+                timeout=TIMEOUT, verify=TLS_VERIFY,
+            )
+            assert r_u2.status_code in (200, 201)
+            key_ids_user2.append(r_u2.json()["id"])
+
+            r_get = requests.get(f"{api_keys_base_url}/{key_ids[0]}", headers=sa_headers, timeout=30, verify=TLS_VERIFY)
+            username = r_get.json().get("username") or r_get.json().get("owner")
+            assert username
+
+            r_bulk = requests.post(
+                f"{api_keys_base_url}/bulk-revoke",
+                headers=admin_headers,
+                json={"username": username, "subscription": sub_name},
+                timeout=30, verify=TLS_VERIFY,
+            )
+            assert r_bulk.status_code == 200
+            data = r_bulk.json()
+            assert data["revokedCount"] == 2
+            print(f"[bulk-revoke] Admin revoked {data['revokedCount']} keys for {username} in {sub_name}")
+
+            # Negative control: second user's key must remain active
+            r_check = requests.get(
+                f"{api_keys_base_url}/{key_ids_user2[0]}", headers=admin_headers, timeout=30, verify=TLS_VERIFY,
+            )
+            assert r_check.status_code == 200, f"Failed to fetch user2 key: {r_check.status_code}"
+            assert r_check.json().get("status") == "active", "User2 key should remain active after combined-scope revoke"
+            print(f"[bulk-revoke] Negative control passed: user2 key {key_ids_user2[0]} still active")
+
+        finally:
+            for kid in key_ids + key_ids_user2:
+                requests.delete(f"{api_keys_base_url}/{kid}", headers=admin_headers, timeout=TIMEOUT, verify=TLS_VERIFY)
+            _delete_cr("maassubscription", sub_name, namespace=ns)
+            _delete_cr("maasauthpolicy", f"{sub_name}-auth", namespace=ns)
+            _delete_sa(sa_name, namespace=MODEL_NAMESPACE)
+            _delete_sa(sa2_name, namespace=MODEL_NAMESPACE)
+            _wait_for_gateway_auth_enforced()
+
+    def test_bulk_revoke_missing_scope_returns_400(self, api_keys_base_url: str, headers: dict):
+        """Bulk revoke with empty body returns 400."""
+        r_bulk = requests.post(
+            f"{api_keys_base_url}/bulk-revoke",
+            headers=headers,
+            json={},
+            timeout=30,
+            verify=TLS_VERIFY,
+        )
+        assert r_bulk.status_code == 400, (
+            f"Expected 400 for empty scope, got {r_bulk.status_code}: {r_bulk.text}"
+        )
+        print("[bulk-revoke] Empty scope correctly returns 400")
 
 
 class TestAPIKeyExpiration:


### PR DESCRIPTION
## Summary

Add subscription-scoped bulk API key revocation, dry-run preview mode, structured audit records, and E2E tests to the bulk revoke endpoint, completing [RHOAIENG-67045](https://redhat.atlassian.net/browse/RHOAIENG-67045).

## Description

The existing `POST /v1/api-keys/bulk-revoke` endpoint only supported revoking by username. This PR extends it with full subscription-scoped revocation, dry-run previews, structured audit logging, and comprehensive test coverage.

- add subscription-scoped bulk revoke — admin can revoke all active keys bound to a specific MaaSSubscription in one operation.
- add combined user + subscription scope — admin can revoke only a specific user's keys within a specific subscription.
- add dry-run mode (`dryRun: true`) — returns the count of keys that would be revoked without performing any mutation.
- subscription-scoped and cross-user revocation require admin privileges; self-revocation by username remains available to regular users.
- `username` field is no longer required — at least one of `username` or `subscription` must be provided.
- consolidate `InvalidateAll`, `InvalidateBySubscription`, `InvalidateByUsernameAndSubscription`, and `DryRunBulkRevoke` into two generic store methods (`BulkRevoke`, `BulkRevokeCount`) with a shared `bulkRevokeWhereClause` helper for dynamic parameterized queries.
- redact subscription and scope details in structured log output (CWE-532).
- add OpenAPI `anyOf` constraint so code generators enforce at least one scope field.
- emit structured `AUDIT bulk-revoke` log entries with stable `audit.*` field schema for log aggregator indexing (action, actor, tenant, scope, count). audit is only emitted for actual revocations, not dry-runs.
- dry-run response returns count only — key IDs are not exposed to avoid unbounded payloads; users can use the search endpoint to identify specific keys.
- isolate E2E bulk-revoke tests with disposable subscriptions, service accounts, and auth policies per test run.
- update OpenAPI spec with new request/response schemas and examples.
- update admin and user-guide documentation with subscription revoke, dry-run, combined scope, and authorization rules.
- add release notes entry under v0.2.1 for bulk API key revocation enhancements.

### Backward compatibility

Old clients sending `{"username": "alice"}` continue to work identically. The `dryRun` field uses `omitempty` so it does not appear in non-dry-run responses.

## How it was tested

- 6 new unit tests covering subscription-scoped revoke (admin, non-admin, combined scope), dry-run (by username, by subscription), and empty request validation.
- 7 E2E pytest cases covering subscription-scoped revoke, dry-run, combined scope, non-admin denial, and empty-scope validation — each isolated with dedicated disposable subscriptions.
- store-level tests updated with subscription and combined-scope coverage via the consolidated `BulkRevoke` method.
- all existing unit tests updated for the new function signature and pass.
- full test suite passes with `-race` (`go test -race ./...` — all 17 packages green).
- `golangci-lint v2.6.2` passes with 0 issues.
- built container image, deployed to a live clusterbot OpenShift cluster, and manually verified all scenarios end-to-end.

| # | Scenario | Expected | Result |
|---|----------|----------|--------|
| 1 | Dry-run by username | 200, `dryRun: true`, count only, no keyIds | Pass |
| 2 | Dry-run by subscription | 200, `dryRun: true`, count only, no keyIds | Pass |
| 3 | Dry-run does NOT emit audit | No `AUDIT bulk-revoke` in pod logs | Pass |
| 4 | Non-admin subscription revoke | 403 Forbidden | Pass |
| 5 | Admin revoke by subscription | 200, only target subscription keys revoked | Pass |
| 6 | Combined user + subscription | 200, only that user's subscription keys revoked | Pass |
| 7 | Empty request `{}` | 400, validation error | Pass |
| 8 | Backward compat (`{"username": "..."}`) | 200, works as before | Pass |
| 9 | Audit log (actual revoke) | Structured `AUDIT bulk-revoke` in pod logs, no dryRun field | Pass |
| 10 | Keys revoked after actual revoke | All targeted keys show `status: revoked` | Pass |

## Risk analysis

- **Risk rating**: 2
- **Why**: changes are scoped to the bulk-revoke handler, store layer, and tests. the consolidated store methods reduce code duplication and use the same parameterized query pattern as existing methods. all paths are covered by unit and E2E tests, and verified on a live cluster.

[RHOAIENG-67045]: https://redhat.atlassian.net/browse/RHOAIENG-67045?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bulk API-key revocation can target a user, subscription, or a specific user within a subscription.
  * Added dry-run previews showing the number of affected keys without revoking them.
  * Added authorization controls and validation for subscription-wide and cross-user revocations.
  * Added structured audit records for revocation activity.

* **Documentation**
  * Expanded API, user-guide, and release documentation with scope options, examples, permissions, validation, and dry-run behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->