### PR TITLE
fix: validate tlrp on `v1/embeddings`

### DIFF
--- a/deployment/components/observability/usage-logs/envoy-otel-access-log.yaml
+++ b/deployment/components/observability/usage-logs/envoy-otel-access-log.yaml
@@ -9,7 +9,8 @@
 #            fields remain on auth identity FILTER_STATE
 #            (wasm.kuadrant.auth.identity.*).
 # Model:     Composite filter wraps json_to_metadata, executing only on
-#            inference paths (suffix match: /v1/chat/completions, /v1/completions).
+#            inference paths (suffix match: /v1/chat/completions,
+#            /v1/completions, /v1/embeddings).
 #            Extracts "model" from request body (covers 429),
 #            then overwrites from response body on 200 (authoritative).
 # Tokens:    json_to_metadata extracts usage.{total,prompt,completion}_tokens
@@ -168,7 +169,9 @@ spec:
   # Matches OpenAI + MaaS conventions:
   #   - /<ns>/<model>/v1/chat/completions  (path-based routing, current)
   #   - /<ns>/<model>/v1/completions       (legacy)
+  #   - /<ns>/<model>/v1/embeddings        (embedding models)
   #   - /v1/chat/completions               (body-based routing, future)
+  #   - /v1/embeddings                     (body-based routing, embeddings)
   #
   # request_rules  — extracts "model" from the JSON request body.
   # response_rules — extracts token counts and authoritative model from the
@@ -224,6 +227,14 @@ spec:
                             header_name: ":path"
                         value_match:
                           suffix: "/v1/completions"
+                    - single_predicate:
+                        input:
+                          name: request-headers
+                          typed_config:
+                            "@type": type.googleapis.com/envoy.type.matcher.v3.HttpRequestHeaderMatchInput
+                            header_name: ":path"
+                        value_match:
+                          suffix: "/v1/embeddings"
                 on_match:
                   action:
                     name: run-json-to-metadata
@@ -350,7 +361,8 @@ spec:
                 local path = request_handle:headers():get(":path")
                 if path
                    and (string.find(path, "/v1/chat/completions", 1, true)
-                     or string.find(path, "/v1/completions", 1, true))
+                     or string.find(path, "/v1/completions", 1, true)
+                     or string.find(path, "/v1/embeddings", 1, true))
                 then
                   request_handle:streamInfo():dynamicMetadata():set(
                     MD_NS, "is_completions", "true")
@@ -421,7 +433,8 @@ spec:
                   expression: >-
                     request.method == 'POST'
                     && (request.path.endsWith('/v1/chat/completions')
-                        || request.path.endsWith('/v1/completions'))
+                        || request.path.endsWith('/v1/completions')
+                        || request.path.endsWith('/v1/embeddings'))
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.access_loggers.open_telemetry.v3.OpenTelemetryAccessLogConfig
               common_config:


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-84036

## Description
`/v1/embeddings` added to all 3 path matchers in envoy-otel-access-log.yaml:
1. Composite filter (line 227+) - suffix match triggers json_to_metadata body parsing for embeddings, extracting model name and usage.prompt_tokens/usage.total_tokens
2. Lua SSE filter (line 361+) - marks embeddings as inference endpoints (harmless for non-streaming; SSE content-type guard skips the streaming path)
3. CEL access log filter (line 433+) - enables OTel log emission for embedding requests
TRLP enforcement - no controller changes needed. The TRLP system is model-type agnostic; it works on MaaSSubscription token quotas regardless of whether the endpoint is `/v1/chat/completions` or `/v1/embeddings`. The gateway-default-deny.yaml catch-all already covers `/v1/embeddings` (only `/maas-api`, `/v1/models`, `/v1/subscriptions`, `/v1/api-keys` are excluded).

## How Has This Been Tested?
Kustomize manifests all pass validation.

**On a cluster:**
All manifests validate. Now let me check if the observability component is deployed on the cluster and apply the updated EnvoyFilter.
Kustomize manifest validation - All pass
EnvoyFilter applies without error - Yes
Gateway pod stable after applying - Yes (no restarts)
Embedding requests (/v1/embeddings) still return 200  - Yes (384-dim vector, prompt_tokens: 5)
Chat completions (/v1/chat/completions) still work -│ Yes (not broken by the change)
Filter processes embedding requests - Confirmed - json_to_metadata ran, access log shows POST /v1/embeddings
Expected warning for missing completion_tokens - Present (embeddings don't have completion tokens - correct behavior)
EnvoyFilter cleaned up - Yes


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added observability support for `/v1/embeddings` inference requests.
  * Embedding requests are now included in access logs, composite filtering, and streaming-event detection.
  * Documented the new inference endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->