### PR TITLE
fix: trigger reconcile before default gateway IPP routing test

### DIFF
--- a/maas-api/internal/tenant/handler.go
+++ b/maas-api/internal/tenant/handler.go
@@ -17,6 +17,12 @@ import (
 	"github.com/opendatahub-io/models-as-a-service/maas-api/internal/logger"
 )
 
+const (
+	protocolHTTPS = "HTTPS"
+	protocolTLS   = "TLS"
+	protocolHTTP  = "HTTP"
+)
+
 // Handler handles /v1/tenant endpoint requests.
 type Handler struct {
 	log              *logger.Logger
@@ -163,50 +169,7 @@ func (h *Handler) extractGatewayMetadata(gateway map[string]any) (*GatewayMetada
 		}
 	}
 
-	// Find first ready listener (has attached routes in status)
-	var port int64 = 443   // default
-	var protocol = "HTTPS" // default
-	var hostname string
-
-	for _, l := range specListenersRaw {
-		specListener, ok := l.(map[string]any)
-		if !ok {
-			continue
-		}
-
-		// Get listener name to check status
-		listenerName, _ := specListener["name"].(string)
-		statusListener, hasStatus := statusListenersByName[listenerName]
-
-		// Check if listener is ready (has attached routes)
-		if hasStatus {
-			attachedRoutes, _ := statusListener["attachedRoutes"].(int64)
-			if attachedRoutes == 0 {
-				continue
-			}
-		} else {
-			// No status for this listener, skip
-			continue
-		}
-
-		// Extract port from spec
-		if portVal, ok := specListener["port"].(int64); ok {
-			port = portVal
-		}
-
-		// Extract protocol from spec
-		if protocolVal, ok := specListener["protocol"].(string); ok {
-			protocol = protocolVal
-		}
-
-		// Extract hostname from spec
-		if hostnameVal, ok := specListener["hostname"].(string); ok {
-			hostname = hostnameVal
-		}
-
-		// Use first ready listener
-		break
-	}
+	port, protocol, hostname := selectBestListener(specListenersRaw, statusListenersByName)
 
 	// Get external hostname from Gateway status
 	externalHost := hostname
@@ -240,7 +203,7 @@ func (h *Handler) extractGatewayMetadata(gateway map[string]any) (*GatewayMetada
 
 	// Build external URL
 	scheme := "https"
-	if protocol == "HTTP" {
+	if protocol == protocolHTTP {
 		scheme = "http"
 	}
 
@@ -257,4 +220,54 @@ func (h *Handler) extractGatewayMetadata(gateway map[string]any) (*GatewayMetada
 		ExternalURL: externalURL,
 		Port:        port,
 	}, nil
+}
+
+// selectBestListener picks the best ready listener from a Gateway spec.
+// Prefers HTTPS/TLS over HTTP to avoid redirect-induced POST→GET conversion.
+func selectBestListener(specListeners []any, statusByName map[string]map[string]any) (int64, string, string) {
+	var foundHTTP bool
+	var httpPort int64
+	var httpHostname string
+
+	for _, l := range specListeners {
+		specListener, ok := l.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		listenerName, _ := specListener["name"].(string)
+		statusListener, hasStatus := statusByName[listenerName]
+		if !hasStatus {
+			continue
+		}
+		attachedRoutes, _ := statusListener["attachedRoutes"].(int64)
+		if attachedRoutes == 0 {
+			continue
+		}
+
+		listenerProtocol := protocolHTTPS
+		if protocolVal, ok := specListener["protocol"].(string); ok {
+			listenerProtocol = protocolVal
+		}
+		listenerPort := int64(443)
+		if portVal, ok := specListener["port"].(int64); ok {
+			listenerPort = portVal
+		}
+		listenerHostname, _ := specListener["hostname"].(string)
+
+		if listenerProtocol == protocolHTTPS || listenerProtocol == protocolTLS {
+			return listenerPort, listenerProtocol, listenerHostname
+		}
+
+		if !foundHTTP {
+			foundHTTP = true
+			httpPort = listenerPort
+			httpHostname = listenerHostname
+		}
+	}
+
+	if foundHTTP {
+		return httpPort, protocolHTTP, httpHostname
+	}
+	return 443, protocolHTTPS, ""
 }

--- a/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
@@ -1699,12 +1699,26 @@ func (r *MaaSAuthPolicyReconciler) handleDeletion(ctx context.Context, log logr.
 			if err != nil {
 				return ctrl.Result{}, err
 			}
+
+			// Guard: when MaasTenantConfig is already gone (AITenant cascade cleanup),
+			// fetchTenantIdentifier returns "" and fetchGatewayInfo falls back to the
+			// default gateway. Without this check, the controller misidentifies the
+			// deleted non-default tenant as the default tenant and resets the default
+			// gateway's maas-gateway-auth to empty model access.
+			isDefaultTenantNamespace := r.TenantNamespace == "" || policy.Namespace == r.TenantNamespace
 			isDefaultGateway := gatewayNs == r.GatewayNamespace && gatewayName == r.GatewayName
 			isNonDefaultTenant := tenantID != ""
+
 			if isNonDefaultTenant && isDefaultGateway {
 				log.Info("skipping gateway AuthPolicy reset: non-default tenant using shared default gateway",
 					"tenantID", tenantID,
 					"tenantNamespace", policy.Namespace,
+					"gatewayNamespace", gatewayNs,
+					"gatewayName", gatewayName)
+			} else if !isDefaultTenantNamespace && !isNonDefaultTenant && isDefaultGateway {
+				log.Info("skipping gateway AuthPolicy reset: policy namespace differs from default tenant namespace (MaasTenantConfig likely already deleted)",
+					"policyNamespace", policy.Namespace,
+					"defaultTenantNamespace", r.TenantNamespace,
 					"gatewayNamespace", gatewayNs,
 					"gatewayName", gatewayName)
 			} else {


### PR DESCRIPTION
## Summary

Fixes flaky `test_default_gateway_hits_default_ipp_only` failure caused by PR #1333's behavior change.

### Root cause

After prior tenant tests delete MaaSAuthPolicies, `handleDeletion` resets `maas-gateway-auth` to empty model access `{}`. The default tenant's model (`/llm/facebook-opt-125m-simulated`) isn't in the allowlist → 403 on inference. The 90s warmup poll wasn't enough time for the allowlist to repopulate because nothing triggered a reconcile of the default MaaSAuthPolicy.

### Fix

1. **Touch the default MaaSAuthPolicy** — annotate `simulator-access` to trigger a controller reconcile that repopulates the gateway allowlist
2. **Increase warmup timeout** from 90s to 180s — allows time for the reconcile + Kuadrant enforcement propagation

## Test plan
- [ ] `test_default_gateway_hits_default_ipp_only` passes consistently in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tenant isolation when managing gateway authentication policies, preventing configurations from one tenant from affecting another.
  * Improved gateway URL selection by preferring ready secure HTTPS listeners and providing reliable fallbacks when listeners are unavailable.
  * Improved cleanup behavior so shared default gateway access remains intact when tenant-specific policies are removed.

* **Tests**
  * Expanded end-to-end validation for tenant IP address pool isolation and gateway authentication.
  * Increased deployment warmup time to improve test reliability in slower environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->