### PR TITLE
fix: address review feedback on run_e2e_tests.sh (#1388)

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -78,7 +78,7 @@ CI runs `./test/e2e/scripts/prow_run_smoke_test.sh`, which follows a **three-pha
 
 `run_e2e_tests.sh` can also be called directly on an existing cluster (env vars must be exported) or via `run-tests-quick.sh` which sets up the env and delegates to the same runner.
 
-Deploys MaaS with **Red Hat Connectivity Link (RHCL)** from the cluster `redhat-operators` catalog (`POLICY_ENGINE=rhcl` by default, channel head unless `RHCL_STARTING_CSV` is set) into **`kuadrant-system`**, then pytest on the default smoke modules listed above (including `test_aitenant_lifecycle.py`, `test_tenant_namespace_discovery.py`, `test_gateway_scoped_authpolicy.py`, `test_multi_tenant_integration.py`, and the gated S24/S4 modules), then deployment validation; reports under `ARTIFACT_DIR` when set.
+Deployment uses **Red Hat Connectivity Link (RHCL)** from the cluster `redhat-operators` catalog (`POLICY_ENGINE=rhcl` by default, channel head unless `RHCL_STARTING_CSV` is set) into **`kuadrant-system`**. Reports are written to `ARTIFACT_DIR` when set.
 
 Multi-tenancy discovery tests run by default in `prow_run_smoke_test.sh`, which sets `ENABLE_TENANT_NAMESPACE_DISCOVERY=true` unless explicitly overridden and patches maas-controller before pytest. If set to `false`, `test_tenant_namespace_discovery.py` and `test_multi_tenant_integration.py` skip. When discovery is enabled, `test_namespace_scoping.py` skips (dormant-mode assumptions).
 

--- a/test/e2e/run-tests-quick.sh
+++ b/test/e2e/run-tests-quick.sh
@@ -9,11 +9,14 @@
 # Usage:
 #   ./run-tests-quick.sh [pytest args]
 #
+# By default runs the same smoke test file list as CI. Pass a file path
+# to override the list and run only that file.
+#
 # Examples:
-#   ./run-tests-quick.sh                          # Run all E2E tests
-#   ./run-tests-quick.sh -k test_auth             # Run tests matching "auth"
+#   ./run-tests-quick.sh                          # Run smoke suite (same as CI)
+#   ./run-tests-quick.sh -k test_auth             # Filter smoke suite by name
 #   ./run-tests-quick.sh --maxfail=2              # Stop after 2 failures
-#   ./run-tests-quick.sh tests/test_api_keys.py   # Run specific file
+#   ./run-tests-quick.sh tests/test_api_keys.py   # Run specific file (replaces smoke list)
 #
 # =============================================================================
 

--- a/test/e2e/scripts/run_e2e_tests.sh
+++ b/test/e2e/scripts/run_e2e_tests.sh
@@ -111,12 +111,37 @@ e2e_test_files=(
     "$TEST_DIR/tests/test_external_oidc.py"
 )
 
-pytest_common_args=(
-    -v --disable-warnings
-    --capture=tee-sys --show-capture=all --log-level=INFO
-    "${e2e_test_files[@]}"
-    "${extra_pytest_args[@]}"
-)
+# If extra args include a path (file or directory), skip the default smoke list
+# so users can target specific tests: ./run_e2e_tests.sh -- tests/test_api_keys.py
+# Resolve relative paths against TEST_DIR so they work regardless of cwd.
+resolved_extra_args=()
+has_path_arg=false
+for arg in "${extra_pytest_args[@]}"; do
+    if [[ -e "$TEST_DIR/$arg" ]]; then
+        resolved_extra_args+=("$TEST_DIR/$arg")
+        has_path_arg=true
+    elif [[ -e "$arg" ]]; then
+        resolved_extra_args+=("$arg")
+        has_path_arg=true
+    else
+        resolved_extra_args+=("$arg")
+    fi
+done
+
+if $has_path_arg; then
+    pytest_common_args=(
+        -v --disable-warnings
+        --capture=tee-sys --show-capture=all --log-level=INFO
+        "${resolved_extra_args[@]}"
+    )
+else
+    pytest_common_args=(
+        -v --disable-warnings
+        --capture=tee-sys --show-capture=all --log-level=INFO
+        "${e2e_test_files[@]}"
+        "${extra_pytest_args[@]}"
+    )
+fi
 
 # ── Run ──────────────────────────────────────────────────────────────────
 parallel_rc=0


### PR DESCRIPTION
## Summary
Addresses review feedback from @chaitanya1731 on #1388:

- **`run_e2e_tests.sh`**: Extra pytest args with file paths now **replace** the smoke list instead of appending. `./run_e2e_tests.sh -- tests/test_api_keys.py` runs only that file, not the full smoke suite plus that file.
- **`run-tests-quick.sh`**: Usage header updated to describe the smoke-list default and path override behavior.
- **`README.md`**: Rewrite stale sentence that had old order (pytest then validation) to match the CI phase table.

## Test plan
- [ ] `./run_e2e_tests.sh` with no args runs full smoke suite (unchanged)
- [ ] `./run_e2e_tests.sh -- tests/test_api_keys.py` runs only `test_api_keys.py`
- [ ] `./run_e2e_tests.sh -- -k test_healthz` filters smoke suite by name (no path = keeps smoke list)
- [ ] `bash -n` passes on all scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CI deployment documentation to describe RHCL deployment and artifact reporting.
  * Clarified quick-run test script usage, including default smoke tests and optional file overrides.

* **Bug Fixes**
  * Improved end-to-end test selection so specified files or directories run directly, while other supported arguments continue to work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->