### PR TITLE
fix: aggregate all warnings before setting Degraded condition on MaasTenantConfig

### DIFF
--- a/maas-controller/pkg/controller/maas/tenant_conditions.go
+++ b/maas-controller/pkg/controller/maas/tenant_conditions.go
@@ -40,16 +40,13 @@ func setPrerequisiteConditionsFromReport(tenant *maasv1alpha1.MaasTenantConfig, 
 		setTenantCondition(tenant, tenantreconcile.ConditionTypeDegraded, metav1.ConditionTrue,
 			"PrerequisitesMissing", agg)
 	case len(rep.Warnings) > 0:
-		agg := strings.Join(rep.Warnings, "; ")
 		setTenantCondition(tenant, tenantreconcile.ConditionMaaSPrerequisitesAvailable, metav1.ConditionTrue,
 			"PrerequisitesMet", "Prerequisites satisfied; see Degraded for warnings")
-		setTenantCondition(tenant, tenantreconcile.ConditionTypeDegraded, metav1.ConditionTrue,
-			"PrerequisitesWarning", agg)
+		// Note: Degraded is set by aggregateWarningsAndSetDegraded
 	default:
 		setTenantCondition(tenant, tenantreconcile.ConditionMaaSPrerequisitesAvailable, metav1.ConditionTrue,
 			"PrerequisitesMet", "All prerequisites are satisfied")
-		setTenantCondition(tenant, tenantreconcile.ConditionTypeDegraded, metav1.ConditionFalse,
-			"PrerequisitesMet", "All prerequisites are satisfied")
+		// Note: Degraded is set by aggregateWarningsAndSetDegraded
 	}
 }
 

--- a/maas-controller/pkg/controller/maas/tenant_reconcile.go
+++ b/maas-controller/pkg/controller/maas/tenant_reconcile.go
@@ -154,18 +154,22 @@ func (r *TenantReconciler) reconcile(ctx context.Context, req ctrl.Request) (ctr
 	}
 
 	// Check dependencies and prerequisites
