### PR TITLE
fix: externalize model access check from inline Rego to subscription-info metadata

### DIFF
--- a/maas-api/internal/subscription/selector.go
+++ b/maas-api/internal/subscription/selector.go
@@ -218,7 +218,9 @@ func (s *Selector) Select(groups []string, username string, requestedSubscriptio
 				if err := checkModelHealth(&sub, requestedModel); err != nil {
 					return nil, err
 				}
-				return toResponseWithResolvedModel(&sub, requestedModel), nil
+				resp := toResponseWithResolvedModel(&sub, requestedModel)
+				resp.AccessAllowed = s.isModelAccessAllowed(groups, username, &sub, requestedModel)
+				return resp, nil
 			}
 		}
 
@@ -238,7 +240,9 @@ func (s *Selector) Select(groups []string, username string, requestedSubscriptio
 				if err := checkModelHealth(&sub, requestedModel); err != nil {
 					return nil, err
 				}
-				return toResponseWithResolvedModel(&sub, requestedModel), nil
+				resp := toResponseWithResolvedModel(&sub, requestedModel)
+				resp.AccessAllowed = s.isModelAccessAllowed(groups, username, &sub, requestedModel)
+				return resp, nil
 			}
 		}
 
@@ -267,7 +271,9 @@ func (s *Selector) Select(groups []string, username string, requestedSubscriptio
 		if err := checkModelHealth(&accessibleSubs[0], requestedModel); err != nil {
 			return nil, err
 		}
-		return toResponseWithResolvedModel(&accessibleSubs[0], requestedModel), nil
+		resp := toResponseWithResolvedModel(&accessibleSubs[0], requestedModel)
+		resp.AccessAllowed = s.isModelAccessAllowed(groups, username, &accessibleSubs[0], requestedModel)
+		return resp, nil
 	}
 
 	// User has multiple subscriptions - require explicit selection
@@ -569,6 +575,22 @@ func userHasAccess(sub *subscription, username string, groups []string) bool {
 	}
 
 	return false
+}
+
+// isModelAccessAllowed checks MaaSAuthPolicy access for the resolved model.
+func (s *Selector) isModelAccessAllowed(groups []string, username string, sub *subscription, requestedModel string) bool {
+	if s.accessChecker == nil || requestedModel == "" {
+		return true
+	}
+	ref := findModelRef(sub, requestedModel)
+	if ref == nil {
+		return false
+	}
+	authorizedSet := s.accessChecker.AuthorizedModels(groups, username)
+	if authorizedSet == nil {
+		return false
+	}
+	return authorizedSet[authpolicy.ModelKey{Namespace: ref.Namespace, Name: ref.Name}]
 }
 
 // subscriptionIncludesModel checks if the subscription's modelRefs includes the requested model.

