### PR TITLE
fix: split config.openshift.io rules into OCP-specific ClusterRole

### DIFF
--- a/deployment/base/maas-controller/base/kustomization.yaml
+++ b/deployment/base/maas-controller/base/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 resources:
   - ../crd
   - ../rbac
+  - ../rbac/ocp
   - ../manager
   - ../monitoring
   - ../webhook

--- a/deployment/base/maas-controller/default/kustomization.yaml
+++ b/deployment/base/maas-controller/default/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 resources:
   - ../crd
   - ../rbac
+  - ../rbac/ocp
   - ../manager
   - ../monitoring
   - ../webhook

--- a/deployment/base/maas-controller/rbac/clusterrole.yaml
+++ b/deployment/base/maas-controller/rbac/clusterrole.yaml
@@ -130,15 +130,6 @@ rules:
   - patch
   - watch
 - apiGroups:
-  - config.openshift.io
-  resources:
-  - apiservers
-  - authentications
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
   - discovery.k8s.io
   resources:
   - endpointslices

--- a/deployment/base/maas-controller/rbac/ocp/clusterrole_ocp.yaml
+++ b/deployment/base/maas-controller/rbac/ocp/clusterrole_ocp.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: maas-controller-ocp-role
+rules:
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - apiservers
+  - authentications
+  verbs:
+  - get
+  - list
+  - watch

--- a/deployment/base/maas-controller/rbac/ocp/clusterrolebinding_ocp.yaml
+++ b/deployment/base/maas-controller/rbac/ocp/clusterrolebinding_ocp.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: maas-controller-ocp-rolebinding
+  labels:
+    app.kubernetes.io/part-of: modelsasservice
+    app.opendatahub.io/modelsasservice: "true"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: maas-controller-ocp-role
+subjects:
+  - kind: ServiceAccount
+    name: maas-controller
+    namespace: opendatahub

--- a/deployment/base/maas-controller/rbac/ocp/kustomization.yaml
+++ b/deployment/base/maas-controller/rbac/ocp/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - clusterrole_ocp.yaml
+  - clusterrolebinding_ocp.yaml

--- a/maas-controller/Makefile
+++ b/maas-controller/Makefile
@@ -95,19 +95,21 @@ endif
 
 .PHONY: generate
 generate: $(CONTROLLER_GEN) ##	generate deepcopy code for API types
-	$(CONTROLLER_GEN) object paths="./api/..."
+	"$(CONTROLLER_GEN)" object paths="./api/..."
 
 .PHONY: manifests
 manifests: $(CONTROLLER_GEN) ##	generate CRD and RBAC manifests
-	$(CONTROLLER_GEN) crd paths="./api/..." output:crd:dir=../deployment/base/maas-controller/crd/bases
-	$(CONTROLLER_GEN) rbac:roleName=maas-controller-role paths="./..." output:rbac:dir=../deployment/base/maas-controller/rbac
+	"$(CONTROLLER_GEN)" crd paths="./api/..." output:crd:dir=../deployment/base/maas-controller/crd/bases
+	"$(CONTROLLER_GEN)" rbac:roleName=maas-controller-role paths=./cmd/... paths=./pkg/... paths=./api/... output:rbac:dir=../deployment/base/maas-controller/rbac
 	@mv ../deployment/base/maas-controller/rbac/role.yaml ../deployment/base/maas-controller/rbac/clusterrole.yaml
+	"$(CONTROLLER_GEN)" rbac:roleName=maas-controller-ocp-role paths=. output:rbac:dir=../deployment/base/maas-controller/rbac/ocp
+	@mv ../deployment/base/maas-controller/rbac/ocp/role.yaml ../deployment/base/maas-controller/rbac/ocp/clusterrole_ocp.yaml
 
 .PHONY: verify-codegen
 verify-codegen: generate manifests ##	run generate + manifests and fail if files changed (CI check)
-	@if ! git diff --quiet HEAD -- api/ ../deployment/base/maas-controller/crd/bases/ ../deployment/base/maas-controller/rbac/clusterrole.yaml; then \
+	@if ! git diff --quiet HEAD -- api/ ../deployment/base/maas-controller/crd/bases/ ../deployment/base/maas-controller/rbac/clusterrole.yaml ../deployment/base/maas-controller/rbac/ocp/clusterrole_ocp.yaml; then \
 		echo "ERROR: Generated files are out of date. Please run 'make -C maas-controller generate manifests' from the repo root and commit the results."; \
-		git diff --stat HEAD -- api/ ../deployment/base/maas-controller/crd/bases/ ../deployment/base/maas-controller/rbac/clusterrole.yaml; \
+		git diff --stat HEAD -- api/ ../deployment/base/maas-controller/crd/bases/ ../deployment/base/maas-controller/rbac/clusterrole.yaml ../deployment/base/maas-controller/rbac/ocp/clusterrole_ocp.yaml; \
 		exit 1; \
 	fi
 	@UNTRACKED=$$(git ls-files --others --exclude-standard -- api/ ../deployment/base/maas-controller/crd/bases/ ../deployment/base/maas-controller/rbac/); \