-	if result, err := r.checkDependenciesAndPrerequisites(ctx, &tenant); result != nil {
+	prereqReport, result, err := r.checkDependenciesAndPrerequisites(ctx, &tenant)
+	if result != nil {
 		return *result, err
 	}
 
 	// Run platform reconciliation
-	result, err = r.reconcilePlatform(ctx, log, &tenant, platformContext, mcfg)
+	runRes, result, err := r.reconcilePlatform(ctx, log, &tenant, platformContext, mcfg)
 	if result != nil {
 		return *result, err
 	}
 	if err != nil {
 		return ctrl.Result{}, err
 	}
+
+	// Aggregate all warnings and set Degraded condition once
+	r.aggregateWarningsAndSetDegraded(&tenant, prereqReport, runRes)
 
 	// Cleanup legacy resources
 	r.attemptLegacyCleanup(ctx, log)
@@ -273,16 +277,16 @@ func (r *TenantReconciler) validateConfigAndGateway(ctx context.Context, log log
 	return mcfg, platformContext, nil, nil
 }
 
-func (r *TenantReconciler) checkDependenciesAndPrerequisites(ctx context.Context, tenant *maasv1alpha1.MaasTenantConfig) (*ctrl.Result, error) {
+func (r *TenantReconciler) checkDependenciesAndPrerequisites(ctx context.Context, tenant *maasv1alpha1.MaasTenantConfig) (tenantreconcile.PrerequisiteReport, *ctrl.Result, error) {
 	if err := tenantreconcile.CheckDependencies(ctx, r.Client); err != nil {
 		setDependenciesCondition(tenant, false, err.Error())
 		setDeploymentsAvailableCondition(tenant, false, "DependenciesNotMet", err.Error())
 		prerequisitesUnevaluatedCondition(tenant, "Prerequisites were not evaluated because required dependencies are not met")
 		if err2 := r.patchStatus(ctx, tenant, "Pending", metav1.ConditionFalse, "DependenciesNotAvailable", err.Error()); err2 != nil {
-			return nil, err2
+			return tenantreconcile.PrerequisiteReport{}, nil, err2
 		}
 		res := ctrl.Result{RequeueAfter: 45 * time.Second}
-		return &res, nil
+		return tenantreconcile.PrerequisiteReport{}, &res, nil
 	}
 	setDependenciesCondition(tenant, true, "")
 
@@ -302,13 +306,13 @@ func (r *TenantReconciler) checkDependenciesAndPrerequisites(ctx context.Context
 			LastTransitionTime: metav1.Now(),
 		})
 		if err := r.Status().Update(ctx, tenant); err != nil {
-			return nil, err
+			return tenantreconcile.PrerequisiteReport{}, nil, err
 		}
 		res := ctrl.Result{RequeueAfter: 45 * time.Second}
-		return &res, nil
+		return tenantreconcile.PrerequisiteReport{}, &res, nil
 	}
 
-	return nil, nil
+	return rep, nil, nil
 }
 
 func (r *TenantReconciler) reconcilePlatform(
@@ -317,26 +321,24 @@ func (r *TenantReconciler) reconcilePlatform(
 	tenant *maasv1alpha1.MaasTenantConfig,
 	platformContext tenantreconcile.PlatformContext,
 	mcfg *maasv1alpha1.Config,
-) (*ctrl.Result, error) {
+) (*tenantreconcile.RunResult, *ctrl.Result, error) {
 	appNs := r.appNamespaceForTenant()
 	runRes, err := tenantreconcile.RunPlatform(ctx, log, r.Client, r.Scheme, tenant, platformContext, r.ManifestPath, appNs, r.ControllerNamespace, r.ClusterAudience, mcfg)
 	if err != nil {
 		log.Error(err, "Tenant platform reconcile failed")
 		setDeploymentsAvailableCondition(tenant, false, "PlatformReconcileFailed", err.Error())
 		if err2 := r.patchStatus(ctx, tenant, "Failed", metav1.ConditionFalse, "PlatformReconcileFailed", err.Error()); err2 != nil {
-			return nil, err2
+			return nil, nil, err2
 		}
 		res := ctrl.Result{RequeueAfter: 45 * time.Second}
-		return &res, nil
+		return nil, &res, nil
 	}
 
 	if err := r.ensureGatewayManagementAuth(ctx, log, tenant); err != nil {
 		log.Error(err, "failed to ensure gateway management auth, will retry")
 		res := ctrl.Result{RequeueAfter: 45 * time.Second}
-		return &res, nil
+		return nil, &res, nil
 	}
-
-	surfaceReplicaWarnings(tenant, runRes)
 
 	if runRes.DeploymentPending {
 		tenant.Status.Phase = "Pending"
@@ -350,22 +352,49 @@ func (r *TenantReconciler) reconcilePlatform(
 			LastTransitionTime: metav1.Now(),
 		})
 		if err := r.Status().Update(ctx, tenant); err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		res := ctrl.Result{RequeueAfter: 20 * time.Second}
-		return &res, nil
+		return nil, &res, nil
 	}
 
-	return nil, nil
+	return runRes, nil, nil
 }
 
