### PR TITLE
fix: pin ODH operator install to 3.5.0-ea.2

### DIFF
--- a/.github/hack/install-odh.sh
+++ b/.github/hack/install-odh.sh
@@ -8,8 +8,9 @@
 #   OPERATOR_CATALOG - Custom catalog image (optional). When unset, uses community-operators.
 #                      Set to e.g. quay.io/opendatahub/opendatahub-operator-catalog:latest for custom builds.
 #   OPERATOR_CHANNEL   - Subscription channel (default: fast-3)
-#   OPERATOR_STARTING_CSV - Pin Subscription startingCSV (optional). When unset,
-#                           follow the channel head (latest in fast-3 by default).
+#   OPERATOR_STARTING_CSV - Pin Subscription startingCSV
+#                           (default: opendatahub-operator.v3.5.0-ea.2).
+#                           Set to "-" to follow the channel head instead.
 #   OPERATOR_INSTALL_PLAN_APPROVAL - Manual (default) or Automatic; use "-" to omit.
 #     Manual: blocks auto-upgrades; this script auto-approves only the first InstallPlan so install does not stall.
 #   OPERATOR_IMAGE   - Custom operator image to patch into CSV (optional)
@@ -27,7 +28,7 @@ DATA_DIR="${REPO_ROOT}/scripts/data"
 NAMESPACE="${OPERATOR_NAMESPACE:-opendatahub}"
 OPERATOR_CATALOG="${OPERATOR_CATALOG:-}"
 OPERATOR_CHANNEL="${OPERATOR_CHANNEL:-}"
-OPERATOR_STARTING_CSV="${OPERATOR_STARTING_CSV:-}"
+OPERATOR_STARTING_CSV="${OPERATOR_STARTING_CSV:-opendatahub-operator.v3.5.0-ea.2}"
 OPERATOR_INSTALL_PLAN_APPROVAL="${OPERATOR_INSTALL_PLAN_APPROVAL:-}"
 OPERATOR_IMAGE="${OPERATOR_IMAGE:-}"
 
@@ -125,9 +126,9 @@ else
   channel="${OPERATOR_CHANNEL:-fast-3}"
 fi
 
-# Follow the configured channel head by default unless OPERATOR_STARTING_CSV
-# explicitly pins a CSV.
-starting_csv="${OPERATOR_STARTING_CSV:-}"
+# Pin to ODH 3.5 EA2 unless overridden (omit with OPERATOR_STARTING_CSV=- to follow channel head)
+starting_csv="${OPERATOR_STARTING_CSV:-opendatahub-operator.v3.5.0-ea.2}"
+[[ "$starting_csv" == "-" ]] && starting_csv=""
 
 # Manual = no auto-upgrades; install_olm_operator still approves the first InstallPlan programmatically
 plan_approval="${OPERATOR_INSTALL_PLAN_APPROVAL:-Manual}"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -147,7 +147,7 @@ DEV_MODE="${DEV_MODE:-false}"
 OPERATOR_CATALOG="${OPERATOR_CATALOG:-}"
 OPERATOR_IMAGE="${OPERATOR_IMAGE:-}"
 OPERATOR_CHANNEL="${OPERATOR_CHANNEL:-}"
-OPERATOR_STARTING_CSV="${OPERATOR_STARTING_CSV:-}"
+OPERATOR_STARTING_CSV="${OPERATOR_STARTING_CSV:-opendatahub-operator.v3.5.0-ea.2}"
 OPERATOR_INSTALL_PLAN_APPROVAL="${OPERATOR_INSTALL_PLAN_APPROVAL:-}"
 MAAS_API_IMAGE="${MAAS_API_IMAGE:-}"
 MAAS_CONTROLLER_IMAGE="${MAAS_CONTROLLER_IMAGE:-}"
@@ -257,7 +257,7 @@ ENVIRONMENT VARIABLES:
   AI_GATEWAY_OPERATOR_IMAGE Custom ai-gateway-operator image (operator mode only)
   OPERATOR_CATALOG          Custom operator catalog
   OPERATOR_IMAGE            Custom operator image
-  OPERATOR_STARTING_CSV     ODH Subscription startingCSV (optional; when unset, follows the channel head)
+  OPERATOR_STARTING_CSV     ODH Subscription startingCSV (default: opendatahub-operator.v3.5.0-ea.2; set "-" to follow channel head)
   OPERATOR_INSTALL_PLAN_APPROVAL  ODH Subscription OLM approval (default: Manual — no auto-upgrades; first InstallPlan is auto-approved by the script)
   OPERATOR_TYPE             Operator type (rhoai/odh)
   POLICY_ENGINE             Policy engine override (rhcl|kuadrant)
@@ -1282,9 +1282,9 @@ install_primary_operator() {
         channel="${OPERATOR_CHANNEL:-fast-3}"
       fi
 
-      # Follow the configured channel head by default unless OPERATOR_STARTING_CSV
-      # explicitly pins a CSV.
-      local odh_starting_csv="${OPERATOR_STARTING_CSV:-}"
+      # Pin to ODH 3.5 EA2 unless overridden (omit with OPERATOR_STARTING_CSV=- to follow channel head)
+      local odh_starting_csv="${OPERATOR_STARTING_CSV:-opendatahub-operator.v3.5.0-ea.2}"
+      [[ "$odh_starting_csv" == "-" ]] && odh_starting_csv=""
 
       # Manual = no auto-upgrades; install_olm_operator auto-approves the first InstallPlan only
       local odh_plan_approval="${OPERATOR_INSTALL_PLAN_APPROVAL:-Manual}"


### PR DESCRIPTION
## Summary
- Pins ODH OLM `startingCSV` to `opendatahub-operator.v3.5.0-ea.2` (`quay.io/opendatahub/opendatahub-operator:v3.5.0-ea.2`) in `.github/hack/install-odh.sh` and `scripts/deploy.sh`.
- Temporary CI/install stability pin while channel-head ODH leaves DSC/KServe NotReady in e2e.
- Override with `OPERATOR_STARTING_CSV=-` to follow the `fast-3` channel head, or set any other CSV explicitly.

## Test plan
- [ ] Confirm smoke/e2e install resolves CSV `opendatahub-operator.v3.5.0-ea.2`
- [ ] Confirm DSC becomes Ready with the pin
- [ ] Optional: `OPERATOR_STARTING_CSV=-` still follows channel head


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Deployments now default to the Open Data Hub Operator version 3.5.0-ea.2 for more predictable installations.
  * Set `OPERATOR_STARTING_CSV` to `-` to continue following the channel head.
  * Updated installation and deployment help text to document the default and override behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->