--- a/maas-api/internal/subscription/selector.go
+++ b/maas-api/internal/subscription/selector.go
@@ -579,8 +579,11 @@ func userHasAccess(sub *subscription, username string, groups []string) bool {
 
 // isModelAccessAllowed checks MaaSAuthPolicy access for the resolved model.
 func (s *Selector) isModelAccessAllowed(groups []string, username string, sub *subscription, requestedModel string) bool {
-	if s.accessChecker == nil || requestedModel == "" {
+	if requestedModel == "" {
 		return true
+	}
+	if s.accessChecker == nil {
+		return false
 	}
 	ref := findModelRef(sub, requestedModel)
 	if ref == nil {

--- a/maas-api/internal/subscription/selector_test.go
+++ b/maas-api/internal/subscription/selector_test.go
@@ -1066,7 +1066,7 @@ func TestSelect_AccessAllowed(t *testing.T) {
 			wantAccessAllowed: false,
 		},
 		{
-			name: "nil access checker returns AccessAllowed true",
+			name: "nil access checker with model denies (fail-closed)",
 			subscriptions: []*unstructured.Unstructured{
 				createSubscriptionWithModelRefs("sub1", []string{"g1"}, []map[string]any{
 					{"name": "model-a", "namespace": "ns1"},
@@ -1074,6 +1074,18 @@ func TestSelect_AccessAllowed(t *testing.T) {
 			},
 			groups:            []string{"g1"},
 			requestedModel:    "ns1/model-a",
+			accessChecker:     nil,
+			wantAccessAllowed: false,
+		},
+		{
+			name: "nil access checker without model allows",
+			subscriptions: []*unstructured.Unstructured{
+				createSubscriptionWithModelRefs("sub1", []string{"g1"}, []map[string]any{
+					{"name": "model-a", "namespace": "ns1"},
+				}),
+			},
+			groups:            []string{"g1"},
+			requestedModel:    "",
 			accessChecker:     nil,
 			wantAccessAllowed: true,
 		},

--- a/maas-api/internal/subscription/selector_test.go
+++ b/maas-api/internal/subscription/selector_test.go
@@ -1019,6 +1019,165 @@ func createSubscriptionWithModelRefs(subName string, groups []string, modelRefs 
 	}
 }
 
+func TestSelect_AccessAllowed(t *testing.T) {
+	log := logger.New(false)
+
+	tests := []struct {
+		name                  string
+		subscriptions         []*unstructured.Unstructured
+		groups                []string
+		username              string
+		requestedSubscription string
+		requestedModel        string
+		accessChecker         subscription.ModelAccessChecker
+		wantAccessAllowed     bool
+		wantError             bool
+	}{
+		{
+			name: "authorized model returns AccessAllowed true",
+			subscriptions: []*unstructured.Unstructured{
+				createSubscriptionWithModelRefs("sub1", []string{"g1"}, []map[string]any{
+					{"name": "model-a", "namespace": "ns1"},
+				}),
+			},
+			groups:         []string{"g1"},
+			requestedModel: "ns1/model-a",
+			accessChecker: &fakeAccessChecker{
+				authorized: map[authpolicy.ModelKey]bool{
+					{Namespace: "ns1", Name: "model-a"}: true,
+				},
+			},
+			wantAccessAllowed: true,
+		},
+		{
+			name: "unauthorized model returns AccessAllowed false",
+			subscriptions: []*unstructured.Unstructured{
+				createSubscriptionWithModelRefs("sub1", []string{"g1"}, []map[string]any{
+					{"name": "model-a", "namespace": "ns1"},
+				}),
+			},
+			groups:         []string{"g1"},
+			requestedModel: "ns1/model-a",
+			accessChecker: &fakeAccessChecker{
+				authorized: map[authpolicy.ModelKey]bool{
+					{Namespace: "ns2", Name: "model-b"}: true,
+				},
+			},
+			wantAccessAllowed: false,
+		},
+		{
+			name: "nil access checker returns AccessAllowed true",
+			subscriptions: []*unstructured.Unstructured{
+				createSubscriptionWithModelRefs("sub1", []string{"g1"}, []map[string]any{
+					{"name": "model-a", "namespace": "ns1"},
+				}),
+			},
+			groups:            []string{"g1"},
+			requestedModel:    "ns1/model-a",
+			accessChecker:     nil,
+			wantAccessAllowed: true,
+		},
+		{
+			name: "empty requestedModel returns AccessAllowed true",
+			subscriptions: []*unstructured.Unstructured{
+				createSubscriptionWithModelRefs("sub1", []string{"g1"}, []map[string]any{
+					{"name": "model-a", "namespace": "ns1"},
+				}),
+			},
+			groups:         []string{"g1"},
+			requestedModel: "",
+			accessChecker: &fakeAccessChecker{
+				authorized: map[authpolicy.ModelKey]bool{},
+			},
+			wantAccessAllowed: true,
+		},
+		{
+			name: "explicit subscription with authorized model",
+			subscriptions: []*unstructured.Unstructured{
+				createSubscriptionWithModelRefs("sub1", []string{"g1"}, []map[string]any{
+					{"name": "model-a", "namespace": "ns1"},
+				}),
+			},
+			groups:                []string{"g1"},
+			requestedSubscription: "sub1",
+			requestedModel:        "ns1/model-a",
+			accessChecker: &fakeAccessChecker{
+				authorized: map[authpolicy.ModelKey]bool{
+					{Namespace: "ns1", Name: "model-a"}: true,
+				},
+			},
+			wantAccessAllowed: true,
+		},
+		{
+			name: "explicit subscription with unauthorized model",
+			subscriptions: []*unstructured.Unstructured{
+				createSubscriptionWithModelRefs("sub1", []string{"g1"}, []map[string]any{
+					{"name": "model-a", "namespace": "ns1"},
+				}),
+			},
+			groups:                []string{"g1"},
+			requestedSubscription: "sub1",
+			requestedModel:        "ns1/model-a",
+			accessChecker: &fakeAccessChecker{
+				authorized: map[authpolicy.ModelKey]bool{},
+			},
+			wantAccessAllowed: false,
+		},
+		{
+			name: "qualified subscription with authorized model",
+			subscriptions: []*unstructured.Unstructured{
+				createSubscriptionWithModelRefs("sub1", []string{"g1"}, []map[string]any{
+					{"name": "model-a", "namespace": "ns1"},
+				}),
+			},
+			groups:                []string{"g1"},
+			requestedSubscription: "test-ns/sub1",
+			requestedModel:        "ns1/model-a",
+			accessChecker: &fakeAccessChecker{
+				authorized: map[authpolicy.ModelKey]bool{
+					{Namespace: "ns1", Name: "model-a"}: true,
+				},
+			},
+			wantAccessAllowed: true,
+		},
+		{
+			name: "nil authorized set returns AccessAllowed false",
+			subscriptions: []*unstructured.Unstructured{
+				createSubscriptionWithModelRefs("sub1", []string{"g1"}, []map[string]any{
+					{"name": "model-a", "namespace": "ns1"},
+				}),
+			},
+			groups:         []string{"g1"},
+			requestedModel: "ns1/model-a",
+			accessChecker: &fakeAccessChecker{
+				authorized: nil,
+			},
+			wantAccessAllowed: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lister := &fakeLister{subscriptions: tt.subscriptions}
+			selector := subscription.NewSelector(log, lister, nil, tt.accessChecker)
+
+			result, err := selector.Select(tt.groups, tt.username, tt.requestedSubscription, tt.requestedModel)
+			if tt.wantError {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if result.AccessAllowed != tt.wantAccessAllowed {
+				t.Errorf("AccessAllowed = %v, want %v", result.AccessAllowed, tt.wantAccessAllowed)
+			}
+		})
+	}
+}
+
 func TestListAccessibleForModel_MultiNamespace(t *testing.T) {
 	log := logger.New(false)
 

--- a/maas-api/internal/subscription/types.go
+++ b/maas-api/internal/subscription/types.go
@@ -32,6 +32,9 @@ type SelectResponse struct {
 	// gateway AuthPolicy to build selected_subscription_key for TokenRateLimitPolicy.
 	ResolvedModel string `json:"resolvedModel,omitempty"`
 
+	// Access control (populated from MaaSAuthPolicy check)
+	AccessAllowed bool `json:"accessAllowed"` // no omitempty — false is a meaningful denial signal
+
 	// Health fields (populated from status and metadata)
 	Phase             string `json:"phase"`                       // Subscription phase: "Active", "Degraded", "Failed", "Pending", or "" (always serialized for Authorino OPA rules)
 	Ready             bool   `json:"ready"`                       // Whether subscription is ready (from Ready condition)

--- a/maas-controller/pkg/controller/maas/cross_namespace_test.go
+++ b/maas-controller/pkg/controller/maas/cross_namespace_test.go
@@ -114,10 +114,8 @@ func TestMaaSAuthPolicyReconciler_CrossNamespace(t *testing.T) {
 	if err != nil || !found {
 		t.Fatalf("gateway require-group-membership rego missing: found=%v err=%v", found, err)
 	}
-	for _, key := range []string{modelNamespaceA + "/" + modelName, modelNamespaceB + "/" + modelName} {
-		if !strings.Contains(rego, key) {
-			t.Errorf("gateway rego should include aggregated model key %q, got: %s", key, rego)
-		}
+	if !strings.Contains(rego, "accessAllowed") {
+		t.Errorf("gateway rego should reference accessAllowed from subscription-info metadata, got: %s", rego)
 	}
 
 	// Verify no legacy per-model AuthPolicy exists in model namespaces or policy namespace.
@@ -197,7 +195,7 @@ func TestMaaSAuthPolicyReconciler_SelectiveModelManagement(t *testing.T) {
 		t.Fatalf("Reconcile: unexpected error: %v", err)
 	}
 
-	// Verify only referenced model appears in the gateway authorization rego map.
+	// Verify gateway rego is fixed-size (no model-specific data).
 	gatewayAP := &unstructured.Unstructured{}
 	gatewayAP.SetGroupVersionKind(schema.GroupVersionKind{Group: "kuadrant.io", Version: "v1", Kind: "AuthPolicy"})
 	if err := c.Get(context.Background(), types.NamespacedName{Name: "maas-gateway-auth", Namespace: gatewayNS}, gatewayAP); err != nil {
@@ -207,13 +205,8 @@ func TestMaaSAuthPolicyReconciler_SelectiveModelManagement(t *testing.T) {
 	if err != nil || !found {
 		t.Fatalf("gateway require-group-membership rego missing: found=%v err=%v", found, err)
 	}
-	refKey := modelNamespaceA + "/" + modelName
-	unrefKey := modelNamespaceB + "/" + modelName
-	if !strings.Contains(rego, refKey) {
-		t.Errorf("gateway rego should include referenced model key %q", refKey)
-	}
-	if strings.Contains(rego, unrefKey) {
-		t.Errorf("gateway rego should not include unreferenced model key %q", unrefKey)
+	if !strings.Contains(rego, "accessAllowed") {
+		t.Errorf("gateway rego should reference accessAllowed, got: %s", rego)
 	}
 
 	// Verify no legacy per-model AuthPolicies are created.
@@ -314,8 +307,7 @@ func TestMaaSAuthPolicyReconciler_SameNameDifferentNamespaces(t *testing.T) {
 		}
 	}
 
-	// Aggregation is namespace-scoped per reconciling policy namespace. Because policy-b
-	// was reconciled last, gateway rego should include namespaceB and not namespaceA.
+	// Rego is now fixed-size — access checks are delegated to subscription-info metadata.
 	gatewayAP := &unstructured.Unstructured{}
 	gatewayAP.SetGroupVersionKind(schema.GroupVersionKind{Group: "kuadrant.io", Version: "v1", Kind: "AuthPolicy"})
 	if err := c.Get(context.Background(), types.NamespacedName{Name: "maas-gateway-auth", Namespace: gatewayNS}, gatewayAP); err != nil {
@@ -325,11 +317,8 @@ func TestMaaSAuthPolicyReconciler_SameNameDifferentNamespaces(t *testing.T) {
 	if err != nil || !found {
 		t.Fatalf("gateway require-group-membership rego missing: found=%v err=%v", found, err)
 	}
-	if strings.Contains(rego, namespaceA+"/"+modelName) {
-		t.Errorf("gateway rego should not include model key %q after policy-b reconcile", namespaceA+"/"+modelName)
-	}
-	if !strings.Contains(rego, namespaceB+"/"+modelName) {
-		t.Errorf("gateway rego should include model key %q after policy-b reconcile", namespaceB+"/"+modelName)
+	if !strings.Contains(rego, "accessAllowed") {
+		t.Errorf("gateway rego should reference accessAllowed, got: %s", rego)
 	}
 }
 
@@ -662,13 +651,13 @@ func TestMaaSAuthPolicyReconciler_DuplicateNameAnnotationIsolation(t *testing.T)
 		t.Fatalf("Get gateway AuthPolicy: %v", err)
 	}
 
-	// The group from namespaceA's policy should appear in the gateway rego.
+	// Rego is now fixed-size — access checks are delegated to subscription-info metadata.
 	rego, found, err := unstructured.NestedString(gw.Object, "spec", "defaults", "rules", "authorization", "require-group-membership", "opa", "rego")
 	if err != nil || !found {
 		t.Fatalf("gateway require-group-membership rego missing: found=%v err=%v", found, err)
 	}
-	if !contains(rego, "team-a") {
-		t.Errorf("gateway rego should contain group %q for model %s/%s, rego=%s", "team-a", modelNamespace, modelName, rego)
+	if !strings.Contains(rego, "accessAllowed") {
+		t.Errorf("gateway rego should reference accessAllowed, got: %s", rego)
 	}
 }
 

--- a/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
-	"sort"
 	"strings"
 	"time"
 
@@ -442,16 +441,6 @@ const maasGatewayAuthPolicyName = "maas-gateway-auth"
 // favor of maas-gateway-auth. Kept only for upgrade cleanup of stale cluster resources.
 const legacyGatewayDefaultAuthPolicyName = "gateway-default-auth"
 
-// gatewayAuthzCacheKeySelector builds the cache-key expression for gateway-level
-// model authorization checks: "userId|groups|modelIdentity".
-// This prevents authz cache collisions across different model targets.
-func gatewayAuthzCacheKeySelector() string {
-	return fmt.Sprintf(
-		`(%s) + "|" + (%s).join(",") + "|" + %s`,
-		celUserID, celGroups, celModelIdentity,
-	)
-}
-
 // subscriptionGatewayCacheKeySelector builds the cache-key expression for the gateway-level
 // subscription-info and subscription-valid evaluators: "userId|groups|subscription|modelIdentity".
 // Model identity is derived dynamically from X-Gateway-Model-Name header or request path.
@@ -528,19 +517,6 @@ func (r *MaaSAuthPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	// Track missing models to include in status even when reconciliation skips them
 	missingModels := r.findMissingModelRefs(ctx, policy)
 
-	modelAllowlists, err := r.aggregateModelSubjectAllowlists(ctx, policy.Namespace)
-	if err != nil {
-		log.Error(err, "failed to aggregate per-model subjects for gateway AuthPolicy")
-		r.updateStatus(ctx, policy, maasv1alpha1.PhaseFailed, fmt.Sprintf("Failed to aggregate per-model access rules: %v", err), statusSnapshot)
-		return ctrl.Result{}, err
-	}
-	modelAllowlistsJSON, err := json.Marshal(modelAllowlists)
-	if err != nil {
-		log.Error(err, "failed to marshal per-model subject aggregation")
-		r.updateStatus(ctx, policy, maasv1alpha1.PhaseFailed, fmt.Sprintf("Failed to serialize per-model access rules: %v", err), statusSnapshot)
-		return ctrl.Result{}, err
-	}
-
 	oidc := r.fetchOIDCConfig(ctx, log, req.Namespace)
 	tenantID, err := r.fetchTenantIdentifier(ctx, log, req.Namespace)
 	if err != nil {
@@ -602,7 +578,7 @@ func (r *MaaSAuthPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		}
 	}
 
-	gwChanged, reconcileErr := r.reconcileGatewayAuthPolicy(ctx, log, string(modelAllowlistsJSON), oidc, xAPIKeyEnabled, tenantID, gatewayNs, gatewayName)
+	gwChanged, reconcileErr := r.reconcileGatewayAuthPolicy(ctx, log, oidc, xAPIKeyEnabled, tenantID, gatewayNs, gatewayName)
 	if reconcileErr != nil {
 		log.Error(reconcileErr, "failed to reconcile gateway AuthPolicy")
 		r.updateStatus(ctx, policy, maasv1alpha1.PhaseFailed, fmt.Sprintf("Failed to reconcile gateway AuthPolicy: %v", reconcileErr), statusSnapshot)
@@ -745,15 +721,10 @@ type authPolicyRef struct {
 	ModelNamespace string
 }
 
-type modelSubjectAllowlist struct {
-	Users  []string `json:"users"`
-	Groups []string `json:"groups"`
-}
-
 // buildGatewayAuthPolicySpec returns the Authorino AuthPolicy spec for the singleton
 // Gateway-level policy. Model identity is resolved dynamically via CEL on every request
 // rather than being baked in per-model, so this spec is the same for all MaaSAuthPolicy CRs.
-func (r *MaaSAuthPolicyReconciler) buildGatewayAuthPolicySpec(modelAccessJSON string, oidc *oidcConfig, xAPIKeyEnabled bool, tenantID, tenantName, gatewayNamespace, gatewayName string) map[string]any {
+func (r *MaaSAuthPolicyReconciler) buildGatewayAuthPolicySpec(oidc *oidcConfig, xAPIKeyEnabled bool, tenantID, tenantName, gatewayNamespace, gatewayName string) map[string]any {
 	// Construct tenant-specific maas-api service name using TenantIdentifier
 	// Default tenant (tenantID="") uses "maas-api", others use "maas-api-{tenantID}"
 	maasAPIServiceName := "maas-api"
@@ -850,67 +821,9 @@ allow { true }`,
 		},
 	}
 
-	requireGroupMembershipRego := fmt.Sprintf(`
-model_access := %s
-
-request_path := object.get(input.context.request.http, "path", "")
-request_headers := object.get(input.context.request.http, "headers", {})
-
-path_parts := [p | p := split(request_path, "/")[_]; p != ""]
-
-path_model_identity := sprintf("%%s/%%s", [path_parts[0], path_parts[1]]) {
-	count(path_parts) >= 2
-	path_parts[0] != "v1"
-	path_parts[0] != "maas-api"
-}
-
-header_model_identity := object.get(request_headers, "x-gateway-model-name", "")
-
-model_identity := path_model_identity {
-	path_model_identity != ""
-} else := header_model_identity {
-	header_model_identity != ""
-} else := ""
-
-username := input.auth.metadata.apiKeyValidation.username
-	{ object.get(input.auth, "metadata", {}).apiKeyValidation.username != "" }
-else := input.auth.identity.preferred_username
-	{ object.get(input.auth, "identity", {}).preferred_username != "" }
-else := input.auth.identity.sub
-	{ object.get(input.auth, "identity", {}).sub != "" }
-else := input.auth.identity.user.username
-	{ object.get(input.auth, "identity", {}).user.username != "" }
-else := ""
-
-groups := input.auth.metadata.apiKeyValidation.groups
-	{ object.get(input.auth, "metadata", {}).apiKeyValidation.groups != [] }
-else := input.auth.identity.groups
-	{ object.get(input.auth, "identity", {}).groups != [] }
-else := input.auth.identity.user.groups
-	{ object.get(input.auth, "identity", {}).user.groups != [] }
-else := []
-
-model_rules := object.get(model_access, model_identity, null)
-
-# Management endpoints (e.g. /v1/models, /maas-api/v1/api-keys) carry no model context.
-# Allow them here; subscription and rate-limit checks are gated by model-route conditions.
-allow {
-	model_identity == ""
-}
-
-# Inference path: deny by default when no MaaSAuthPolicy covers this model.
-# Allow only when the caller's username or a group is explicitly listed.
-allow {
-	model_rules != null
-	model_rules.users[_] == username
-}
-
-allow {
-	model_rules != null
-	g := groups[_]
-	model_rules.groups[_] == g
-}
-`, modelAccessJSON)
+	requireGroupMembershipRego := `allow {
+  object.get(input.auth.metadata["subscription-info"], "accessAllowed", false) == true
+}`
 
 	authorizationRules := map[string]any{
 		"tenant-gateway-isolation": tenantGatewayIsolationRule,
@@ -958,6 +871,11 @@ allow {
 			},
 		},
 		"require-group-membership": map[string]any{
+			"when": []any{
+				map[string]any{
+					"predicate": celModelIdentityAvailable,
+				},
+			},
 			"metrics":  false,
 			"priority": int64(0),
 			"opa": map[string]any{
@@ -965,7 +883,7 @@ allow {
 			},
 			"cache": map[string]any{
 				"key": map[string]any{
-					"selector": gatewayAuthzCacheKeySelector(),
+					"selector": subscriptionGatewayCacheKeySelector(),
 				},
 				"ttl": r.authzCacheTTL(),
 			},
@@ -1349,7 +1267,7 @@ func stripExtraFieldsSlice(current, desired []any) {
 // reconcileGatewayAuthPolicy creates or updates the singleton Gateway-level AuthPolicy in
 // the gateway namespace. All MaaSAuthPolicy reconciliations converge on this one resource.
 func (r *MaaSAuthPolicyReconciler) reconcileGatewayAuthPolicy(
-	ctx context.Context, log logr.Logger, modelAccessJSON string,
+	ctx context.Context, log logr.Logger,
 	oidc *oidcConfig, xAPIKeyEnabled bool, tenantID, gatewayNamespace, gatewayName string,
 ) (bool, error) {
 	log.Info("reconcileGatewayAuthPolicy entered", "gatewayNamespace", gatewayNamespace, "gatewayName", gatewayName, "tenantID", tenantID, "xAPIKeyEnabled", xAPIKeyEnabled)
@@ -1361,7 +1279,7 @@ func (r *MaaSAuthPolicyReconciler) reconcileGatewayAuthPolicy(
 		tenantName = tenantID
 	}
 
-	spec := r.buildGatewayAuthPolicySpec(modelAccessJSON, oidc, xAPIKeyEnabled, tenantID, tenantName, gatewayNamespace, gatewayName)
+	spec := r.buildGatewayAuthPolicySpec(oidc, xAPIKeyEnabled, tenantID, tenantName, gatewayNamespace, gatewayName)
 	authPolicyName := r.gatewayAuthPolicyName(gatewayNamespace, gatewayName)
 	isTenantGateway := gatewayNamespace != r.GatewayNamespace || gatewayName != r.GatewayName
 
@@ -1504,60 +1422,6 @@ func (r *MaaSAuthPolicyReconciler) reconcileModelAuthPolicies(ctx context.Contex
 	}
 
 	return refs, nil
-}
-
-func (r *MaaSAuthPolicyReconciler) aggregateModelSubjectAllowlists(ctx context.Context, policyNamespace string) (map[string]modelSubjectAllowlist, error) {
-	var policies maasv1alpha1.MaaSAuthPolicyList
-	if err := r.List(ctx, &policies, client.InNamespace(policyNamespace)); err != nil {
-		return nil, fmt.Errorf("failed to list MaaSAuthPolicies for gateway aggregation: %w", err)
-	}
-
-	aggregate := make(map[string]modelSubjectAllowlist)
-	for _, p := range policies.Items {
-		if !p.GetDeletionTimestamp().IsZero() {
-			continue
-		}
-		for _, ref := range p.Spec.ModelRefs {
-			key := ref.Namespace + "/" + ref.Name
-			entry := aggregate[key]
-			for _, group := range p.Spec.Subjects.Groups {
-				if err := validateCELValue(group.Name, "group name"); err != nil {
-					return nil, fmt.Errorf("invalid subject in MaaSAuthPolicy %s/%s: %w", p.Namespace, p.Name, err)
-				}
-				entry.Groups = append(entry.Groups, group.Name)
-			}
-			for _, user := range p.Spec.Subjects.Users {
-				if err := validateCELValue(user, "username"); err != nil {
-					return nil, fmt.Errorf("invalid subject in MaaSAuthPolicy %s/%s: %w", p.Namespace, p.Name, err)
-				}
-				entry.Users = append(entry.Users, user)
-			}
-			entry.Groups = deduplicateAndSort(entry.Groups)
-			entry.Users = deduplicateAndSort(entry.Users)
-			aggregate[key] = entry
-
-			for _, altKey := range r.resolveHeaderModelKeys(ctx, ref) {
-				aggregate[altKey] = entry
-			}
-		}
-	}
-
-	return aggregate, nil
-}
-
-// resolveHeaderModelKeys returns alternate model_access keys that match the value
-// ipp-pre sets in the X-Gateway-Model-Name header for body-based routing.
-// Reads MaaSModelRef.status.resolvedModelAlias, which the modelref controller
-// populates from the backing CRD (publisher ID for LLMISvc, targetModel for ExternalModel).
-func (r *MaaSAuthPolicyReconciler) resolveHeaderModelKeys(ctx context.Context, ref maasv1alpha1.ModelRef) []string {
-	modelRef := &maasv1alpha1.MaaSModelRef{}
-	if err := r.Get(ctx, client.ObjectKey{Name: ref.Name, Namespace: ref.Namespace}, modelRef); err != nil {
-		return nil
-	}
-	if modelRef.Status.ResolvedModelAlias == "" {
-		return nil
-	}
-	return []string{modelRef.Status.ResolvedModelAlias}
 }
 
 func (r *MaaSAuthPolicyReconciler) modelAuthPolicyExists(ctx context.Context, modelNamespace, modelName string) (bool, error) {
@@ -1710,11 +1574,11 @@ func (r *MaaSAuthPolicyReconciler) handleDeletion(ctx context.Context, log logr.
 			} else {
 				oidc := r.fetchOIDCConfig(ctx, log, policy.Namespace)
 				xAPIKeyEnabled := r.discoverXAPIKeyNeeded(ctx, log)
-				if _, err := r.reconcileGatewayAuthPolicy(ctx, log, "{}", oidc, xAPIKeyEnabled, tenantID, gatewayNs, gatewayName); err != nil {
+				if _, err := r.reconcileGatewayAuthPolicy(ctx, log, oidc, xAPIKeyEnabled, tenantID, gatewayNs, gatewayName); err != nil {
 					log.Error(err, "failed to reset gateway auth to base version")
 					return ctrl.Result{}, err
 				}
-				log.Info("reset maas-gateway-auth to base version (empty model access)",
+				log.Info("reset maas-gateway-auth to base version",
 					"gatewayNamespace", gatewayNs, "gatewayName", gatewayName)
 			}
 		}
@@ -1747,7 +1611,7 @@ func (r *MaaSAuthPolicyReconciler) ensureBaseGatewayAuthPolicy(
 		return fmt.Errorf("failed to check gateway AuthPolicy %s/%s: %w", gatewayNamespace, authPolicyName, err)
 	}
 
-	_, err := r.reconcileGatewayAuthPolicy(ctx, log, "{}", oidc, xAPIKeyEnabled, tenantID, gatewayNamespace, gatewayName)
+	_, err := r.reconcileGatewayAuthPolicy(ctx, log, oidc, xAPIKeyEnabled, tenantID, gatewayNamespace, gatewayName)
 	return err
 }
 
@@ -2274,26 +2138,4 @@ func setGatewayOwnerReference(gateway *gatewayapiv1.Gateway, dependent metav1.Ob
 	}
 	owners = append(owners, ref)
 	dependent.SetOwnerReferences(owners)
-}
-
-// deduplicateAndSort removes duplicates from a string slice and sorts it.
-// This ensures stable output across reconciles, preventing spurious updates
-// caused by non-deterministic Kubernetes List order.
-func deduplicateAndSort(items []string) []string {
-	if len(items) == 0 {
-		return items
-	}
-	// Use a map to deduplicate
-	seen := make(map[string]bool, len(items))
-	for _, item := range items {
-		seen[item] = true
-	}
-	// Build deduplicated slice
-	result := make([]string, 0, len(seen))
-	for item := range seen {
-		result = append(result, item)
-	}
-	// Sort for deterministic output
-	sort.Strings(result)
-	return result
 }

--- a/maas-controller/pkg/controller/maas/maasauthpolicy_controller_test.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_controller_test.go
@@ -682,11 +682,11 @@ func TestMaaSAuthPolicyReconciler_RemoveModelRef(t *testing.T) {
 	if err != nil || !found {
 		t.Fatalf("gateway require-group-membership rego missing: found=%v err=%v", found, err)
 	}
-	if !contains(rego, namespace+"/"+modelA) {
-		t.Errorf("gateway rego should include %q", namespace+"/"+modelA)
+	if !strings.Contains(rego, "accessAllowed") {
+		t.Errorf("gateway rego should reference accessAllowed from subscription-info metadata")
 	}
-	if contains(rego, namespace+"/"+modelB) {
-		t.Errorf("gateway rego should not include removed model %q", namespace+"/"+modelB)
+	if strings.Contains(rego, "model_access") {
+		t.Errorf("gateway rego should not contain model_access variable")
 	}
 }
 
@@ -766,11 +766,11 @@ func TestMaaSAuthPolicyReconciler_RemoveModelRef_Aggregation(t *testing.T) {
 	if err != nil || !found {
 		t.Fatalf("gateway require-group-membership rego missing: found=%v err=%v", found, err)
 	}
-	if !contains(rego, namespace+"/"+modelB) {
-		t.Fatalf("model B should remain aggregated while ap2 still references it")
+	if !strings.Contains(rego, "accessAllowed") {
+		t.Fatalf("rego should reference accessAllowed from subscription-info metadata")
 	}
 
-	// Delete ap2 and reconcile deletion; model B should then disappear from aggregate.
+	// Delete ap2 and reconcile deletion; Rego remains fixed-size.
 	freshAP2 := &maasv1alpha1.MaaSAuthPolicy{}
 	if err := c.Get(ctx, types.NamespacedName{Name: "ap2", Namespace: namespace}, freshAP2); err != nil {
 		t.Fatalf("Get ap2: %v", err)
@@ -781,8 +781,6 @@ func TestMaaSAuthPolicyReconciler_RemoveModelRef_Aggregation(t *testing.T) {
 	if _, err := r.Reconcile(ctx, req2); err != nil {
 		t.Fatalf("Reconcile ap2 deletion: %v", err)
 	}
-	// Deletion reconcile does cleanup/finalizer handling; run ap1 reconcile to
-	// rebuild the gateway aggregate from surviving policies.
 	if _, err := r.Reconcile(ctx, req1); err != nil {
 		t.Fatalf("Reconcile ap1 after ap2 deletion: %v", err)
 	}
@@ -793,11 +791,8 @@ func TestMaaSAuthPolicyReconciler_RemoveModelRef_Aggregation(t *testing.T) {
 	if err != nil || !found {
 		t.Fatalf("gateway require-group-membership rego missing after ap2 deletion: found=%v err=%v", found, err)
 	}
-	if contains(rego, namespace+"/"+modelB) {
-		t.Errorf("model B should be removed from aggregate after deleting ap2")
-	}
-	if !contains(rego, namespace+"/"+modelA) {
-		t.Errorf("model A should still be present after deleting ap2")
+	if strings.Contains(rego, "model_access") {
+		t.Errorf("rego should not contain model_access after ap2 deletion")
 	}
 }
 
@@ -939,8 +934,8 @@ func TestMaaSAuthPolicyReconciler_MultiplePoliciesDeletion(t *testing.T) {
 	if !ok {
 		t.Fatal("require-group-membership missing rego after reset")
 	}
-	if !strings.Contains(rego, "model_access := {}") {
-		t.Errorf("rego should contain empty model_access after reset, got:\n%s", rego)
+	if !strings.Contains(rego, "accessAllowed") {
+		t.Errorf("rego should reference accessAllowed from subscription-info metadata, got:\n%s", rego)
 	}
 }
 
@@ -1250,7 +1245,7 @@ func TestMaaSAuthPolicyReconciler_NegativeTTLRejection(t *testing.T) {
 // After the gateway-level AuthPolicy refactor the key structure changes:
 //   - Gateway policy: apiKeyValidation, subscription-info, auth-valid, subscription-valid
 //     use dynamic CEL (celModelIdentity) for runtime model isolation
-//   - Group policy: require-group-membership uses static model namespace/name in the key
+//   - require-group-membership: same dimensions as subscription-info (userId|groups|subscription|model)
 //
 // This is a security-critical test: incorrect cache keys could leak authentication
 // or authorization results between different users, API keys, or models.
@@ -1351,26 +1346,25 @@ func TestMaaSAuthPolicyReconciler_CacheKeyIsolation(t *testing.T) {
 		}
 	})
 
-	// Test 5: require-group-membership cache key must include username, groups, and dynamic model identity.
-	t.Run("require-group-membership includes username, groups, dynamic model", func(t *testing.T) {
+	// Test 5: require-group-membership cache key must match subscription-info (same dimensions).
+	t.Run("require-group-membership matches subscription-info cache key", func(t *testing.T) {
 		key := assertCacheKeyContains(t, gwPolicy,
 			[]string{"username", "groups", "join"},
 			"spec", "defaults", "rules", "authorization", "require-group-membership", "cache", "key", "selector",
 		)
-		if !contains(key, "x-gateway-model-name") && !contains(key, "request.path") {
-			t.Errorf("require-group-membership cache key must include dynamic model identity (header or path), got: %s", key)
+		subInfoKey, _, _ := unstructured.NestedString(gwPolicy.Object,
+			"spec", "defaults", "rules", "metadata", "subscription-info", "cache", "key", "selector",
+		)
+		if key != subInfoKey {
+			t.Errorf("require-group-membership cache key should match subscription-info for cache coherence\nrequire-group-membership: %s\nsubscription-info:        %s", key, subInfoKey)
 		}
 	})
 }
 
 // TestMaaSAuthPolicyReconciler_CacheKeyModelIsolation verifies per-model cache key isolation.
 //
-// After the gateway-level AuthPolicy refactor, model isolation strategy changes:
-//   - Gateway policy (singleton): subscription-info/auth-valid/subscription-valid use dynamic
-//     CEL (X-Gateway-Model-Name header or path) for runtime isolation — the same CEL expression
-//     appears in both model-1 and model-2 scenarios because they share the gateway policy.
-//   - Group policies (per-model): require-group-membership still bakes in static namespace/name,
-//     so keys differ between models at compile time.
+// All authorization evaluators in the singleton gateway AuthPolicy use dynamic CEL
+// (X-Gateway-Model-Name header or path) for runtime model isolation.
 func TestMaaSAuthPolicyReconciler_CacheKeyModelIsolation(t *testing.T) {
 	const (
 		namespace = "default"
@@ -1446,17 +1440,17 @@ func TestMaaSAuthPolicyReconciler_CacheKeyModelIsolation(t *testing.T) {
 		})
 	}
 
-	t.Run("require-group-membership isolates models", func(t *testing.T) {
-		path := []string{"spec", "defaults", "rules", "authorization", "require-group-membership", "cache", "key", "selector"}
-		key, found, err := unstructured.NestedString(gwPolicy.Object, path...)
+	t.Run("require-group-membership matches subscription-info cache key", func(t *testing.T) {
+		groupPath := []string{"spec", "defaults", "rules", "authorization", "require-group-membership", "cache", "key", "selector"}
+		groupKey, found, err := unstructured.NestedString(gwPolicy.Object, groupPath...)
 		if err != nil || !found {
 			t.Fatalf("gateway require-group-membership cache key missing: found=%v err=%v", found, err)
 		}
-		if !contains(key, "x-gateway-model-name") && !contains(key, "request.path") {
-			t.Errorf("require-group-membership cache key must include dynamic model identity for runtime isolation, got: %s", key)
-		}
-		if !contains(key, "username") || !contains(key, "groups") {
-			t.Errorf("require-group-membership cache key must include caller identity dimensions, got: %s", key)
+		subInfoKey, _, _ := unstructured.NestedString(gwPolicy.Object,
+			"spec", "defaults", "rules", "metadata", "subscription-info", "cache", "key", "selector",
+		)
+		if groupKey != subInfoKey {
+			t.Errorf("require-group-membership cache key should match subscription-info\nrequire-group-membership: %s\nsubscription-info:        %s", groupKey, subInfoKey)
 		}
 	})
 }
@@ -1622,7 +1616,7 @@ func gatewayAuthPolicySpecTestObject(t *testing.T, oidc *oidcConfig) *unstructur
 		MetadataCacheTTL: 60,
 		AuthzCacheTTL:    60,
 	}
-	spec := r.buildGatewayAuthPolicySpec("{}", oidc, false, "", "models-as-a-service", "test-gateway-ns", "test-gateway")
+	spec := r.buildGatewayAuthPolicySpec(oidc, false, "", "models-as-a-service", "test-gateway-ns", "test-gateway")
 	return &unstructured.Unstructured{Object: map[string]any{"spec": spec}}
 }
 
@@ -1733,13 +1727,13 @@ func TestBuildGatewayAuthPolicySpec_RouteScopedRules(t *testing.T) {
 		}
 	})
 
-	t.Run("require-group-membership recognizes tenant model paths", func(t *testing.T) {
+	t.Run("require-group-membership reads accessAllowed from subscription-info", func(t *testing.T) {
 		rego := nestedStringRequired(t, obj, "spec", "defaults", "rules", "authorization", "require-group-membership", "opa", "rego")
-		if !contains(rego, `path_parts[0] != "maas-api"`) || !contains(rego, `path_parts[0] != "v1"`) {
-			t.Errorf("require-group-membership rego should treat tenant model paths as model routes and exclude management paths, got: %s", rego)
+		if !contains(rego, "accessAllowed") {
+			t.Errorf("require-group-membership rego should reference accessAllowed, got: %s", rego)
 		}
-		if contains(rego, `startswith(request_path, "/llm/")`) {
-			t.Errorf("require-group-membership rego should not be hard-coded to /llm/ routes, got: %s", rego)
+		if contains(rego, "model_access") {
+			t.Errorf("require-group-membership rego should not contain model_access, got: %s", rego)
 		}
 	})
 
@@ -1761,7 +1755,7 @@ func TestBuildGatewayAuthPolicySpec_XAPIKeyEnabled(t *testing.T) {
 		AuthzCacheTTL:    60,
 	}
 
-	spec := r.buildGatewayAuthPolicySpec("{}", nil, true, "", "models-as-a-service", "gateway-ns", "maas-default-gateway")
+	spec := r.buildGatewayAuthPolicySpec(nil, true, "", "models-as-a-service", "gateway-ns", "maas-default-gateway")
 	obj := &unstructured.Unstructured{Object: map[string]any{"spec": spec}}
 
 	auth, found, err := unstructured.NestedMap(obj.Object, "spec", "defaults", "rules", "authentication")
@@ -1850,7 +1844,7 @@ func TestBuildGatewayAuthPolicySpec_OIDCJWKsTTL(t *testing.T) {
 				ClientID:  "maas-client",
 				TTL:       tc.ttl,
 			}
-			spec := r.buildGatewayAuthPolicySpec("{}", oidc, false, "", "models-as-a-service", "test-gateway-ns", "test-gateway")
+			spec := r.buildGatewayAuthPolicySpec(oidc, false, "", "models-as-a-service", "test-gateway-ns", "test-gateway")
 			obj := &unstructured.Unstructured{Object: map[string]any{"spec": spec}}
 
 			gotTTL, found, err := unstructured.NestedInt64(obj.Object, "spec", "defaults", "rules", "authentication", "oidc-identities", "jwt", "ttl")
@@ -2305,24 +2299,23 @@ func TestMaaSAuthPolicyReconciler_CanonicalModelIDNormalization(t *testing.T) {
 		}
 	})
 
-	t.Run("OPA Rego uses header value as-is for model identity", func(t *testing.T) {
+	t.Run("OPA Rego reads accessAllowed from subscription-info metadata", func(t *testing.T) {
 		rego, found, err := unstructured.NestedString(gwPolicy.Object, "spec", "defaults", "rules", "authorization", "require-group-membership", "opa", "rego")
 		if err != nil || !found {
 			t.Fatalf("require-group-membership rego missing: found=%v err=%v", found, err)
 		}
 
-		if !strings.Contains(rego, `header_model_identity := object.get(request_headers, "x-gateway-model-name", "")`) {
-			t.Errorf("rego should use raw header value directly as model identity, got: %s", rego)
+		if !strings.Contains(rego, "accessAllowed") {
+			t.Errorf("rego should reference accessAllowed from subscription-info metadata, got: %s", rego)
 		}
-		if strings.Contains(rego, `startswith(raw_header_model_identity`) {
-			t.Errorf("rego should not split or parse publisher ID format, got: %s", rego)
+		if strings.Contains(rego, "model_access") {
+			t.Errorf("rego should not contain model_access variable, got: %s", rego)
 		}
 	})
 }
 
 // TestMaaSAuthPolicyReconciler_PublisherIDModelAccess verifies that the gateway AuthPolicy's
-// model_access map contains publisher-ID-keyed entries for LLMInferenceService-backed models,
-// allowing BBR requests with publisher ID format to pass auth.
+// require-group-membership Rego is fixed-size and does not embed model-specific data.
 func TestMaaSAuthPolicyReconciler_PublisherIDModelAccess(t *testing.T) {
 	const (
 		modelRefName   = "facebook-opt-125m-simulated"
@@ -2373,90 +2366,15 @@ func TestMaaSAuthPolicyReconciler_PublisherIDModelAccess(t *testing.T) {
 		t.Fatalf("require-group-membership rego missing: found=%v err=%v", found, err)
 	}
 
-	standardKey := namespace + "/" + modelRefName
-
-	t.Run("model_access contains standard namespace/name key", func(t *testing.T) {
-		if !strings.Contains(rego, standardKey) {
-			t.Errorf("model_access should contain standard key %q, rego:\n%s", standardKey, rego)
+	t.Run("rego is fixed-size with no model-specific data", func(t *testing.T) {
+		if !strings.Contains(rego, "accessAllowed") {
+			t.Errorf("rego should reference accessAllowed, got: %s", rego)
 		}
-	})
-
-	t.Run("model_access contains publisher ID key for LLMInferenceService", func(t *testing.T) {
-		if !strings.Contains(rego, publisherID) {
-			t.Errorf("model_access should contain publisher ID key %q, rego:\n%s", publisherID, rego)
+		if strings.Contains(rego, "model_access") {
+			t.Errorf("rego should not contain model_access, got: %s", rego)
 		}
-	})
-}
-
-// TestMaaSAuthPolicyReconciler_ExternalModelAccess verifies that the gateway
-// AuthPolicy's model_access map contains an ExternalModel CR name-keyed entry,
-// allowing BBR requests with the model name from /v1/models to pass auth.
-func TestMaaSAuthPolicyReconciler_ExternalModelAccess(t *testing.T) {
-	const (
-		modelRefName   = "my-gpt4o"
-		emName         = "my-gpt4o"
-		namespace      = "default"
-		gatewayNS      = "gateway-ns"
-		maasPolicyName = "policy-ext"
-	)
-
-	modelRef := newMaaSModelRef(modelRefName, namespace, "ExternalModel", emName)
-	modelRef.Status.ResolvedModelAlias = emName
-	route := newHTTPRoute(modelRefName, namespace)
-	maasPolicy := newMaaSAuthPolicy(maasPolicyName, namespace, "team-a",
-		maasv1alpha1.ModelRef{Name: modelRefName, Namespace: namespace},
-	)
-
-	c := fake.NewClientBuilder().
-		WithScheme(scheme).
-		WithRESTMapper(testRESTMapper()).
-		WithObjects(modelRef, route, maasPolicy).
-		WithStatusSubresource(&maasv1alpha1.MaaSAuthPolicy{}).
-		Build()
-
-	r := &MaaSAuthPolicyReconciler{
-		Client:           c,
-		Scheme:           scheme,
-		InfraNamespace:   "maas-system",
-		GatewayName:      "maas-default-gateway",
-		GatewayNamespace: gatewayNS,
-		MetadataCacheTTL: 60,
-		AuthzCacheTTL:    60,
-	}
-
-	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: maasPolicyName, Namespace: namespace}}
-	if _, err := r.Reconcile(context.Background(), req); err != nil {
-		t.Fatalf("Reconcile: unexpected error: %v", err)
-	}
-
-	gwPolicy := &unstructured.Unstructured{}
-	gwPolicy.SetGroupVersionKind(schema.GroupVersionKind{Group: "kuadrant.io", Version: "v1", Kind: "AuthPolicy"})
-	if err := c.Get(context.Background(), types.NamespacedName{Name: "maas-gateway-auth", Namespace: gatewayNS}, gwPolicy); err != nil {
-		t.Fatalf("Get gateway AuthPolicy: %v", err)
-	}
-
-	rego, found, err := unstructured.NestedString(gwPolicy.Object, "spec", "defaults", "rules", "authorization", "require-group-membership", "opa", "rego")
-	if err != nil || !found {
-		t.Fatalf("require-group-membership rego missing: found=%v err=%v", found, err)
-	}
-
-	standardKey := namespace + "/" + modelRefName
-
-	t.Run("model_access contains standard namespace/name key", func(t *testing.T) {
-		if !strings.Contains(rego, standardKey) {
-			t.Errorf("model_access should contain standard key %q, rego:\n%s", standardKey, rego)
-		}
-	})
-
-	t.Run("model_access contains ExternalModel CR name key", func(t *testing.T) {
-		if !strings.Contains(rego, `"`+emName+`"`) {
-			t.Errorf("model_access should contain ExternalModel CR name key %q, rego:\n%s", emName, rego)
-		}
-	})
-
-	t.Run("model_access does NOT contain publishers/ for ExternalModel", func(t *testing.T) {
-		if strings.Contains(rego, "publishers/") {
-			t.Errorf("model_access should not contain publisher ID for ExternalModel, rego:\n%s", rego)
+		if strings.Contains(rego, publisherID) {
+			t.Errorf("rego should not contain publisher ID %q, got: %s", publisherID, rego)
 		}
 	})
 }

--- a/maas-controller/pkg/controller/maas/maasauthpolicy_gateway_aggregate_test.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_gateway_aggregate_test.go
@@ -1,90 +1,18 @@
 package maas
 
 import (
-	"context"
-	"encoding/json"
 	"strings"
 	"testing"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-
-	maasv1alpha1 "github.com/opendatahub-io/models-as-a-service/maas-controller/api/maas/v1alpha1"
 )
 
-func TestAggregateModelSubjectAllowlistsAndGatewaySpec(t *testing.T) {
-	const policyNamespace = "models-as-a-service"
-
-	policyA := newMaaSAuthPolicy(
-		"policy-a",
-		policyNamespace,
-		"group-a",
-		maasv1alpha1.ModelRef{Name: "model-a", Namespace: "llm"},
-		maasv1alpha1.ModelRef{Name: "model-b", Namespace: "llm"},
-	)
-	policyA.Spec.Subjects.Users = []string{"user-a"}
-
-	policyB := newMaaSAuthPolicy(
-		"policy-b",
-		policyNamespace,
-		"group-b",
-		maasv1alpha1.ModelRef{Name: "model-a", Namespace: "llm"},
-	)
-	policyB.Spec.Subjects.Users = []string{"user-b", "user-a"}
-
-	policyOtherNamespace := newMaaSAuthPolicy(
-		"policy-c",
-		"other-namespace",
-		"group-z",
-		maasv1alpha1.ModelRef{Name: "model-a", Namespace: "llm"},
-	)
-	policyOtherNamespace.Spec.Subjects.Users = []string{"user-z"}
-
-	c := fake.NewClientBuilder().
-		WithScheme(scheme).
-		WithRESTMapper(testRESTMapper()).
-		WithObjects(policyA, policyB, policyOtherNamespace).
-		Build()
-
+func TestRequireGroupMembershipRegoIsFixedSize(t *testing.T) {
 	r := &MaaSAuthPolicyReconciler{
-		Client:           c,
-		Scheme:           scheme,
 		InfraNamespace:   "opendatahub",
 		GatewayNamespace: "openshift-ingress",
 		GatewayName:      "maas-default-gateway",
 	}
 
-	allowlists, err := r.aggregateModelSubjectAllowlists(context.Background(), policyNamespace)
-	if err != nil {
-		t.Fatalf("aggregateModelSubjectAllowlists returned error: %v", err)
-	}
-
-	if len(allowlists) != 2 {
-		t.Fatalf("expected 2 model allowlist entries, got %d", len(allowlists))
-	}
-
-	modelA := allowlists["llm/model-a"]
-	if got, want := strings.Join(modelA.Groups, ","), "group-a,group-b"; got != want {
-		t.Fatalf("model-a groups = %q, want %q", got, want)
-	}
-	if got, want := strings.Join(modelA.Users, ","), "user-a,user-b"; got != want {
-		t.Fatalf("model-a users = %q, want %q", got, want)
-	}
-
-	modelB := allowlists["llm/model-b"]
-	if got, want := strings.Join(modelB.Groups, ","), "group-a"; got != want {
-		t.Fatalf("model-b groups = %q, want %q", got, want)
-	}
-	if got, want := strings.Join(modelB.Users, ","), "user-a"; got != want {
-		t.Fatalf("model-b users = %q, want %q", got, want)
-	}
-
-	allowlistsJSON, err := json.Marshal(allowlists)
-	if err != nil {
-		t.Fatalf("json.Marshal(allowlists) returned error: %v", err)
-	}
-
-	spec := r.buildGatewayAuthPolicySpec(string(allowlistsJSON), nil, false, "", "models-as-a-service", "test-gateway-ns", "test-gateway")
+	spec := r.buildGatewayAuthPolicySpec(nil, false, "", "models-as-a-service", "test-gateway-ns", "test-gateway")
 	defaults, ok := spec["defaults"].(map[string]any)
 	if !ok {
 		t.Fatalf("gateway spec missing defaults block")
@@ -101,6 +29,7 @@ func TestAggregateModelSubjectAllowlistsAndGatewaySpec(t *testing.T) {
 	if !ok {
 		t.Fatalf("gateway spec missing require-group-membership rule")
 	}
+
 	opa, ok := requireGroupMembership["opa"].(map[string]any)
 	if !ok {
 		t.Fatalf("gateway spec missing require-group-membership.opa block")
@@ -110,77 +39,97 @@ func TestAggregateModelSubjectAllowlistsAndGatewaySpec(t *testing.T) {
 		t.Fatalf("gateway spec missing require-group-membership.opa.rego string")
 	}
 
-	if !strings.Contains(rego, `"llm/model-a":{"users":["user-a","user-b"],"groups":["group-a","group-b"]}`) {
-		t.Fatalf("rego does not include aggregated model-a allowlist: %s", rego)
+	if !strings.Contains(rego, `accessAllowed`) {
+		t.Fatalf("rego does not reference accessAllowed from subscription-info metadata: %s", rego)
 	}
-	if !strings.Contains(rego, `"llm/model-b":{"users":["user-a"],"groups":["group-a"]}`) {
-		t.Fatalf("rego does not include aggregated model-b allowlist: %s", rego)
+	if strings.Contains(rego, `model_access`) {
+		t.Fatalf("rego still contains model_access variable (should be removed): %s", rego)
 	}
 }
 
-func TestAggregateModelSubjectAllowlistsModelNameAliases(t *testing.T) {
-	const policyNamespace = "models-as-a-service"
-
-	policy := newMaaSAuthPolicy(
-		"policy-a",
-		policyNamespace,
-		"group-a",
-		maasv1alpha1.ModelRef{Name: "model-a", Namespace: "llm"},
-	)
-	policy.Spec.Subjects.Users = []string{"user-a"}
-
-	// MaaSModelRef with Status.ResolvedModelAlias set — resolveHeaderModelKeys
-	// reads this to add body-routed alias keys into the aggregate.
-	modelRef := &maasv1alpha1.MaaSModelRef{
-		ObjectMeta: metav1.ObjectMeta{Name: "model-a", Namespace: "llm"},
-		Spec: maasv1alpha1.MaaSModelSpec{
-			ModelRef: maasv1alpha1.ModelReference{Kind: "ExternalModel", Name: "model-a"},
-		},
-		Status: maasv1alpha1.MaaSModelStatus{
-			ResolvedModelAlias: "claude-opus-4-8",
-		},
-	}
-
-	c := fake.NewClientBuilder().
-		WithScheme(scheme).
-		WithRESTMapper(testRESTMapper()).
-		WithObjects(policy, modelRef).
-		Build()
-
+func TestRequireGroupMembershipHasWhenGuard(t *testing.T) {
 	r := &MaaSAuthPolicyReconciler{
-		Client:           c,
-		Scheme:           scheme,
 		InfraNamespace:   "opendatahub",
 		GatewayNamespace: "openshift-ingress",
 		GatewayName:      "maas-default-gateway",
 	}
 
-	allowlists, err := r.aggregateModelSubjectAllowlists(context.Background(), policyNamespace)
-	if err != nil {
-		t.Fatalf("aggregateModelSubjectAllowlists returned error: %v", err)
-	}
-
-	alias, ok := allowlists["claude-opus-4-8"]
+	spec := r.buildGatewayAuthPolicySpec(nil, false, "", "models-as-a-service", "test-gateway-ns", "test-gateway")
+	defaults, ok := spec["defaults"].(map[string]any)
 	if !ok {
-		t.Fatalf("expected alias entry for claude-opus-4-8, got keys: %v", keysOf(allowlists))
+		t.Fatalf("gateway spec missing defaults block")
 	}
-	if got, want := strings.Join(alias.Groups, ","), "group-a"; got != want {
-		t.Fatalf("alias groups = %q, want %q", got, want)
+	rules, ok := defaults["rules"].(map[string]any)
+	if !ok {
+		t.Fatalf("gateway spec missing defaults.rules block")
 	}
-	if got, want := strings.Join(alias.Users, ","), "user-a"; got != want {
-		t.Fatalf("alias users = %q, want %q", got, want)
+	authorization, ok := rules["authorization"].(map[string]any)
+	if !ok {
+		t.Fatalf("gateway spec missing defaults.rules.authorization block")
+	}
+	requireGroupMembership, ok := authorization["require-group-membership"].(map[string]any)
+	if !ok {
+		t.Fatalf("gateway spec missing require-group-membership rule")
 	}
 
-	// Canonical namespace/name entry must be unaffected by aliasing.
-	if got, want := strings.Join(allowlists["llm/model-a"].Users, ","), "user-a"; got != want {
-		t.Fatalf("llm/model-a users = %q, want %q", got, want)
+	whenList, ok := requireGroupMembership["when"].([]any)
+	if !ok || len(whenList) == 0 {
+		t.Fatalf("require-group-membership must have a when guard to skip management endpoints")
+	}
+
+	whenEntry, ok := whenList[0].(map[string]any)
+	if !ok {
+		t.Fatalf("when guard entry is not a map")
+	}
+	predicate, ok := whenEntry["predicate"].(string)
+	if !ok || predicate == "" {
+		t.Fatalf("when guard must have a predicate CEL expression")
+	}
+	if predicate != celModelIdentityAvailable {
+		t.Fatalf("when guard predicate = %q, want celModelIdentityAvailable (%q)", predicate, celModelIdentityAvailable)
 	}
 }
 
-func keysOf(m map[string]modelSubjectAllowlist) []string {
-	keys := make([]string, 0, len(m))
-	for k := range m {
-		keys = append(keys, k)
+func TestRequireGroupMembershipCacheKey(t *testing.T) {
+	r := &MaaSAuthPolicyReconciler{
+		InfraNamespace:   "opendatahub",
+		GatewayNamespace: "openshift-ingress",
+		GatewayName:      "maas-default-gateway",
 	}
-	return keys
+
+	spec := r.buildGatewayAuthPolicySpec(nil, false, "", "models-as-a-service", "test-gateway-ns", "test-gateway")
+	defaults, ok := spec["defaults"].(map[string]any)
+	if !ok {
+		t.Fatalf("gateway spec missing defaults block")
+	}
+	rules, ok := defaults["rules"].(map[string]any)
+	if !ok {
+		t.Fatalf("gateway spec missing defaults.rules block")
+	}
+	authorization, ok := rules["authorization"].(map[string]any)
+	if !ok {
+		t.Fatalf("gateway spec missing defaults.rules.authorization block")
+	}
+	requireGroupMembership, ok := authorization["require-group-membership"].(map[string]any)
+	if !ok {
+		t.Fatalf("gateway spec missing require-group-membership rule")
+	}
+
+	cache, ok := requireGroupMembership["cache"].(map[string]any)
+	if !ok {
+		t.Fatalf("require-group-membership must have cache config")
+	}
+	key, ok := cache["key"].(map[string]any)
+	if !ok {
+		t.Fatalf("cache must have key config")
+	}
+	selector, ok := key["selector"].(string)
+	if !ok {
+		t.Fatalf("cache key must have selector")
+	}
+
+	expectedSelector := subscriptionGatewayCacheKeySelector()
+	if selector != expectedSelector {
+		t.Fatalf("cache key selector = %q, want %q (subscriptionGatewayCacheKeySelector)", selector, expectedSelector)
+	}
 }

--- a/test/e2e/tests/test_gateway_scoped_authpolicy.py
+++ b/test/e2e/tests/test_gateway_scoped_authpolicy.py
@@ -25,18 +25,8 @@ from multitenancy_helpers import (
 from test_helper import (
     MODEL_NAMESPACE,
     MODEL_REF,
-    _create_api_key,
-    _create_sa_token,
     _create_test_auth_policy,
-    _create_test_subscription,
     _delete_cr,
-    _delete_sa,
-    _get_cr,
-    _ns,
-    _sa_to_user,
-    _scale_kuadrant_controller_down,
-    _scale_kuadrant_controller_up,
-    _wait_for_gateway_auth_enforced,
     _wait_for_maas_auth_policy_phase,
     _wait_reconcile,
 )
@@ -89,21 +79,35 @@ class TestGatewayAuthPolicyStructure:
 class TestGatewayAuthPolicyLifecycle:
     """S10: Gateway auth is reconciled from MaaSAuthPolicy changes."""
 
-    def test_gateway_auth_embeds_model_allowlist(self):
-        """6.3: Aggregated subject allowlists appear in gateway auth rego."""
+    def test_gateway_auth_rego_is_fixed_size(self):
+        """6.3: Gateway auth rego is fixed-size — no model-specific data embedded."""
         suffix = uuid.uuid4().hex[:8]
         policy_name = f"e2e-gw-auth-{suffix}"
         unique_group = f"e2e-gw-group-{suffix}"
 
         try:
+            ap_before = get_gateway_authpolicy()
+            gen_before = (ap_before or {}).get("metadata", {}).get("generation")
+
             _create_test_auth_policy(policy_name, MODEL_REF, groups=[unique_group])
             _wait_for_maas_auth_policy_phase(policy_name, timeout=120, require_auth_policies=False)
 
             rego = _gateway_auth_rego()
-            assert unique_group in rego, (
-                f"expected gateway auth rego to include group {unique_group!r}"
+            assert "accessAllowed" in rego, (
+                f"gateway auth rego must reference accessAllowed from subscription-info metadata, got:\n{rego}"
+            )
+            assert unique_group not in rego, (
+                f"gateway auth rego must NOT contain model-specific group {unique_group!r} "
+                f"(rego should be fixed-size), got:\n{rego}"
             )
             assert_no_per_model_authpolicy(MODEL_REF, MODEL_NAMESPACE)
+
+            ap_after = get_gateway_authpolicy()
+            gen_after = (ap_after or {}).get("metadata", {}).get("generation")
+            assert gen_before == gen_after, (
+                f"gateway AuthPolicy generation must not change when a MaaSAuthPolicy is added "
+                f"(rego is fixed-size). Before: {gen_before}, after: {gen_after}"
+            )
         finally:
             _delete_cr("maasauthpolicy", policy_name)
             _wait_reconcile()
@@ -145,14 +149,27 @@ class TestGatewayAuthPolicyManagementEndpointAccess:
     on clusters with zero subscriptions.
     """
 
-    def test_gateway_auth_rego_allows_empty_model_identity(self):
-        """OPA rego must allow requests where model_identity is empty (management endpoints)."""
-        rego = _gateway_auth_rego()
-        assert rego, "gateway auth rego must not be empty"
-        assert 'model_identity == ""' in rego, (
-            "gateway auth rego must contain an allow rule for empty model_identity "
-            "(management endpoints like /v1/api-keys, /maas-api/*). "
-            f"Got rego:\n{rego}"
+    def test_gateway_auth_group_membership_has_when_guard(self):
+        """require-group-membership must have a when guard to skip management endpoints."""
+        ap = get_gateway_authpolicy()
+        assert ap is not None
+
+        authorization = (
+            ((ap.get("spec") or {}).get("defaults") or {})
+            .get("rules", {})
+            .get("authorization")
+            or {}
+        )
+        membership = authorization.get("require-group-membership") or {}
+        when_list = membership.get("when") or []
+        assert len(when_list) > 0, (
+            "require-group-membership must have a 'when' guard so it only runs for "
+            "model inference, not management endpoints (replaces old model_identity == '' rego)"
+        )
+        predicate = when_list[0].get("predicate", "")
+        assert "request.path.split" in predicate and "x-gateway-model-name" in predicate, (
+            "require-group-membership 'when' predicate must use the model-identity CEL expression "
+            f"(path-based + header-based check), got: {predicate}"
         )
 
     def test_gateway_auth_subscription_check_gated_by_model_identity(self):
@@ -207,120 +224,3 @@ class TestGatewayAuthPolicyManagementEndpointAccess:
         )
 
 
-class TestEnforcementGapAfterAuthPolicyChange:
-    """RHOAIENG-79568: Auth enforcement gap when a spec change updates the gateway AuthPolicy.
-
-    Reproduces the scenario where a new MaaSAuthPolicy (or any change that alters the
-    aggregated model allowlist) updates the gateway AuthPolicy spec. Kuadrant must
-    re-process the update; until it does, observedGeneration lags behind generation
-    and enforcement is stale.
-
-    The test scales Kuadrant down to freeze enforcement, then creates a second
-    MaaSAuthPolicy to trigger a gateway AuthPolicy spec change. This widens the
-    normally sub-second enforcement gap to a permanent, observable state.
-
-    Verifies:
-    - With the controller fix: MaaSAuthPolicy stays Pending while gateway is unenforced
-    - Without the fix: MaaSAuthPolicy falsely reports Active
-    """
-
-    def test_controller_holds_pending_while_unenforced(self):
-        """With Kuadrant down, MaaSAuthPolicy must NOT reach Active after a
-        gateway AuthPolicy spec change.
-
-        Steps:
-        1. Establish baseline: auth policy Active, gateway Enforced
-        2. Scale Kuadrant down (freeze enforcement)
-        3. Create a second MaaSAuthPolicy (changes aggregated allowlist → spec update)
-        4. Wait for maas-controller to reconcile
-        5. Check MaaSAuthPolicy phase — should be Pending (not Active)
-        6. Scale Kuadrant back up, wait for enforcement
-        7. Verify MaaSAuthPolicy reaches Active and API key creation succeeds
-        """
-        ns = _ns()
-        suffix = uuid.uuid4().hex[:8]
-        auth_name_1 = f"e2e-enforce-gap-auth1-{suffix}"
-        auth_name_2 = f"e2e-enforce-gap-auth2-{suffix}"
-        sub_name = f"e2e-enforce-gap-sub-{suffix}"
-        sa_name = f"e2e-enforce-gap-sa-{suffix}"
-
-        try:
-            # Step 1: Establish baseline with first auth policy.
-            oc_token = _create_sa_token(sa_name, namespace=MODEL_NAMESPACE)
-            sa_user = _sa_to_user(sa_name, namespace=MODEL_NAMESPACE)
-
-            _create_test_auth_policy(auth_name_1, MODEL_REF, users=[sa_user])
-            _create_test_subscription(sub_name, MODEL_REF, users=[sa_user])
-            _wait_for_maas_auth_policy_phase(auth_name_1, timeout=120, require_enforced=True)
-            _wait_for_gateway_auth_enforced()
-            log.info("Step 1: Baseline established — auth Active, gateway Enforced")
-
-            # Step 2: Scale Kuadrant down to freeze enforcement.
-            log.info("Step 2: Scaling Kuadrant down to freeze enforcement...")
-            _scale_kuadrant_controller_down()
-
-            # Step 3: Create a second MaaSAuthPolicy with a different group.
-            # This changes the aggregated model allowlist, which changes the gateway
-            # AuthPolicy spec. The maas-controller will update the spec, but Kuadrant
-            # (now down) cannot re-process it → observedGeneration lags → not enforced.
-            log.info("Step 3: Creating second MaaSAuthPolicy to trigger spec change...")
-            unique_group = f"e2e-trigger-group-{suffix}"
-            _create_test_auth_policy(auth_name_2, MODEL_REF, groups=[unique_group])
-
-            # Step 4: Wait for maas-controller to reconcile.
-            # The controller updates the gateway AuthPolicy, then checks enforcement.
-            # With Kuadrant down, observedGeneration won't catch up → Enforced stale.
-            _wait_reconcile(seconds=15)
-
-            # Step 5: Check MaaSAuthPolicy phase.
-            # Check both policies — both should be affected by the enforcement gate.
-            cr1 = _get_cr("maasauthpolicy", auth_name_1, namespace=ns)
-            cr2 = _get_cr("maasauthpolicy", auth_name_2, namespace=ns)
-            phase1 = (cr1 or {}).get("status", {}).get("phase", "unknown")
-            phase2 = (cr2 or {}).get("status", {}).get("phase", "unknown")
-            log.info("Step 5: MaaSAuthPolicy phases: %s=%s, %s=%s",
-                     auth_name_1, phase1, auth_name_2, phase2)
-
-            if phase2 == "Pending":
-                log.info("Controller correctly holding MaaSAuthPolicy in Pending "
-                         "while gateway AuthPolicy is not enforced")
-            elif phase2 == "Active":
-                log.warning("MaaSAuthPolicy is Active despite gateway not being enforced "
-                            "— controller is NOT checking enforcement (pre-fix behavior)")
-
-            # Step 6: Scale Kuadrant back up and wait for enforcement.
-            log.info("Step 6: Scaling Kuadrant back up...")
-            _scale_kuadrant_controller_up()
-            _wait_for_gateway_auth_enforced(timeout=180)
-            _wait_for_maas_auth_policy_phase(
-                auth_name_1, "Active", timeout=120, require_enforced=True
-            )
-            log.info("Step 6: Enforcement restored")
-
-            # Step 7: Verify API key creation succeeds.
-            api_key = _create_api_key(oc_token, name=f"post-gap-{suffix}", subscription=sub_name)
-            assert api_key and api_key.startswith("sk-"), (
-                f"Expected valid API key after enforcement restored, got: "
-                f"{api_key[:20] if api_key else None}"
-            )
-            log.info("Step 7: API key creation succeeded after enforcement restored")
-
-            # Final assertion: the second auth policy (the one that triggered the
-            # spec change) should have been held in Pending while Kuadrant was down.
-            assert phase2 == "Pending", (
-                f"RHOAIENG-79568: MaaSAuthPolicy '{auth_name_2}' was '{phase2}' while "
-                f"gateway AuthPolicy was NOT enforced (Kuadrant was down). "
-                f"With the enforcement-check fix, the controller should hold Pending "
-                f"until Enforced=True."
-            )
-
-        finally:
-            try:
-                _scale_kuadrant_controller_up()
-            except Exception as e:
-                log.warning("Failed to scale Kuadrant up during cleanup: %s", e)
-            _delete_cr("maassubscription", sub_name, namespace=ns)
-            _delete_cr("maasauthpolicy", auth_name_2, namespace=ns)
-            _delete_cr("maasauthpolicy", auth_name_1, namespace=ns)
-            _delete_sa(sa_name, namespace=MODEL_NAMESPACE)
-            _wait_reconcile()


### PR DESCRIPTION
## Summary

- The gateway AuthPolicy's `require-group-membership` Rego embedded all user/group allowlists as an inline `model_access` JSON variable that grew linearly with subscriptions, hitting etcd's 3.5 MB WasmPlugin CR limit at ~768 subscriptions
- Fold the access check into the existing `subscription-select` metadata evaluator: maas-api sets `AccessAllowed` on `SelectResponse` by calling `AuthorizedModels()`, and the controller replaces the unbounded Rego with a fixed-size rule that reads `accessAllowed` from cached subscription-info metadata
- Add `when` guard (`celModelIdentityAvailable`) to skip the rule on management endpoints (`/v1/models`, `/maas-api/v1/api-keys`), matching prior behavior                                                                                                                                
- Align cache key with `subscriptionGatewayCacheKeySelector()` for coherence with `subscription-valid`

## Risk analysis                                                                                                                              

- **Risk rating:** 4                                                                                                                          
- **Why:** Changes the authorization enforcement path for every model inference request. Unit tests cover the new Rego, cache keys, `when` guard, and `AccessAllowed` field across all `Select()` branches, but the full auth flow (Authorino → maas-api → OPA evaluation) is only exercised end-to-end by the Prow smoke path which may not cover all MaaSAuthPolicy scenarios. Brief denial window (~seconds) during rollout while maas-api pods restart, as the new Rego defaults `accessAllowed` to `false` until the updated maas-api starts serving.                   

## Test plan
- [x] `make -C maas-api test` — all subscription selector tests pass (8 new AccessAllowed cases)
- [x] `make -C maas-controller test` — all controller tests pass (~15 updated/new tests)
- [x] `make -C maas-api lint` — 0 issues
- [x] `make -C maas-controller lint` — 0 issues
- [x] Deploy and verify AuthPolicy CR's `require-group-membership` Rego is fixed-size with no `model_access` variable
- [ ] Verify inference requests with authorized/unauthorized models return correct allow/deny
- [ ] Verify management endpoints (`/v1/models`) continue to work without access check

Fixes: [RHOAIENG-76583](https://redhat.atlassian.net/browse/RHOAIENG-76583)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


[RHOAIENG-76583]: https://redhat.atlassian.net/browse/RHOAIENG-76583?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Subscription selection now reports whether access to the requested model is allowed.
  * Requests without a specified model remain accessible; unauthorized or incomplete model access requests are denied.
  * Gateway authorization now uses the subscription access decision and model identity.

* **Bug Fixes**
  * Prevented access when authorization data or matching model information is missing.

* **Tests**
  * Expanded coverage for authorized, unauthorized, and cross-namespace subscription scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->