### PR TITLE
chore: add fail-fast and time tracking for parallel processing e2e setup

### DIFF
--- a/.github/hack/install-odh.sh
+++ b/.github/hack/install-odh.sh
@@ -164,15 +164,17 @@ wait_for_crd "datascienceclusters.datasciencecluster.opendatahub.io" 180 || {
   exit 1
 }
 
-# 5. Wait for webhook
+# 5. Wait for webhook (fail-fast: a non-ready operator webhook breaks DSCI/DSC apply)
 echo "5. Waiting for operator webhook..."
 wait_for_resource "deployment" "opendatahub-operator-controller-manager" "$NAMESPACE" 120 || {
-  log_warn "Webhook deployment not found after 120s, proceeding anyway..."
+  log_error "Webhook deployment not found after 120s"
+  exit 1
 }
 if kubectl get deployment opendatahub-operator-controller-manager -n "$NAMESPACE" &>/dev/null; then
   kubectl wait --for=condition=Available --timeout=120s \
-    deployment/opendatahub-operator-controller-manager -n "$NAMESPACE" 2>/dev/null || {
-    log_warn "Webhook deployment not fully ready, proceeding anyway..."
+    deployment/opendatahub-operator-controller-manager -n "$NAMESPACE" || {
+    log_error "Operator webhook deployment did not become Available"
+    exit 1
   }
 fi
 
@@ -210,6 +212,25 @@ EOF
   fi
 fi
 
+echo "   Waiting for DSCInitialization to be Ready..."
+dsci_ready=false
+for attempt in $(seq 1 30); do
+  dsci_phase=$(kubectl get dscinitialization default-dsci -o jsonpath='{.status.phase}' 2>/dev/null || echo "")
+  dsci_cond=$(kubectl get dscinitialization default-dsci -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "")
+  if [[ "$dsci_phase" == "Ready" ]] || [[ "$dsci_cond" == "True" ]]; then
+    echo "   DSCInitialization is Ready"
+    dsci_ready=true
+    break
+  fi
+  echo "   Waiting for DSCInitialization Ready (attempt ${attempt}/30, phase=${dsci_phase:-unknown}, Ready=${dsci_cond:-unknown})..."
+  sleep 10
+done
+if [[ "$dsci_ready" != "true" ]]; then
+  log_error "DSCInitialization did not become Ready after 300s"
+  kubectl describe dscinitialization default-dsci || true
+  exit 1
+fi
+
 # 7. Apply DataScienceCluster (KServe + ModelsAsService Managed)
 # The manifest filename retains "unmanaged" for backward compat; contents include
 # modelsAsService.managementState: Managed so the operator deploys maas-controller.
@@ -232,7 +253,8 @@ wait_datasciencecluster_ready "default-dsc" 600 || {
 # its pods are ready, any ConfigMap create/update fails with "no endpoints available".
 echo "9. Waiting for odh-model-controller webhook..."
 wait_for_validating_webhooks "$NAMESPACE" 180 || {
-  log_warn "Validating webhooks in $NAMESPACE not ready after 180s, proceeding anyway..."
+  log_error "Validating webhooks in $NAMESPACE not ready after 180s"
+  exit 1
 }
 
 echo ""

--- a/docs/content/contributing/testing-guide.md
+++ b/docs/content/contributing/testing-guide.md
@@ -252,6 +252,26 @@ graph TB
 
 Konflux provisions a fresh cluster, deploys ODH + MaaS with the PR's built images, and runs `test/e2e/scripts/prow_run_smoke_test.sh`. Nightly builds use the same script against the latest `main` images — there is no separate nightly test suite.
 
+### Deploy phase timings and fail-fast
+
+`/group-test` is sequential: cluster provision → **deploy + validate** → pytest. `prow_run_smoke_test.sh` writes UTC start/end stamps for `deploy_platform`, `deploy_models`, `validate`, `pytest_pass1`, and `pytest_pass2` to **`phase-timings.txt`**.
+
+| Where | Path |
+|-------|------|
+| Local | `$PROJECT_ROOT/test/e2e/reports/phase-timings.txt` (or `$ARTIFACT_DIR` / `$ARTIFACTS` / `$LOG_DIR` if set) |
+| Konflux / Prow | `artifacts/<job>/<step>/phase-timings.txt` (OpenShift CI copies `ARTIFACT_DIR`) |
+
+Each line looks like `2026-08-19T20:01:02Z deploy_platform start`. A start without a matching end means that phase failed or the job was killed.
+
+Readiness gates **fail the job before pytest** so a bad DSC, AuthPolicy, or ODH install does not burn another ~40 minutes of pytest:
+
+- DataScienceCluster wait in `prow_run_smoke_test.sh` exits 1 and dumps DSC conditions.
+- After models are applied, AuthPolicy `Enforced=True` is required (`wait_for_auth_policies_enforced` returns 1 on timeout). `SKIP_AUTH_CHECK` still defaults to true **before** models exist (RHOAIENG-48760 chicken-egg).
+- `.github/hack/install-odh.sh` exits 1 if the operator webhook, DSCInitialization, or DataScienceCluster never become Ready.
+- `validate-deployment.sh` retries after polling gateway/pods, not after a fixed 30s sleep.
+
+`SKIP_DEPLOYMENT=true` still skips platform and model install; timings are then recorded only for validate and pytest.
+
 !!! tip "Docs-only changes"
     PRs that only touch `docs/**` or `*.md` files skip Konflux builds and E2E entirely (controlled via CEL expressions in `.tekton/` pipeline definitions).
 

--- a/test/e2e/scripts/prow_run_smoke_test.sh
+++ b/test/e2e/scripts/prow_run_smoke_test.sh
@@ -146,7 +146,11 @@ AITENANT_NAMESPACE="${AITENANT_NAMESPACE:-ai-tenants}"
 
 # Artifact collection: OpenShift CI provides ARTIFACT_DIR (docs.ci.openshift.org/docs/architecture/step-registry).
 # Files written here are collected to artifacts/<job>/<step>/ in Prow. Fallbacks: ARTIFACTS, LOG_DIR, or local reports.
+# Phase timings (RHOAIENG-82332): UTC start/end stamps for deploy_platform, deploy_models,
+# validate, pytest_pass1, and pytest_pass2 are appended to ${ARTIFACTS_DIR}/phase-timings.txt
+# (Konflux/Prow: artifacts/<job>/<step>/phase-timings.txt).
 ARTIFACTS_DIR="${ARTIFACT_DIR:-${ARTIFACTS:-${LOG_DIR:-$PROJECT_ROOT/test/e2e/reports}}}"
+mkdir -p "$ARTIFACTS_DIR"
 
 # Source auth utils (patch_authorino_debug, collect_e2e_artifacts)
 source "$PROJECT_ROOT/test/e2e/scripts/auth_utils.sh"
@@ -157,6 +161,15 @@ print_header() {
     echo "$1"
     echo "----------------------------------------"
     echo ""
+}
+
+# Record a UTC start/end stamp for a named CI phase. Appended to phase-timings.txt
+# so Konflux artifacts show how long deploy vs validate vs pytest actually took.
+phase_mark() {
+    local name="${1:?phase_mark requires a phase name}"
+    local event="${2:?phase_mark requires start or end}"
+    mkdir -p "$ARTIFACTS_DIR"
+    echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) ${name} ${event}" | tee -a "${ARTIFACTS_DIR}/phase-timings.txt"
 }
 
 wait_for_gateway_programmed() {
@@ -406,9 +419,14 @@ deploy_maas_platform() {
         fi
     fi
 
-    # Wait for DataScienceCluster (install-odh already waited; deploy may have updated)
+    # Wait for DataScienceCluster (install-odh already waited; deploy may have updated).
+    # Fail-fast: a non-Ready DSC will fail pytest later after ~40 more minutes.
     if ! wait_datasciencecluster_ready "default-dsc" "$CUSTOM_RESOURCE_TIMEOUT"; then
-        echo "⚠️  WARNING: DataScienceCluster readiness check had issues (timeout: ${CUSTOM_RESOURCE_TIMEOUT}s), continuing anyway"
+        echo "❌ ERROR: DataScienceCluster did not become ready (timeout: ${CUSTOM_RESOURCE_TIMEOUT}s)"
+        echo "Last DataScienceCluster conditions:"
+        kubectl get datasciencecluster default-dsc -o jsonpath='{range .status.conditions[*]}{.type}={.status} ({.reason}): {.message}{"\n"}{end}' 2>/dev/null \
+            || kubectl describe datasciencecluster default-dsc || true
+        exit 1
     fi
 
     # Wait for Authorino to be ready and auth service cluster to be healthy
@@ -416,6 +434,7 @@ deploy_maas_platform() {
     # once the operator creates the gateway→Authorino TLS EnvoyFilter at Gateway/AuthPolicy creation
     # time, not at first LLMInferenceService creation. Currently there's a chicken-egg problem where
     # auth checks fail before any model is deployed because the TLS config doesn't exist yet.
+    # Default remains true until models exist; AuthPolicy Enforced is gated after deploy_models.
     if [[ "${SKIP_AUTH_CHECK:-true}" == "true" ]]; then
         echo "⚠️  WARNING: Skipping Authorino readiness check (SKIP_AUTH_CHECK=true)"
         echo "   This is a temporary workaround for the gateway→Authorino TLS chicken-egg problem"
@@ -423,7 +442,8 @@ deploy_maas_platform() {
         # Using configurable timeout (default suitable for Prow's 15m job limit)
         echo "Waiting for Authorino and auth service to be ready (namespace: ${AUTHORINO_NAMESPACE})..."
         if ! wait_authorino_ready "$AUTHORINO_NAMESPACE" "$AUTHORINO_TIMEOUT"; then
-            echo "⚠️  WARNING: Authorino readiness check had issues (timeout: ${AUTHORINO_TIMEOUT}s), continuing anyway"
+            echo "❌ ERROR: Authorino did not become ready (timeout: ${AUTHORINO_TIMEOUT}s)"
+            exit 1
         fi
     fi
 
@@ -524,7 +544,9 @@ deploy_models() {
         exit 1
     fi
 
-    wait_for_auth_policies_enforced
+    if ! wait_for_auth_policies_enforced; then
+        exit 1
+    fi
 }
 
 wait_for_auth_policies_enforced() {
@@ -557,8 +579,9 @@ wait_for_auth_policies_enforced() {
         echo "  Waiting... ($total policies found, not all enforced yet)"
         sleep 10
     done
-    echo "⚠️  WARNING: AuthPolicies not all enforced after ${timeout}s, tests may fail"
+    echo "❌ ERROR: AuthPolicies not all enforced after ${timeout}s"
     oc get authpolicies -A -o wide 2>/dev/null || true
+    return 1
 }
 
 validate_deployment() {
@@ -571,8 +594,14 @@ validate_deployment() {
         # maas-api deploys to the resolved infrastructure namespace.
         # validate-deployment.sh derives INFRA_NAMESPACE the same way.
         if ! "$PROJECT_ROOT/scripts/validate-deployment.sh"; then
-            echo "⚠️  First validation attempt failed, waiting 30 seconds and retrying..."
-            sleep 30
+            echo "⚠️  First validation attempt failed; polling gateway and core deployments then retrying..."
+            wait_for_gateway_programmed "$GATEWAY_NAME" "$GATEWAY_NAMESPACE" 60 || true
+            kubectl wait --for=condition=Available --timeout=60s \
+                "deployment/maas-controller" -n "$DEPLOYMENT_NAMESPACE" 2>/dev/null || true
+            if [[ -n "${MAAS_API_DEPLOYMENT_NAMESPACE:-}" ]]; then
+                kubectl wait --for=condition=Available --timeout=60s \
+                    "deployment/maas-api" -n "$MAAS_API_DEPLOYMENT_NAMESPACE" 2>/dev/null || true
+            fi
             if ! "$PROJECT_ROOT/scripts/validate-deployment.sh"; then
                 echo "❌ ERROR: Deployment validation failed after retry"
                 exit 1
@@ -834,7 +863,9 @@ run_e2e_tests() {
     export E2E_RECONCILE_WAIT="${E2E_RECONCILE_WAIT:-4}"
     local script_dir
     script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    phase_mark pytest start
     "${script_dir}/run_e2e_tests.sh"
+    phase_mark pytest end
 }
 
 
@@ -1092,10 +1123,14 @@ if [[ "$SKIP_DEPLOYMENT" == "true" ]]; then
     echo "  Skipping deployment (SKIP_DEPLOYMENT=true)"
     echo "  Assuming MaaS platform and models are already deployed"
 else
+    phase_mark deploy_platform start
     deploy_maas_platform
+    phase_mark deploy_platform end
 
-    print_header "Deploying Models"  
+    print_header "Deploying Models"
+    phase_mark deploy_models start
     deploy_models
+    phase_mark deploy_models end
     patch_authorino_debug  # from auth_utils.sh
 fi
 
@@ -1128,7 +1163,9 @@ setup_test_tokens
 # The main oc session is still system:admin for any kubectl/oc commands.
 # ═══════════════════════════════════════════════════════════════════════════════
 print_header "Validating Deployment"
+phase_mark validate start
 validate_deployment
+phase_mark validate end
 
 print_header "Running E2E Tests"
 run_e2e_tests


### PR DESCRIPTION
This pull request introduces a fail-fast approach to the deployment and validation scripts, ensuring that critical readiness gates (such as operator webhooks, DSCInitialization, DataScienceCluster, and AuthPolicies) must be met before proceeding to time-consuming end-to-end (E2E) tests. It also adds phase timing instrumentation to help diagnose where failures or delays occur during CI runs. The changes improve reliability and debuggability of the CI pipeline, especially for Konflux/Prow jobs.

https://redhat.atlassian.net/browse/RHOAIENG-82332
Key improvements include:

**Fail-fast readiness gates:**

* [`.github/hack/install-odh.sh`](diffhunk://#diff-59c12929a217b181e9c84c2e8bfca265169513ae5aafec48aba77c52bc6f3066L167-R177): Now exits immediately with an error if the operator webhook, DSCInitialization, DataScienceCluster, or validating webhooks do not become ready within their timeouts, instead of issuing warnings and proceeding. This prevents wasted time running tests on broken environments. [[1]](diffhunk://#diff-59c12929a217b181e9c84c2e8bfca265169513ae5aafec48aba77c52bc6f3066L167-R177) [[2]](diffhunk://#diff-59c12929a217b181e9c84c2e8bfca265169513ae5aafec48aba77c52bc6f3066R215-R233) [[3]](diffhunk://#diff-59c12929a217b181e9c84c2e8bfca265169513ae5aafec48aba77c52bc6f3066L235-R257)
* [`test/e2e/scripts/prow_run_smoke_test.sh`](diffhunk://#diff-840d637e20f21c8d574a57385e41a64abd192ba1567711c933418a90cfdf4ef3L409-R446): DataScienceCluster and Authorino readiness checks are now strict; failures cause an immediate exit instead of a warning. AuthPolicy enforcement is also required to proceed. [[1]](diffhunk://#diff-840d637e20f21c8d574a57385e41a64abd192ba1567711c933418a90cfdf4ef3L409-R446) [[2]](diffhunk://#diff-840d637e20f21c8d574a57385e41a64abd192ba1567711c933418a90cfdf4ef3L527-R549) [[3]](diffhunk://#diff-840d637e20f21c8d574a57385e41a64abd192ba1567711c933418a90cfdf4ef3L560-R584)

**Phase timing and diagnostics:**

* [`test/e2e/scripts/prow_run_smoke_test.sh`](diffhunk://#diff-840d637e20f21c8d574a57385e41a64abd192ba1567711c933418a90cfdf4ef3R149-R153): Adds a `phase_mark` function to record UTC start/end timestamps for major phases (deploy_platform, deploy_models, validate, pytest) in `phase-timings.txt`, which is collected as a CI artifact. [[1]](diffhunk://#diff-840d637e20f21c8d574a57385e41a64abd192ba1567711c933418a90cfdf4ef3R149-R153) [[2]](diffhunk://#diff-840d637e20f21c8d574a57385e41a64abd192ba1567711c933418a90cfdf4ef3R166-R174) [[3]](diffhunk://#diff-840d637e20f21c8d574a57385e41a64abd192ba1567711c933418a90cfdf4ef3R1126-R1133) [[4]](diffhunk://#diff-840d637e20f21c8d574a57385e41a64abd192ba1567711c933418a90cfdf4ef3R1166-R1168) [[5]](diffhunk://#diff-840d637e20f21c8d574a57385e41a64abd192ba1567711c933418a90cfdf4ef3R866-R868)
* [`docs/content/contributing/testing-guide.md`](diffhunk://#diff-4c8300d84fcaaa683938c48b87c89255f7e6d14bef4f756e09fe5035247f8bb8R255-R274): Documents the new phase timing mechanism, its artifacts, and the fail-fast readiness gates, clarifying how CI failures are now detected earlier and how to interpret timing data.

**Deployment validation improvements:**

* [`test/e2e/scripts/prow_run_smoke_test.sh`](diffhunk://#diff-840d637e20f21c8d574a57385e41a64abd192ba1567711c933418a90cfdf4ef3L574-R604): On deployment validation failure, the script now polls for gateway and deployment readiness before retrying, rather than simply sleeping, improving the chance of recovery from transient issues.

These changes make CI feedback faster and more actionable by failing early on unrecoverable deployment issues and providing precise timing information for troubleshooting.<!--- Provide a general summary of your changes in the Title above -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Installation and deployment now stop promptly when required services fail readiness checks, instead of continuing with warnings.
  - Validation now waits for required gateway, controller, and monitoring services to become ready, improving reliability.
  - Authentication policy failures are now reported as deployment errors.
  - Deployment and test phases now record timing information to aid troubleshooting.

- **Documentation**
  - Added guidance on deployment timing, readiness gates, validation retries, timing records, and behavior when deployment is skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->