### PR TITLE
fix: [release-3.4] prune dead RBAC grants from maas-api ClusterRole [DO NOT MERGE]

### DIFF
--- a/deployment/base/maas-api/rbac/clusterrole.yaml
+++ b/deployment/base/maas-api/rbac/clusterrole.yaml
@@ -9,40 +9,22 @@ rules:
   resourceNames: ["maas-db-config"]
   verbs: ["get"]
 
-# SA token provider resources
+# Namespace read access
 - apiGroups: [""]
   resources: ["namespaces"]
-  verbs: ["get", "list", "watch", "create"]
+  verbs: ["get", "list", "watch"]
+
+# ServiceAccount read access (informer)
 - apiGroups: [""]
   resources: ["serviceaccounts"]
-  verbs: ["get", "list", "watch", "create", "delete"]
-- apiGroups: [""]
-  # Needed for TokenRequest API
-  resources: ["serviceaccounts/token"]
-  verbs: ["create"]
-
-# Token review for authentication
-- apiGroups: ["authentication.k8s.io"]
-  resources: ["tokenreviews"]
-  verbs: ["create"]
+  verbs: ["get", "list", "watch"]
 
 # Subject access review for admin authorization (SAR-based admin check)
 - apiGroups: ["authorization.k8s.io"]
   resources: ["subjectaccessreviews"]
   verbs: ["create"]
 
-
 # MaaS CRs for the models endpoint and subscription selector (cached via informer)
 - apiGroups: ["maas.opendatahub.io"]
   resources: ["maasmodelrefs", "maassubscriptions"]
-  verbs: ["get", "list", "watch"]
-
-# HTTPRoutes (for future use, e.g. listing or resolving model routes)
-- apiGroups: ["gateway.networking.k8s.io"]
-  resources: ["httproutes"]
-  verbs: ["get", "list", "watch"]
-
-# Metrics and monitoring
-- apiGroups: [""]
-  resources: ["pods", "services", "endpoints"]
   verbs: ["get", "list", "watch"]


### PR DESCRIPTION
## Summary

Cherry-pick of #1342 to `release-3.4` so upstream CI runs against the change.

Jira: [RHOAIENG-75781](https://redhat.atlassian.net/browse/RHOAIENG-75781)

Remove unused cluster-wide permissions from the maas-api ClusterRole (CVE-2026-15218):

| Rule | Change | Verification |
|------|--------|-------------|
| `namespaces` | remove `create` | No `Namespace.Create()` in maas-api code |
| `serviceaccounts` | remove `create`, `delete` | Code only reads SAs via informer |
| `serviceaccounts/token` | remove entire rule | Dead from pre-opaque-key era |
| `tokenreviews` | remove | Not used in 3.4 maas-api |
| `httproutes` | remove entire rule | Not implemented |
| `pods`, `services`, `endpoints` | remove entire rule | None used in 3.4 |

Downstream PR: red-hat-data-services/models-as-a-service#675
Upstream PR: #1342

## Test plan
- [ ] CI passes (build + e2e)
- [ ] maas-api starts without permission errors
- [ ] All endpoints return 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RHOAIENG-75781]: https://redhat.atlassian.net/browse/RHOAIENG-75781?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