### PR TITLE
refactor(RHOAIENG-82333): extract pytest runner from prow smoke script

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -16,7 +16,7 @@ Existing cluster (skip deploy):
 SKIP_DEPLOYMENT=true ./test/e2e/scripts/prow_run_smoke_test.sh
 ```
 
-Parallel pytest on an existing cluster (default 4 workers):
+Parallel pytest on an existing cluster (default 7 workers):
 
 ```bash
 SKIP_DEPLOYMENT=true ./test/e2e/run-tests-quick.sh

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -66,7 +66,19 @@ Modules outside the explicit smoke list (for example `test_subscription_list_end
 
 ## CI
 
-CI runs `./test/e2e/scripts/prow_run_smoke_test.sh`: deploys MaaS with **Red Hat Connectivity Link (RHCL)** from the cluster `redhat-operators` catalog (`POLICY_ENGINE=rhcl` by default, channel head unless `RHCL_STARTING_CSV` is set) into **`kuadrant-system`**, then pytest on the default smoke modules listed above (including `test_aitenant_lifecycle.py`, `test_tenant_namespace_discovery.py`, `test_gateway_scoped_authpolicy.py`, `test_multi_tenant_integration.py`, and the gated S24/S4 modules), then deployment validation; reports under `ARTIFACT_DIR` when set.
+CI runs `./test/e2e/scripts/prow_run_smoke_test.sh`, which follows a **three-phase model**:
+
+| Phase | Script | Responsibility |
+|-------|--------|----------------|
+| 1. Deploy | `prow_run_smoke_test.sh` | Install RHCL, deploy MaaS, configure gateway |
+| 2. Validate | `prow_run_smoke_test.sh` | Wait for gateway reachability, verify auth chain |
+| 3. Test | `scripts/run_e2e_tests.sh` | pytest only: two-pass xdist, artifact paths |
+
+`prow_run_smoke_test.sh` is the thin orchestrator — it delegates pytest execution to `run_e2e_tests.sh`. Test-only PRs touch the runner and test files, not deploy helpers.
+
+`run_e2e_tests.sh` can also be called directly on an existing cluster (env vars must be exported) or via `run-tests-quick.sh` which sets up the env and delegates to the same runner.
+
+Deploys MaaS with **Red Hat Connectivity Link (RHCL)** from the cluster `redhat-operators` catalog (`POLICY_ENGINE=rhcl` by default, channel head unless `RHCL_STARTING_CSV` is set) into **`kuadrant-system`**, then pytest on the default smoke modules listed above (including `test_aitenant_lifecycle.py`, `test_tenant_namespace_discovery.py`, `test_gateway_scoped_authpolicy.py`, `test_multi_tenant_integration.py`, and the gated S24/S4 modules), then deployment validation; reports under `ARTIFACT_DIR` when set.
 
 Multi-tenancy discovery tests run by default in `prow_run_smoke_test.sh`, which sets `ENABLE_TENANT_NAMESPACE_DISCOVERY=true` unless explicitly overridden and patches maas-controller before pytest. If set to `false`, `test_tenant_namespace_discovery.py` and `test_multi_tenant_integration.py` skip. When discovery is enabled, `test_namespace_scoping.py` skips (dormant-mode assumptions).
 
@@ -78,9 +90,9 @@ External OIDC runs require `EXTERNAL_OIDC=true` and `OIDC_ISSUER_URL`, `OIDC_TOK
 
 ## Parallel execution (pytest-xdist)
 
-By default, CI and `prow_run_smoke_test.sh` run tests in **two passes** when `E2E_PARALLEL_WORKERS=2`:
+By default, `run_e2e_tests.sh` runs tests in **two passes** when `E2E_PARALLEL_WORKERS > 1` (default: 7):
 
-1. **Pass 1:** `-m "not serial"` — parallel across files (`--dist=loadfile`)
+1. **Pass 1:** `-m "not serial"` — parallel across files (`--dist=loadgroup`)
 2. **Pass 2:** `-m serial` — cluster-wide mutators (single worker): simulator-subscription lifecycle, UNCONFIGURED model auth, TRLP rebuilds, operator scale tests
 
 For fully serial debugging:
@@ -97,7 +109,7 @@ SKIP_DEPLOYMENT=true ./test/e2e/run-tests-quick.sh
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `E2E_PARALLEL_WORKERS` | `2` | Parallel workers for pass 1. Pass 2 (`@serial`) always runs on one worker. Set to `1` to run everything serially in one pass. |
+| `E2E_PARALLEL_WORKERS` | `7` | Parallel workers for pass 1. Pass 2 (`@serial`) always runs on one worker. Set to `1` to run everything serially in one pass. |
 | `E2E_AUTHPOLICY_PHASE_TIMEOUT` | `120` (parallel) / `60` (serial) | MaaSAuthPolicy phase wait |
 | `E2E_GATEWAY_ENFORCED_TIMEOUT` | `240` (parallel) / `180` (serial) | Kuadrant gateway auth enforced wait |
 | `E2E_MULTITENANCY_PHASE_TIMEOUT` | `180` (parallel) / `120` (serial) | Tenant discovery phase wait |

--- a/test/e2e/run-tests-quick.sh
+++ b/test/e2e/run-tests-quick.sh
@@ -53,8 +53,13 @@ echo "  DEPLOYMENT_NAMESPACE: ${DEPLOYMENT_NAMESPACE}"
 echo "  MAAS_SUBSCRIPTION_NAMESPACE: ${MAAS_SUBSCRIPTION_NAMESPACE}"
 echo "  MAAS_API_BASE_URL: ${MAAS_API_BASE_URL}"
 echo "  TOKEN: ${TOKEN:0:20}..."
-if [[ "${E2E_PARALLEL_WORKERS:-7}" -gt 1 ]]; then
-    echo "  E2E_PARALLEL_WORKERS: ${E2E_PARALLEL_WORKERS:-7}"
+E2E_PARALLEL_WORKERS="${E2E_PARALLEL_WORKERS:-7}"
+if ! [[ "$E2E_PARALLEL_WORKERS" =~ ^[0-9]+$ ]]; then
+    echo "ERROR: E2E_PARALLEL_WORKERS must be a positive integer, got '$E2E_PARALLEL_WORKERS'" >&2
+    exit 1
+fi
+if [[ "$E2E_PARALLEL_WORKERS" -gt 1 ]]; then
+    echo "  E2E_PARALLEL_WORKERS: ${E2E_PARALLEL_WORKERS}"
 fi
 echo ""
 echo "Running tests..."

--- a/test/e2e/run-tests-quick.sh
+++ b/test/e2e/run-tests-quick.sh
@@ -60,45 +60,7 @@ echo ""
 echo "Running tests..."
 echo ""
 
-# Activate venv and run tests
-cd "$PROJECT_ROOT/test/e2e"
-
-if [[ ! -d .venv ]]; then
-    echo "Creating Python venv..."
-    python3 -m venv .venv --upgrade-deps
-    source .venv/bin/activate
-    pip install -q --upgrade pip
-    pip install -q -r requirements.txt
-else
-    source .venv/bin/activate
-fi
-
-pytest_args=(-v --tb=short)
-E2E_PARALLEL_WORKERS="${E2E_PARALLEL_WORKERS:-7}"
-if [[ "$E2E_PARALLEL_WORKERS" -gt 1 ]]; then
-    export E2E_AUTHPOLICY_PHASE_TIMEOUT="${E2E_AUTHPOLICY_PHASE_TIMEOUT:-120}"
-    export E2E_MAAS_SUBSCRIPTION_PHASE_TIMEOUT="${E2E_MAAS_SUBSCRIPTION_PHASE_TIMEOUT:-90}"
-    export E2E_GATEWAY_ENFORCED_TIMEOUT="${E2E_GATEWAY_ENFORCED_TIMEOUT:-240}"
-    export E2E_MULTITENANCY_PHASE_TIMEOUT="${E2E_MULTITENANCY_PHASE_TIMEOUT:-180}"
-fi
-user_args=("$@")
-
-run_pytest_pass() {
-    python -m pytest "${pytest_args[@]}" "$@"
-}
-
-parallel_rc=0
-serial_rc=0
-if [[ "$E2E_PARALLEL_WORKERS" -gt 1 ]]; then
-    echo "Pass 1/2: parallel (-m 'not serial', -n ${E2E_PARALLEL_WORKERS})"
-    run_pytest_pass -n "$E2E_PARALLEL_WORKERS" --dist=loadgroup -m "not serial" "${user_args[@]}" || parallel_rc=1
-    echo ""
-    echo "Pass 2/2: serial cluster mutators (-m serial)"
-    run_pytest_pass -m serial "${user_args[@]}" || serial_rc=1
-else
-    run_pytest_pass "${user_args[@]}" || parallel_rc=1
-fi
-
-if [[ "$parallel_rc" -ne 0 || "$serial_rc" -ne 0 ]]; then
-    exit 1
-fi
+# Delegate to the shared test runner (same script CI uses).
+export E2E_PARALLEL_WORKERS="${E2E_PARALLEL_WORKERS:-7}"
+export ARTIFACTS_DIR="${ARTIFACTS_DIR:-$PROJECT_ROOT/test/e2e/reports}"
+exec "$PROJECT_ROOT/test/e2e/scripts/run_e2e_tests.sh" "$@"

--- a/test/e2e/run-tests-quick.sh
+++ b/test/e2e/run-tests-quick.sh
@@ -53,9 +53,9 @@ echo "  DEPLOYMENT_NAMESPACE: ${DEPLOYMENT_NAMESPACE}"
 echo "  MAAS_SUBSCRIPTION_NAMESPACE: ${MAAS_SUBSCRIPTION_NAMESPACE}"
 echo "  MAAS_API_BASE_URL: ${MAAS_API_BASE_URL}"
 echo "  TOKEN: ${TOKEN:0:20}..."
-E2E_PARALLEL_WORKERS="${E2E_PARALLEL_WORKERS:-7}"
-if ! [[ "$E2E_PARALLEL_WORKERS" =~ ^[0-9]+$ ]]; then
-    echo "ERROR: E2E_PARALLEL_WORKERS must be a positive integer, got '$E2E_PARALLEL_WORKERS'" >&2
+export E2E_PARALLEL_WORKERS="${E2E_PARALLEL_WORKERS:-7}"
+if ! [[ "$E2E_PARALLEL_WORKERS" =~ ^[1-9][0-9]*$ ]]; then
+    echo "ERROR: E2E_PARALLEL_WORKERS must be a positive integer (>= 1), got '$E2E_PARALLEL_WORKERS'" >&2
     exit 1
 fi
 if [[ "$E2E_PARALLEL_WORKERS" -gt 1 ]]; then
@@ -66,6 +66,5 @@ echo "Running tests..."
 echo ""
 
 # Delegate to the shared test runner (same script CI uses).
-export E2E_PARALLEL_WORKERS="${E2E_PARALLEL_WORKERS:-7}"
 export ARTIFACTS_DIR="${ARTIFACTS_DIR:-$PROJECT_ROOT/test/e2e/reports}"
 exec "$PROJECT_ROOT/test/e2e/scripts/run_e2e_tests.sh" "$@"

--- a/test/e2e/scripts/prow_run_smoke_test.sh
+++ b/test/e2e/scripts/prow_run_smoke_test.sh
@@ -842,93 +842,14 @@ run_e2e_tests() {
         fi
     fi
 
-    # Run the default smoke e2e tests
+    # Delegate pytest execution to run_e2e_tests.sh (test-only changes
+    # touch that script, not this deploy/validate orchestrator).
+    export ARTIFACTS_DIR
+    export E2E_PARALLEL_WORKERS="${E2E_PARALLEL_WORKERS:-7}"
     export E2E_RECONCILE_WAIT="${E2E_RECONCILE_WAIT:-4}"
-    E2E_PARALLEL_WORKERS="${E2E_PARALLEL_WORKERS:-7}"
-    if [[ "$E2E_PARALLEL_WORKERS" -gt 1 ]]; then
-        export E2E_AUTHPOLICY_PHASE_TIMEOUT="${E2E_AUTHPOLICY_PHASE_TIMEOUT:-120}"
-        export E2E_MAAS_SUBSCRIPTION_PHASE_TIMEOUT="${E2E_MAAS_SUBSCRIPTION_PHASE_TIMEOUT:-90}"
-        export E2E_GATEWAY_ENFORCED_TIMEOUT="${E2E_GATEWAY_ENFORCED_TIMEOUT:-240}"
-        export E2E_MULTITENANCY_PHASE_TIMEOUT="${E2E_MULTITENANCY_PHASE_TIMEOUT:-180}"
-    fi
-
-    local -a e2e_test_files=(
-        "$test_dir/tests/test_api_keys.py"
-        "$test_dir/tests/test_namespace_scoping.py"
-        "$test_dir/tests/test_negative_security.py"
-        "$test_dir/tests/test_subscription.py"
-        "$test_dir/tests/test_models_endpoint.py"
-        "$test_dir/tests/test_external_models.py"
-        "$test_dir/tests/test_smoke.py"
-        "$test_dir/tests/test_tenant.py"
-        "$test_dir/tests/test_config_tenant.py"
-        "$test_dir/tests/test_tenant_discovery.py"
-        "$test_dir/tests/test_aitenant_lifecycle.py"
-        "$test_dir/tests/test_tenant_namespace_discovery.py"
-        "$test_dir/tests/test_tenant_discovery_isolation.py"
-        "$test_dir/tests/test_gateway_scoped_authpolicy.py"
-        "$test_dir/tests/test_multi_tenant_integration.py"
-        "$test_dir/tests/test_multi_tenant_maas_api.py"
-        "$test_dir/tests/test_tenant_model_inference.py"
-        "$test_dir/tests/test_tenant_auth_isolation.py"
-        "$test_dir/tests/test_tenant_subscription_isolation.py"
-        "$test_dir/tests/test_tenant_rate_limit_isolation.py"
-        "$test_dir/tests/test_per_tenant_ipp_isolation.py"
-        "$test_dir/tests/test_external_oidc.py"
-    )
-
-    local pytest_common_args=(
-        -v --disable-warnings
-        --capture=tee-sys --show-capture=all --log-level=INFO
-        "${e2e_test_files[@]}"
-    )
-
-    local parallel_rc=0 serial_rc=0
-    local xml_serial="${xml%.xml}-serial.xml"
-
-    if [[ "$E2E_PARALLEL_WORKERS" -gt 1 ]]; then
-        echo "Running E2E pass 1/2: parallel (E2E_PARALLEL_WORKERS=${E2E_PARALLEL_WORKERS}, --dist=loadgroup, -m 'not serial')"
-        if ! PYTHONPATH="$test_dir:${PYTHONPATH:-}" pytest \
-            --maxfail=5 \
-            -n "$E2E_PARALLEL_WORKERS" --dist=loadgroup \
-            -m "not serial" \
-            --junitxml="$xml" \
-            --html="$html" --self-contained-html \
-            "${pytest_common_args[@]}"; then
-            parallel_rc=1
-        fi
-
-        echo "Running E2E pass 2/2: serial cluster mutators (-m serial, single worker)"
-        if ! PYTHONPATH="$test_dir:${PYTHONPATH:-}" pytest \
-            --maxfail=5 \
-            -m serial \
-            --junitxml="$xml_serial" \
-            --html="${html%.html}-serial.html" --self-contained-html \
-            "${pytest_common_args[@]}"; then
-            serial_rc=1
-        fi
-    else
-        echo "Running E2E tests serially (E2E_PARALLEL_WORKERS=1)"
-        if ! PYTHONPATH="$test_dir:${PYTHONPATH:-}" pytest \
-            --maxfail=5 \
-            --junitxml="$xml" \
-            --html="$html" --self-contained-html \
-            "${pytest_common_args[@]}"; then
-            parallel_rc=1
-        fi
-    fi
-
-    if [[ "$parallel_rc" -ne 0 || "$serial_rc" -ne 0 ]]; then
-        echo "❌ ERROR: E2E tests failed (parallel_rc=${parallel_rc}, serial_rc=${serial_rc})"
-        exit 1
-    fi
-
-    echo "✅ E2E tests completed"
-    echo " - JUnit XML : ${xml}"
-    if [[ -f "$xml_serial" ]]; then
-        echo " - JUnit XML (serial pass): ${xml_serial}"
-    fi
-    echo " - HTML      : ${html}"
+    local script_dir
+    script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    "${script_dir}/run_e2e_tests.sh"
 }
 
 

--- a/test/e2e/scripts/prow_run_smoke_test.sh
+++ b/test/e2e/scripts/prow_run_smoke_test.sh
@@ -718,21 +718,6 @@ run_e2e_tests() {
     # TOKEN and ADMIN_OC_TOKEN are already exported by setup_test_tokens()
 
     local test_dir="$PROJECT_ROOT/test/e2e"
-    # Use ARTIFACTS_DIR so pytest reports go to Prow artifact collection (ARTIFACT_DIR)
-    mkdir -p "$ARTIFACTS_DIR"
-
-    if [[ ! -d "$test_dir/.venv" ]]; then
-        echo "Creating Python venv for e2e tests..."
-        python3 -m venv "$test_dir/.venv" --upgrade-deps
-    fi
-    source "$test_dir/.venv/bin/activate"
-    python -m pip install --upgrade pip --quiet
-    python -m pip install -r "$test_dir/requirements.txt" --quiet
-
-    local user
-    user="$(oc whoami 2>/dev/null || echo 'unknown')"
-    local html="$ARTIFACTS_DIR/e2e-${user}.html"
-    local xml="$ARTIFACTS_DIR/e2e-${user}.xml"
 
     echo "Running e2e tests with:"
     echo "  - TOKEN: $(echo "${TOKEN:-not set}" | cut -c1-20)..."

--- a/test/e2e/scripts/run_e2e_tests.sh
+++ b/test/e2e/scripts/run_e2e_tests.sh
@@ -1,0 +1,164 @@
+#!/bin/bash
+# =============================================================================
+# E2E Test Runner — pytest execution only
+# =============================================================================
+#
+# Owns pytest invocation for MaaS E2E tests. Separated from
+# prow_run_smoke_test.sh so that test-only changes don't touch deploy/validate
+# logic. Implements the two-phase model:
+#   Pass 1: parallel with pytest-xdist (-m "not serial", --dist=loadgroup)
+#   Pass 2: serial cluster mutators (-m serial, single worker)
+#
+# Called by:
+#   - prow_run_smoke_test.sh (CI: deploy → validate → THIS)
+#   - run-tests-quick.sh     (local: env setup → THIS)
+#   - directly               (when env is already exported)
+#
+# Required env vars (caller must export):
+#   GATEWAY_HOST, TOKEN, ADMIN_OC_TOKEN,
+#   DEPLOYMENT_NAMESPACE, MAAS_SUBSCRIPTION_NAMESPACE
+#
+# Optional env vars:
+#   E2E_PARALLEL_WORKERS          pytest-xdist worker count (default: 7)
+#   E2E_AUTHPOLICY_PHASE_TIMEOUT  seconds (default: 120, parallel only)
+#   E2E_MAAS_SUBSCRIPTION_PHASE_TIMEOUT  seconds (default: 90, parallel only)
+#   E2E_GATEWAY_ENFORCED_TIMEOUT  seconds (default: 240, parallel only)
+#   E2E_MULTITENANCY_PHASE_TIMEOUT seconds (default: 180, parallel only)
+#   E2E_RECONCILE_WAIT            seconds between reconcile polls (default: 4)
+#   ARTIFACTS_DIR                 output directory for JUnit/HTML (default: test/e2e/reports)
+#
+# Usage:
+#   export GATEWAY_HOST=maas.apps.cluster.example.com TOKEN=$(oc whoami -t) ...
+#   ./run_e2e_tests.sh                       # run all tests
+#   ./run_e2e_tests.sh -- -k test_api_keys   # pass extra pytest args
+#   ./run_e2e_tests.sh --serial-only         # skip parallel pass
+# =============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+TEST_DIR="$PROJECT_ROOT/test/e2e"
+
+# ── Parse script flags (before --) vs pytest args (after --) ─────────────
+serial_only=false
+extra_pytest_args=()
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --serial-only) serial_only=true; shift ;;
+        --) shift; extra_pytest_args=("$@"); break ;;
+        *) extra_pytest_args+=("$1"); shift ;;
+    esac
+done
+
+# ── Defaults ─────────────────────────────────────────────────────────────
+export E2E_RECONCILE_WAIT="${E2E_RECONCILE_WAIT:-4}"
+E2E_PARALLEL_WORKERS="${E2E_PARALLEL_WORKERS:-7}"
+
+ARTIFACTS_DIR="${ARTIFACTS_DIR:-${ARTIFACT_DIR:-${ARTIFACTS:-${LOG_DIR:-$TEST_DIR/reports}}}}"
+mkdir -p "$ARTIFACTS_DIR"
+
+# ── Phase timeouts (parallel only) ───────────────────────────────────────
+if [[ "$E2E_PARALLEL_WORKERS" -gt 1 ]]; then
+    export E2E_AUTHPOLICY_PHASE_TIMEOUT="${E2E_AUTHPOLICY_PHASE_TIMEOUT:-120}"
+    export E2E_MAAS_SUBSCRIPTION_PHASE_TIMEOUT="${E2E_MAAS_SUBSCRIPTION_PHASE_TIMEOUT:-90}"
+    export E2E_GATEWAY_ENFORCED_TIMEOUT="${E2E_GATEWAY_ENFORCED_TIMEOUT:-240}"
+    export E2E_MULTITENANCY_PHASE_TIMEOUT="${E2E_MULTITENANCY_PHASE_TIMEOUT:-180}"
+fi
+
+# ── Venv ─────────────────────────────────────────────────────────────────
+if [[ ! -d "$TEST_DIR/.venv" ]]; then
+    echo "Creating Python venv for e2e tests..."
+    python3 -m venv "$TEST_DIR/.venv" --upgrade-deps
+fi
+source "$TEST_DIR/.venv/bin/activate"
+python -m pip install --upgrade pip --quiet
+python -m pip install -r "$TEST_DIR/requirements.txt" --quiet
+
+# ── Output paths ─────────────────────────────────────────────────────────
+user="$(oc whoami 2>/dev/null || echo 'unknown')"
+html="$ARTIFACTS_DIR/e2e-${user}.html"
+xml="$ARTIFACTS_DIR/e2e-${user}.xml"
+xml_serial="${xml%.xml}-serial.xml"
+
+# ── Test file list ───────────────────────────────────────────────────────
+e2e_test_files=(
+    "$TEST_DIR/tests/test_api_keys.py"
+    "$TEST_DIR/tests/test_namespace_scoping.py"
+    "$TEST_DIR/tests/test_negative_security.py"
+    "$TEST_DIR/tests/test_subscription.py"
+    "$TEST_DIR/tests/test_models_endpoint.py"
+    "$TEST_DIR/tests/test_external_models.py"
+    "$TEST_DIR/tests/test_smoke.py"
+    "$TEST_DIR/tests/test_tenant.py"
+    "$TEST_DIR/tests/test_config_tenant.py"
+    "$TEST_DIR/tests/test_tenant_discovery.py"
+    "$TEST_DIR/tests/test_aitenant_lifecycle.py"
+    "$TEST_DIR/tests/test_tenant_namespace_discovery.py"
+    "$TEST_DIR/tests/test_tenant_discovery_isolation.py"
+    "$TEST_DIR/tests/test_gateway_scoped_authpolicy.py"
+    "$TEST_DIR/tests/test_multi_tenant_integration.py"
+    "$TEST_DIR/tests/test_multi_tenant_maas_api.py"
+    "$TEST_DIR/tests/test_tenant_model_inference.py"
+    "$TEST_DIR/tests/test_tenant_auth_isolation.py"
+    "$TEST_DIR/tests/test_tenant_subscription_isolation.py"
+    "$TEST_DIR/tests/test_tenant_rate_limit_isolation.py"
+    "$TEST_DIR/tests/test_per_tenant_ipp_isolation.py"
+    "$TEST_DIR/tests/test_external_oidc.py"
+)
+
+pytest_common_args=(
+    -v --disable-warnings
+    --capture=tee-sys --show-capture=all --log-level=INFO
+    "${e2e_test_files[@]}"
+    "${extra_pytest_args[@]}"
+)
+
+# ── Run ──────────────────────────────────────────────────────────────────
+parallel_rc=0
+serial_rc=0
+
+if [[ "$serial_only" == "true" || "$E2E_PARALLEL_WORKERS" -le 1 ]]; then
+    echo "Running E2E tests serially (E2E_PARALLEL_WORKERS=${E2E_PARALLEL_WORKERS})"
+    if ! PYTHONPATH="$TEST_DIR:${PYTHONPATH:-}" pytest \
+        --maxfail=5 \
+        --junitxml="$xml" \
+        --html="$html" --self-contained-html \
+        "${pytest_common_args[@]}"; then
+        parallel_rc=1
+    fi
+else
+    echo "Running E2E pass 1/2: parallel (E2E_PARALLEL_WORKERS=${E2E_PARALLEL_WORKERS}, --dist=loadgroup, -m 'not serial')"
+    if ! PYTHONPATH="$TEST_DIR:${PYTHONPATH:-}" pytest \
+        --maxfail=5 \
+        -n "$E2E_PARALLEL_WORKERS" --dist=loadgroup \
+        -m "not serial" \
+        --junitxml="$xml" \
+        --html="$html" --self-contained-html \
+        "${pytest_common_args[@]}"; then
+        parallel_rc=1
+    fi
+
+    echo "Running E2E pass 2/2: serial cluster mutators (-m serial, single worker)"
+    if ! PYTHONPATH="$TEST_DIR:${PYTHONPATH:-}" pytest \
+        --maxfail=5 \
+        -m serial \
+        --junitxml="$xml_serial" \
+        --html="${html%.html}-serial.html" --self-contained-html \
+        "${pytest_common_args[@]}"; then
+        serial_rc=1
+    fi
+fi
+
+# ── Result ───────────────────────────────────────────────────────────────
+if [[ "$parallel_rc" -ne 0 || "$serial_rc" -ne 0 ]]; then
+    echo "❌ ERROR: E2E tests failed (parallel_rc=${parallel_rc}, serial_rc=${serial_rc})"
+    exit 1
+fi
+
+echo "✅ E2E tests completed"
+echo " - JUnit XML : ${xml}"
+if [[ -f "$xml_serial" ]]; then
+    echo " - JUnit XML (serial pass): ${xml_serial}"
+fi
+echo " - HTML      : ${html}"

