### PR TITLE
fix: remove redundant openshift-service-ca.crt ConfigMap declaration

### DIFF
--- a/deployment/base/maas-api/overlays/tls/kustomization.yaml
+++ b/deployment/base/maas-api/overlays/tls/kustomization.yaml
@@ -4,7 +4,6 @@ kind: Kustomization
 resources:
   - ../../default
   - destinationrule.yaml
-  - service-ca-configmap.yaml
 
 patches:
   - path: deployment-patch.yaml

--- a/deployment/base/maas-api/overlays/tls/service-ca-configmap.yaml
+++ b/deployment/base/maas-api/overlays/tls/service-ca-configmap.yaml
@@ -1,6 +1,0 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: openshift-service-ca.crt
-  annotations:
-    service.beta.openshift.io/inject-cabundle: "true"


### PR DESCRIPTION
## Description

OpenShift's service-ca controller automatically creates a ConfigMap named `openshift-service-ca.crt` in every namespace, pre-populated with the cluster CA bundle. No operator intervention is needed.

The `maas-api` TLS overlay was declaring this ConfigMap with `inject-cabundle: "true"`. This causes annotation bouncing on every reconcile when `maas-controller` SSA-writes the manifest with field manager `maas-controller`, while the service-ca injector also owns the `data` field.

**Fix:** remove `service-ca-configmap.yaml` from the TLS overlay. The deployment's volume mount and `SSL_CERT_DIR` reference to `openshift-service-ca.crt` are kept as-is since OpenShift creates that ConfigMap automatically.

Same fix pattern as [model-registry-operator#638](https://github.com/opendatahub-io/model-registry-operator/pull/638).

Related: [RHOAIENG-72400](https://redhat.atlassian.net/browse/RHOAIENG-72400), [RHAISTRAT-1716](https://redhat.atlassian.net/browse/RHAISTRAT-1716)

## How Has This Been Tested?

- `kustomize build deployment/base/maas-api/overlays/tls` succeeds
- Verified deployment still mounts the platform-managed `openshift-service-ca.crt` ConfigMap via `deployment-patch.yaml`

## Screenshot or short clip

N/A

## Merge criteria

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work

Made with [Cursor](https://cursor.com)

[RHOAIENG-72400]: https://redhat.atlassian.net/browse/RHOAIENG-72400?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHAISTRAT-1716]: https://redhat.atlassian.net/browse/RHAISTRAT-1716?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the redundant service CA ConfigMap from the TLS deployment configuration.
  * Simplified TLS resource handling by relying on the platform-provided service CA bundle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->