### PR TITLE
docs: warn against RHCL v1.4.0-v1.4.1 token rate limit bypass

### DIFF
--- a/docs/content/install/prerequisites.md
+++ b/docs/content/install/prerequisites.md
@@ -11,13 +11,22 @@ Red Hat OpenShift AI (RHOAI). MaaS is installed by enabling it in the DataScienc
 | MaaS Version | OCP | Kuadrant (ODH) / RHCL (RHOAI) | Gateway API |
 |--------------|-----|-------------------------------|-------------|
 | v0.0.2       | 4.19.9+ | v1.3+ / v1.2+             | v1.2+       |
-| v0.1.0+      | 4.19.9+ | v1.4.2+ / v1.3            | v1.2+       |
+| v0.1.0+      | 4.19.9+ | v1.4.2+ / v1.3, v1.4.2+   | v1.2+       |
 
-!!! warning "RHCL v1.4.0 — silent auth bypass"
-    RHCL v1.4.0 contains a Wasm shim bug that silently bypasses gateway authentication.
-    Management endpoints return `AUTH_FAILURE`; inference endpoints work but are
-    unauthenticated. Upgrade to **RHCL v1.4.1+**. See
-    [Troubleshooting #16](troubleshooting.md#16-management-endpoints-return-auth_failure-on-rhcl-v140)
+!!! warning "RHCL v1.4.0 and v1.4.1 -- known issues"
+    RHCL v1.4.0 and v1.4.1 ship wasm-shim v0.12.0, which has bugs handling
+    nested JSON objects in auth dynamic metadata. This causes:
+
+    - **v1.4.0**: Silent authentication bypass on management endpoints
+      ([RHOAIENG-78563](https://redhat.atlassian.net/browse/RHOAIENG-78563)).
+    - **v1.4.0 and v1.4.1**: Token rate limits silently bypassed -- 429
+      responses never fire
+      ([RHOAIENG-75778](https://redhat.atlassian.net/browse/RHOAIENG-75778)).
+
+    These were fixed upstream in wasm-shim v0.12.1
+    ([Kuadrant/wasm-shim#312](https://github.com/Kuadrant/wasm-shim/pull/312)),
+    shipped in **RHCL v1.4.2**. Upgrade to RHCL v1.4.2+ or use RHCL v1.3.x.
+    See [Troubleshooting #16](troubleshooting.md#16-token-rate-limits-bypassed-on-rhcl-v140v141)
     for diagnosis.
 
 !!! note "Other Kubernetes flavors"
@@ -48,7 +57,7 @@ MaaS requires Red Hat OpenShift AI (RHOAI) version 3.0 or later, with the Model 
 component enabled (KServe) and properly configured for deploying models with
 `LLMInferenceService` resources.
 
-A specific requirement for MaaS v0.1.0+ is to set up RHOAI Model Serving with Red Hat Connectivity Link (RHCL) v1.3 or later.
+A specific requirement for MaaS v0.1.0+ is to set up RHOAI Model Serving with Red Hat Connectivity Link (RHCL) v1.3 or v1.4.2+. RHCL v1.4.0 and v1.4.1 have known issues with token rate limiting and authentication -- see the warning above.
 
 ## Optional: Observability Prerequisites
 

--- a/docs/content/install/troubleshooting.md
+++ b/docs/content/install/troubleshooting.md
@@ -42,6 +42,7 @@ This guide helps you diagnose and resolve common issues with MaaS Platform deplo
       - [ ] Verify the model is deployed and the `LLMInferenceService` has the `maas-default-gateway` gateway specified
       - [ ] Verify that the model is recognized by maas-api by checking the `maas-api/v1/models` endpoint (see [Validation Guide - List Available Models](validation.md#3-list-available-models))
 5. **Rate limiting not working**: Verify AuthPolicy and TokenRateLimitPolicy are applied
+      - [ ] If using RHCL v1.4.0 or v1.4.1, see [issue #17](#16-token-rate-limits-bypassed-on-rhcl-v140v141) -- token rate limits are silently bypassed due to an upstream wasm-shim bug. Upgrade to RHCL v1.4.2+
       - [ ] Verify `gateway-rate-limits` RateLimitPolicy is applied
       - [ ] Verify TokenRateLimitPolicy is applied (e.g. gateway-default-deny or per-route policies)
       - [ ] If **multiple** TokenRateLimitPolicies target the **same** HTTPRoute, see [Quota and Access Configuration](../configuration-and-management/quota-and-access-configuration.md)
@@ -187,7 +188,19 @@ This guide helps you diagnose and resolve common issues with MaaS Platform deplo
       kubectl get subscription -A -o custom-columns='NS:.metadata.namespace,NAME:.metadata.name,VERSION:.status.currentCSV' | grep -i rhcl
       ```
 
-      - [ ] Upgrade RHCL to v1.4.1 or later
+      - [ ] Upgrade RHCL to v1.4.2 or later (v1.4.1 fixes auth bypass but still has the token rate limit bypass below)
+
+17. <a id="16-token-rate-limits-bypassed-on-rhcl-v140v141"></a>**Token rate limits bypassed on RHCL v1.4.0/v1.4.1**: Token rate limits set in `MaaSSubscription` are silently ignored -- HTTP 429 responses never fire. Adding `tokenMetadata` to the subscription spec appears to work around the issue but is not a proper fix. This is caused by a bug in the Kuadrant wasm-shim v0.12.0 (shipped with RHCL 1.4.0 and 1.4.1) that cannot handle nested JSON objects in auth dynamic metadata. The MaaS identity filter stores a `subscription_info` object with nested fields (e.g., `modelRefs` arrays), which the wasm-shim silently drops or fails to convert to CEL values, breaking the TRLP `when` predicate evaluation. Fixed in wasm-shim v0.12.1 ([Kuadrant/wasm-shim#312](https://github.com/Kuadrant/wasm-shim/pull/312)), shipped in RHCL v1.4.2.
+
+      - [ ] Confirm you are on RHCL v1.4.0 or v1.4.1:
+
+      ```bash
+      kubectl get subscription -A -o custom-columns='NS:.metadata.namespace,NAME:.metadata.name,VERSION:.status.currentCSV' | grep -i rhcl
+      ```
+
+      - [ ] Upgrade RHCL to v1.4.2 or later, or downgrade to RHCL v1.3.x
+
+      - [ ] After upgrading, verify rate limits are enforced by sending requests that exceed the configured `tokenRateLimits` and confirming HTTP 429 responses
 
 ## Conflicting AuthPolicy Detection
 

--- a/maas-controller/pkg/controller/maas/maassubscription_controller_test.go
+++ b/maas-controller/pkg/controller/maas/maassubscription_controller_test.go
@@ -1449,6 +1449,143 @@ func TestMaaSSubscriptionReconciler_WindowValuesInTRLP(t *testing.T) {
 	}
 }
 
+// TestMaaSSubscriptionReconciler_TRLPIndependentOfTokenMetadata verifies that the
+// generated TokenRateLimitPolicy spec is identical whether or not the subscription
+// has tokenMetadata set. This proves that token rate limit bypass on RHCL 1.4.1
+// (RHOAIENG-75778) is NOT caused by our TRLP generation -- the controller produces
+// the same when/counters/rates regardless of tokenMetadata.
+func TestMaaSSubscriptionReconciler_TRLPIndependentOfTokenMetadata(t *testing.T) {
+	const (
+		modelName     = "llm"
+		namespace     = "default"
+		httpRouteName = "maas-" + modelName
+		trlpName      = "maas-trlp-" + modelName
+	)
+
+	tests := []struct {
+		name          string
+		tokenMetadata *maasv1alpha1.TokenMetadata
+	}{
+		{
+			name:          "without tokenMetadata",
+			tokenMetadata: nil,
+		},
+		{
+			name: "with tokenMetadata",
+			tokenMetadata: &maasv1alpha1.TokenMetadata{
+				OrganizationID: "org-123",
+				CostCenter:     "cc-456",
+			},
+		},
+	}
+
+	// Collect the TRLP spec from each run and compare them.
+	var trlpSpecs []map[string]any
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			model := newMaaSModelRef(modelName, namespace, "ExternalModel", modelName)
+			route := newHTTPRoute(httpRouteName, namespace)
+
+			maasSub := &maasv1alpha1.MaaSSubscription{
+				ObjectMeta: metav1.ObjectMeta{Name: "sub-meta-test", Namespace: namespace},
+				Spec: maasv1alpha1.MaaSSubscriptionSpec{
+					Owner: maasv1alpha1.OwnerSpec{
+						Groups: []maasv1alpha1.GroupReference{{Name: "team-a"}},
+					},
+					ModelRefs: []maasv1alpha1.ModelSubscriptionRef{
+						{
+							Name:      modelName,
+							Namespace: namespace,
+							TokenRateLimits: []maasv1alpha1.TokenRateLimit{
+								{Limit: 50, Window: "1h"},
+							},
+						},
+					},
+					TokenMetadata: tc.tokenMetadata,
+				},
+			}
+
+			c := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithRESTMapper(testRESTMapper()).
+				WithObjects(model, route, maasSub).
+				WithStatusSubresource(&maasv1alpha1.MaaSSubscription{}).
+				WithIndex(&maasv1alpha1.MaaSSubscription{}, "spec.modelRef", subscriptionModelRefIndexer).
+				Build()
+
+			r := &MaaSSubscriptionReconciler{Client: c, Scheme: scheme}
+			req := ctrl.Request{NamespacedName: types.NamespacedName{Name: "sub-meta-test", Namespace: namespace}}
+			if _, err := r.Reconcile(context.Background(), req); err != nil {
+				t.Fatalf("Reconcile: unexpected error: %v", err)
+			}
+
+			trlp := &unstructured.Unstructured{}
+			trlp.SetGroupVersionKind(schema.GroupVersionKind{Group: "kuadrant.io", Version: "v1alpha1", Kind: "TokenRateLimitPolicy"})
+			if err := c.Get(context.Background(), types.NamespacedName{Name: trlpName, Namespace: namespace}, trlp); err != nil {
+				t.Fatalf("Get TokenRateLimitPolicy: %v", err)
+			}
+
+			spec, found, err := unstructured.NestedMap(trlp.Object, "spec")
+			if err != nil || !found {
+				t.Fatalf("spec not found: found=%v err=%v", found, err)
+			}
+
+			// Verify the TRLP has the expected structure
+			limitKey := namespace + "-sub-meta-test-" + modelName + "-tokens"
+			limitsRaw, found, err := unstructured.NestedMap(spec, "limits", limitKey)
+			if err != nil || !found {
+				t.Fatalf("spec.limits.%s not found: found=%v err=%v", limitKey, found, err)
+			}
+
+			// Verify when predicate references selected_subscription_key (not tokenMetadata)
+			whenSlice, found, err := unstructured.NestedSlice(limitsRaw, "when")
+			if err != nil || !found || len(whenSlice) == 0 {
+				t.Fatal("when clause not found in TRLP limits")
+			}
+			whenMap, ok := whenSlice[0].(map[string]any)
+			if !ok {
+				t.Fatalf("when[0] is not map: %T", whenSlice[0])
+			}
+			predicate, ok := whenMap["predicate"].(string)
+			if !ok {
+				t.Fatal("when[0].predicate not a string")
+			}
+			expectedPredicate := fmt.Sprintf(
+				`auth.identity.selected_subscription_key == "%s/sub-meta-test@%s/%s" && !request.path.endsWith("/v1/models")`,
+				namespace, namespace, modelName,
+			)
+			if predicate != expectedPredicate {
+				t.Errorf("predicate = %q, want %q", predicate, expectedPredicate)
+			}
+
+			// Verify counters reference userid (not tokenMetadata fields)
+			countersSlice, found, err := unstructured.NestedSlice(limitsRaw, "counters")
+			if err != nil || !found || len(countersSlice) == 0 {
+				t.Fatal("counters not found in TRLP limits")
+			}
+			counterMap, ok := countersSlice[0].(map[string]any)
+			if !ok {
+				t.Fatalf("counters[0] is not map: %T", countersSlice[0])
+			}
+			if expr, ok := counterMap["expression"].(string); !ok || expr != "auth.identity.userid" {
+				t.Errorf("counter expression = %v, want %q", counterMap["expression"], "auth.identity.userid")
+			}
+
+			trlpSpecs = append(trlpSpecs, spec)
+		})
+	}
+
+	// The definitive check: specs must be identical regardless of tokenMetadata
+	if len(trlpSpecs) == 2 {
+		spec1 := fmt.Sprintf("%v", trlpSpecs[0])
+		spec2 := fmt.Sprintf("%v", trlpSpecs[1])
+		if spec1 != spec2 {
+			t.Errorf("TRLP specs differ with/without tokenMetadata:\nwithout: %s\nwith:    %s", spec1, spec2)
+		}
+	}
+}
+
 // TestMaaSSubscriptionReconciler_NoSpec verifies that a legacy subscription created
 // without a spec field is marked Failed without adding a finalizer.
 func TestMaaSSubscriptionReconciler_NoSpec(t *testing.T) {


### PR DESCRIPTION
## Summary

Addresses [RHOAIENG-75778](https://redhat.atlassian.net/browse/RHOAIENG-75778): token rate limits silently bypassed on RHCL v1.4.0/v1.4.1.

### Root cause (upstream, not MaaS)

RHCL v1.4.0 and v1.4.1 ship wasm-shim v0.12.0, which has two bugs in handling auth dynamic metadata:

1. `json_to_cel()` in `src/data/cel.rs` hit `todo!("Need support for more Json!")` for arrays/objects
2. `process_metadata()` in `src/kuadrant/pipeline/tasks/auth.rs` silently dropped list/struct protobuf values

MaaS stores `subscription_info` (containing nested `modelRefs` arrays) in the identity filter. The wasm-shim fails to convert these to CEL values, breaking TRLP `when` predicate evaluation so rate limits never fire.

Fixed upstream in wasm-shim v0.12.1 ([Kuadrant/wasm-shim#312](https://github.com/Kuadrant/wasm-shim/pull/312)), shipped in RHCL v1.4.2.

### Changes

- **prerequisites.md**: Update version table (RHCL column: `v1.3, v1.4.2+`), expand warning to cover both v1.4.0 auth bypass and v1.4.1 rate limit bypass
- **troubleshooting.md**: Add entry #17 for token rate limit bypass diagnosis, cross-reference from entry #5
- **maassubscription_controller_test.go**: Add `TestMaaSSubscriptionReconciler_TRLPIndependentOfTokenMetadata` proving TRLP spec is identical with/without `tokenMetadata`

### Risk analysis

- **Risk rating**: 0
- **Why**: Documentation-only changes plus a read-only unit test. No runtime behavior change.

[RHOAIENG-75778]: https://redhat.atlassian.net/browse/RHOAIENG-75778?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