--- a/test/e2e/scripts/run_e2e_tests.sh
+++ b/test/e2e/scripts/run_e2e_tests.sh
@@ -54,6 +54,10 @@ done
 # ── Defaults ─────────────────────────────────────────────────────────────
 export E2E_RECONCILE_WAIT="${E2E_RECONCILE_WAIT:-4}"
 E2E_PARALLEL_WORKERS="${E2E_PARALLEL_WORKERS:-7}"
+if ! [[ "$E2E_PARALLEL_WORKERS" =~ ^[0-9]+$ ]]; then
+    echo "ERROR: E2E_PARALLEL_WORKERS must be a positive integer, got '$E2E_PARALLEL_WORKERS'" >&2
+    exit 1
+fi
 
 ARTIFACTS_DIR="${ARTIFACTS_DIR:-${ARTIFACT_DIR:-${ARTIFACTS:-${LOG_DIR:-$TEST_DIR/reports}}}}"
 mkdir -p "$ARTIFACTS_DIR"

--- a/test/e2e/scripts/run_e2e_tests.sh
+++ b/test/e2e/scripts/run_e2e_tests.sh
@@ -54,8 +54,8 @@ done
 # ── Defaults ─────────────────────────────────────────────────────────────
 export E2E_RECONCILE_WAIT="${E2E_RECONCILE_WAIT:-4}"
 E2E_PARALLEL_WORKERS="${E2E_PARALLEL_WORKERS:-7}"