-func surfaceReplicaWarnings(tenant *maasv1alpha1.MaasTenantConfig, runRes *tenantreconcile.RunResult) {
-	if len(runRes.Warnings) > 0 {
+func (r *TenantReconciler) aggregateWarningsAndSetDegraded(
+	tenant *maasv1alpha1.MaasTenantConfig,
+	prereqReport tenantreconcile.PrerequisiteReport,
+	runRes *tenantreconcile.RunResult,
+) {
+	var allWarnings []string
+	hasPrereqWarnings := len(prereqReport.Warnings) > 0
+	hasReplicaWarnings := runRes != nil && len(runRes.Warnings) > 0
+
+	// Collect prerequisite warnings
+	if hasPrereqWarnings {
+		allWarnings = append(allWarnings, prereqReport.Warnings...)
+	}
+
+	// Collect replica warnings
+	if hasReplicaWarnings {
+		allWarnings = append(allWarnings, runRes.Warnings...)
+	}
+
+	// Set Degraded condition once with all aggregated warnings
+	if len(allWarnings) > 0 {
+		var reason string
+		switch {
+		case hasPrereqWarnings && hasReplicaWarnings:
+			reason = "MultipleWarnings"
+		case hasPrereqWarnings:
+			reason = "PrerequisitesWarning"
+		case hasReplicaWarnings:
+			reason = "InvalidReplicaAnnotation"
+		}
 		setTenantCondition(tenant, tenantreconcile.ConditionTypeDegraded, metav1.ConditionTrue,
-			"InvalidReplicaAnnotation", strings.Join(runRes.Warnings, "; "))
-	} else if apimeta.IsStatusConditionTrue(tenant.Status.Conditions, tenantreconcile.ConditionTypeDegraded) {
-		setTenantCondition(tenant, tenantreconcile.ConditionTypeDegraded, metav1.ConditionFalse,
-			"Resolved", "")
+			reason, strings.Join(allWarnings, "; "))
+	} else {
+		setTenantCondition(tenant, tenantreconcile.ConditionTypeDegraded, metav1.ConditionFalse, "NoWarnings", "")
 	}
 }
 

--- a/maas-controller/pkg/controller/maas/tenant_reconcile_test.go
+++ b/maas-controller/pkg/controller/maas/tenant_reconcile_test.go
@@ -840,3 +840,110 @@ func TestTenantReconcile_NotFoundIsNoOp(t *testing.T) {
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(res).To(Equal(ctrl.Result{}))
 }
+
+func TestAggregateWarningsAndSetDegraded(t *testing.T) {
+	tests := []struct {
+		name            string
+		prereqWarnings  []string
+		replicaWarnings []string
+		wantReason      string
+		wantStatus      metav1.ConditionStatus
+		wantMessage     string
+	}{
+		{
+			name:            "no warnings",
+			prereqWarnings:  nil,
+			replicaWarnings: nil,
+			wantReason:      "NoWarnings",
+			wantStatus:      metav1.ConditionFalse,
+			wantMessage:     "",
+		},
+		{
+			name:            "single prerequisite warning",
+			prereqWarnings:  []string{"DSCI monitoring stack not available"},
+			replicaWarnings: nil,
+			wantReason:      "PrerequisitesWarning",
+			wantStatus:      metav1.ConditionTrue,
+			wantMessage:     "DSCI monitoring stack not available",
+		},
+		{
+			name:            "multiple prerequisite warnings",
+			prereqWarnings:  []string{"DSCI monitoring stack not available", "Perses not available"},
+			replicaWarnings: nil,
+			wantReason:      "PrerequisitesWarning",
+			wantStatus:      metav1.ConditionTrue,
+			wantMessage:     "DSCI monitoring stack not available; Perses not available",
+		},
+		{
+			name:            "single replica warning",
+			prereqWarnings:  nil,
+			replicaWarnings: []string{"invalid replica annotation on maas-api"},
+			wantReason:      "InvalidReplicaAnnotation",
+			wantStatus:      metav1.ConditionTrue,
+			wantMessage:     "invalid replica annotation on maas-api",
+		},
+		{
+			name:            "multiple replica warnings",
+			prereqWarnings:  nil,
+			replicaWarnings: []string{"invalid replica annotation on maas-api", "invalid replica annotation on payload-processing"},
+			wantReason:      "InvalidReplicaAnnotation",
+			wantStatus:      metav1.ConditionTrue,
+			wantMessage:     "invalid replica annotation on maas-api; invalid replica annotation on payload-processing",
+		},
+		{
+			name:            "both prerequisite and replica warnings",
+			prereqWarnings:  []string{"DSCI monitoring stack not available"},
+			replicaWarnings: []string{"invalid replica annotation on maas-api"},
+			wantReason:      "MultipleWarnings",
+			wantStatus:      metav1.ConditionTrue,
+			wantMessage:     "DSCI monitoring stack not available; invalid replica annotation on maas-api",
+		},
+		{
+			name:            "multiple of both types",
+			prereqWarnings:  []string{"DSCI monitoring stack not available", "Perses not available"},
+			replicaWarnings: []string{"invalid replica annotation on maas-api", "invalid replica annotation on payload-processing"},
+			wantReason:      "MultipleWarnings",
+			wantStatus:      metav1.ConditionTrue,
+			wantMessage:     "DSCI monitoring stack not available; Perses not available; invalid replica annotation on maas-api; invalid replica annotation on payload-processing",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			s := tenantTestScheme(t)
+
+			tenant := &maasv1alpha1.MaasTenantConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "default-tenant",
+					Namespace:  "models-as-a-service",
+					Generation: 1,
+				},
+			}
+
+			prereqReport := tenantreconcile.PrerequisiteReport{
+				Warnings: tt.prereqWarnings,
+			}
+
+			var runRes *tenantreconcile.RunResult
+			if tt.replicaWarnings != nil {
+				runRes = &tenantreconcile.RunResult{
+					Warnings: tt.replicaWarnings,
+				}
+			}
+
+			r := &TenantReconciler{
+				Client: fake.NewClientBuilder().WithScheme(s).Build(),
+				Scheme: s,
+			}
+
+			r.aggregateWarningsAndSetDegraded(tenant, prereqReport, runRes)
+
+			degradedCond := apimeta.FindStatusCondition(tenant.Status.Conditions, tenantreconcile.ConditionTypeDegraded)
+			g.Expect(degradedCond).NotTo(BeNil(), "Degraded condition should be set")
+			g.Expect(degradedCond.Status).To(Equal(tt.wantStatus), "Degraded status mismatch")
+			g.Expect(degradedCond.Reason).To(Equal(tt.wantReason), "Degraded reason mismatch")
+			g.Expect(degradedCond.Message).To(Equal(tt.wantMessage), "Degraded message mismatch")
+		})
+	}
+}

