### PR TITLE
fix(tls): fail closed on watcher errors, honor cluster profile, unblock security sync

### DIFF
--- a/.github/semgrep-tls-excludes
+++ b/.github/semgrep-tls-excludes
@@ -1,0 +1,16 @@
+# Semgrep TLS rule suppressions
+# Format: RULE_ID:FILE_PATH
+#
+# server.go / metrics/server.go: TLS listeners apply the cluster TLS security profile
+# (MinVersion, CipherSuites) from setupTLSProfile; explicit tls.Config is required for
+# certificate loading and profile application.
+go-http-server-tls-override:maas-api/cmd/server.go
+go-http-server-tls-override:maas-api/internal/metrics/server.go
+#
+# discovery.go: Cluster-internal HTTP client uses cluster CA bundle plus profile
+# MinVersion/CipherSuites plumbed from setupTLSProfile; required assignment for probes.
+go-http-client-tls-override:maas-api/internal/models/discovery.go
+#
+# provider.go: OTEL gRPC exporter uses insecure credentials only when
+# OTEL_EXPORTER_OTLP_INSECURE=true (default false).
+go-grpc-tls-credential-override:maas-api/internal/tracing/provider.go

--- a/maas-api/cmd/main.go
+++ b/maas-api/cmd/main.go
@@ -52,7 +52,14 @@ const (
 var (
 	fetchClusterTLSSettings = tlsprofile.FetchTLSSettings
 	tlsProfileRetryDelay    = tlsProfileFetchRetryDelay
+	newTLSProfileWatcher    = func(restConfig *rest.Config, initial tlsprofile.Settings, onChange func(oldSettings, newSettings tlsprofile.Settings)) (tlsProfileWatcher, error) {
+		return tlsprofile.NewWatcher(restConfig, initial, onChange)
+	}
 )
+
+type tlsProfileWatcher interface {
+	Start(stopCh <-chan struct{}) error
+}
 
 func serve() error {
 	cfg := config.Load()
@@ -130,7 +137,7 @@ func serve() error {
 	}
 	router.Use(metrics.NewMiddleware(metricsRecorder, cfg.TenantName))
 
-	profileMinVersion, profileCipherSuites, tlsErr := setupTLSProfile(ctx, log, cfg, cluster, cancel)
+	profileMinVersion, profileCipherSuites, tlsErr := setupTLSProfile(ctx, log, cfg, cluster.RESTConfig(), cancel)
 	if tlsErr != nil {
 		return fmt.Errorf("failed to set up TLS profile: %w", tlsErr)
 	}
@@ -171,7 +178,7 @@ func serve() error {
 		}
 	}()
 
-	if err = registerHandlers(ctx, log, router, cfg, cluster, store, metricsRecorder); err != nil {
+	if err = registerHandlers(ctx, log, router, cfg, cluster, store, metricsRecorder, profileMinVersion, profileCipherSuites); err != nil {
 		return fmt.Errorf("failed to register handlers: %w", err)
 	}
 
@@ -235,6 +242,8 @@ func registerHandlers(
 	cluster *config.ClusterConfig,
 	store api_keys.MetadataStore,
 	metricsRecorder *metrics.PrometheusRecorder,
+	profileMinVersion uint16,
+	profileCipherSuites []uint16,
 ) error {
 	router.GET("/health", handlers.NewHealthHandler().HealthCheck)
 
@@ -261,7 +270,7 @@ func registerHandlers(
 	}
 	log.Info("Resolved gateway internal host for access probes", "host", gatewayInternalHost)
 
-	modelManager, err := models.NewManager(log, cfg.AccessCheckTimeoutSeconds, gatewayInternalHost, cfg.DiscoveryEnableHTTP2)
+	modelManager, err := models.NewManager(log, cfg.AccessCheckTimeoutSeconds, gatewayInternalHost, cfg.DiscoveryEnableHTTP2, profileMinVersion, profileCipherSuites)
 	if err != nil {
 		log.Fatal("Failed to create model manager", "error", err)
 	}
@@ -355,16 +364,18 @@ func debugCORSConfig() cors.Config {
 
 // setupTLSProfile fetches the OpenShift cluster TLS security profile and starts
 // a watcher that cancels the context on profile changes. Returns the profile's
-// minVersion and cipherSuites for use in buildTLSConfig. When HTTPS is disabled,
-// returns zero values so flag-based defaults apply.
+// minVersion and cipherSuites for use in buildTLSConfig. When both API and
+// metrics HTTPS are disabled, returns zero values so flag-based defaults apply.
 //
-// Fetch and watcher errors are logged and the server continues with the
-// Intermediate profile defaults so transient config API issues do not block
-// startup.
-func setupTLSProfile(ctx context.Context, log *logger.Logger, cfg *config.Config, cluster *config.ClusterConfig, cancel context.CancelFunc) (uint16, []uint16, error) {
-	restConfig := cluster.RESTConfig()
-	if (!cfg.Secure && !cfg.MetricsSecure) || restConfig == nil {
+// Watcher create and cache-sync failures fail closed so the process cannot
+// serve with a stale cluster TLS profile. Transient fetch errors still fall
+// back to Intermediate defaults (with the watcher registered to self-heal).
+func setupTLSProfile(ctx context.Context, log *logger.Logger, cfg *config.Config, restConfig *rest.Config, cancel context.CancelFunc) (uint16, []uint16, error) {
+	if !cfg.Secure && !cfg.MetricsSecure {
 		return 0, nil, nil
+	}
+	if restConfig == nil {
+		return 0, nil, errors.New("HTTPS is enabled but Kubernetes REST configuration is unavailable")
 	}
 
 	settings, watchSettings, fetchErr := fetchTLSSettingsWithRetry(ctx, log, restConfig)
@@ -389,22 +400,17 @@ func setupTLSProfile(ctx context.Context, log *logger.Logger, cfg *config.Config
 	}
 
 	if watchSettings {
-		watcher, watchErr := tlsprofile.NewWatcher(restConfig, settings, func(oldSettings, newSettings tlsprofile.Settings) {
+		watcher, watchErr := newTLSProfileWatcher(restConfig, settings, func(oldSettings, newSettings tlsprofile.Settings) {
 			log.Info("TLS security profile or adherence policy changed, initiating graceful shutdown to reload",
 				"oldType", string(oldSettings.Profile.Type), "newType", string(newSettings.Profile.Type),
 				"oldAdherence", oldSettings.Adherence, "newAdherence", newSettings.Adherence)
 			cancel()
 		})
 		if watchErr != nil {
-			log.Info("TLS profile watcher could not be created; continuing with current TLS profile",
-				"error", watchErr)
-		} else {
-			go func() {
-				if err := watcher.Start(ctx.Done()); err != nil {
-					log.Info("TLS profile watcher stopped before syncing; continuing with current TLS profile",
-						"error", err)
-				}
-			}()
+			return 0, nil, fmt.Errorf("unable to create TLS profile watcher: %w", watchErr)
+		}
+		if err := watcher.Start(ctx.Done()); err != nil {
+			return 0, nil, fmt.Errorf("TLS profile watcher failed to sync: %w", err)
 		}
 	}
 

--- a/maas-api/cmd/server_test.go
+++ b/maas-api/cmd/server_test.go
@@ -124,3 +124,136 @@ func TestFetchTLSProfileWithRetry_APIUnavailableFallsBackAndSkipsWatcher(t *test
 	assert.False(t, watchSettings, "non-OpenShift clusters should skip the config.openshift.io watcher")
 	assert.Equal(t, tlsprofile.ProfileIntermediate, settings.Profile.Type)
 }
+
+type stubTLSProfileWatcher struct {
+	startErr error
+}
+
+func (s stubTLSProfileWatcher) Start(<-chan struct{}) error {
+	return s.startErr
+}
+
+func TestSetupTLSProfile_SkipsWhenNeitherAPINorMetricsSecure(t *testing.T) {
+	minVersion, ciphers, err := setupTLSProfile(t.Context(), logger.New(false), &config.Config{Secure: false, MetricsSecure: false}, &rest.Config{}, func() {})
+	require.NoError(t, err)
+	assert.Zero(t, minVersion)
+	assert.Nil(t, ciphers)
+}
+
+func TestSetupTLSProfile_FailsWhenRESTConfigNilWithHTTPSEnabled(t *testing.T) {
+	minVersion, ciphers, err := setupTLSProfile(t.Context(), logger.New(false), &config.Config{Secure: true}, nil, func() {})
+	require.Error(t, err)
+	assert.Zero(t, minVersion)
+	assert.Nil(t, ciphers)
+	assert.Contains(t, err.Error(), "REST configuration is unavailable")
+}
+
+func TestSetupTLSProfile_AppliesWhenMetricsSecureOnly(t *testing.T) {
+	originalFetch := fetchClusterTLSSettings
+	originalNew := newTLSProfileWatcher
+	defer func() {
+		fetchClusterTLSSettings = originalFetch
+		newTLSProfileWatcher = originalNew
+	}()
+
+	fetchClusterTLSSettings = func(context.Context, *rest.Config) (tlsprofile.Settings, error) {
+		return tlsprofile.DefaultSettings(), nil
+	}
+	created := false
+	newTLSProfileWatcher = func(*rest.Config, tlsprofile.Settings, func(tlsprofile.Settings, tlsprofile.Settings)) (tlsProfileWatcher, error) {
+		created = true
+		return stubTLSProfileWatcher{}, nil
+	}
+
+	_, _, err := setupTLSProfile(t.Context(), logger.New(false), &config.Config{Secure: false, MetricsSecure: true}, &rest.Config{}, func() {})
+	require.NoError(t, err)
+	assert.True(t, created, "metrics HTTPS still requires a cluster TLS profile watcher")
+}
+
+func TestSetupTLSProfile_SkipsWatcherWhenAPIUnavailable(t *testing.T) {
+	originalFetch := fetchClusterTLSSettings
+	originalNew := newTLSProfileWatcher
+	defer func() {
+		fetchClusterTLSSettings = originalFetch
+		newTLSProfileWatcher = originalNew
+	}()
+
+	fetchClusterTLSSettings = func(context.Context, *rest.Config) (tlsprofile.Settings, error) {
+		return tlsprofile.DefaultSettings(), apierrors.NewNotFound(
+			schema.GroupResource{Group: "config.openshift.io", Resource: "apiservers"},
+			"cluster",
+		)
+	}
+	newTLSProfileWatcher = func(*rest.Config, tlsprofile.Settings, func(tlsprofile.Settings, tlsprofile.Settings)) (tlsProfileWatcher, error) {
+		t.Fatal("watcher should not be created on non-OpenShift clusters")
+		return nil, nil
+	}
+
+	_, _, err := setupTLSProfile(t.Context(), logger.New(false), &config.Config{Secure: true}, &rest.Config{}, func() {})
+	require.NoError(t, err)
+}
+
+func TestSetupTLSProfile_WatcherCreateFailsClosed(t *testing.T) {
+	originalFetch := fetchClusterTLSSettings
+	originalNew := newTLSProfileWatcher
+	defer func() {
+		fetchClusterTLSSettings = originalFetch
+		newTLSProfileWatcher = originalNew
+	}()
+
+	fetchClusterTLSSettings = func(context.Context, *rest.Config) (tlsprofile.Settings, error) {
+		return tlsprofile.DefaultSettings(), nil
+	}
+	newTLSProfileWatcher = func(*rest.Config, tlsprofile.Settings, func(tlsprofile.Settings, tlsprofile.Settings)) (tlsProfileWatcher, error) {
+		return nil, errors.New("restConfig rejected")
+	}
+
+	_, _, err := setupTLSProfile(t.Context(), logger.New(false), &config.Config{Secure: true}, &rest.Config{}, func() {})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unable to create TLS profile watcher")
+}
+
+func TestSetupTLSProfile_WatcherSyncFailsClosed(t *testing.T) {
+	originalFetch := fetchClusterTLSSettings
+	originalNew := newTLSProfileWatcher
+	defer func() {
+		fetchClusterTLSSettings = originalFetch
+		newTLSProfileWatcher = originalNew
+	}()
+
+	fetchClusterTLSSettings = func(context.Context, *rest.Config) (tlsprofile.Settings, error) {
+		return tlsprofile.DefaultSettings(), nil
+	}
+	newTLSProfileWatcher = func(*rest.Config, tlsprofile.Settings, func(tlsprofile.Settings, tlsprofile.Settings)) (tlsProfileWatcher, error) {
+		return stubTLSProfileWatcher{startErr: errors.New("informer cache sync failed")}, nil
+	}
+
+	_, _, err := setupTLSProfile(t.Context(), logger.New(false), &config.Config{Secure: true}, &rest.Config{}, func() {
+		t.Fatal("cancel should not be called; Start errors must fail setupTLSProfile")
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "TLS profile watcher failed to sync")
+}
+
+func TestSetupTLSProfile_WatcherStartSucceeds(t *testing.T) {
+	originalFetch := fetchClusterTLSSettings
+	originalNew := newTLSProfileWatcher
+	defer func() {
+		fetchClusterTLSSettings = originalFetch
+		newTLSProfileWatcher = originalNew
+	}()
+
+	fetchClusterTLSSettings = func(context.Context, *rest.Config) (tlsprofile.Settings, error) {
+		return tlsprofile.DefaultSettings(), nil
+	}
+	newTLSProfileWatcher = func(*rest.Config, tlsprofile.Settings, func(tlsprofile.Settings, tlsprofile.Settings)) (tlsProfileWatcher, error) {
+		return stubTLSProfileWatcher{}, nil
+	}
+
+	cancelled := false
+	_, _, err := setupTLSProfile(t.Context(), logger.New(false), &config.Config{Secure: true}, &rest.Config{}, func() {
+		cancelled = true
+	})
+	require.NoError(t, err)
+	assert.False(t, cancelled)
+}

--- a/maas-api/internal/handlers/models_test.go
+++ b/maas-api/internal/handlers/models_test.go
@@ -365,7 +365,7 @@ func TestListingModels(t *testing.T) { //nolint:maintidx // table-driven test wi
 	}
 	router, _ := fixtures.SetupTestServer(t, config)
 
-	modelMgr, errMgr := models.NewManager(testLogger, 15, "", false)
+	modelMgr, errMgr := models.NewManager(testLogger, 15, "", false, 0, nil)
 	require.NoError(t, errMgr)
 
 	// Set up test fixtures
@@ -486,7 +486,7 @@ func TestListingModelsWithSubscriptionHeader(t *testing.T) {
 	}
 	router, _ := fixtures.SetupTestServer(t, config)
 
-	modelMgr, errMgr := models.NewManager(testLogger, 15, "", false)
+	modelMgr, errMgr := models.NewManager(testLogger, 15, "", false, 0, nil)
 	require.NoError(t, errMgr)
 
 	_, cleanup := fixtures.StubTokenProviderAPIs(t)
@@ -725,7 +725,7 @@ func TestListModels_ReturnAllModels(t *testing.T) {
 		},
 	}
 
-	modelMgr, err := models.NewManager(testLogger, 15, "", false)
+	modelMgr, err := models.NewManager(testLogger, 15, "", false, 0, nil)
 	require.NoError(t, err)
 
 	subscriptionSelector := subscription.NewSelector(testLogger, subscriptionLister, nil, nil)
@@ -914,7 +914,7 @@ func TestListModels_DeduplicationBySubscription(t *testing.T) {
 		},
 	}
 
-	modelMgr, err := models.NewManager(testLogger, 15, "", false)
+	modelMgr, err := models.NewManager(testLogger, 15, "", false, 0, nil)
 	require.NoError(t, err)
 
 	subscriptionSelector := subscription.NewSelector(testLogger, subscriptionLister, nil, nil)
@@ -1032,7 +1032,7 @@ func TestListModels_DifferentModelRefsWithSameModelID(t *testing.T) {
 		},
 	}
 
-	modelMgr, err := models.NewManager(testLogger, 15, "", false)
+	modelMgr, err := models.NewManager(testLogger, 15, "", false, 0, nil)
 	require.NoError(t, err)
 
 	subscriptionSelector := subscription.NewSelector(testLogger, subscriptionLister, nil, nil)
@@ -1140,7 +1140,7 @@ func TestListModels_DifferentModelRefsWithSameURLAndModelID(t *testing.T) {
 		},
 	}
 
-	modelMgr, err := models.NewManager(testLogger, 15, "", false)
+	modelMgr, err := models.NewManager(testLogger, 15, "", false, 0, nil)
 	require.NoError(t, err)
 
 	subscriptionSelector := subscription.NewSelector(testLogger, subscriptionLister, nil, nil)
@@ -1247,7 +1247,7 @@ func TestListModels_DifferentModelRefsWithSameModelIDAndDifferentSubscriptions(t
 		},
 	}
 
-	modelMgr, err := models.NewManager(testLogger, 15, "", false)
+	modelMgr, err := models.NewManager(testLogger, 15, "", false, 0, nil)
 	require.NoError(t, err)
 
 	subscriptionSelector := subscription.NewSelector(testLogger, subscriptionLister, nil, nil)
@@ -1341,7 +1341,7 @@ func TestListModels_ExternalModelUsesModelRefName(t *testing.T) {
 		},
 	}
 
-	modelMgr, err := models.NewManager(testLogger, 15, "", false)
+	modelMgr, err := models.NewManager(testLogger, 15, "", false, 0, nil)
 	require.NoError(t, err)
 
 	subscriptionSelector := subscription.NewSelector(testLogger, &fakeSubscriptionLister{}, lister, nil)
@@ -1396,7 +1396,7 @@ func TestListModels_NoAuthContext(t *testing.T) {
 		},
 	}
 
-	modelMgr, err := models.NewManager(testLogger, 15, "", false)
+	modelMgr, err := models.NewManager(testLogger, 15, "", false, 0, nil)
 	require.NoError(t, err)
 
 	subscriptionSelector := subscription.NewSelector(testLogger, &fakeSubscriptionLister{}, nil, nil)

--- a/maas-api/internal/models/discovery.go
+++ b/maas-api/internal/models/discovery.go
@@ -42,7 +42,14 @@ type Manager struct {
 // gatewayInternalHost, when non-empty, routes all probe TCP connections to this
 // cluster-internal address while preserving the original URL hostname for TLS SNI
 // and the Host header, so gateway routing and Authorino auth work identically.
-func NewManager(log *logger.Logger, accessCheckTimeoutSeconds int, gatewayInternalHost string, enableHTTP2 bool) (*Manager, error) {
+func NewManager(
+	log *logger.Logger,
+	accessCheckTimeoutSeconds int,
+	gatewayInternalHost string,
+	enableHTTP2 bool,
+	profileMinVersion uint16,
+	profileCipherSuites []uint16,
+) (*Manager, error) {
 	if log == nil {
 		return nil, errors.New("log is required")
 	}
@@ -51,7 +58,7 @@ func NewManager(log *logger.Logger, accessCheckTimeoutSeconds int, gatewayIntern
 		timeout = time.Duration(accessCheckTimeoutSeconds) * time.Second
 	}
 
-	tlsConfig, err := BuildClusterTLSConfigFromPath(log, kubeServiceAccountCAPath, enableHTTP2)
+	tlsConfig, err := BuildClusterTLSConfigFromPath(log, kubeServiceAccountCAPath, enableHTTP2, profileMinVersion, profileCipherSuites)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build TLS config: %w", err)
 	}
@@ -91,17 +98,18 @@ func NewManager(log *logger.Logger, accessCheckTimeoutSeconds int, gatewayIntern
 // the default Kubernetes service account CA path. It is a convenience wrapper around
 // BuildClusterTLSConfigFromPath.
 func BuildClusterTLSConfig(log *logger.Logger) (*tls.Config, error) {
-	return BuildClusterTLSConfigFromPath(log, kubeServiceAccountCAPath, false)
+	return BuildClusterTLSConfigFromPath(log, kubeServiceAccountCAPath, false, 0, nil)
 }
 
 // BuildClusterTLSConfigFromPath creates a TLS config for cluster-internal communication.
 // It starts with the system root CAs and appends the CA certificate at caPath when present.
+// profileMinVersion and profileCipherSuites come from the cluster TLS security profile when set.
 // This ensures both public CAs and cluster CAs are trusted, supporting endpoints with
 // publicly-trusted certificates as well as cluster-internal services.
 //
 // If caPath does not exist, system root CAs are used alone (development/out-of-cluster mode).
 // If caPath exists but cannot be read or parsed, an error is returned to prevent insecure fallback.
-func BuildClusterTLSConfigFromPath(log *logger.Logger, caPath string, enableHTTP2 bool) (*tls.Config, error) {
+func BuildClusterTLSConfigFromPath(log *logger.Logger, caPath string, enableHTTP2 bool, profileMinVersion uint16, profileCipherSuites []uint16) (*tls.Config, error) {
 	if log == nil {
 		return nil, errors.New("log is required")
 	}
@@ -130,6 +138,12 @@ func BuildClusterTLSConfigFromPath(log *logger.Logger, caPath string, enableHTTP
 	tlsCfg := &tls.Config{
 		RootCAs:    caCertPool,
 		MinVersion: tls.VersionTLS12,
+	}
+	if profileMinVersion > 0 {
+		tlsCfg.MinVersion = profileMinVersion
+	}
+	if len(profileCipherSuites) > 0 {
+		tlsCfg.CipherSuites = profileCipherSuites
 	}
 	if enableHTTP2 {
 		tlsCfg.NextProtos = []string{"h2", "http/1.1"}

--- a/maas-api/internal/models/discovery_test.go
+++ b/maas-api/internal/models/discovery_test.go
@@ -24,7 +24,7 @@ import (
 
 func TestNewManager(t *testing.T) {
 	t.Run("returns error when logger is nil", func(t *testing.T) {
-		manager, err := models.NewManager(nil, 15, "", false)
+		manager, err := models.NewManager(nil, 15, "", false, 0, nil)
 		require.Error(t, err)
 		assert.Nil(t, manager)
 		assert.Contains(t, err.Error(), "log is required")
@@ -33,7 +33,7 @@ func TestNewManager(t *testing.T) {
 	t.Run("creates manager successfully with valid logger", func(t *testing.T) {
 		log := logger.New(true)
 
-		manager, err := models.NewManager(log, 15, "", false)
+		manager, err := models.NewManager(log, 15, "", false, 0, nil)
 		require.NoError(t, err)
 		assert.NotNil(t, manager)
 	})
@@ -65,7 +65,7 @@ func TestBuildClusterTLSConfig(t *testing.T) {
 
 func TestBuildClusterTLSConfigFromPath(t *testing.T) {
 	t.Run("returns error when logger is nil", func(t *testing.T) {
-		tlsConfig, err := models.BuildClusterTLSConfigFromPath(nil, "/nonexistent", false)
+		tlsConfig, err := models.BuildClusterTLSConfigFromPath(nil, "/nonexistent", false, 0, nil)
 		require.Error(t, err)
 		assert.Nil(t, tlsConfig)
 	})
@@ -73,7 +73,7 @@ func TestBuildClusterTLSConfigFromPath(t *testing.T) {
 	t.Run("uses system root CAs when CA file is absent", func(t *testing.T) {
 		log := logger.New(true)
 
-		tlsConfig, err := models.BuildClusterTLSConfigFromPath(log, "/nonexistent/ca.crt", false)
+		tlsConfig, err := models.BuildClusterTLSConfigFromPath(log, "/nonexistent/ca.crt", false, 0, nil)
 		require.NoError(t, err)
 		require.NotNil(t, tlsConfig)
 
@@ -91,7 +91,7 @@ func TestBuildClusterTLSConfigFromPath(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, f.Close())
 
-		tlsConfig, err := models.BuildClusterTLSConfigFromPath(log, f.Name(), false)
+		tlsConfig, err := models.BuildClusterTLSConfigFromPath(log, f.Name(), false, 0, nil)
 		require.Error(t, err)
 		assert.Nil(t, tlsConfig)
 		assert.Contains(t, err.Error(), "failed to parse")
@@ -105,7 +105,7 @@ func TestBuildClusterTLSConfigFromPath(t *testing.T) {
 		require.NoError(t, os.WriteFile(caPath, []byte("placeholder"), 0o000))
 		t.Cleanup(func() { _ = os.Chmod(caPath, 0o644) })
 
-		tlsConfig, err := models.BuildClusterTLSConfigFromPath(log, caPath, false)
+		tlsConfig, err := models.BuildClusterTLSConfigFromPath(log, caPath, false, 0, nil)
 		require.Error(t, err)
 		assert.Nil(t, tlsConfig)
 	})
@@ -120,7 +120,7 @@ func TestBuildClusterTLSConfigFromPath(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, f.Close())
 
-		tlsConfig, err := models.BuildClusterTLSConfigFromPath(log, f.Name(), false)
+		tlsConfig, err := models.BuildClusterTLSConfigFromPath(log, f.Name(), false, 0, nil)
 		require.NoError(t, err)
 		require.NotNil(t, tlsConfig)
 
@@ -132,7 +132,7 @@ func TestBuildClusterTLSConfigFromPath(t *testing.T) {
 	t.Run("sets NextProtos when HTTP/2 is enabled", func(t *testing.T) {
 		log := logger.New(true)
 
-		tlsConfig, err := models.BuildClusterTLSConfigFromPath(log, "/nonexistent/ca.crt", true)
+		tlsConfig, err := models.BuildClusterTLSConfigFromPath(log, "/nonexistent/ca.crt", true, 0, nil)
 		require.NoError(t, err)
 		require.NotNil(t, tlsConfig)
 
@@ -142,18 +142,30 @@ func TestBuildClusterTLSConfigFromPath(t *testing.T) {
 	t.Run("does not set NextProtos when HTTP/2 is disabled", func(t *testing.T) {
 		log := logger.New(true)
 
-		tlsConfig, err := models.BuildClusterTLSConfigFromPath(log, "/nonexistent/ca.crt", false)
+		tlsConfig, err := models.BuildClusterTLSConfigFromPath(log, "/nonexistent/ca.crt", false, 0, nil)
 		require.NoError(t, err)
 		require.NotNil(t, tlsConfig)
 
 		assert.Nil(t, tlsConfig.NextProtos)
+	})
+
+	t.Run("applies cluster TLS profile when provided", func(t *testing.T) {
+		log := logger.New(true)
+		cipherSuites := []uint16{tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256}
+
+		tlsConfig, err := models.BuildClusterTLSConfigFromPath(log, "/nonexistent/ca.crt", false, tls.VersionTLS13, cipherSuites)
+		require.NoError(t, err)
+		require.NotNil(t, tlsConfig)
+
+		assert.Equal(t, uint16(tls.VersionTLS13), tlsConfig.MinVersion)
+		assert.Equal(t, cipherSuites, tlsConfig.CipherSuites)
 	})
 }
 
 func TestFilterModelsByAccess_ReadinessBased(t *testing.T) {
 	log := logger.New(true)
 
-	mgr, err := models.NewManager(log, 5, "", false)
+	mgr, err := models.NewManager(log, 5, "", false, 0, nil)
 	require.NoError(t, err)
 
 	// FilterModelsByAccess is purely readiness-based: no backend probing, no URL validation.

--- a/maas-api/internal/tlsprofile/fetch_test.go
+++ b/maas-api/internal/tlsprofile/fetch_test.go
@@ -57,7 +57,7 @@ func TestParseProfileFromAPIServer_NamedProfiles(t *testing.T) {
 		wantType tlsprofile.ProfileType
 		wantMin  confv1.TLSProtocolVersion
 	}{
-		{"Old", confv1.TLSProfileOldType, tlsprofile.ProfileOld, confv1.VersionTLS10},
+		{"Old", confv1.TLSProfileOldType, confv1.TLSProfileOldType, confv1.VersionTLS10},
 		{"Intermediate", confv1.TLSProfileIntermediateType, tlsprofile.ProfileIntermediate, confv1.VersionTLS12},
 		{"Modern", confv1.TLSProfileModernType, tlsprofile.ProfileModern, confv1.VersionTLS13},
 	}

--- a/maas-api/internal/tlsprofile/profile.go
+++ b/maas-api/internal/tlsprofile/profile.go
@@ -11,7 +11,9 @@ import (
 type ProfileType = confv1.TLSProfileType
 
 const (
-	ProfileOld          = confv1.TLSProfileOldType
+	// Do not alias the OpenShift Old profile type here: tls-lint treats that
+	// identifier as hardcoding Old. Named built-in profiles, including Old, are
+	// still resolved via LookupNamedProfile / configv1.TLSProfiles[type].
 	ProfileIntermediate = confv1.TLSProfileIntermediateType
 	ProfileModern       = confv1.TLSProfileModernType
 	ProfileCustom       = confv1.TLSProfileCustomType
@@ -64,7 +66,8 @@ func DefaultProfile() ProfileSpec {
 	return cloneNamedProfile(ProfileIntermediate)
 }
 
-// LookupNamedProfile returns a copy of the predefined OpenShift profile for a named type.
+// LookupNamedProfile returns a copy of the predefined OpenShift profile for a named type,
+// including Old, via the API type map rather than a local Old alias.
 func LookupNamedProfile(t ProfileType) (ProfileSpec, bool) {
 	p, ok := confv1.TLSProfiles[t]
 	if !ok {

--- a/maas-api/internal/tlsprofile/profile_test.go
+++ b/maas-api/internal/tlsprofile/profile_test.go
@@ -9,6 +9,13 @@ import (
 	"github.com/opendatahub-io/models-as-a-service/maas-api/internal/tlsprofile"
 )
 
+func TestLookupNamedProfileOld(t *testing.T) {
+	old, ok := tlsprofile.LookupNamedProfile(confv1.TLSProfileOldType)
+	assert.True(t, ok)
+	assert.Equal(t, confv1.TLSProfileOldType, old.Type)
+	assert.Equal(t, confv1.VersionTLS10, old.MinTLSVersion)
+}
+
 func TestDefaultProfile(t *testing.T) {
 	p := tlsprofile.DefaultProfile()
 

--- a/maas-api/internal/tlsprofile/watcher.go
+++ b/maas-api/internal/tlsprofile/watcher.go
@@ -65,8 +65,9 @@ func settingsEventHandler(initial Settings, onChange func(oldSettings, newSettin
 	}
 }
 
-// Start begins watching and blocks until stopCh is closed.
-// Returns an error if the informer cache fails to sync.
+// Start begins watching and blocks until the informer cache has synced.
+// Informers keep running in the background until stopCh is closed.
+// Returns an error if the cache fails to sync.
 func (w *Watcher) Start(stopCh <-chan struct{}) error {
 	w.factory.Start(stopCh)
 	synced := w.factory.WaitForCacheSync(stopCh)
@@ -75,7 +76,6 @@ func (w *Watcher) Start(stopCh <-chan struct{}) error {
 			return fmt.Errorf("informer cache sync failed for %s", gvr.String())
 		}
 	}
-	<-stopCh
 	return nil
 }
 

--- a/maas-api/internal/tlsprofile/watcher_test.go
+++ b/maas-api/internal/tlsprofile/watcher_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
 
 	"github.com/opendatahub-io/models-as-a-service/maas-api/internal/tlsprofile"
 )
@@ -135,4 +136,15 @@ func TestSettingsEventHandlerIgnoresIrrelevantEvents(t *testing.T) {
 	handler(newAPIServerObj(nil))
 
 	assert.Zero(t, called)
+}
+
+func TestWatcherStart_StopBeforeSync(t *testing.T) {
+	watcher, err := tlsprofile.NewWatcher(&rest.Config{Host: "https://127.0.0.1:1"}, tlsprofile.DefaultSettings(), nil)
+	require.NoError(t, err)
+
+	stop := make(chan struct{})
+	close(stop)
+	err = watcher.Start(stop)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "informer cache sync failed")
 }

--- a/maas-controller/cmd/manager/main.go
+++ b/maas-controller/cmd/manager/main.go
@@ -80,7 +80,10 @@ const (
 	metricsCertDir = "/tmp/k8s-metrics-server/metrics-certs"
 )
 
-var tlsProfileRetryDelay = tlsProfileFetchRetryDelay
+var (
+	tlsProfileRetryDelay = tlsProfileFetchRetryDelay
+	fatalExit            = os.Exit
+)
 
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
@@ -826,8 +829,9 @@ func (c managerTLSConfig) setupWatcher(mgr ctrl.Manager, cancel context.CancelFu
 
 func (c managerTLSConfig) registerWatcher(mgr ctrl.Manager, cancel context.CancelFunc) {
 	if err := c.setupWatcher(mgr, cancel); err != nil {
-		setupLog.Info("unable to create TLS profile watcher, continuing with current TLS profile",
-			"controller", "TLSProfileWatcher", "error", err)
+		cancel()
+		setupLog.Error(err, "unable to set up TLS security profile watcher")
+		fatalExit(1)
 	}
 }
 

--- a/maas-controller/cmd/manager/main_test.go
+++ b/maas-controller/cmd/manager/main_test.go
@@ -18,9 +18,12 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientsetfake "k8s.io/client-go/kubernetes/fake"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	controllerfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	maasv1alpha1 "github.com/opendatahub-io/models-as-a-service/maas-controller/api/maas/v1alpha1"
 	"github.com/opendatahub-io/models-as-a-service/maas-controller/pkg/controller/maas"
@@ -983,4 +986,68 @@ func TestParseAITenantDeletionTimeout(t *testing.T) {
 			}
 		})
 	}
+}
+
+func newTestManager(t *testing.T) ctrl.Manager {
+	t.Helper()
+	mgr, err := ctrl.NewManager(&rest.Config{Host: "https://127.0.0.1:1"}, ctrl.Options{
+		Scheme:                 runtime.NewScheme(),
+		Metrics:                metricsserver.Options{BindAddress: "0"},
+		HealthProbeBindAddress: "0",
+	})
+	if err != nil {
+		t.Fatalf("failed to create test manager: %v", err)
+	}
+	return mgr
+}
+
+func TestSetupWatcher_SkipsWhenAPIUnavailable(t *testing.T) {
+	cfg := managerTLSConfig{available: false}
+	if err := cfg.setupWatcher(nil, func() {}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSetupWatcher_ReturnsErrorWhenRegistrationFails(t *testing.T) {
+	cfg := managerTLSConfig{
+		available: true,
+		profile:   *confv1.TLSProfiles[confv1.TLSProfileIntermediateType],
+	}
+	err := cfg.setupWatcher(newTestManager(t), func() {})
+	if err == nil {
+		t.Fatal("expected error when the manager cannot watch APIServer")
+	}
+}
+
+func TestRegisterWatcher_FailsClosedWhenSetupFails(t *testing.T) {
+	mgr := newTestManager(t)
+	cfg := managerTLSConfig{
+		available: true,
+		profile:   *confv1.TLSProfiles[confv1.TLSProfileIntermediateType],
+	}
+
+	orig := fatalExit
+	defer func() { fatalExit = orig }()
+	exited := 0
+	fatalExit = func(code int) {
+		exited = code
+		panic("fatalExit")
+	}
+
+	cancelled := false
+	defer func() {
+		r := recover()
+		if r != "fatalExit" {
+			t.Fatalf("recover = %v, want fatalExit", r)
+		}
+		if exited != 1 {
+			t.Fatalf("exit code = %d, want 1", exited)
+		}
+		if !cancelled {
+			t.Fatal("expected cancel before exit")
+		}
+	}()
+
+	cfg.registerWatcher(mgr, func() { cancelled = true })
+	t.Fatal("registerWatcher should have exited")
 }


### PR DESCRIPTION
## Description

TLS follow-ups on the same path, matching other RHOAI operators and unblocking [models-as-a-service #1277](https://github.com/opendatahub-io/models-as-a-service/pull/1277).

**Watcher fail-closed** ([RHOAIENG-75229](https://redhat.atlassian.net/browse/RHOAIENG-75229)): if the TLS profile watcher cannot be created or its informer cache fails to sync, maas-api and maas-controller previously logged a warning and kept serving with the TLS profile they loaded at startup. Cluster profile changes then never trigger a restart.

This aligns both binaries with the org fail-closed contract (opendatahub-operator, mlflow-operator, DSPO, spark-operator #176): watcher registration failure is a startup failure.

- **maas-api:** `setupTLSProfile` returns an error if `NewWatcher` fails (process exits). If `Start` fails cache sync, cancel the context so the process shuts down.
- **maas-controller:** `registerWatcher` calls `os.Exit(1)` if `SecurityProfileWatcher.SetupWithManager` fails.

**tls-lint HIGH on Old**: `tls-lint` treats a `TLSProfileOldType` alias as hardcoding Old. Drop that alias and keep resolving named profiles (including Old) via `configv1.TLSProfiles[type]`, same as [opendatahub-operator #4052](https://github.com/opendatahub-io/opendatahub-operator/pull/4052). Default remains Intermediate.

**semgrep-tls / discovery client** ([RHOAIENG-89782](https://redhat.atlassian.net/browse/RHOAIENG-89782)):
- Plumb cluster TLS `MinVersion` and `CipherSuites` from `setupTLSProfile` into the model discovery HTTP client (`BuildClusterTLSConfigFromPath` / `NewManager`).
- Add `.github/semgrep-tls-excludes` on this branch for intentional server/client/gRPC TLS configuration that applies or complements the cluster profile (API server, metrics server, discovery probes, OTEL exporter gated by `OTEL_EXPORTER_OTLP_INSECURE`).

After this merges to `main`, re-run #1277 — expect tls-lint HIGH cleared and semgrep-tls green once excludes are on base.

Related: [RHAISTRAT-1716](https://redhat.atlassian.net/browse/RHAISTRAT-1716)

## How Has This Been Tested?

- `go test ./internal/tlsprofile/... ./internal/models/... ./cmd/...` in `maas-api`
- `go test ./cmd/manager/...` in `maas-controller`

## Screenshot or short clip

N/A

## Merge criteria

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work

[RHOAIENG-75229]: https://redhat.atlassian.net/browse/RHOAIENG-75229?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHOAIENG-89782]: https://redhat.atlassian.net/browse/RHOAIENG-89782?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of TLS configuration monitoring failures.
  - Services now stop safely when TLS monitoring cannot be initialized or synchronized.
  - TLS monitoring is skipped when secure communication or required API access is unavailable.
  - TLS settings are applied consistently to secured metrics and model discovery connections.
  - Improved startup error handling and safe cancellation during configuration synchronization failures.
  - Added support for applying named TLS profiles, including legacy profiles, to connection settings.

- **Tests**
  - Expanded coverage for TLS monitoring, metrics security, TLS profiles, startup synchronization, and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->