--- a/maas-controller/cmd/manager/main.go
+++ b/maas-controller/cmd/manager/main.go
@@ -87,7 +87,6 @@ func init() {
 }
 
 //+kubebuilder:rbac:groups="",resources=namespaces,verbs=get;create;patch
-//+kubebuilder:rbac:groups=config.openshift.io,resources=apiservers,verbs=get;list;watch
 
 // ensureManagedNamespaceWithClient checks whether a controller-managed namespace exists
 // and creates it if missing. It checks for existence first so that the controller can

--- a/maas-controller/ocp_rbac.go
+++ b/maas-controller/ocp_rbac.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package main holds OpenShift-specific RBAC markers. These are emitted into
+// a separate ClusterRole (maas-controller-ocp-role) so that non-OpenShift
+// deployments can exclude them without touching the generated maas-controller-role.
+package main
+
+// +kubebuilder:rbac:groups=config.openshift.io,resources=apiservers,verbs=get;list;watch
+// +kubebuilder:rbac:groups=config.openshift.io,resources=authentications,verbs=get;list;watch

--- a/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
@@ -459,7 +459,6 @@ func subscriptionGatewayCacheKeySelector() string {
 //+kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=httproutes,verbs=get;list;watch
 //+kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=gateways,verbs=get;list;watch
 //+kubebuilder:rbac:groups=discovery.k8s.io,resources=endpointslices,verbs=list;watch
-//+kubebuilder:rbac:groups=config.openshift.io,resources=authentications,verbs=get
 //+kubebuilder:rbac:groups=maas.opendatahub.io,resources=maastenantconfigs,verbs=get;list;watch
 //+kubebuilder:rbac:groups=maas.opendatahub.io,resources=tenants,verbs=get;list;watch
 //+kubebuilder:rbac:groups="",resources=events,verbs=create;patch

--- a/maas-controller/pkg/controller/maas/tenant_controller.go
+++ b/maas-controller/pkg/controller/maas/tenant_controller.go
@@ -92,7 +92,6 @@ type TenantReconciler struct {
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;patch;delete
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;create;patch;delete
 // +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=httproutes,verbs=get;list;watch;create;patch;delete
-// +kubebuilder:rbac:groups=config.openshift.io,resources=authentications,verbs=get;list;watch
 // +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch
 // +kubebuilder:rbac:groups=dscinitialization.opendatahub.io,resources=dscinitializations,verbs=get;list;watch
 // +kubebuilder:rbac:groups=operator.authorino.kuadrant.io,resources=authorinos,verbs=get;list;watch


### PR DESCRIPTION
## Description

`maas-controller-role` contains `config.openshift.io` rules (`apiservers`,
`authentications`) used by maas-controller on OpenShift for TLS profile and
OAuth/OIDC issuer discovery. On xKS those APIs do not exist and the rules are
dead weight.

The problem surfaces in ai-gateway-operator, which deploys MaaS manifests via
server-side apply with `ForceOwnership`. Kubernetes RBAC escalation prevention
requires the operator SA to hold every permission it grants in a ClusterRole it
applies. With `config.openshift.io` in `maas-controller-role`, the operator's
own `manager-role` must carry those rules cluster-wide on both OpenShift and
xKS — even though xKS never uses them.

### Changes

- Add `maas-controller/ocp_rbac.go` (package main, module root) holding only the
  `config.openshift.io` kubebuilder RBAC markers
- Wire two-pass controller-gen in the Makefile `manifests` target:
  - First pass: `paths=./cmd/... paths=./pkg/... paths=./api/...` → produces
    `rbac/clusterrole.yaml` (maas-controller-role, no config.openshift.io)
  - Second pass: `paths=.` (module root only) → produces
    `rbac/ocp/clusterrole_ocp.yaml` (maas-controller-ocp-role, only
    config.openshift.io)
- Remove the `config.openshift.io` markers from `cmd/manager/main.go`,
  `maasauthpolicy_controller.go`, and `tenant_controller.go` — they now live
  exclusively in `ocp_rbac.go`
- `rbac/ocp/` gets its own `kustomization.yaml`; the xKS overlay references
  `../../rbac` which resolves through `rbac/kustomization.yaml` (does not
  include `ocp/`), so OCP resources are automatically excluded from xKS with no
  overlay changes needed
- `verify-codegen` CI check updated to watch both generated files
- Quote `$(CONTROLLER_GEN)` in all four Makefile invocations

### Result

On OpenShift: maas-controller SA gets `config.openshift.io` permissions via
`maas-controller-ocp-role` as before. Both ClusterRoles are now fully generated
— `verify-codegen` will catch any drift.

On xKS: `maas-controller-ocp-role` and its binding are never applied. The
operator SA no longer needs to hold `config.openshift.io` permissions on xKS.

### Follow-up

After this merges, ai-gateway-operator (PR #76) will bump the MaaS commit SHA
and remove `config.openshift.io` from `manager-role`, moving it to the
OpenShift-only overlay where it belongs.