--- a/maas-controller/pkg/platform/tenantreconcile/prerequisites.go
+++ b/maas-controller/pkg/platform/tenantreconcile/prerequisites.go
@@ -145,6 +145,8 @@ func checkDatabaseSecret(ctx context.Context, c client.Client, appNamespace stri
 }
 
 func checkDSCIMonitoring(ctx context.Context, c client.Client) string {
+	log := log.FromContext(ctx)
+
 	// Look for DSCInitialization resources
 	dsciList := &unstructured.UnstructuredList{}
 	dsciList.SetGroupVersionKind(schema.GroupVersionKind{
@@ -158,7 +160,7 @@ func checkDSCIMonitoring(ctx context.Context, c client.Client) string {
 			return "DSCI monitoring not configured: DSCInitialization CRD not found. " +
 				"Showback/FinOps usage views will not work without monitoring stack enabled"
 		}
-		log.FromContext(ctx).Error(err, "unable to verify DSCI monitoring status")
+		log.Error(err, "unable to verify DSCI monitoring status")
 		return "unable to verify DSCI monitoring status due to a cluster API error. " +
 			"Ensure monitoring is enabled in DSCInitialization for showback functionality"
 	}
@@ -181,7 +183,7 @@ func checkDSCIMonitoring(ctx context.Context, c client.Client) string {
 	// Check MonitoringStackAvailable, MonitoringReady, and PersesAvailable conditions
 	conditionsSlice, found, err := unstructured.NestedSlice(dsci.Object, "status", "conditions")
 	if err != nil {
-		log.FromContext(ctx).Error(err, "unable to read DSCI conditions")
+		log.Error(err, "unable to read DSCI conditions")
 		return "unable to verify DSCI monitoring conditions due to a status read error. " +
 			"Ensure monitoring stack is deployed in DSCInitialization"
 	}


### PR DESCRIPTION
## Description
Previously, surfaceReplicaWarnings() unconditionally cleared the Degraded condition when no replica warnings existed, overwriting prerequisite warnings (e.g., DSCI MonitoringStackAvailable=False) that were set earlier in the reconciliation flow.

Refactored to collect all warnings (prerequisites + replica config) and set the Degraded condition once at the end of reconciliation with aggregated messages:

- PrerequisitesWarning: only prerequisite warnings present
- InvalidReplicaAnnotation: only replica config warnings present
- MultipleWarnings: both types present
- NoWarnings: no warnings

## How Has This Been Tested?
Tested manually

## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved degraded-status reporting by combining prerequisite and replica warnings.
  * Preserved accurate failure reasons, warning messages, status updates, and retry behavior.
  * Prevented degraded conditions from being incorrectly overwritten during reconciliation.

* **Tests**
  * Added coverage for no warnings, prerequisite warnings, replica warnings, and combined warning scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->