-if ! [[ "$E2E_PARALLEL_WORKERS" =~ ^[0-9]+$ ]]; then
-    echo "ERROR: E2E_PARALLEL_WORKERS must be a positive integer, got '$E2E_PARALLEL_WORKERS'" >&2
+if ! [[ "$E2E_PARALLEL_WORKERS" =~ ^[1-9][0-9]*$ ]]; then
+    echo "ERROR: E2E_PARALLEL_WORKERS must be a positive integer (>= 1), got '$E2E_PARALLEL_WORKERS'" >&2
     exit 1
 fi
 


### PR DESCRIPTION
## Summary
- Extract the ~80-line pytest execution block from `prow_run_smoke_test.sh` into a standalone `test/e2e/scripts/run_e2e_tests.sh`
- `prow_run_smoke_test.sh` becomes a thin orchestrator: deploy → validate → delegate to `run_e2e_tests.sh`
- `run-tests-quick.sh` delegates to the same runner via `exec`, ensuring CI/local parity
- Fix README.md: `E2E_PARALLEL_WORKERS` default was documented as 2 (actual: 7), `--dist=loadfile` corrected to `--dist=loadgroup`

### Three-phase CI model

| Phase | Script | Responsibility |
|-------|--------|----------------|
| 1. Deploy | `prow_run_smoke_test.sh` | Install RHCL, deploy MaaS, configure gateway |
| 2. Validate | `prow_run_smoke_test.sh` | Wait for gateway reachability, verify auth chain |
| 3. Test | `scripts/run_e2e_tests.sh` | pytest only: two-pass xdist, artifact paths |

### Why
Pytest-only changes currently require touching the 1200-line monolithic prow script, increasing review risk. After this change, test behavior PRs touch the runner + test files — not deploy helpers.

## Test plan
- [ ] One green `/group-test` before and after extraction with identical pytest args and pass/fail
- [ ] Diff prow log shows delegate call only (no pytest args inline)
- [ ] `run-tests-quick.sh` on an existing cluster produces same two-phase output
- [ ] `run_e2e_tests.sh` can be invoked standalone with exported env vars

Related: [RHOAIENG-82332](https://redhat.atlassian.net/browse/RHOAIENG-82332) (deploy hardening), [RHOAIENG-79794](https://redhat.atlassian.net/browse/RHOAIENG-79794) (epic), PR #1353 (introduced two-phase model)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RHOAIENG-82332]: https://redhat.atlassian.net/browse/RHOAIENG-82332?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Testing**
  * Added a shared end-to-end test runner with automatic environment setup, serial and parallel execution, and JUnit/HTML result artifacts.
  * Improved validation and failure reporting across test phases.
  * Increased the default parallel test capacity to seven workers.

* **Documentation**
  * Clarified the deployment, validation, testing, and artifact-reporting workflow.
  * Added direct runner usage guidance and updated quick-start instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->