### PR TITLE
fix(deps): bump Go to 1.25.12 for CVE-2026-33814 remediation

### DIFF
--- a/maas-api/go.mod
+++ b/maas-api/go.mod
@@ -1,6 +1,6 @@
 module github.com/opendatahub-io/models-as-a-service/maas-api
 
-go 1.25.8
+go 1.25.12
 
 require (
 	github.com/gin-contrib/cors v1.7.6

--- a/maas-controller/go.mod
+++ b/maas-controller/go.mod
@@ -1,6 +1,6 @@
 module github.com/opendatahub-io/models-as-a-service/maas-controller
 
-go 1.25.8
+go 1.25.12
 
 require (
 	github.com/go-logr/logr v1.4.3


### PR DESCRIPTION
## Summary
- Bumps Go version from 1.25.8 to 1.25.12 in both `maas-controller/go.mod` and `maas-api/go.mod`
- Remediates **CVE-2026-33814**: Go HTTP/2 DoS via malformed `SETTINGS_MAX_FRAME_SIZE` frame (infinite loop in stdlib `net/http/internal/http2`)
- Also remediates additional stdlib vulnerabilities fixed between Go 1.25.8 and 1.25.12:
  - GO-2026-5856 (`crypto/tls` ECH privacy leak)
  - GO-2026-5039 (`net/textproto` error escaping)
  - GO-2026-5038 (`mime` quadratic decode)
  - GO-2026-5037 (`crypto/x509` hostname parsing)

Ref: https://redhat.atlassian.net/browse/RHOAIENG-74177

## Risk analysis
- **Risk rating**: 1
- **Why**: Go version bump with no code changes. All existing tests pass. The `golang.org/x/net` dependency was already at v0.57.0 (patched). This only changes the stdlib version used at compile time. The Konflux SHA-pinned go-toolset image will need a separate rebuild to pick up Go 1.25.12 in the container build.

## Test plan
- [x] `make -C maas-controller test` passes
- [x] `make -C maas-api test` passes
- [ ] CI pipeline passes (govulncheck still non-blocking due to KEDA dependency vuln GO-2026-5940)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Go toolchain version used by the MAAS API and controller components.
  * No user-facing functionality or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->