### PR TITLE
feat(controller): generate MaaS enforcement config directly

### DIFF
--- a/deployment/base/maas-controller/rbac/clusterrole.yaml
+++ b/deployment/base/maas-controller/rbac/clusterrole.yaml
@@ -100,6 +100,17 @@ rules:
   verbs:
   - create
 - apiGroups:
+  - authorino.kuadrant.io
+  resources:
+  - authconfigs
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - authorization.k8s.io
   resources:
   - subjectaccessreviews
@@ -249,6 +260,16 @@ rules:
   - get
   - list
   - patch
+  - watch
+- apiGroups:
+  - limitador.kuadrant.io
+  resources:
+  - limitadors
+  verbs:
+  - get
+  - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - loki.grafana.com

--- a/maas-controller/cmd/manager/main.go
+++ b/maas-controller/cmd/manager/main.go
@@ -78,6 +78,11 @@ const (
 	// metricsCertDir is where OpenShift service-ca mounts the metrics serving cert.
 	// Must match the Deployment volumeMount added for SecureServing.
 	metricsCertDir = "/tmp/k8s-metrics-server/metrics-certs"
+
+	// defaultEnforcementLimitadorName is the shared Limitador CR native enforcement
+	// merges token limits into. Other native-enforcement flags default to empty; the
+	// deployment supplies environment-specific values.
+	defaultEnforcementLimitadorName = "limitador"
 )
 
 var tlsProfileRetryDelay = tlsProfileFetchRetryDelay
@@ -956,6 +961,50 @@ func setupWebhooks(mgr ctrl.Manager, aitenantNamespace, gatewayNamespace string)
 	return nil
 }
 
+// gatewayEnforcementOptions carries the native-enforcement wiring from flags.
+type gatewayEnforcementOptions struct {
+	infraNamespace      string
+	clusterAudience     string
+	metadataCacheTTL    int64
+	authzCacheTTL       int64
+	authConfigNamespace string
+	limitadorNamespace  string
+	limitadorName       string
+	authUpstream        string
+	ratelimitUpstream   string
+	authCACert          string
+	authSNI             string
+	maasAPIURL          string
+}
+
+// setupNativeEnforcement registers the GatewayEnforcement reconciler when enabled.
+// It logs and exits on failure, matching the other controller setups in main.
+func setupNativeEnforcement(mgr ctrl.Manager, enabled bool, o gatewayEnforcementOptions) {
+	if !enabled {
+		return
+	}
+	if err := (&maas.GatewayEnforcementReconciler{
+		Client:              mgr.GetClient(),
+		Scheme:              mgr.GetScheme(),
+		InfraNamespace:      o.infraNamespace,
+		ClusterAudience:     o.clusterAudience,
+		MetadataCacheTTL:    o.metadataCacheTTL,
+		AuthzCacheTTL:       o.authzCacheTTL,
+		AuthConfigNamespace: o.authConfigNamespace,
+		LimitadorNamespace:  o.limitadorNamespace,
+		LimitadorName:       o.limitadorName,
+		AuthUpstream:        o.authUpstream,
+		RatelimitUpstream:   o.ratelimitUpstream,
+		AuthCACertPath:      o.authCACert,
+		AuthSNI:             o.authSNI,
+		MaaSAPIURL:          o.maasAPIURL,
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "GatewayEnforcement")
+		os.Exit(1)
+	}
+	setupLog.Info("native enforcement enabled")
+}
+
 func main() {
 	var metricsAddr string
 	var secureMetrics bool
@@ -975,6 +1024,15 @@ func main() {
 	var observabilityManifestsPath string
 	var monitoringNamespace string
 	var usageLogsManifestPath string
+	var enableNativeEnforcement bool
+	var authConfigNamespace string
+	var limitadorNamespace string
+	var limitadorName string
+	var authUpstream string
+	var ratelimitUpstream string
+	var authCACert string
+	var authSNI string
+	var maasAPIURL string
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8443", "The address the metrics endpoint binds to.")
 	flag.BoolVar(&secureMetrics, "metrics-secure", true,
@@ -1002,6 +1060,24 @@ func main() {
 		"Maximum number of concurrent reconciles for subscription and auth policy controllers (1-10). Values above 5 may require increased CPU/memory on the controller pod.")
 	flag.BoolVar(&enableTenantNamespaceDiscovery, "enable-tenant-namespace-discovery", false,
 		"Discover AITenant-managed tenant namespaces labeled ai-gateway.opendatahub.io/tenant or maas.opendatahub.io/managed-by-aitenant=true and reconcile MaaS tenant CRs from them.")
+	flag.BoolVar(&enableNativeEnforcement, "enable-native-enforcement", false,
+		"Compile enforcement config directly (ext_proc ConfigMap, AuthConfig, Limitador limits) instead of Kuadrant policies.")
+	flag.StringVar(&authConfigNamespace, "authconfig-namespace", "",
+		"Namespace to apply the generated AuthConfig into. Empty disables the apply.")
+	flag.StringVar(&limitadorNamespace, "limitador-namespace", "",
+		"Namespace of the Limitador CR to merge token limits into. Empty disables the apply.")
+	flag.StringVar(&limitadorName, "limitador-name", defaultEnforcementLimitadorName,
+		"Name of the Limitador CR to merge token limits into.")
+	flag.StringVar(&authUpstream, "auth-upstream", "",
+		"gRPC endpoint ext_proc dials for Authorino auth.")
+	flag.StringVar(&ratelimitUpstream, "ratelimit-upstream", "",
+		"Endpoint ext_proc dials for Limitador rate limiting.")
+	flag.StringVar(&authCACert, "auth-ca-cert", "",
+		"Path to the CA trusting the Authorino TLS cert. Empty means plaintext.")
+	flag.StringVar(&authSNI, "auth-sni", "",
+		"Server name to verify the Authorino TLS certificate against.")
+	flag.StringVar(&maasAPIURL, "maas-api-url", "",
+		"Overrides scheme://host:port of the AuthConfig maas-api callouts. Empty keeps the default.")
 
 	opts := zap.Options{Development: false}
 	opts.BindFlags(flag.CommandLine)
@@ -1110,7 +1186,7 @@ func main() {
 		},
 	}
 	setupLog.Info("watching namespace for MaaS CRs", "namespace", maasSubscriptionNamespace)
-	if enableTenantNamespaceDiscovery || !defaultSubscriptionNamespaceExists {
+	if enableTenantNamespaceDiscovery || enableNativeEnforcement || !defaultSubscriptionNamespaceExists {
 		allNamespacesCfg := map[string]cache.Config{cache.AllNamespaces: {}}
 		cacheOpts = cache.Options{
 			ByObject: map[client.Object]cache.ByObject{
@@ -1231,6 +1307,23 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "ExternalModel")
 		os.Exit(1)
 	}
+
+	// GatewayEnforcement (opt-in): compile enforcement config directly instead of
+	// via Kuadrant policies.
+	setupNativeEnforcement(mgr, enableNativeEnforcement, gatewayEnforcementOptions{
+		infraNamespace:      infraNamespace,
+		clusterAudience:     clusterAudience,
+		metadataCacheTTL:    metadataCacheTTL,
+		authzCacheTTL:       authzCacheTTL,
+		authConfigNamespace: authConfigNamespace,
+		limitadorNamespace:  limitadorNamespace,
+		limitadorName:       limitadorName,
+		authUpstream:        authUpstream,
+		ratelimitUpstream:   ratelimitUpstream,
+		authCACert:          authCACert,
+		authSNI:             authSNI,
+		maasAPIURL:          maasAPIURL,
+	})
 
 	if err := mgr.Add(&managedNamespaceMonitor{
 		clientset:          clientset,

--- a/maas-controller/cmd/manager/main.go
+++ b/maas-controller/cmd/manager/main.go
@@ -977,6 +977,54 @@ type gatewayEnforcementOptions struct {
 	maasAPIURL          string
 }
 
+// subscriptionReconcilerOptions carries the config for the Kuadrant-policy reconcilers.
+type subscriptionReconcilerOptions struct {
+	infraNamespace, subscriptionNamespace string
+	gatewayName, gatewayNamespace         string
+	clusterAudience                       string
+	metadataCacheTTL, authzCacheTTL       int64
+	tenantNamespaceDiscovery              bool
+	maxConcurrentReconciles               int
+}
+
+// setupSubscriptionReconcilers registers the MaaSAuthPolicy and MaaSSubscription
+// reconcilers, which compile subscriptions into Kuadrant policies. Native
+// enforcement replaces that path and owns the subscription status, so skip them
+// when it is on. Logs and exits on failure, matching the other setups.
+func setupSubscriptionReconcilers(mgr ctrl.Manager, nativeEnforcement bool, o subscriptionReconcilerOptions) {
+	if nativeEnforcement {
+		return
+	}
+	if err := (&maas.MaaSAuthPolicyReconciler{
+		Client:                          mgr.GetClient(),
+		Scheme:                          mgr.GetScheme(),
+		InfraNamespace:                  o.infraNamespace,
+		TenantNamespace:                 o.subscriptionNamespace,
+		GatewayName:                     o.gatewayName,
+		GatewayNamespace:                o.gatewayNamespace,
+		ClusterAudience:                 o.clusterAudience,
+		MetadataCacheTTL:                o.metadataCacheTTL,
+		AuthzCacheTTL:                   o.authzCacheTTL,
+		TenantNamespaceDiscoveryEnabled: o.tenantNamespaceDiscovery,
+		MaxConcurrentReconciles:         o.maxConcurrentReconciles,
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "MaaSAuthPolicy")
+		os.Exit(1)
+	}
+	if err := (&maas.MaaSSubscriptionReconciler{
+		Client:                          mgr.GetClient(),
+		Scheme:                          mgr.GetScheme(),
+		DefaultTenantNamespace:          o.subscriptionNamespace,
+		TenantNamespaceDiscoveryEnabled: o.tenantNamespaceDiscovery,
+		GatewayName:                     o.gatewayName,
+		GatewayNamespace:                o.gatewayNamespace,
+		MaxConcurrentReconciles:         o.maxConcurrentReconciles,
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "MaaSSubscription")
+		os.Exit(1)
+	}
+}
+
 // setupNativeEnforcement registers the GatewayEnforcement reconciler when enabled.
 // It logs and exits on failure, matching the other controller setups in main.
 func setupNativeEnforcement(mgr ctrl.Manager, enabled bool, o gatewayEnforcementOptions) {
@@ -1253,37 +1301,18 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "MaaSModelRef")
 		os.Exit(1)
 	}
-	// Native enforcement replaces the Kuadrant-policy reconcilers, so skip them when it is on.
-	if !enableNativeEnforcement {
-		if err := (&maas.MaaSAuthPolicyReconciler{
-			Client:                          mgr.GetClient(),
-			Scheme:                          mgr.GetScheme(),
-			InfraNamespace:                  infraNamespace,
-			TenantNamespace:                 maasSubscriptionNamespace,
-			GatewayName:                     gatewayName,
-			GatewayNamespace:                gatewayNamespace,
-			ClusterAudience:                 clusterAudience,
-			MetadataCacheTTL:                metadataCacheTTL,
-			AuthzCacheTTL:                   authzCacheTTL,
-			TenantNamespaceDiscoveryEnabled: enableTenantNamespaceDiscovery,
-			MaxConcurrentReconciles:         maxConcurrentReconciles,
-		}).SetupWithManager(mgr); err != nil {
-			setupLog.Error(err, "unable to create controller", "controller", "MaaSAuthPolicy")
-			os.Exit(1)
-		}
-		if err := (&maas.MaaSSubscriptionReconciler{
-			Client:                          mgr.GetClient(),
-			Scheme:                          mgr.GetScheme(),
-			DefaultTenantNamespace:          maasSubscriptionNamespace,
-			TenantNamespaceDiscoveryEnabled: enableTenantNamespaceDiscovery,
-			GatewayName:                     gatewayName,
-			GatewayNamespace:                gatewayNamespace,
-			MaxConcurrentReconciles:         maxConcurrentReconciles,
-		}).SetupWithManager(mgr); err != nil {
-			setupLog.Error(err, "unable to create controller", "controller", "MaaSSubscription")
-			os.Exit(1)
-		}
-	}
+	// Native enforcement replaces the Kuadrant-policy reconcilers.
+	setupSubscriptionReconcilers(mgr, enableNativeEnforcement, subscriptionReconcilerOptions{
+		infraNamespace:           infraNamespace,
+		subscriptionNamespace:    maasSubscriptionNamespace,
+		gatewayName:              gatewayName,
+		gatewayNamespace:         gatewayNamespace,
+		clusterAudience:          clusterAudience,
+		metadataCacheTTL:         metadataCacheTTL,
+		authzCacheTTL:            authzCacheTTL,
+		tenantNamespaceDiscovery: enableTenantNamespaceDiscovery,
+		maxConcurrentReconciles:  maxConcurrentReconciles,
+	})
 	aitenantDeletionTimeout := parseAITenantDeletionTimeout()
 	if err := (&maas.AITenantReconciler{
 		Client:            mgr.GetClient(),

--- a/maas-controller/cmd/manager/main.go
+++ b/maas-controller/cmd/manager/main.go
@@ -1253,33 +1253,36 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "MaaSModelRef")
 		os.Exit(1)
 	}
-	if err := (&maas.MaaSAuthPolicyReconciler{
-		Client:                          mgr.GetClient(),
-		Scheme:                          mgr.GetScheme(),
-		InfraNamespace:                  infraNamespace,
-		TenantNamespace:                 maasSubscriptionNamespace,
-		GatewayName:                     gatewayName,
-		GatewayNamespace:                gatewayNamespace,
-		ClusterAudience:                 clusterAudience,
-		MetadataCacheTTL:                metadataCacheTTL,
-		AuthzCacheTTL:                   authzCacheTTL,
-		TenantNamespaceDiscoveryEnabled: enableTenantNamespaceDiscovery,
-		MaxConcurrentReconciles:         maxConcurrentReconciles,
-	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "MaaSAuthPolicy")
-		os.Exit(1)
-	}
-	if err := (&maas.MaaSSubscriptionReconciler{
-		Client:                          mgr.GetClient(),
-		Scheme:                          mgr.GetScheme(),
-		DefaultTenantNamespace:          maasSubscriptionNamespace,
-		TenantNamespaceDiscoveryEnabled: enableTenantNamespaceDiscovery,
-		GatewayName:                     gatewayName,
-		GatewayNamespace:                gatewayNamespace,
-		MaxConcurrentReconciles:         maxConcurrentReconciles,
-	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "MaaSSubscription")
-		os.Exit(1)
+	// Native enforcement replaces the Kuadrant-policy reconcilers, so skip them when it is on.
+	if !enableNativeEnforcement {
+		if err := (&maas.MaaSAuthPolicyReconciler{
+			Client:                          mgr.GetClient(),
+			Scheme:                          mgr.GetScheme(),
+			InfraNamespace:                  infraNamespace,
+			TenantNamespace:                 maasSubscriptionNamespace,
+			GatewayName:                     gatewayName,
+			GatewayNamespace:                gatewayNamespace,
+			ClusterAudience:                 clusterAudience,
+			MetadataCacheTTL:                metadataCacheTTL,
+			AuthzCacheTTL:                   authzCacheTTL,
+			TenantNamespaceDiscoveryEnabled: enableTenantNamespaceDiscovery,
+			MaxConcurrentReconciles:         maxConcurrentReconciles,
+		}).SetupWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create controller", "controller", "MaaSAuthPolicy")
+			os.Exit(1)
+		}
+		if err := (&maas.MaaSSubscriptionReconciler{
+			Client:                          mgr.GetClient(),
+			Scheme:                          mgr.GetScheme(),
+			DefaultTenantNamespace:          maasSubscriptionNamespace,
+			TenantNamespaceDiscoveryEnabled: enableTenantNamespaceDiscovery,
+			GatewayName:                     gatewayName,
+			GatewayNamespace:                gatewayNamespace,
+			MaxConcurrentReconciles:         maxConcurrentReconciles,
+		}).SetupWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create controller", "controller", "MaaSSubscription")
+			os.Exit(1)
+		}
 	}
 	aitenantDeletionTimeout := parseAITenantDeletionTimeout()
 	if err := (&maas.AITenantReconciler{

--- a/maas-controller/pkg/controller/maas/enforcement_authconfig.go
+++ b/maas-controller/pkg/controller/maas/enforcement_authconfig.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package maas
+
+import (
+	neturl "net/url"
+)
+
+// AuthConfig generation. The rule content is already produced by
+// buildGatewayAuthPolicySpec; Kuadrant copies those sections into an AuthConfig
+// and adds a hosts selector, so we reuse that builder instead of rewriting the
+// CEL-heavy auth logic.
+
+// authConfigSections are the AuthPolicy rule sections carried into the AuthConfig.
+var authConfigSections = []string{"authentication", "metadata", "authorization", "response"}
+
+// buildAuthConfigSpec wraps AuthPolicy rules as an AuthConfig spec. host MUST
+// equal the auth scope in the pluginConfig action sets so Authorino selects it.
+func buildAuthConfigSpec(host string, rules map[string]any) map[string]any {
+	spec := map[string]any{"hosts": []any{host}}
+	for _, section := range authConfigSections {
+		if v, ok := rules[section]; ok {
+			spec[section] = v
+		}
+	}
+	injectDefaultCredentials(spec)
+	renameResponseFilters(spec)
+	return spec
+}
+
+// renameResponseFilters translates response.success.filters to dynamicMetadata,
+// matching how Kuadrant compiles an AuthPolicy into an AuthConfig.
+func renameResponseFilters(spec map[string]any) {
+	resp, ok := spec["response"].(map[string]any)
+	if !ok {
+		return
+	}
+	success, ok := resp["success"].(map[string]any)
+	if !ok {
+		return
+	}
+	if f, ok := success["filters"]; ok {
+		success["dynamicMetadata"] = f
+		delete(success, "filters")
+	}
+}
+
+// injectDefaultCredentials adds the empty credentials{} Authorino expects on each
+// authentication method and each metadata HTTP callout.
+func injectDefaultCredentials(spec map[string]any) {
+	if auth, ok := spec["authentication"].(map[string]any); ok {
+		for _, m := range auth {
+			ensureCredentials(m)
+		}
+	}
+	if meta, ok := spec["metadata"].(map[string]any); ok {
+		for _, m := range meta {
+			if mm, ok := m.(map[string]any); ok {
+				ensureCredentials(mm["http"])
+			}
+		}
+	}
+}
+
+// ensureCredentials sets credentials to an empty map on v if unset.
+func ensureCredentials(v any) {
+	if m, ok := v.(map[string]any); ok {
+		if _, has := m["credentials"]; !has {
+			m["credentials"] = map[string]any{}
+		}
+	}
+}
+
+// rewriteMetadataURLs rewrites the scheme://host of every metadata callout URL to
+// base, keeping each path. A malformed base or url is left untouched.
+func rewriteMetadataURLs(spec map[string]any, base string) {
+	b, err := neturl.Parse(base)
+	if err != nil || b.Host == "" {
+		return
+	}
+	meta, ok := spec["metadata"].(map[string]any)
+	if !ok {
+		return
+	}
+	for _, m := range meta {
+		mm, ok := m.(map[string]any)
+		if !ok {
+			continue
+		}
+		http, ok := mm["http"].(map[string]any)
+		if !ok {
+			continue
+		}
+		raw, ok := http["url"].(string)
+		if !ok {
+			continue
+		}
+		u, err := neturl.Parse(raw)
+		if err != nil {
+			continue
+		}
+		u.Scheme = b.Scheme
+		u.Host = b.Host
+		http["url"] = u.String()
+	}
+}
+
+// authPolicyRules extracts defaults.rules from a buildGatewayAuthPolicySpec spec.
+func authPolicyRules(authPolicySpec map[string]any) (map[string]any, bool) {
+	defaults, ok := authPolicySpec["defaults"].(map[string]any)
+	if !ok {
+		return nil, false
+	}
+	rules, ok := defaults["rules"].(map[string]any)
+	return rules, ok
+}

--- a/maas-controller/pkg/controller/maas/enforcement_authconfig_test.go
+++ b/maas-controller/pkg/controller/maas/enforcement_authconfig_test.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package maas
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func loadOracleAuthConfig(t *testing.T) map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join("testdata", "oracle-authconfig-site-a.json"))
+	if err != nil {
+		t.Fatalf("read oracle authconfig: %v", err)
+	}
+	var spec map[string]any
+	if err := json.Unmarshal(data, &spec); err != nil {
+		t.Fatalf("parse oracle authconfig: %v", err)
+	}
+	return spec
+}
+
+func TestBuildAuthConfigSpecWrapsRules(t *testing.T) {
+	rules := map[string]any{
+		"authentication": map[string]any{"api-keys": "x"},
+		"metadata":       map[string]any{"apiKeyValidation": "y"},
+		"authorization":  map[string]any{"auth-valid": "z"},
+		"response":       map[string]any{"success": "w"},
+		"ignored":        "should not appear",
+	}
+	spec := buildAuthConfigSpec("the-host", rules)
+
+	if hosts, ok := spec["hosts"].([]any); !ok || len(hosts) != 1 || hosts[0] != "the-host" {
+		t.Errorf("hosts = %v, want [the-host]", spec["hosts"])
+	}
+	for _, section := range authConfigSections {
+		if !reflect.DeepEqual(spec[section], rules[section]) {
+			t.Errorf("section %s not carried through", section)
+		}
+	}
+	if _, ok := spec["ignored"]; ok {
+		t.Errorf("non-rule key leaked into the AuthConfig spec")
+	}
+}
+
+func TestGatewayAuthPolicyRulesMatchOracle(t *testing.T) {
+	r := &MaaSAuthPolicyReconciler{
+		InfraNamespace:   "redhat-ai-gateway-infra",
+		ClusterAudience:  "https://kubernetes.default.svc",
+		MetadataCacheTTL: 60,
+	}
+	// A non-empty tenantID yields a tenant-scoped maas-api service name in the URLs.
+	spec := r.buildGatewayAuthPolicySpec(nil, false, "site-a", "site-a", "openshift-ingress", "maas-site-a-gateway")
+
+	rules, ok := authPolicyRules(spec)
+	if !ok {
+		t.Fatalf("could not extract defaults.rules from AuthPolicy spec")
+	}
+	ac := buildAuthConfigSpec("ignored-host", rules)
+	oracle := loadOracleAuthConfig(t)
+
+	// Authentication is data-independent and must match the oracle exactly.
+	if got, want := jsonNormalize(t, ac["authentication"]), jsonNormalize(t, oracle["authentication"]); !reflect.DeepEqual(got, want) {
+		gj := mustJSON(t, got)
+		wj := mustJSON(t, want)
+		t.Errorf("AuthConfig authentication does not match oracle:\n--- got ---\n%s\n--- want ---\n%s", gj, wj)
+	}
+
+	// Metadata: the oracle may encode equivalent CEL differently, so compare the
+	// functional fields, not the raw CEL.
+	gotMeta, _ := ac["metadata"].(map[string]any)
+	wantMeta, ok := oracle["metadata"].(map[string]any)
+	if !ok {
+		t.Fatalf("oracle metadata is not a map")
+	}
+	if len(gotMeta) != len(wantMeta) {
+		t.Fatalf("metadata callouts: got %d, want %d", len(gotMeta), len(wantMeta))
+	}
+	for name, wv := range wantMeta {
+		gv, ok := gotMeta[name].(map[string]any)
+		if !ok {
+			t.Errorf("metadata callout %q missing", name)
+			continue
+		}
+		wm, ok := wv.(map[string]any)
+		if !ok {
+			t.Errorf("oracle metadata callout %q is not a map", name)
+			continue
+		}
+		gHTTP, _ := gv["http"].(map[string]any)
+		wHTTP, _ := wm["http"].(map[string]any)
+		for _, f := range []string{"url", "method", "contentType"} {
+			if gHTTP[f] != wHTTP[f] {
+				t.Errorf("metadata %q http.%s = %v, want %v", name, f, gHTTP[f], wHTTP[f])
+			}
+		}
+		gCache, _ := gv["cache"].(map[string]any)
+		wCache, _ := wm["cache"].(map[string]any)
+		if !reflect.DeepEqual(jsonNormalize(t, gCache["ttl"]), jsonNormalize(t, wCache["ttl"])) {
+			t.Errorf("metadata %q cache.ttl = %v, want %v", name, gCache["ttl"], wCache["ttl"])
+		}
+	}
+}

--- a/maas-controller/pkg/controller/maas/enforcement_bench_test.go
+++ b/maas-controller/pkg/controller/maas/enforcement_bench_test.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package maas
+
+import (
+	"fmt"
+	"testing"
+)
+
+// These benchmark the control-plane compile path (run per config-change reconcile,
+// not per request). They exist to catch super-linear cost as tenants grow.
+
+func benchInput(nSubs, nMatches int) GatewayEnforcementInput {
+	in := GatewayEnforcementInput{
+		Hostname:        "gw.example.com",
+		AuthConfigHost:  "authhost",
+		AuthSource:      "authpolicy.kuadrant.io:ns/gw-maas-auth",
+		ModelRouteScope: "ns/model-route",
+		ModelSource:     "tokenratelimitpolicy.kuadrant.io:ns/model-route",
+		MaasAPIMatches:  []RouteMatch{{PathType: "PathPrefix", PathValue: "/maas-api"}},
+		DenyAll: SubscriptionBinding{
+			RouteScope:    "ns/maas-api-route",
+			Source:        "tokenratelimitpolicy.kuadrant.io:ns/maas-api-route",
+			TokenLimitKey: descriptorKey("deny-all-by-default"),
+			LimitName:     "deny-all-by-default",
+			Window:        "1m",
+		},
+	}
+	for i := range nMatches {
+		in.ModelMatches = append(in.ModelMatches, RouteMatch{PathType: "Exact", PathValue: fmt.Sprintf("/v1/p%d", i)})
+	}
+	for i := range nSubs {
+		name := fmt.Sprintf("ns-sub%d-model-tokens", i)
+		in.Subscriptions = append(in.Subscriptions, SubscriptionBinding{
+			SubscriptionKey: fmt.Sprintf("ns/sub%d@ns/model", i),
+			TokenLimitKey:   descriptorKey(name),
+			LimitName:       name,
+			MaxValue:        int64(1000 * (i + 1)),
+			Window:          "1h",
+		})
+	}
+	return in
+}
+
+func BenchmarkGenerateGatewayArtifacts(b *testing.B) {
+	in := benchInput(50, 20)
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := generateGatewayArtifacts(in); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkAssembleGatewayPluginConfig(b *testing.B) {
+	in := benchInput(50, 20)
+	p := GatewayPluginParams{
+		Hostname:       in.Hostname,
+		AuthScope:      in.AuthConfigHost,
+		AuthSource:     in.AuthSource,
+		ModelMatches:   in.ModelMatches,
+		ModelRL:        RateLimitBinding{Scope: in.ModelRouteScope, Source: in.ModelSource},
+		MaasAPIMatches: in.MaasAPIMatches,
+		DenyAllRL:      RateLimitBinding{Scope: in.DenyAll.RouteScope, Source: in.DenyAll.Source, Descriptors: []RateLimitDescriptor{in.DenyAll.descriptor(true)}},
+	}
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = assembleGatewayPluginConfig(p)
+	}
+}
+
+func BenchmarkMergeLimits(b *testing.B) {
+	// A shared CR holding many tenants' limits; this gateway owns one scope.
+	var existing []LimitadorLimit
+	for i := range 500 {
+		existing = append(existing, LimitadorLimit{Name: fmt.Sprintf("t%d", i), Namespace: fmt.Sprintf("ns%d/route", i)})
+	}
+	owned := map[string]bool{"ns0/route": true}
+	ours := []LimitadorLimit{{Name: "new", Namespace: "ns0/route", MaxValue: 100}}
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = mergeLimits(existing, owned, ours)
+	}
+}

--- a/maas-controller/pkg/controller/maas/enforcement_controller.go
+++ b/maas-controller/pkg/controller/maas/enforcement_controller.go
@@ -1,0 +1,336 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package maas
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+	"sigs.k8s.io/yaml"
+
+	maasv1alpha1 "github.com/opendatahub-io/models-as-a-service/maas-controller/api/maas/v1alpha1"
+)
+
+// fieldOwner is the server-side-apply field manager, shared with the rest of the controller.
+const fieldOwner = "maas-controller"
+
+var (
+	authConfigGVK = schema.GroupVersionKind{Group: "authorino.kuadrant.io", Version: "v1beta3", Kind: "AuthConfig"}
+	limitadorGVK  = schema.GroupVersionKind{Group: "limitador.kuadrant.io", Version: "v1alpha1", Kind: "Limitador"}
+)
+
+// GatewayEnforcementReconciler compiles a MaaS gateway's enforcement config
+// directly and drives the backends without Kuadrant: it gathers the gateway's
+// routes, subscription limits, and auth rules, then applies the ext_proc
+// ConfigMap, the Authorino AuthConfig, and the Limitador limits. Registered only
+// when --enable-native-enforcement is set.
+type GatewayEnforcementReconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+
+	// Infra namespace (maas-api), audience, and cache TTLs, for the generated AuthConfig.
+	InfraNamespace   string
+	ClusterAudience  string
+	MetadataCacheTTL int64
+	AuthzCacheTTL    int64
+
+	// AuthConfigNamespace is where the AuthConfig is applied (Authorino is
+	// cluster-wide, so any namespace works). Empty disables the apply.
+	AuthConfigNamespace string
+
+	// LimitadorNamespace/LimitadorName identify the shared Limitador CR whose
+	// spec.limits this gateway's token limits merge into. Empty disables the apply.
+	LimitadorNamespace string
+	LimitadorName      string
+
+	// ext_proc upstreams + Authorino TLS trust, written into the ConfigMap.
+	AuthUpstream      string
+	RatelimitUpstream string
+	AuthCACertPath    string
+	AuthSNI           string
+
+	// MaaSAPIURL overrides the scheme://host:port of the AuthConfig maas-api
+	// callouts, keeping each path. Empty keeps the buildGatewayAuthPolicySpec
+	// default; set it when maas-api is served at a different scheme, host, or port.
+	MaaSAPIURL string
+}
+
+//+kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=gateways;httproutes,verbs=get;list;watch
+//+kubebuilder:rbac:groups=maas.opendatahub.io,resources=maassubscriptions;maasmodelrefs,verbs=get;list;watch
+//+kubebuilder:rbac:groups=authorino.kuadrant.io,resources=authconfigs,verbs=get;list;watch;create;update;patch
+//+kubebuilder:rbac:groups=limitador.kuadrant.io,resources=limitadors,verbs=get;list;watch;update;patch
+//+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch
+
+// Reconcile compiles and applies the enforcement config for the gateway named in
+// the request. A gateway that is not yet a complete MaaS gateway is skipped
+// without requeue; the HTTPRoute and subscription watches re-trigger it.
+func (r *GatewayEnforcementReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := ctrl.LoggerFrom(ctx)
+
+	in, err := r.gatherGatewayInput(ctx, req.NamespacedName)
+	if err != nil {
+		if isGatewayNotReady(err) {
+			log.V(1).Info("gateway not ready for enforcement, skipping", "gateway", req.NamespacedName, "reason", err.Error())
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, fmt.Errorf("gather gateway input: %w", err)
+	}
+
+	arts, err := generateGatewayArtifacts(in)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("generate artifacts: %w", err)
+	}
+
+	rendered, err := r.renderPluginConfig(arts.PluginConfig)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	cm := configMapFor(req.Name, req.Namespace, rendered)
+	if err := r.Patch(ctx, cm, client.Apply, client.ForceOwnership, client.FieldOwner(fieldOwner)); err != nil {
+		return ctrl.Result{}, fmt.Errorf("apply extproc ConfigMap %s/%s: %w", cm.Namespace, cm.Name, err)
+	}
+
+	if r.MaaSAPIURL != "" {
+		rewriteMetadataURLs(arts.AuthConfig, r.MaaSAPIURL)
+	}
+	if r.AuthConfigNamespace != "" {
+		if err := r.applyAuthConfig(ctx, in.AuthConfigHost, arts.AuthConfig); err != nil {
+			return ctrl.Result{}, fmt.Errorf("apply AuthConfig: %w", err)
+		}
+	}
+	if r.LimitadorName != "" {
+		if err := r.applyLimits(ctx, arts); err != nil {
+			return ctrl.Result{}, fmt.Errorf("apply Limitador limits: %w", err)
+		}
+	}
+
+	log.Info("reconciled gateway enforcement", "gateway", req.NamespacedName,
+		"actionSets", len(arts.PluginConfig.ActionSets), "limits", len(arts.Limits))
+	return ctrl.Result{}, nil
+}
+
+// isGatewayNotReady reports whether err means the gateway is not yet a complete
+// MaaS gateway (missing hostname, routes, or subscriptions) and should be skipped
+// without requeue rather than treated as a failure.
+func isGatewayNotReady(err error) bool {
+	return errors.Is(err, ErrGatewayNoHostname) ||
+		errors.Is(err, ErrNoModelRoute) ||
+		errors.Is(err, ErrNoMaaSAPIRoute) ||
+		errors.Is(err, ErrNoSubscription)
+}
+
+// managedLabels marks the resources this reconciler owns.
+func managedLabels() map[string]string {
+	return map[string]string{
+		"app.kubernetes.io/managed-by": fieldOwner,
+		"app.kubernetes.io/part-of":    "native-enforcement",
+	}
+}
+
+// applyAuthConfig server-side-applies the AuthConfig. Its name is the host hash;
+// Authorino selects it by spec.hosts, which equals the pluginConfig auth scope.
+func (r *GatewayEnforcementReconciler) applyAuthConfig(ctx context.Context, host string, spec map[string]any) error {
+	ac := &unstructured.Unstructured{}
+	ac.SetGroupVersionKind(authConfigGVK)
+	ac.SetNamespace(r.AuthConfigNamespace)
+	ac.SetName(host)
+	ac.SetLabels(managedLabels())
+	ac.Object["spec"] = spec
+	return r.Patch(ctx, ac, client.Apply, client.ForceOwnership, client.FieldOwner(fieldOwner))
+}
+
+// applyLimits merges this gateway's token limits into the shared Limitador CR,
+// leaving other gateways' limits untouched. It skips the update when the merge is
+// a no-op, so a redundant reconcile does not churn the shared CR.
+func (r *GatewayEnforcementReconciler) applyLimits(ctx context.Context, arts GatewayArtifacts) error {
+	lim := &unstructured.Unstructured{}
+	lim.SetGroupVersionKind(limitadorGVK)
+	if err := r.Get(ctx, types.NamespacedName{Namespace: r.LimitadorNamespace, Name: r.LimitadorName}, lim); err != nil {
+		return fmt.Errorf("get Limitador %s/%s: %w", r.LimitadorNamespace, r.LimitadorName, err)
+	}
+
+	log := ctrl.LoggerFrom(ctx)
+	rawExisting, _, err := unstructured.NestedSlice(lim.Object, "spec", "limits")
+	if err != nil {
+		log.V(1).Info("reading existing Limitador limits, treating as empty", "error", err.Error())
+	}
+	var existing []LimitadorLimit
+	if b, err := json.Marshal(rawExisting); err != nil {
+		log.V(1).Info("marshaling existing Limitador limits, treating as empty", "error", err.Error())
+	} else if err := json.Unmarshal(b, &existing); err != nil {
+		log.V(1).Info("decoding existing Limitador limits, treating as empty", "error", err.Error())
+	}
+
+	mergedSlice, err := toUnstructuredSlice(mergeLimits(existing, arts.ownedScopes(), arts.Limits))
+	if err != nil {
+		return err
+	}
+	if unstructuredSlicesEqual(rawExisting, mergedSlice) {
+		return nil
+	}
+	if err := unstructured.SetNestedSlice(lim.Object, mergedSlice, "spec", "limits"); err != nil {
+		return err
+	}
+	if err := r.Update(ctx, lim); err != nil {
+		return fmt.Errorf("update Limitador limits: %w", err)
+	}
+	return nil
+}
+
+// toUnstructuredSlice round-trips typed limits into the []any shape
+// unstructured.SetNestedSlice requires.
+func toUnstructuredSlice(limits []LimitadorLimit) ([]any, error) {
+	b, err := json.Marshal(limits)
+	if err != nil {
+		return nil, err
+	}
+	var out []any
+	if err := json.Unmarshal(b, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// unstructuredSlicesEqual compares two limit slices by their canonical JSON.
+func unstructuredSlicesEqual(a, b []any) bool {
+	aj, err := json.Marshal(a)
+	if err != nil {
+		return false
+	}
+	bj, err := json.Marshal(b)
+	if err != nil {
+		return false
+	}
+	return bytes.Equal(aj, bj)
+}
+
+// extprocConfig is the ext_proc --kuadrant-config document.
+type extprocConfig struct {
+	Plugin    PluginConfiguration   `json:"plugin"`
+	Upstreams map[string]string     `json:"upstreams"`
+	TLS       map[string]extprocTLS `json:"tls,omitempty"`
+}
+
+// extprocTLS is the TLS trust for one upstream.
+type extprocTLS struct {
+	CACert string `json:"ca_cert"`
+	SNI    string `json:"sni"`
+}
+
+// renderPluginConfig marshals the pluginConfig, upstreams, and TLS trust into the
+// ext_proc config YAML. TLS is emitted only when a CA is configured.
+func (r *GatewayEnforcementReconciler) renderPluginConfig(pc PluginConfiguration) (string, error) {
+	doc := extprocConfig{
+		Plugin: pc,
+		Upstreams: map[string]string{
+			authServiceEndpoint:      r.AuthUpstream,
+			ratelimitServiceEndpoint: r.RatelimitUpstream,
+		},
+	}
+	if r.AuthCACertPath != "" {
+		doc.TLS = map[string]extprocTLS{authServiceEndpoint: {CACert: r.AuthCACertPath, SNI: r.AuthSNI}}
+	}
+	out, err := yaml.Marshal(doc)
+	if err != nil {
+		return "", fmt.Errorf("marshal kuadrant config: %w", err)
+	}
+	return string(out), nil
+}
+
+// configMapFor builds the extproc ConfigMap for a gateway.
+func configMapFor(gwName, gwNamespace, kuadrantYAML string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "ConfigMap"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      gwName + "-extproc",
+			Namespace: gwNamespace,
+			Labels:    managedLabels(),
+		},
+		Data: map[string]string{"kuadrant.yaml": kuadrantYAML},
+	}
+}
+
+// SetupWithManager reconciles MaaS gateways (identified by the AITenant label) on
+// their own spec changes and on changes to the HTTPRoutes and subscriptions that
+// feed them. Generation predicates drop status-only churn.
+func (r *GatewayEnforcementReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	isMaaSGateway := predicate.NewPredicateFuncs(func(o client.Object) bool {
+		_, ok := o.GetLabels()[aiGatewayTenantLabel]
+		return ok
+	})
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&gatewayapiv1.Gateway{}, builder.WithPredicates(isMaaSGateway, predicate.GenerationChangedPredicate{})).
+		Watches(&gatewayapiv1.HTTPRoute{},
+			handler.EnqueueRequestsFromMapFunc(r.gatewaysForRoute),
+			builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		Watches(&maasv1alpha1.MaaSSubscription{}, handler.EnqueueRequestsFromMapFunc(r.gatewaysForSubscription)).
+		Named("gateway-enforcement").
+		Complete(r)
+}
+
+// gatewaysForRoute enqueues the gateways an HTTPRoute parent-refs.
+func (r *GatewayEnforcementReconciler) gatewaysForRoute(_ context.Context, o client.Object) []reconcile.Request {
+	rt, ok := o.(*gatewayapiv1.HTTPRoute)
+	if !ok {
+		return nil
+	}
+	var reqs []reconcile.Request
+	for _, p := range rt.Spec.ParentRefs {
+		if !parentRefTargetsGateway(p) {
+			continue
+		}
+		ns := rt.Namespace
+		if p.Namespace != nil {
+			ns = string(*p.Namespace)
+		}
+		reqs = append(reqs, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: ns, Name: string(p.Name)}})
+	}
+	return reqs
+}
+
+// gatewaysForSubscription enqueues every MaaS gateway, since a subscription change
+// can shift limits on any of them. Gateways are few and subscription writes rare.
+func (r *GatewayEnforcementReconciler) gatewaysForSubscription(ctx context.Context, _ client.Object) []reconcile.Request {
+	var gws gatewayapiv1.GatewayList
+	if err := r.List(ctx, &gws, client.HasLabels{aiGatewayTenantLabel}); err != nil {
+		ctrl.LoggerFrom(ctx).V(1).Info("listing gateways for subscription mapping", "error", err.Error())
+		return nil
+	}
+	reqs := make([]reconcile.Request, 0, len(gws.Items))
+	for i := range gws.Items {
+		reqs = append(reqs, reconcile.Request{NamespacedName: types.NamespacedName{
+			Namespace: gws.Items[i].Namespace, Name: gws.Items[i].Name,
+		}})
+	}
+	return reqs
+}

--- a/maas-controller/pkg/controller/maas/enforcement_controller.go
+++ b/maas-controller/pkg/controller/maas/enforcement_controller.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -87,6 +88,7 @@ type GatewayEnforcementReconciler struct {
 
 //+kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=gateways;httproutes,verbs=get;list;watch
 //+kubebuilder:rbac:groups=maas.opendatahub.io,resources=maassubscriptions;maasmodelrefs,verbs=get;list;watch
+//+kubebuilder:rbac:groups=maas.opendatahub.io,resources=maassubscriptions/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=authorino.kuadrant.io,resources=authconfigs,verbs=get;list;watch;create;update;patch
 //+kubebuilder:rbac:groups=limitador.kuadrant.io,resources=limitadors,verbs=get;list;watch;update;patch
 //+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch
@@ -134,9 +136,41 @@ func (r *GatewayEnforcementReconciler) Reconcile(ctx context.Context, req ctrl.R
 		}
 	}
 
+	if err := r.markSubscriptionsActive(ctx, in.EnforcedSubscriptions); err != nil {
+		return ctrl.Result{}, fmt.Errorf("mark subscriptions active: %w", err)
+	}
+
 	log.Info("reconciled gateway enforcement", "gateway", req.NamespacedName,
 		"actionSets", len(arts.PluginConfig.ActionSets), "limits", len(arts.Limits))
 	return ctrl.Result{}, nil
+}
+
+// markSubscriptionsActive sets each enforced subscription Active. In native mode
+// the MaaSSubscription reconciler is off, so this owns the status maas-api and the
+// authorization policy read.
+func (r *GatewayEnforcementReconciler) markSubscriptionsActive(ctx context.Context, subs []types.NamespacedName) error {
+	for _, nn := range subs {
+		sub := &maasv1alpha1.MaaSSubscription{}
+		if err := r.Get(ctx, nn, sub); err != nil {
+			return fmt.Errorf("get subscription %s: %w", nn, err)
+		}
+		ready := apimeta.IsStatusConditionTrue(sub.Status.Conditions, "Ready")
+		if sub.Status.Phase == maasv1alpha1.PhaseActive && ready {
+			continue
+		}
+		sub.Status.Phase = maasv1alpha1.PhaseActive
+		apimeta.SetStatusCondition(&sub.Status.Conditions, metav1.Condition{
+			Type:               "Ready",
+			Status:             metav1.ConditionTrue,
+			Reason:             "EnforcementApplied",
+			Message:            "auth and token limits applied",
+			ObservedGeneration: sub.Generation,
+		})
+		if err := r.Status().Update(ctx, sub); err != nil {
+			return fmt.Errorf("update subscription %s status: %w", nn, err)
+		}
+	}
+	return nil
 }
 
 // isGatewayNotReady reports whether err means the gateway is not yet a complete

--- a/maas-controller/pkg/controller/maas/enforcement_controller_test.go
+++ b/maas-controller/pkg/controller/maas/enforcement_controller_test.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package maas
+
+import (
+	"testing"
+
+	"sigs.k8s.io/yaml"
+)
+
+func TestRenderPluginConfig(t *testing.T) {
+	r := &GatewayEnforcementReconciler{
+		AuthUpstream:      "https://authorino:50051",
+		RatelimitUpstream: "http://limitador:8081",
+		AuthCACertPath:    "/etc/kuadrant-tls/service-ca.crt",
+		AuthSNI:           "authorino.svc",
+	}
+	pc := PluginConfiguration{
+		Services:   standardServices(),
+		ActionSets: []ActionSet{{Name: "x", RouteRuleConditions: RouteRuleConditions{Hostnames: []string{"h"}}}},
+	}
+
+	rendered, err := r.renderPluginConfig(pc)
+	if err != nil {
+		t.Fatalf("renderPluginConfig: %v", err)
+	}
+
+	var doc struct {
+		Plugin    map[string]any               `json:"plugin"`
+		Upstreams map[string]string            `json:"upstreams"`
+		TLS       map[string]map[string]string `json:"tls"`
+	}
+	if err := yaml.Unmarshal([]byte(rendered), &doc); err != nil {
+		t.Fatalf("rendered config does not parse: %v\n%s", err, rendered)
+	}
+	if _, ok := doc.Plugin["actionSets"]; !ok {
+		t.Errorf("plugin.actionSets missing")
+	}
+	if doc.Upstreams[authServiceEndpoint] != r.AuthUpstream {
+		t.Errorf("auth upstream = %q, want %q", doc.Upstreams[authServiceEndpoint], r.AuthUpstream)
+	}
+	if doc.Upstreams[ratelimitServiceEndpoint] != r.RatelimitUpstream {
+		t.Errorf("ratelimit upstream = %q", doc.Upstreams[ratelimitServiceEndpoint])
+	}
+	if tls := doc.TLS[authServiceEndpoint]; tls["ca_cert"] != r.AuthCACertPath || tls["sni"] != r.AuthSNI {
+		t.Errorf("auth tls = %v", tls)
+	}
+}
+
+func TestConfigMapForGateway(t *testing.T) {
+	cm := configMapFor("maas-site-a-gateway", "openshift-ingress", "plugin: {}\n")
+
+	if cm.Name != "maas-site-a-gateway-extproc" {
+		t.Errorf("ConfigMap name = %q", cm.Name)
+	}
+	if cm.Namespace != "openshift-ingress" {
+		t.Errorf("ConfigMap namespace = %q", cm.Namespace)
+	}
+	if _, ok := cm.Data["kuadrant.yaml"]; !ok {
+		t.Errorf("ConfigMap missing kuadrant.yaml key")
+	}
+}

--- a/maas-controller/pkg/controller/maas/enforcement_input.go
+++ b/maas-controller/pkg/controller/maas/enforcement_input.go
@@ -69,6 +69,7 @@ func (r *GatewayEnforcementReconciler) gatherGatewayInput(ctx context.Context, g
 	if err != nil {
 		return in, err
 	}
+	seenSub := map[types.NamespacedName]bool{}
 	for _, sm := range subs {
 		limit := sm.ref.TokenRateLimits[0]
 		limitName := strings.ReplaceAll(qualifiedName(sm.sub.Namespace, sm.sub.Name), "/", "-") + "-" + sm.ref.Name + "-tokens"
@@ -79,6 +80,11 @@ func (r *GatewayEnforcementReconciler) gatherGatewayInput(ctx context.Context, g
 			MaxValue:        limit.Limit,
 			Window:          limit.Window,
 		})
+		nn := types.NamespacedName{Namespace: sm.sub.Namespace, Name: sm.sub.Name}
+		if !seenSub[nn] {
+			seenSub[nn] = true
+			in.EnforcedSubscriptions = append(in.EnforcedSubscriptions, nn)
+		}
 	}
 	slices.SortFunc(in.Subscriptions, func(a, b SubscriptionBinding) int {
 		return cmp.Compare(a.LimitName, b.LimitName)

--- a/maas-controller/pkg/controller/maas/enforcement_input.go
+++ b/maas-controller/pkg/controller/maas/enforcement_input.go
@@ -1,0 +1,266 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package maas
+
+import (
+	"cmp"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	maasv1alpha1 "github.com/opendatahub-io/models-as-a-service/maas-controller/api/maas/v1alpha1"
+)
+
+// Gateway-readiness sentinels: a gateway missing any of these is skipped without
+// requeue and re-triggered by the relevant watch.
+var (
+	ErrGatewayNoHostname = errors.New("gateway has no listener hostname")
+	ErrNoModelRoute      = errors.New("no model HTTPRoute for gateway")
+	ErrNoMaaSAPIRoute    = errors.New("no maas-api HTTPRoute for gateway")
+	ErrNoSubscription    = errors.New("no subscription for model route")
+)
+
+// gatherGatewayInput reads the cluster state a gateway's enforcement artifacts are
+// generated from. This is the cluster-side half; the generators are pure.
+func (r *GatewayEnforcementReconciler) gatherGatewayInput(ctx context.Context, gw types.NamespacedName) (GatewayEnforcementInput, error) {
+	in := GatewayEnforcementInput{}
+
+	hostname, err := r.gatewayHostname(ctx, gw)
+	if err != nil {
+		return in, err
+	}
+	in.Hostname = hostname
+
+	modelRoute, maasAPIRoute, err := r.gatewayRoutes(ctx, gw)
+	if err != nil {
+		return in, err
+	}
+	in.ModelMatches = httpRouteMatches(modelRoute)
+	in.MaasAPIMatches = httpRouteMatches(maasAPIRoute)
+
+	modelRouteScope := qualifiedName(modelRoute.Namespace, modelRoute.Name)
+	maasAPIScope := qualifiedName(maasAPIRoute.Namespace, maasAPIRoute.Name)
+
+	in.ModelRouteScope = modelRouteScope
+	in.ModelSource = "tokenratelimitpolicy.kuadrant.io:" + modelRouteScope
+	subs, err := r.subscriptionsForRoute(ctx, modelRoute)
+	if err != nil {
+		return in, err
+	}
+	for _, sm := range subs {
+		limit := sm.ref.TokenRateLimits[0]
+		limitName := strings.ReplaceAll(qualifiedName(sm.sub.Namespace, sm.sub.Name), "/", "-") + "-" + sm.ref.Name + "-tokens"
+		in.Subscriptions = append(in.Subscriptions, SubscriptionBinding{
+			SubscriptionKey: qualifiedName(sm.sub.Namespace, sm.sub.Name) + "@" + qualifiedName(sm.ref.Namespace, sm.ref.Name),
+			TokenLimitKey:   descriptorKey(limitName),
+			LimitName:       limitName,
+			MaxValue:        limit.Limit,
+			Window:          limit.Window,
+		})
+	}
+	slices.SortFunc(in.Subscriptions, func(a, b SubscriptionBinding) int {
+		return cmp.Compare(a.LimitName, b.LimitName)
+	})
+
+	in.DenyAll = SubscriptionBinding{
+		RouteScope:    maasAPIScope,
+		Source:        "tokenratelimitpolicy.kuadrant.io:" + maasAPIScope,
+		TokenLimitKey: descriptorKey("deny-all-by-default"),
+		LimitName:     "deny-all-by-default",
+		MaxValue:      0,
+		Window:        "1m",
+	}
+
+	// One AuthConfig per gateway; its host is the auth scope, so it only needs to be stable.
+	in.AuthConfigHost = hashHex(qualifiedName(gw.Namespace, gw.Name))
+	in.AuthSource = "authpolicy.kuadrant.io:" + qualifiedName(gw.Namespace, gw.Name) + "-maas-auth"
+
+	rules, err := r.gatherAuthRules(ctx, gw)
+	if err != nil {
+		return in, err
+	}
+	in.AuthRules = rules
+
+	return in, nil
+}
+
+// gatewayHostname returns the gateway's first listener hostname.
+func (r *GatewayEnforcementReconciler) gatewayHostname(ctx context.Context, gw types.NamespacedName) (string, error) {
+	g := &gatewayapiv1.Gateway{}
+	if err := r.Get(ctx, gw, g); err != nil {
+		return "", fmt.Errorf("get gateway %s: %w", gw, err)
+	}
+	for _, l := range g.Spec.Listeners {
+		if l.Hostname != nil && *l.Hostname != "" {
+			return string(*l.Hostname), nil
+		}
+	}
+	return "", fmt.Errorf("%w: %s", ErrGatewayNoHostname, gw)
+}
+
+// gatewayRoutes splits the gateway's routes into the model route and the maas-api
+// route (named "maas-api-route*"; the rest is the model).
+func (r *GatewayEnforcementReconciler) gatewayRoutes(ctx context.Context, gw types.NamespacedName) (model, maasAPI *gatewayapiv1.HTTPRoute, err error) {
+	var routes gatewayapiv1.HTTPRouteList
+	if err := r.List(ctx, &routes); err != nil {
+		return nil, nil, fmt.Errorf("list httproutes: %w", err)
+	}
+	for i := range routes.Items {
+		rt := &routes.Items[i]
+		if !routeTargetsGateway(rt, gw) {
+			continue
+		}
+		if strings.HasPrefix(rt.Name, "maas-api-route") {
+			maasAPI = rt
+		} else {
+			model = rt
+		}
+	}
+	if model == nil {
+		return nil, nil, fmt.Errorf("%w: %s", ErrNoModelRoute, gw)
+	}
+	if maasAPI == nil {
+		return nil, nil, fmt.Errorf("%w: %s", ErrNoMaaSAPIRoute, gw)
+	}
+	return model, maasAPI, nil
+}
+
+// routeTargetsGateway reports whether an HTTPRoute parent-refs the given gateway.
+func routeTargetsGateway(rt *gatewayapiv1.HTTPRoute, gw types.NamespacedName) bool {
+	for _, p := range rt.Spec.ParentRefs {
+		if !parentRefTargetsGateway(p) || string(p.Name) != gw.Name {
+			continue
+		}
+		ns := rt.Namespace
+		if p.Namespace != nil {
+			ns = string(*p.Namespace)
+		}
+		if ns == gw.Namespace {
+			return true
+		}
+	}
+	return false
+}
+
+// httpRouteMatches flattens an HTTPRoute's rule matches into RouteMatch entries.
+func httpRouteMatches(rt *gatewayapiv1.HTTPRoute) []RouteMatch {
+	var out []RouteMatch
+	for _, rule := range rt.Spec.Rules {
+		for _, m := range rule.Matches {
+			rm := RouteMatch{}
+			if m.Path != nil {
+				if m.Path.Type != nil {
+					rm.PathType = string(*m.Path.Type)
+				}
+				if m.Path.Value != nil {
+					rm.PathValue = *m.Path.Value
+				}
+			}
+			for _, h := range m.Headers {
+				rm.HeaderName = string(h.Name)
+				rm.HeaderValue = h.Value
+				break // MaaS routes use at most one header match
+			}
+			out = append(out, rm)
+		}
+	}
+	return out
+}
+
+// subModelRef pairs a subscription with the model ref that resolves to a route.
+type subModelRef struct {
+	sub *maasv1alpha1.MaaSSubscription
+	ref *maasv1alpha1.ModelSubscriptionRef
+}
+
+// subscriptionsForRoute finds every subscription+model ref whose model resolves to
+// the given model HTTPRoute.
+func (r *GatewayEnforcementReconciler) subscriptionsForRoute(ctx context.Context, modelRoute *gatewayapiv1.HTTPRoute) ([]subModelRef, error) {
+	log := ctrl.LoggerFrom(ctx)
+	var subs maasv1alpha1.MaaSSubscriptionList
+	if err := r.List(ctx, &subs); err != nil {
+		return nil, fmt.Errorf("list subscriptions: %w", err)
+	}
+	var out []subModelRef
+	for i := range subs.Items {
+		sub := &subs.Items[i]
+		for j := range sub.Spec.ModelRefs {
+			ref := &sub.Spec.ModelRefs[j]
+			routeName, routeNS, err := findHTTPRouteForModel(ctx, r.Client, ref.Namespace, ref.Name)
+			if err != nil {
+				log.V(1).Info("skipping model ref with no resolvable route",
+					"model", qualifiedName(ref.Namespace, ref.Name), "error", err.Error())
+				continue
+			}
+			if routeName == modelRoute.Name && routeNS == modelRoute.Namespace && len(ref.TokenRateLimits) > 0 {
+				out = append(out, subModelRef{sub: sub, ref: ref})
+			}
+		}
+	}
+	log.V(1).Info("subscriptionsForRoute", "subscriptions", len(subs.Items),
+		"matched", len(out), "targetRoute", qualifiedName(modelRoute.Namespace, modelRoute.Name))
+	if len(out) == 0 {
+		return nil, fmt.Errorf("%w: %s", ErrNoSubscription, qualifiedName(modelRoute.Namespace, modelRoute.Name))
+	}
+	return out, nil
+}
+
+// gatherAuthRules builds the auth rule sections via the existing AuthPolicy
+// builder, keeping the auth logic single-sourced. Model access is decided at
+// request time by the subscription-info callout, so no allowlist is injected here.
+func (r *GatewayEnforcementReconciler) gatherAuthRules(ctx context.Context, gw types.NamespacedName) (map[string]any, error) {
+	tenantID := strings.TrimSuffix(strings.TrimPrefix(gw.Name, "maas-"), "-gateway")
+	if tenantID == "default" {
+		tenantID = "" // the default tenant uses the bare maas-api service name
+	}
+	ap := &MaaSAuthPolicyReconciler{
+		Client:           r.Client,
+		InfraNamespace:   r.InfraNamespace,
+		ClusterAudience:  r.ClusterAudience,
+		MetadataCacheTTL: r.MetadataCacheTTL,
+		AuthzCacheTTL:    r.AuthzCacheTTL,
+	}
+	xAPIKeyEnabled := ap.discoverXAPIKeyNeeded(ctx, ctrl.LoggerFrom(ctx))
+	spec := ap.buildGatewayAuthPolicySpec(nil, xAPIKeyEnabled, tenantID, tenantID, gw.Namespace, gw.Name)
+	rules, ok := authPolicyRules(spec)
+	if !ok {
+		return nil, fmt.Errorf("could not extract auth rules for gateway %s", gw)
+	}
+	return rules, nil
+}
+
+// descriptorKey builds a Limitador descriptor key body from a limit name: the name
+// with separators normalized, plus a short stable hash suffix.
+func descriptorKey(limitName string) string {
+	body := strings.ReplaceAll(limitName, "-", "_")
+	h := sha256.Sum256([]byte(limitName))
+	return fmt.Sprintf("%s__%s", body, hex.EncodeToString(h[:])[:8])
+}
+
+// hashHex is a stable hex hash, used for the per-gateway AuthConfig host.
+func hashHex(s string) string {
+	h := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(h[:])
+}

--- a/maas-controller/pkg/controller/maas/enforcement_input_test.go
+++ b/maas-controller/pkg/controller/maas/enforcement_input_test.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package maas
+
+import (
+	"reflect"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func TestHTTPRouteMatches(t *testing.T) {
+	exact := gatewayapiv1.PathMatchExact
+	prefix := gatewayapiv1.PathMatchPathPrefix
+	p1, p2 := "/v1/chat/completions", "/v1"
+	rt := &gatewayapiv1.HTTPRoute{
+		Spec: gatewayapiv1.HTTPRouteSpec{Rules: []gatewayapiv1.HTTPRouteRule{
+			{Matches: []gatewayapiv1.HTTPRouteMatch{
+				{Path: &gatewayapiv1.HTTPPathMatch{Type: &exact, Value: &p1}, Headers: []gatewayapiv1.HTTPHeaderMatch{{Name: "X-Model", Value: "m"}}},
+				{Path: &gatewayapiv1.HTTPPathMatch{Type: &prefix, Value: &p2}},
+			}},
+		}},
+	}
+	got := httpRouteMatches(rt)
+	want := []RouteMatch{
+		{PathType: "Exact", PathValue: p1, HeaderName: "X-Model", HeaderValue: "m"},
+		{PathType: "PathPrefix", PathValue: p2},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("httpRouteMatches = %#v, want %#v", got, want)
+	}
+}
+
+func TestRouteTargetsGateway(t *testing.T) {
+	gw := types.NamespacedName{Namespace: "openshift-ingress", Name: "maas-gw"}
+	if !routeTargetsGateway(newHTTPRouteWithGateway("r", "default", "maas-gw", "openshift-ingress"), gw) {
+		t.Error("route parent-refs the gateway but was not matched")
+	}
+	if routeTargetsGateway(newHTTPRouteWithGateway("r", "default", "other-gw", "openshift-ingress"), gw) {
+		t.Error("route targeting a different gateway name was matched")
+	}
+	if routeTargetsGateway(newHTTPRouteWithGateway("r", "default", "maas-gw", "other-ns"), gw) {
+		t.Error("route targeting the gateway in a different namespace was matched")
+	}
+}

--- a/maas-controller/pkg/controller/maas/enforcement_limitador.go
+++ b/maas-controller/pkg/controller/maas/enforcement_limitador.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package maas
+
+import (
+	"cmp"
+	"errors"
+	"fmt"
+	"slices"
+	"strconv"
+)
+
+// ErrInvalidWindow is returned when a rate-limit window cannot be parsed.
+var ErrInvalidWindow = errors.New("invalid rate-limit window")
+
+// Generates entries for the shared Limitador CR's spec.limits. The token-usage
+// descriptor key must match the pluginConfig action set for the counter to line up.
+
+// LimitadorLimit is one entry in the Limitador CR's spec.limits.
+type LimitadorLimit struct {
+	Name       string   `json:"name"`
+	Namespace  string   `json:"namespace"`
+	MaxValue   int64    `json:"max_value"`
+	Seconds    int64    `json:"seconds"`
+	Conditions []string `json:"conditions"`
+	Variables  []string `json:"variables"`
+}
+
+// userIDCounter is the per-user counter variable every MaaS limit is keyed on.
+const userIDCounter = `descriptors[0]["auth.identity.userid"]`
+
+// buildLimitadorLimit compiles one token-rate limit into a Limitador entry.
+func buildLimitadorLimit(name, namespace, tokenLimitKey string, maxValue int64, window string) (LimitadorLimit, error) {
+	seconds, err := windowSeconds(window)
+	if err != nil {
+		return LimitadorLimit{}, err
+	}
+	return LimitadorLimit{
+		Name:       name,
+		Namespace:  namespace,
+		MaxValue:   maxValue,
+		Seconds:    seconds,
+		Conditions: []string{fmt.Sprintf(`descriptors[0]["tokenlimit.%s"] == "1"`, tokenLimitKey)},
+		Variables:  []string{userIDCounter},
+	}, nil
+}
+
+// mergeLimits replaces this gateway's limits in the shared Limitador CR without
+// disturbing other tenants'. ownedScopes is the set of RLS domains (limit
+// Namespace) this gateway owns; existing limits in those scopes are dropped and
+// replaced by ours. Sorted for a stable CR.
+func mergeLimits(existing []LimitadorLimit, ownedScopes map[string]bool, ours []LimitadorLimit) []LimitadorLimit {
+	out := make([]LimitadorLimit, 0, len(existing)+len(ours))
+	for _, l := range existing {
+		if !ownedScopes[l.Namespace] {
+			out = append(out, l)
+		}
+	}
+	out = append(out, ours...)
+	slices.SortFunc(out, func(a, b LimitadorLimit) int {
+		return cmp.Or(cmp.Compare(a.Namespace, b.Namespace), cmp.Compare(a.Name, b.Name))
+	})
+	return out
+}
+
+// windowSeconds converts a TRLP window ("<n>s|m|h") to seconds.
+func windowSeconds(window string) (int64, error) {
+	if len(window) < 2 {
+		return 0, fmt.Errorf("%w: %q", ErrInvalidWindow, window)
+	}
+	unit := window[len(window)-1]
+	n, err := strconv.ParseInt(window[:len(window)-1], 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("%w: %q: %w", ErrInvalidWindow, window, err)
+	}
+	switch unit {
+	case 's':
+		return n, nil
+	case 'm':
+		return n * 60, nil
+	case 'h':
+		return n * 3600, nil
+	default:
+		return 0, fmt.Errorf("%w: %q (want s, m, or h)", ErrInvalidWindow, window)
+	}
+}

--- a/maas-controller/pkg/controller/maas/enforcement_limitador_test.go
+++ b/maas-controller/pkg/controller/maas/enforcement_limitador_test.go
@@ -1,0 +1,136 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package maas
+
+import (
+	"cmp"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"slices"
+	"testing"
+)
+
+func loadOracleLimits(t *testing.T) map[string]LimitadorLimit {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join("testdata", "oracle-limitador-site-a.json"))
+	if err != nil {
+		t.Fatalf("read oracle limits: %v", err)
+	}
+	var limits []LimitadorLimit
+	if err := json.Unmarshal(data, &limits); err != nil {
+		t.Fatalf("parse oracle limits: %v", err)
+	}
+	byName := map[string]LimitadorLimit{}
+	for _, l := range limits {
+		byName[l.Name] = l
+	}
+	return byName
+}
+
+func TestMergeLimitsPreservesOtherTenants(t *testing.T) {
+	siteBToken := LimitadorLimit{Name: "site-b-tokens", Namespace: "ai-tenant-site-b/qwen3-kserve-route", MaxValue: 500}
+	existing := []LimitadorLimit{
+		{Name: "old-site-a-tokens", Namespace: "ai-tenant-site-a/qwen3-kserve-route", MaxValue: 100},
+		{Name: "old-site-a-deny", Namespace: "redhat-ai-gateway-infra/maas-api-route-site-a", MaxValue: 0},
+		siteBToken,
+	}
+	owned := map[string]bool{
+		"ai-tenant-site-a/qwen3-kserve-route":           true,
+		"redhat-ai-gateway-infra/maas-api-route-site-a": true,
+	}
+	ours := []LimitadorLimit{
+		{Name: "ai-tenant-site-a-site-a-tier-qwen3-tokens", Namespace: "ai-tenant-site-a/qwen3-kserve-route", MaxValue: 200000},
+		{Name: "deny-all-by-default", Namespace: "redhat-ai-gateway-infra/maas-api-route-site-a", MaxValue: 0},
+	}
+
+	got := mergeLimits(existing, owned, ours)
+
+	foundB := false
+	for _, l := range got {
+		if reflect.DeepEqual(l, siteBToken) {
+			foundB = true
+		}
+		if l.Name == "old-site-a-tokens" || l.Name == "old-site-a-deny" {
+			t.Errorf("stale site-a limit %q survived the merge", l.Name)
+		}
+	}
+	if !foundB {
+		t.Errorf("site-b limit was clobbered")
+	}
+	if len(got) != 3 {
+		t.Errorf("merged limits = %d, want 3 (site-b + 2 new site-a)", len(got))
+	}
+	if !slices.IsSortedFunc(got, func(a, b LimitadorLimit) int {
+		return cmp.Or(cmp.Compare(a.Namespace, b.Namespace), cmp.Compare(a.Name, b.Name))
+	}) {
+		t.Errorf("merged limits not sorted: %v", got)
+	}
+}
+
+func TestWindowSeconds(t *testing.T) {
+	valid := map[string]int64{"1h": 3600, "1m": 60, "30s": 30, "24h": 86400, "1s": 1}
+	for w, want := range valid {
+		t.Run(w, func(t *testing.T) {
+			got, err := windowSeconds(w)
+			if err != nil || got != want {
+				t.Errorf("windowSeconds(%q) = %d, %v; want %d", w, got, err, want)
+			}
+		})
+	}
+	for _, bad := range []string{"", "h", "10x", "1d", "abc"} {
+		t.Run("invalid/"+bad, func(t *testing.T) {
+			if _, err := windowSeconds(bad); !errors.Is(err, ErrInvalidWindow) {
+				t.Errorf("windowSeconds(%q) error = %v; want ErrInvalidWindow", bad, err)
+			}
+		})
+	}
+}
+
+func TestBuildLimitadorLimitMatchesOracle(t *testing.T) {
+	oracle := loadOracleLimits(t)
+
+	tok, err := buildLimitadorLimit(
+		"ai-tenant-site-a-site-a-tier-qwen3-tokens",
+		"ai-tenant-site-a/qwen3-kserve-route",
+		"ai_tenant_site_a_site_a_tier_qwen3_tokens__b42c1f29",
+		200000, "1h")
+	if err != nil {
+		t.Fatalf("build token limit: %v", err)
+	}
+	if want := oracle["ai-tenant-site-a-site-a-tier-qwen3-tokens"]; !reflect.DeepEqual(tok, want) {
+		gj := mustJSON(t, tok)
+		wj := mustJSON(t, want)
+		t.Errorf("token limit mismatch:\n--- got ---\n%s\n--- want ---\n%s", gj, wj)
+	}
+
+	deny, err := buildLimitadorLimit(
+		"deny-all-by-default",
+		"redhat-ai-gateway-infra/maas-api-route-site-a",
+		"deny_all_by_default__d3136ae7",
+		0, "1m")
+	if err != nil {
+		t.Fatalf("build deny-all limit: %v", err)
+	}
+	if want := oracle["deny-all-by-default"]; !reflect.DeepEqual(deny, want) {
+		gj := mustJSON(t, deny)
+		wj := mustJSON(t, want)
+		t.Errorf("deny-all limit mismatch:\n--- got ---\n%s\n--- want ---\n%s", gj, wj)
+	}
+}

--- a/maas-controller/pkg/controller/maas/enforcement_pluginconfig.go
+++ b/maas-controller/pkg/controller/maas/enforcement_pluginconfig.go
@@ -21,6 +21,8 @@ import (
 	"encoding/hex"
 	"fmt"
 	"strings"
+
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // Compiles the ext_proc pluginConfig from a gateway's routes and
@@ -266,6 +268,9 @@ type GatewayEnforcementInput struct {
 	Subscriptions   []SubscriptionBinding
 	MaasAPIMatches  []RouteMatch
 	DenyAll         SubscriptionBinding
+
+	// EnforcedSubscriptions get marked Active after their config is applied.
+	EnforcedSubscriptions []types.NamespacedName
 }
 
 // GatewayArtifacts are the three resources MaaS emits per gateway to enforce

--- a/maas-controller/pkg/controller/maas/enforcement_pluginconfig.go
+++ b/maas-controller/pkg/controller/maas/enforcement_pluginconfig.go
@@ -1,0 +1,374 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package maas
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+)
+
+// Compiles the ext_proc pluginConfig from a gateway's routes and
+// subscription intent. Cross-artifact hashes need only be internally consistent,
+// not equal to Kuadrant's.
+
+// PluginConfiguration is the pluginConfig ext_proc consumes.
+type PluginConfiguration struct {
+	Services   map[string]Service `json:"services"`
+	ActionSets []ActionSet        `json:"actionSets"`
+}
+
+// Service is one entry in the pluginConfig services block.
+type Service struct {
+	Endpoint    string `json:"endpoint"`
+	FailureMode string `json:"failureMode"`
+	Timeout     string `json:"timeout"`
+	Type        string `json:"type"`
+}
+
+// ActionSet is one route's match conditions plus its ordered actions.
+type ActionSet struct {
+	Name                string              `json:"name"`
+	RouteRuleConditions RouteRuleConditions `json:"routeRuleConditions"`
+	Actions             []Action            `json:"actions"`
+}
+
+// RouteRuleConditions selects a request by hostname and CEL predicates.
+type RouteRuleConditions struct {
+	Hostnames  []string `json:"hostnames"`
+	Predicates []string `json:"predicates"`
+}
+
+// Action is one policy step (auth, ratelimit-check, ratelimit-report).
+type Action struct {
+	Service         string            `json:"service"`
+	Scope           string            `json:"scope"`
+	Sources         []string          `json:"sources,omitempty"`
+	Predicates      []string          `json:"predicates,omitempty"`
+	ConditionalData []ConditionalData `json:"conditionalData,omitempty"`
+}
+
+// ConditionalData is a descriptor set applied when its predicates hold.
+type ConditionalData struct {
+	Predicates []string   `json:"predicates,omitempty"`
+	Data       []DataItem `json:"data"`
+}
+
+// DataItem is one descriptor entry.
+type DataItem struct {
+	Expression Expression `json:"expression"`
+}
+
+// Expression is a Kuadrant descriptor expression.
+type Expression struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+// Upstream endpoints the services block maps to; ext_proc's upstreams map
+// resolves each to an address.
+const (
+	authServiceEndpoint      = "kuadrant-auth-service"
+	ratelimitServiceEndpoint = "kuadrant-ratelimit-service"
+)
+
+// Logical service names the action sets reference; the services block maps each
+// to an endpoint that ext_proc's upstreams map resolves to an address.
+const (
+	authServiceName            = "auth-service"
+	ratelimitServiceName       = "ratelimit-service"
+	ratelimitCheckServiceName  = "ratelimit-check-service"
+	ratelimitReportServiceName = "ratelimit-report-service"
+)
+
+// standardServices is the fixed services block MaaS gateways use.
+func standardServices() map[string]Service {
+	return map[string]Service{
+		authServiceName:            {Endpoint: authServiceEndpoint, FailureMode: "deny", Timeout: "200ms", Type: "auth"},
+		ratelimitServiceName:       {Endpoint: ratelimitServiceEndpoint, FailureMode: "allow", Timeout: "100ms", Type: "ratelimit"},
+		ratelimitCheckServiceName:  {Endpoint: ratelimitServiceEndpoint, FailureMode: "allow", Timeout: "100ms", Type: "ratelimit-check"},
+		ratelimitReportServiceName: {Endpoint: ratelimitServiceEndpoint, FailureMode: "allow", Timeout: "100ms", Type: "ratelimit-report"},
+	}
+}
+
+// RouteMatch is the subset of an HTTPRoute match we compile.
+type RouteMatch struct {
+	PathType    string // "Exact" or "PathPrefix"
+	PathValue   string
+	HeaderName  string
+	HeaderValue string
+}
+
+// routePredicates turns one HTTPRoute match into its CEL predicates. A header
+// match becomes the case-insensitive exists() form.
+func routePredicates(m RouteMatch) []string {
+	var preds []string
+	switch m.PathType {
+	case "Exact":
+		preds = append(preds, fmt.Sprintf("request.url_path == '%s'", m.PathValue))
+	case "PathPrefix":
+		preds = append(preds, fmt.Sprintf("request.url_path.startsWith('%s')", m.PathValue))
+	}
+	if m.HeaderName != "" {
+		preds = append(preds, fmt.Sprintf(
+			"request.headers.exists(h, h.lowerAscii() == '%s' && request.headers[h] == '%s')",
+			strings.ToLower(m.HeaderName), m.HeaderValue))
+	}
+	return preds
+}
+
+// ModelActionSetParams carries the identities a model action set is built from.
+type ModelActionSetParams struct {
+	Hostname        string
+	RoutePredicates []string
+	AuthScope       string // = the generated AuthConfig host
+	AuthSource      string // provenance ref
+	RLScope         string // "<routeNamespace>/<routeName>"
+	TRLPSource      string // ratelimit policy provenance ref
+	SubscriptionKey string // "<subNs>/<subName>@<modelNs>/<modelName>"
+	TokenLimitKey   string // descriptor key body
+}
+
+// authGatePredicate excludes the maas-api health probe from auth.
+const authGatePredicate = `request.path != "/maas-api/health" || request.method != "GET"`
+
+// tokenUsageAddend is the report-phase hits_addend: the response's total tokens.
+const tokenUsageAddend = `responseBodyJSON("/usage/total_tokens")`
+
+// RateLimitDescriptor is one counter within a ratelimit action: the Limitador
+// token limit (by descriptor key) and the CEL guard it applies under.
+type RateLimitDescriptor struct {
+	TokenLimitKey string
+	WhenPredicate string
+}
+
+// RateLimitBinding is the ratelimit half of an action set: the counter domain
+// (scope), provenance, and one descriptor per subscription.
+type RateLimitBinding struct {
+	Scope       string
+	Source      string
+	Descriptors []RateLimitDescriptor
+}
+
+// buildActionSet compiles one route match into its action set: an auth action, a
+// ratelimit check (hits_addend 0), and a ratelimit report (hits_addend = tokens).
+func buildActionSet(hostname string, routePreds []string, authScope, authSource string, rl RateLimitBinding) ActionSet {
+	rlData := func(hitsAddend string) []ConditionalData {
+		cds := make([]ConditionalData, 0, len(rl.Descriptors))
+		for _, d := range rl.Descriptors {
+			cds = append(cds, ConditionalData{
+				Predicates: []string{d.WhenPredicate},
+				Data: []DataItem{
+					{Expression: Expression{Key: "tokenlimit." + d.TokenLimitKey, Value: "1"}},
+					{Expression: Expression{Key: "auth.identity.userid", Value: "auth.identity.userid"}},
+					{Expression: Expression{Key: "ratelimit.hits_addend", Value: hitsAddend}},
+				},
+			})
+		}
+		return cds
+	}
+
+	return ActionSet{
+		Name:                actionSetName(hostname, routePreds),
+		RouteRuleConditions: RouteRuleConditions{Hostnames: []string{hostname}, Predicates: routePreds},
+		Actions: []Action{
+			{Service: authServiceName, Scope: authScope, Sources: []string{authSource}, Predicates: []string{authGatePredicate}},
+			{Service: ratelimitCheckServiceName, Scope: rl.Scope, Sources: []string{rl.Source}, ConditionalData: rlData("0")},
+			{Service: ratelimitReportServiceName, Scope: rl.Scope, Sources: []string{rl.Source}, ConditionalData: rlData(tokenUsageAddend)},
+		},
+	}
+}
+
+// modelWhenPredicate guards a subscription's token limit to its own requests,
+// excluding the model-listing endpoint.
+func modelWhenPredicate(subscriptionKey string) string {
+	return fmt.Sprintf(
+		`auth.identity.selected_subscription_key == "%s" && !request.path.endsWith("/v1/models")`,
+		subscriptionKey)
+}
+
+// denyAllWhenPredicate is the gateway safety net: applies to any request that is
+// not a maas-api control-plane path.
+const denyAllWhenPredicate = `!request.path.startsWith("/maas-api") && ` +
+	`!request.path.startsWith("/v1/models") && ` +
+	`!request.path.startsWith("/v1/subscriptions") && ` +
+	`!request.path.startsWith("/v1/api-keys")`
+
+// buildModelActionSet compiles one model route match for a single subscription.
+func buildModelActionSet(p ModelActionSetParams) ActionSet {
+	return buildActionSet(p.Hostname, p.RoutePredicates, p.AuthScope, p.AuthSource, RateLimitBinding{
+		Scope:  p.RLScope,
+		Source: p.TRLPSource,
+		Descriptors: []RateLimitDescriptor{
+			{TokenLimitKey: p.TokenLimitKey, WhenPredicate: modelWhenPredicate(p.SubscriptionKey)},
+		},
+	})
+}
+
+// buildRouteActionSets compiles every match of one route into an action set,
+// sharing the same auth and ratelimit policy.
+func buildRouteActionSets(matches []RouteMatch, base ModelActionSetParams) []ActionSet {
+	out := make([]ActionSet, 0, len(matches))
+	for _, m := range matches {
+		p := base
+		p.RoutePredicates = routePredicates(m)
+		out = append(out, buildModelActionSet(p))
+	}
+	return out
+}
+
+// SubscriptionBinding is one subscription's ratelimit identity and budget, shared
+// across the pluginConfig action set and the Limitador limit.
+type SubscriptionBinding struct {
+	SubscriptionKey string // empty for deny-all
+	RouteScope      string // "<routeNs>/<routeName>"
+	Source          string
+	TokenLimitKey   string
+	LimitName       string
+	MaxValue        int64 // 0 = deny-all
+	Window          string
+}
+
+// descriptor turns a subscription binding into its ratelimit descriptor.
+func (b SubscriptionBinding) descriptor(denyAll bool) RateLimitDescriptor {
+	when := modelWhenPredicate(b.SubscriptionKey)
+	if denyAll {
+		when = denyAllWhenPredicate
+	}
+	return RateLimitDescriptor{TokenLimitKey: b.TokenLimitKey, WhenPredicate: when}
+}
+
+// GatewayEnforcementInput is the cluster state a gateway's artifacts are
+// generated from: the contract between input gathering and the pure generators.
+type GatewayEnforcementInput struct {
+	Hostname        string
+	AuthConfigHost  string // the single AuthConfig host == the pluginConfig auth scope
+	AuthSource      string
+	AuthRules       map[string]any // from buildGatewayAuthPolicySpec
+	ModelMatches    []RouteMatch
+	ModelRouteScope string // the model route's RLS domain, shared by its subscriptions
+	ModelSource     string
+	Subscriptions   []SubscriptionBinding
+	MaasAPIMatches  []RouteMatch
+	DenyAll         SubscriptionBinding
+}
+
+// GatewayArtifacts are the three resources MaaS emits per gateway to enforce
+// natively: the extproc pluginConfig, the AuthConfig, and the Limitador limits.
+type GatewayArtifacts struct {
+	PluginConfig PluginConfiguration
+	AuthConfig   map[string]any
+	Limits       []LimitadorLimit
+}
+
+// generateGatewayArtifacts composes the three artifacts from one input. Pure: the
+// reconciler gathers the input and applies the output.
+func generateGatewayArtifacts(in GatewayEnforcementInput) (GatewayArtifacts, error) {
+	modelRL := RateLimitBinding{Scope: in.ModelRouteScope, Source: in.ModelSource}
+	limits := make([]LimitadorLimit, 0, len(in.Subscriptions)+1)
+	for _, s := range in.Subscriptions {
+		modelRL.Descriptors = append(modelRL.Descriptors, s.descriptor(false))
+		l, err := buildLimitadorLimit(s.LimitName, in.ModelRouteScope, s.TokenLimitKey, s.MaxValue, s.Window)
+		if err != nil {
+			return GatewayArtifacts{}, fmt.Errorf("token limit %s: %w", s.LimitName, err)
+		}
+		limits = append(limits, l)
+	}
+
+	denyRL := RateLimitBinding{
+		Scope:       in.DenyAll.RouteScope,
+		Source:      in.DenyAll.Source,
+		Descriptors: []RateLimitDescriptor{in.DenyAll.descriptor(true)},
+	}
+
+	pc := assembleGatewayPluginConfig(GatewayPluginParams{
+		Hostname:       in.Hostname,
+		AuthScope:      in.AuthConfigHost,
+		AuthSource:     in.AuthSource,
+		ModelMatches:   in.ModelMatches,
+		ModelRL:        modelRL,
+		MaasAPIMatches: in.MaasAPIMatches,
+		DenyAllRL:      denyRL,
+	})
+
+	ac := buildAuthConfigSpec(in.AuthConfigHost, in.AuthRules)
+
+	denyLimit, err := buildLimitadorLimit(in.DenyAll.LimitName, in.DenyAll.RouteScope, in.DenyAll.TokenLimitKey, in.DenyAll.MaxValue, in.DenyAll.Window)
+	if err != nil {
+		return GatewayArtifacts{}, fmt.Errorf("deny-all limit: %w", err)
+	}
+	limits = append(limits, denyLimit)
+
+	return GatewayArtifacts{PluginConfig: pc, AuthConfig: ac, Limits: limits}, nil
+}
+
+// ownedScopes is the set of Limitador RLS domains this gateway's artifacts own.
+func (a GatewayArtifacts) ownedScopes() map[string]bool {
+	scopes := map[string]bool{}
+	for _, l := range a.Limits {
+		scopes[l.Namespace] = true
+	}
+	return scopes
+}
+
+// GatewayPluginParams is everything needed to assemble a gateway's pluginConfig.
+type GatewayPluginParams struct {
+	Hostname       string
+	AuthScope      string
+	AuthSource     string
+	ModelMatches   []RouteMatch
+	ModelRL        RateLimitBinding
+	MaasAPIMatches []RouteMatch
+	DenyAllRL      RateLimitBinding
+}
+
+// assembleGatewayPluginConfig compiles a gateway's model and maas-api routes into
+// the full pluginConfig: the fixed services block plus one action set per match.
+func assembleGatewayPluginConfig(p GatewayPluginParams) PluginConfiguration {
+	sets := make([]ActionSet, 0, len(p.ModelMatches)+len(p.MaasAPIMatches))
+	for _, m := range p.ModelMatches {
+		sets = append(sets, buildActionSet(p.Hostname, routePredicates(m), p.AuthScope, p.AuthSource, p.ModelRL))
+	}
+	for _, m := range p.MaasAPIMatches {
+		sets = append(sets, buildActionSet(p.Hostname, routePredicates(m), p.AuthScope, p.AuthSource, p.DenyAllRL))
+	}
+	return PluginConfiguration{Services: standardServices(), ActionSets: sets}
+}
+
+// actionSetCondKey is a stable identity for an action set's route conditions,
+// used to diff generated action sets against Kuadrant's output.
+func actionSetCondKey(a ActionSet) string {
+	return strings.Join(a.RouteRuleConditions.Predicates, "|")
+}
+
+// actionSetRLKey summarizes an action set's ratelimit binding for diffing.
+func actionSetRLKey(a ActionSet) string {
+	if len(a.Actions) < 3 || len(a.Actions[2].ConditionalData) == 0 || len(a.Actions[2].ConditionalData[0].Data) == 0 {
+		if len(a.Actions) > 1 {
+			return a.Actions[1].Scope
+		}
+		return ""
+	}
+	return a.Actions[1].Scope + " " + a.Actions[2].ConditionalData[0].Data[0].Expression.Key
+}
+
+// actionSetName hashes the hostname and predicates into a stable per-match id.
+func actionSetName(hostname string, predicates []string) string {
+	h := sha256.Sum256([]byte(hostname + "\n" + strings.Join(predicates, "\n")))
+	return hex.EncodeToString(h[:])
+}

--- a/maas-controller/pkg/controller/maas/enforcement_pluginconfig_test.go
+++ b/maas-controller/pkg/controller/maas/enforcement_pluginconfig_test.go
@@ -1,0 +1,389 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package maas
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+// loadOraclePluginConfig loads captured Kuadrant pluginConfig output, used as the
+// diff oracle for generation.
+func loadOraclePluginConfig(t *testing.T) PluginConfiguration {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join("testdata", "oracle-pluginconfig-site-a.json"))
+	if err != nil {
+		t.Fatalf("read oracle: %v", err)
+	}
+	var pc PluginConfiguration
+	if err := json.Unmarshal(data, &pc); err != nil {
+		t.Fatalf("parse oracle: %v", err)
+	}
+	return pc
+}
+
+// loadOracleActionSet loads the reference Kuadrant action set for a
+// /v1/chat/completions model route; the generator must reproduce it (except the
+// internal name hash).
+func loadOracleActionSet(t *testing.T) ActionSet {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join("testdata", "oracle-actionset-chat-completions.json"))
+	if err != nil {
+		t.Fatalf("read oracle action set: %v", err)
+	}
+	var a ActionSet
+	if err := json.Unmarshal(data, &a); err != nil {
+		t.Fatalf("parse oracle action set: %v", err)
+	}
+	return a
+}
+
+func TestRoutePredicates(t *testing.T) {
+	cases := []struct {
+		name  string
+		match RouteMatch
+		want  []string
+	}{
+		{
+			name: "exact with header",
+			match: RouteMatch{
+				PathType:    "Exact",
+				PathValue:   "/v1/chat/completions",
+				HeaderName:  "X-Gateway-Model-Name",
+				HeaderValue: "publishers/ai-tenant-site-a/models/Qwen/Qwen3-0.6B",
+			},
+			want: []string{
+				"request.url_path == '/v1/chat/completions'",
+				"request.headers.exists(h, h.lowerAscii() == 'x-gateway-model-name' && request.headers[h] == 'publishers/ai-tenant-site-a/models/Qwen/Qwen3-0.6B')",
+			},
+		},
+		{
+			name:  "path prefix",
+			match: RouteMatch{PathType: "PathPrefix", PathValue: "/ai-tenant-site-a/qwen3"},
+			want:  []string{"request.url_path.startsWith('/ai-tenant-site-a/qwen3')"},
+		},
+		{
+			name:  "exact without header",
+			match: RouteMatch{PathType: "Exact", PathValue: "/v1/models"},
+			want:  []string{"request.url_path == '/v1/models'"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := routePredicates(tc.match); !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("routePredicates mismatch:\n got %#v\nwant %#v", got, tc.want)
+			}
+		})
+	}
+}
+
+// qwen3RouteMatches is a model route's flattened match list, compiling to the
+// model action sets in the oracle.
+func qwen3RouteMatches() []RouteMatch {
+	const modelHdr = "publishers/ai-tenant-site-a/models/Qwen/Qwen3-0.6B"
+	hdr := func(pathType, path string) RouteMatch {
+		return RouteMatch{PathType: pathType, PathValue: path, HeaderName: "X-Gateway-Model-Name", HeaderValue: modelHdr}
+	}
+	pfx := func(path string) RouteMatch { return RouteMatch{PathType: "PathPrefix", PathValue: path} }
+	var m []RouteMatch
+	for _, p := range []string{
+		"/v1/completions", "/v1/completions/", "/v1/chat/completions", "/v1/chat/completions/",
+		"/v1/responses", "/v1/responses/", "/v1/messages", "/v1/messages/",
+	} {
+		m = append(m, hdr("Exact", p))
+	}
+	for _, p := range []string{
+		"/ai-tenant-site-a/qwen3/v1/completions", "/ai-tenant-site-a/qwen3/v1/chat/completions",
+		"/ai-tenant-site-a/qwen3/v1/responses", "/ai-tenant-site-a/qwen3/v1/messages",
+	} {
+		m = append(m, pfx(p))
+	}
+	for _, p := range []string{
+		"/publishers/ai-tenant-site-a/models/Qwen/Qwen3-0.6B/v1/completions",
+		"/publishers/ai-tenant-site-a/models/Qwen/Qwen3-0.6B/v1/chat/completions",
+		"/publishers/ai-tenant-site-a/models/Qwen/Qwen3-0.6B/v1/responses",
+		"/publishers/ai-tenant-site-a/models/Qwen/Qwen3-0.6B/v1/messages",
+	} {
+		m = append(m, pfx(p))
+	}
+	m = append(m, pfx("/publishers/ai-tenant-site-a/models/Qwen/Qwen3-0.6B"))
+	m = append(m, pfx("/ai-tenant-site-a/qwen3"))
+	m = append(m, hdr("PathPrefix", "/"))
+	return m
+}
+
+func TestBuildRouteActionSetsAggregatesModelRoute(t *testing.T) {
+	base := ModelActionSetParams{
+		Hostname:        "site-a.example.com",
+		AuthScope:       "gateway-authconfig-host", // our single AuthConfig; Kuadrant uses per-rule hashes
+		AuthSource:      "authpolicy.kuadrant.io:openshift-ingress/maas-site-a-gateway-maas-auth",
+		RLScope:         "ai-tenant-site-a/qwen3-kserve-route",
+		TRLPSource:      "tokenratelimitpolicy.kuadrant.io:ai-tenant-site-a/maas-trlp-qwen3",
+		SubscriptionKey: "ai-tenant-site-a/site-a-tier@ai-tenant-site-a/qwen3",
+		TokenLimitKey:   "ai_tenant_site_a_site_a_tier_qwen3_tokens__b42c1f29",
+	}
+	got := buildRouteActionSets(qwen3RouteMatches(), base)
+
+	// Collect the oracle's model action sets (ratelimit scope is the model route).
+	oracle := loadOraclePluginConfig(t)
+	wantConds := map[string]bool{}
+	for _, a := range oracle.ActionSets {
+		if a.Actions[1].Scope == "ai-tenant-site-a/qwen3-kserve-route" {
+			wantConds[actionSetCondKey(a)] = true
+		}
+	}
+	if len(got) != len(wantConds) {
+		t.Fatalf("generated %d model action sets, oracle has %d", len(got), len(wantConds))
+	}
+	for _, a := range got {
+		if !wantConds[actionSetCondKey(a)] {
+			t.Errorf("generated an action set with no oracle match: %v", a.RouteRuleConditions.Predicates)
+		}
+		if a.Actions[1].Scope != base.RLScope {
+			t.Errorf("ratelimit-check scope = %q, want %q", a.Actions[1].Scope, base.RLScope)
+		}
+		if a.Actions[2].ConditionalData[0].Data[0].Expression.Key != "tokenlimit."+base.TokenLimitKey {
+			t.Errorf("report token key = %q", a.Actions[2].ConditionalData[0].Data[0].Expression.Key)
+		}
+	}
+}
+
+func TestGenerateGatewayArtifactsMultiSubscription(t *testing.T) {
+	in := GatewayEnforcementInput{
+		Hostname:        "site-a.example.com",
+		AuthConfigHost:  "gw-authconfig-host",
+		AuthSource:      "authpolicy.kuadrant.io:openshift-ingress/maas-site-a-gateway-maas-auth",
+		AuthRules:       map[string]any{"authentication": map[string]any{}},
+		ModelMatches:    []RouteMatch{{PathType: "Exact", PathValue: "/v1/chat/completions"}},
+		ModelRouteScope: "ai-tenant-site-a/qwen3-kserve-route",
+		ModelSource:     "tokenratelimitpolicy.kuadrant.io:ai-tenant-site-a/maas-trlp-qwen3",
+		Subscriptions: []SubscriptionBinding{
+			{SubscriptionKey: "ai-tenant-site-a/alice@ai-tenant-site-a/qwen3", TokenLimitKey: "alice__k", LimitName: "alice-qwen3-tokens", MaxValue: 100, Window: "1h"},
+			{SubscriptionKey: "ai-tenant-site-a/bob@ai-tenant-site-a/qwen3", TokenLimitKey: "bob__k", LimitName: "bob-qwen3-tokens", MaxValue: 200, Window: "1h"},
+		},
+		MaasAPIMatches: []RouteMatch{{PathType: "PathPrefix", PathValue: "/maas-api"}},
+		DenyAll:        SubscriptionBinding{RouteScope: "redhat-ai-gateway-infra/maas-api-route-site-a", Source: "trlp:deny", TokenLimitKey: "deny__k", LimitName: "deny-all-by-default", MaxValue: 0, Window: "1m"},
+	}
+
+	arts, err := generateGatewayArtifacts(in)
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+
+	// One Limitador limit per subscription, plus the deny-all.
+	if len(arts.Limits) != 3 {
+		t.Errorf("limits = %d, want 3 (alice, bob, deny-all)", len(arts.Limits))
+	}
+
+	// Each model action set's ratelimit-check and -report carry two descriptors.
+	modelSets := 0
+	for _, a := range arts.PluginConfig.ActionSets {
+		if a.Actions[1].Scope != in.ModelRouteScope {
+			continue
+		}
+		modelSets++
+		for _, actIdx := range []int{1, 2} { // check, report
+			if got := len(a.Actions[actIdx].ConditionalData); got != 2 {
+				t.Errorf("action %d conditionalData = %d, want 2 (alice+bob)", actIdx, got)
+			}
+		}
+	}
+	if modelSets == 0 {
+		t.Errorf("no model action sets generated")
+	}
+}
+
+// TestGenerateGatewayArtifacts is a composition test: one gathered
+// input produces all three artifacts, each matching its oracle.
+func TestGenerateGatewayArtifacts(t *testing.T) {
+	r := &MaaSAuthPolicyReconciler{
+		InfraNamespace:   "redhat-ai-gateway-infra",
+		ClusterAudience:  "https://kubernetes.default.svc",
+		MetadataCacheTTL: 60,
+	}
+	authSpec := r.buildGatewayAuthPolicySpec(nil, false, "site-a", "site-a", "openshift-ingress", "maas-site-a-gateway")
+	authRules, ok := authPolicyRules(authSpec)
+	if !ok {
+		t.Fatalf("extract auth rules")
+	}
+
+	in := GatewayEnforcementInput{
+		Hostname:        "site-a.example.com",
+		AuthConfigHost:  "gateway-authconfig-host",
+		AuthSource:      "authpolicy.kuadrant.io:openshift-ingress/maas-site-a-gateway-maas-auth",
+		AuthRules:       authRules,
+		ModelMatches:    qwen3RouteMatches(),
+		ModelRouteScope: "ai-tenant-site-a/qwen3-kserve-route",
+		ModelSource:     "tokenratelimitpolicy.kuadrant.io:ai-tenant-site-a/maas-trlp-qwen3",
+		Subscriptions: []SubscriptionBinding{{
+			SubscriptionKey: "ai-tenant-site-a/site-a-tier@ai-tenant-site-a/qwen3",
+			TokenLimitKey:   "ai_tenant_site_a_site_a_tier_qwen3_tokens__b42c1f29",
+			LimitName:       "ai-tenant-site-a-site-a-tier-qwen3-tokens",
+			MaxValue:        200000,
+			Window:          "1h",
+		}},
+		MaasAPIMatches: maasAPIRouteMatches(),
+		DenyAll: SubscriptionBinding{ //nolint:gosec // descriptor key is a Kuadrant identifier, not a credential
+			RouteScope:    "redhat-ai-gateway-infra/maas-api-route-site-a",
+			Source:        "tokenratelimitpolicy.kuadrant.io:openshift-ingress/gateway-default-deny-site-a",
+			TokenLimitKey: "deny_all_by_default__d3136ae7",
+			LimitName:     "deny-all-by-default",
+			MaxValue:      0,
+			Window:        "1m",
+		},
+	}
+
+	arts, err := generateGatewayArtifacts(in)
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+
+	// pluginConfig: all 23 action sets match on route conditions and RL binding.
+	oraclePC := loadOraclePluginConfig(t)
+	want := map[string]string{}
+	for _, a := range oraclePC.ActionSets {
+		want[actionSetCondKey(a)] = actionSetRLKey(a)
+	}
+	got := map[string]string{}
+	for _, a := range arts.PluginConfig.ActionSets {
+		got[actionSetCondKey(a)] = actionSetRLKey(a)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("pluginConfig action sets differ from oracle (got %d, want %d)", len(got), len(want))
+	}
+
+	// AuthConfig: host set, authentication matches oracle.
+	if hosts, _ := arts.AuthConfig["hosts"].([]any); len(hosts) != 1 || hosts[0] != in.AuthConfigHost {
+		t.Errorf("authConfig hosts = %v", arts.AuthConfig["hosts"])
+	}
+	oracleAC := loadOracleAuthConfig(t)
+	if gA, wA := jsonNormalize(t, arts.AuthConfig["authentication"]), jsonNormalize(t, oracleAC["authentication"]); !reflect.DeepEqual(gA, wA) {
+		t.Errorf("authConfig authentication differs from oracle")
+	}
+
+	// Limits: both match the oracle.
+	oracleLim := loadOracleLimits(t)
+	if len(arts.Limits) != 2 {
+		t.Fatalf("got %d limits, want 2", len(arts.Limits))
+	}
+	for _, l := range arts.Limits {
+		if want, ok := oracleLim[l.Name]; !ok || !reflect.DeepEqual(l, want) {
+			t.Errorf("limit %q differs from oracle", l.Name)
+		}
+	}
+}
+
+// maasAPIRouteMatches is a maas-api route: four control-plane path prefixes, no
+// header.
+func maasAPIRouteMatches() []RouteMatch {
+	pfx := func(p string) RouteMatch { return RouteMatch{PathType: "PathPrefix", PathValue: p} }
+	return []RouteMatch{pfx("/v1/models"), pfx("/v1/subscriptions"), pfx("/v1/api-keys"), pfx("/maas-api")}
+}
+
+func TestAssembleGatewayPluginConfigMatchesOracle(t *testing.T) {
+	pc := assembleGatewayPluginConfig(GatewayPluginParams{
+		Hostname:     "site-a.example.com",
+		AuthScope:    "gateway-authconfig-host",
+		AuthSource:   "authpolicy.kuadrant.io:openshift-ingress/maas-site-a-gateway-maas-auth",
+		ModelMatches: qwen3RouteMatches(),
+		ModelRL: RateLimitBinding{
+			Scope:  "ai-tenant-site-a/qwen3-kserve-route",
+			Source: "tokenratelimitpolicy.kuadrant.io:ai-tenant-site-a/maas-trlp-qwen3",
+			Descriptors: []RateLimitDescriptor{{
+				TokenLimitKey: "ai_tenant_site_a_site_a_tier_qwen3_tokens__b42c1f29",
+				WhenPredicate: modelWhenPredicate("ai-tenant-site-a/site-a-tier@ai-tenant-site-a/qwen3"),
+			}},
+		},
+		MaasAPIMatches: maasAPIRouteMatches(),
+		DenyAllRL: RateLimitBinding{
+			Scope:  "redhat-ai-gateway-infra/maas-api-route-site-a",
+			Source: "tokenratelimitpolicy.kuadrant.io:openshift-ingress/gateway-default-deny-site-a",
+			Descriptors: []RateLimitDescriptor{{ //nolint:gosec // descriptor key is a Kuadrant identifier, not a credential
+				TokenLimitKey: "deny_all_by_default__d3136ae7",
+				WhenPredicate: denyAllWhenPredicate,
+			}},
+		},
+	})
+
+	oracle := loadOraclePluginConfig(t)
+
+	if len(pc.ActionSets) != len(oracle.ActionSets) {
+		t.Fatalf("generated %d action sets, oracle has %d", len(pc.ActionSets), len(oracle.ActionSets))
+	}
+
+	// Diff every action set's route conditions and ratelimit binding against the
+	// oracle. Auth scope is intentionally not compared (we use one AuthConfig
+	// per gateway; Kuadrant uses per-rule hashes).
+	want := map[string]string{}
+	for _, a := range oracle.ActionSets {
+		want[actionSetCondKey(a)] = actionSetRLKey(a)
+	}
+	got := map[string]string{}
+	for _, a := range pc.ActionSets {
+		got[actionSetCondKey(a)] = actionSetRLKey(a)
+	}
+	if !reflect.DeepEqual(got, want) {
+		for k, wv := range want {
+			if gv, ok := got[k]; !ok {
+				t.Errorf("missing action set: %s", k)
+			} else if gv != wv {
+				t.Errorf("rl binding mismatch for %s:\n got %s\nwant %s", k, gv, wv)
+			}
+		}
+		for k := range got {
+			if _, ok := want[k]; !ok {
+				t.Errorf("unexpected action set: %s", k)
+			}
+		}
+	}
+
+	// The services block must match the oracle (structurally).
+	if !reflect.DeepEqual(pc.Services, oracle.Services) {
+		gj := mustJSON(t, pc.Services)
+		wj := mustJSON(t, oracle.Services)
+		t.Errorf("services mismatch:\n--- got ---\n%s\n--- want ---\n%s", gj, wj)
+	}
+}
+
+func TestBuildModelActionSetMatchesOracle(t *testing.T) {
+	want := loadOracleActionSet(t)
+
+	got := buildModelActionSet(ModelActionSetParams{
+		Hostname:        "site-a.example.com",
+		RoutePredicates: routePredicates(RouteMatch{PathType: "Exact", PathValue: "/v1/chat/completions", HeaderName: "X-Gateway-Model-Name", HeaderValue: "publishers/ai-tenant-site-a/models/Qwen/Qwen3-0.6B"}),
+		AuthScope:       "410f8ee4ef0bb20b515d4c56db735b69d29d244f2091bfcb8bd32f5c93ef312f",
+		AuthSource:      "authpolicy.kuadrant.io:openshift-ingress/maas-site-a-gateway-maas-auth",
+		RLScope:         "ai-tenant-site-a/qwen3-kserve-route",
+		TRLPSource:      "tokenratelimitpolicy.kuadrant.io:ai-tenant-site-a/maas-trlp-qwen3",
+		SubscriptionKey: "ai-tenant-site-a/site-a-tier@ai-tenant-site-a/qwen3",
+		TokenLimitKey:   "ai_tenant_site_a_site_a_tier_qwen3_tokens__b42c1f29",
+	})
+
+	// The internal name hash is ours, not Kuadrant's, so compare only conditions
+	// and actions.
+	if !reflect.DeepEqual(got.RouteRuleConditions, want.RouteRuleConditions) {
+		t.Errorf("routeRuleConditions mismatch:\n got %#v\nwant %#v", got.RouteRuleConditions, want.RouteRuleConditions)
+	}
+	if !reflect.DeepEqual(got.Actions, want.Actions) {
+		gj := mustJSON(t, got.Actions)
+		wj := mustJSON(t, want.Actions)
+		t.Errorf("actions mismatch:\n--- got ---\n%s\n--- want ---\n%s", gj, wj)
+	}
+}

--- a/maas-controller/pkg/controller/maas/enforcement_reconcile_test.go
+++ b/maas-controller/pkg/controller/maas/enforcement_reconcile_test.go
@@ -1,0 +1,151 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package maas
+
+import (
+	"context"
+	"reflect"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	maasv1alpha1 "github.com/opendatahub-io/models-as-a-service/maas-controller/api/maas/v1alpha1"
+)
+
+// withExactPath gives a route a single Exact path-match rule.
+func withExactPath(rt *gatewayapiv1.HTTPRoute, path string) *gatewayapiv1.HTTPRoute {
+	pt := gatewayapiv1.PathMatchExact
+	rt.Spec.Rules = []gatewayapiv1.HTTPRouteRule{{
+		Matches: []gatewayapiv1.HTTPRouteMatch{{Path: &gatewayapiv1.HTTPPathMatch{Type: &pt, Value: &path}}},
+	}}
+	return rt
+}
+
+// TestGatherAndGenerateForGateway covers gather, compile, render, and ConfigMap
+// build. The fake client cannot exercise server-side apply, so the skip test
+// covers Reconcile's no-requeue path.
+func TestGatherAndGenerateForGateway(t *testing.T) {
+	const gwNS, gwName = "openshift-ingress", "maas-site-a-gateway"
+	gw := newGatewayWithHostname(gwName, gwNS, "site.example.com")
+	modelRoute := withExactPath(newHTTPRouteWithGateway("maas-foo", "default", gwName, gwNS), "/v1/chat/completions")
+	apiRoute := withExactPath(newHTTPRouteWithGateway("maas-api-route-site-a", "default", gwName, gwNS), "/maas-api/v1/models")
+	model := newMaaSModelRef("foo", "default", "ExternalModel", "foo")
+	sub := newMaaSSubscription("sub-a", "default", "group-a", "foo", 1000)
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithRESTMapper(testRESTMapper()).
+		WithObjects(gw, modelRoute, apiRoute, model, sub).
+		Build()
+	r := &GatewayEnforcementReconciler{
+		Client:           c,
+		Scheme:           scheme,
+		InfraNamespace:   "opendatahub",
+		ClusterAudience:  "https://kubernetes.default.svc",
+		MetadataCacheTTL: 60,
+	}
+
+	in, err := r.gatherGatewayInput(context.Background(), types.NamespacedName{Namespace: gwNS, Name: gwName})
+	if err != nil {
+		t.Fatalf("gatherGatewayInput: %v", err)
+	}
+	if in.Hostname != "site.example.com" {
+		t.Errorf("hostname = %q, want site.example.com", in.Hostname)
+	}
+	if len(in.Subscriptions) != 1 || in.Subscriptions[0].MaxValue != 1000 {
+		t.Errorf("subscriptions = %+v, want one with limit 1000", in.Subscriptions)
+	}
+
+	arts, err := generateGatewayArtifacts(in)
+	if err != nil {
+		t.Fatalf("generateGatewayArtifacts: %v", err)
+	}
+	if len(arts.PluginConfig.ActionSets) == 0 {
+		t.Error("no action sets generated")
+	}
+	if len(arts.Limits) != 2 { // one subscription limit + the deny-all
+		t.Errorf("limits = %d, want 2 (subscription + deny-all)", len(arts.Limits))
+	}
+
+	rendered, err := r.renderPluginConfig(arts.PluginConfig)
+	if err != nil {
+		t.Fatalf("renderPluginConfig: %v", err)
+	}
+	cm := configMapFor(gwName, gwNS, rendered)
+	if cm.Name != gwName+"-extproc" || !strings.Contains(cm.Data["kuadrant.yaml"], "actionSets") {
+		t.Errorf("configMap = %+v", cm)
+	}
+}
+
+func TestReconcileSkipsNotReadyGateway(t *testing.T) {
+	const gwNS, gwName = "openshift-ingress", "maas-x-gateway"
+	cases := []struct {
+		name string
+		objs []client.Object
+	}{
+		{"no hostname", []client.Object{&gatewayapiv1.Gateway{ObjectMeta: metav1.ObjectMeta{Name: gwName, Namespace: gwNS}}}},
+		{"no routes", []client.Object{newGatewayWithHostname(gwName, gwNS, "x.example.com")}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := fake.NewClientBuilder().WithScheme(scheme).WithRESTMapper(testRESTMapper()).WithObjects(tc.objs...).Build()
+			r := &GatewayEnforcementReconciler{Client: c, Scheme: scheme, InfraNamespace: "opendatahub"}
+			res, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: types.NamespacedName{Namespace: gwNS, Name: gwName}})
+			if err != nil {
+				t.Fatalf("Reconcile should skip, got error: %v", err)
+			}
+			if res != (reconcile.Result{}) {
+				t.Errorf("result = %+v, want no requeue", res)
+			}
+			cm := &corev1.ConfigMap{}
+			if err := c.Get(context.Background(), types.NamespacedName{Namespace: gwNS, Name: gwName + "-extproc"}, cm); !apierrors.IsNotFound(err) {
+				t.Errorf("expected no ConfigMap, got err=%v", err)
+			}
+		})
+	}
+}
+
+func TestGatewaysForRoute(t *testing.T) {
+	r := &GatewayEnforcementReconciler{}
+	rt := newHTTPRouteWithGateway("m", "default", "gw-1", "openshift-ingress")
+	got := r.gatewaysForRoute(context.Background(), rt)
+	want := []reconcile.Request{{NamespacedName: types.NamespacedName{Namespace: "openshift-ingress", Name: "gw-1"}}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("gatewaysForRoute = %v, want %v", got, want)
+	}
+}
+
+func TestGatewaysForSubscription(t *testing.T) {
+	gw1 := newGatewayWithHostname("gw-1", "ns", "h1")
+	gw1.Labels = map[string]string{aiGatewayTenantLabel: "t1"}
+	gw2 := newGatewayWithHostname("gw-2", "ns", "h2") // unlabeled: must be ignored
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithRESTMapper(testRESTMapper()).WithObjects(gw1, gw2).Build()
+	r := &GatewayEnforcementReconciler{Client: c}
+	got := r.gatewaysForSubscription(context.Background(), &maasv1alpha1.MaaSSubscription{})
+	if len(got) != 1 || got[0].Name != "gw-1" {
+		t.Errorf("gatewaysForSubscription = %v, want only gw-1", got)
+	}
+}

--- a/maas-controller/pkg/controller/maas/enforcement_testutil_test.go
+++ b/maas-controller/pkg/controller/maas/enforcement_testutil_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package maas
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// mustJSON renders v as indented JSON for diff messages.
+func mustJSON(t *testing.T, v any) string {
+	t.Helper()
+	b, err := json.MarshalIndent(v, "", " ")
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return string(b)
+}
+
+// jsonNormalize round-trips a value through JSON so Go ints and JSON float64s
+// compare equal.
+func jsonNormalize(t *testing.T, v any) any {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var out any
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	return out
+}

--- a/maas-controller/pkg/controller/maas/maasmodelref_controller.go
+++ b/maas-controller/pkg/controller/maas/maasmodelref_controller.go
@@ -175,6 +175,13 @@ func (r *MaaSModelRefReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			r.updateStatusWithReason(ctx, model, "Failed", fmt.Sprintf("kind not implemented: %s", kind), "Unsupported", statusSnapshot)
 			return ctrl.Result{}, nil
 		}
+		// Backing kind's CRD not installed on this cluster: don't hot-loop.
+		if apimeta.IsNoMatchError(err) {
+			model.Status.Endpoint = ""
+			model.Status.Phase = "Failed"
+			r.updateStatusWithReason(ctx, model, "Failed", fmt.Sprintf("backing kind not installed: %s", kind), "Unsupported", statusSnapshot)
+			return ctrl.Result{}, nil
+		}
 		log.Error(err, "failed to update model status")
 		model.Status.Endpoint = ""
 		model.Status.Phase = "Failed"

--- a/maas-controller/pkg/controller/maas/testdata/README.md
+++ b/maas-controller/pkg/controller/maas/testdata/README.md
@@ -1,0 +1,20 @@
+# Enforcement oracle fixtures
+
+Reference Kuadrant output used as generation oracles: the GatewayEnforcement
+compiler must reproduce these. Captured from Kuadrant (Red Hat Connectivity Link
+1.3.3), which compiles an AuthPolicy and a TokenRateLimitPolicy into them.
+
+| File | Kuadrant artifact |
+|------|-------------------|
+| `oracle-pluginconfig-site-a.json` | WasmPlugin `spec.pluginConfig` |
+| `oracle-actionset-chat-completions.json` | one WasmPlugin action set |
+| `oracle-authconfig-site-a.json` | Authorino `AuthConfig` `spec` |
+| `oracle-limitador-site-a.json` | Limitador `spec.limits` |
+
+## Regenerating
+
+Regenerate when a new Kuadrant version changes the compiled output: apply the
+MaaS AuthPolicy and TokenRateLimitPolicy, export the generated WasmPlugin,
+AuthConfig, and Limitador, update these files, and bump the version above. The
+compiler tests compare route conditions and rate-limit bindings, not the
+internal name hashes, so hash differences across versions are expected.

--- a/maas-controller/pkg/controller/maas/testdata/oracle-actionset-chat-completions.json
+++ b/maas-controller/pkg/controller/maas/testdata/oracle-actionset-chat-completions.json
@@ -1,0 +1,48 @@
+{
+  "name": "468e50f9a4615ade432b54834f37d8ce85e02d98ac321ba0402829c58e8e3848",
+  "routeRuleConditions": {
+    "hostnames": ["site-a.example.com"],
+    "predicates": [
+      "request.url_path == '/v1/chat/completions'",
+      "request.headers.exists(h, h.lowerAscii() == 'x-gateway-model-name' && request.headers[h] == 'publishers/ai-tenant-site-a/models/Qwen/Qwen3-0.6B')"
+    ]
+  },
+  "actions": [
+    {
+      "service": "auth-service",
+      "scope": "410f8ee4ef0bb20b515d4c56db735b69d29d244f2091bfcb8bd32f5c93ef312f",
+      "sources": ["authpolicy.kuadrant.io:openshift-ingress/maas-site-a-gateway-maas-auth"],
+      "predicates": ["request.path != \"/maas-api/health\" || request.method != \"GET\""]
+    },
+    {
+      "service": "ratelimit-check-service",
+      "scope": "ai-tenant-site-a/qwen3-kserve-route",
+      "sources": ["tokenratelimitpolicy.kuadrant.io:ai-tenant-site-a/maas-trlp-qwen3"],
+      "conditionalData": [
+        {
+          "predicates": ["auth.identity.selected_subscription_key == \"ai-tenant-site-a/site-a-tier@ai-tenant-site-a/qwen3\" && !request.path.endsWith(\"/v1/models\")"],
+          "data": [
+            {"expression": {"key": "tokenlimit.ai_tenant_site_a_site_a_tier_qwen3_tokens__b42c1f29", "value": "1"}},
+            {"expression": {"key": "auth.identity.userid", "value": "auth.identity.userid"}},
+            {"expression": {"key": "ratelimit.hits_addend", "value": "0"}}
+          ]
+        }
+      ]
+    },
+    {
+      "service": "ratelimit-report-service",
+      "scope": "ai-tenant-site-a/qwen3-kserve-route",
+      "sources": ["tokenratelimitpolicy.kuadrant.io:ai-tenant-site-a/maas-trlp-qwen3"],
+      "conditionalData": [
+        {
+          "predicates": ["auth.identity.selected_subscription_key == \"ai-tenant-site-a/site-a-tier@ai-tenant-site-a/qwen3\" && !request.path.endsWith(\"/v1/models\")"],
+          "data": [
+            {"expression": {"key": "tokenlimit.ai_tenant_site_a_site_a_tier_qwen3_tokens__b42c1f29", "value": "1"}},
+            {"expression": {"key": "auth.identity.userid", "value": "auth.identity.userid"}},
+            {"expression": {"key": "ratelimit.hits_addend", "value": "responseBodyJSON(\"/usage/total_tokens\")"}}
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/maas-controller/pkg/controller/maas/testdata/oracle-authconfig-site-a.json
+++ b/maas-controller/pkg/controller/maas/testdata/oracle-authconfig-site-a.json
@@ -1,0 +1,286 @@
+{
+ "authentication": {
+  "api-keys": {
+   "credentials": {},
+   "metrics": false,
+   "plain": {
+    "selector": "request.headers.authorization"
+   },
+   "priority": 0,
+   "when": [
+    {
+     "operator": "matches",
+     "selector": "request.headers.authorization",
+     "value": "^Bearer sk-oai-.*"
+    }
+   ]
+  },
+  "openshift-identities": {
+   "credentials": {},
+   "kubernetesTokenReview": {
+    "audiences": [
+     "https://kubernetes.default.svc"
+    ]
+   },
+   "metrics": false,
+   "priority": 2,
+   "when": [
+    {
+     "predicate": "!request.headers.authorization.startsWith(\"Bearer sk-oai-\")"
+    }
+   ]
+  }
+ },
+ "authorization": {
+  "auth-valid": {
+   "cache": {
+    "key": {
+     "selector": "\"api-key|\" + (request.headers.authorization.replace(\"Bearer \", \"\")) + \"|\" + (size(request.path.split(\"/\").filter(x, x != \"\")) >= 2 && request.path.split(\"/\").filter(x, x != \"\")[0] != \"v1\" && request.path.split(\"/\").filter(x, x != \"\")[0] != \"maas-api\" ? request.path.split(\"/\").filter(x, x != \"\")[0] + \"/\" + request.path.split(\"/\").filter(x, x != \"\")[1] : (\"x-gateway-model-name\" in request.headers   ? request.headers[\"x-gateway-model-name\"]   : \"\"))"
+    },
+    "ttl": 60
+   },
+   "metrics": false,
+   "opa": {
+    "allValues": false,
+    "rego": "allow {\n  object.get(input.auth.metadata, \"apiKeyValidation\", {})\n  input.auth.metadata.apiKeyValidation.valid == true\n}\nallow {\n  not input.auth.metadata.apiKeyValidation\n}"
+   },
+   "priority": 0
+  },
+  "deny-client-identity-headers": {
+   "metrics": false,
+   "patternMatching": {
+    "patterns": [
+     {
+      "predicate": "!(\"x-maas-username\" in request.headers)"
+     },
+     {
+      "predicate": "!(\"x-maas-group\" in request.headers)"
+     }
+    ]
+   },
+   "priority": 0
+  },
+  "require-group-membership": {
+   "cache": {
+    "key": {
+     "selector": "((has(auth.metadata) && has(auth.metadata.apiKeyValidation)) ? auth.metadata.apiKeyValidation.userId : (has(auth.identity.preferred_username) ? auth.identity.preferred_username : (has(auth.identity.sub) ? auth.identity.sub : auth.identity.user.username))) + \"|\" + ((has(auth.metadata) && has(auth.metadata.apiKeyValidation)) ? auth.metadata.apiKeyValidation.groups : (has(auth.identity.groups) ? auth.identity.groups : auth.identity.user.groups)).join(\",\") + \"|\" + (size(request.path.split(\"/\").filter(x, x != \"\")) >= 2 && request.path.split(\"/\").filter(x, x != \"\")[0] != \"v1\" && request.path.split(\"/\").filter(x, x != \"\")[0] != \"maas-api\" ? request.path.split(\"/\").filter(x, x != \"\")[0] + \"/\" + request.path.split(\"/\").filter(x, x != \"\")[1] : (\"x-gateway-model-name\" in request.headers   ? request.headers[\"x-gateway-model-name\"]   : \"\"))"
+    },
+    "ttl": 60
+   },
+   "metrics": false,
+   "opa": {
+    "allValues": false,
+    "rego": "\nmodel_access := {\"ai-tenant-site-a/qwen3\":{\"users\":null,\"groups\":[\"system:authenticated\"]},\"publishers/ai-tenant-site-a/models/Qwen/Qwen3-0.6B\":{\"users\":null,\"groups\":[\"system:authenticated\"]}}\n\nrequest_path := object.get(input.context.request.http, \"path\", \"\")\nrequest_headers := object.get(input.context.request.http, \"headers\", {})\n\npath_parts := [p | p := split(request_path, \"/\")[_]; p != \"\"]\n\npath_model_identity := sprintf(\"%s/%s\", [path_parts[0], path_parts[1]]) {\n\tcount(path_parts) >= 2\n\tpath_parts[0] != \"v1\"\n\tpath_parts[0] != \"maas-api\"\n}\n\nheader_model_identity := object.get(request_headers, \"x-gateway-model-name\", \"\")\n\nmodel_identity := path_model_identity {\n\tpath_model_identity != \"\"\n} else := header_model_identity {\n\theader_model_identity != \"\"\n} else := \"\"\n\nusername := input.auth.metadata.apiKeyValidation.username\n\t{ object.get(input.auth, \"metadata\", {}).apiKeyValidation.username != \"\" }\nelse := input.auth.identity.preferred_username\n\t{ object.get(input.auth, \"identity\", {}).preferred_username != \"\" }\nelse := input.auth.identity.sub\n\t{ object.get(input.auth, \"identity\", {}).sub != \"\" }\nelse := input.auth.identity.user.username\n\t{ object.get(input.auth, \"identity\", {}).user.username != \"\" }\nelse := \"\"\n\ngroups := input.auth.metadata.apiKeyValidation.groups\n\t{ object.get(input.auth, \"metadata\", {}).apiKeyValidation.groups != [] }\nelse := input.auth.identity.groups\n\t{ object.get(input.auth, \"identity\", {}).groups != [] }\nelse := input.auth.identity.user.groups\n\t{ object.get(input.auth, \"identity\", {}).user.groups != [] }\nelse := []\n\nmodel_rules := object.get(model_access, model_identity, null)\n\n# Management endpoints (e.g. /v1/models, /maas-api/v1/api-keys) carry no model context.\n# Allow them here; subscription and rate-limit checks are gated by model-route conditions.\nallow {\n\tmodel_identity == \"\"\n}\n\n# Inference path: deny by default when no MaaSAuthPolicy covers this model.\n# Allow only when the caller's username or a group is explicitly listed.\nallow {\n\tmodel_rules != null\n\tmodel_rules.users[_] == username\n}\n\nallow {\n\tmodel_rules != null\n\tg := groups[_]\n\tmodel_rules.groups[_] == g\n}\n"
+   },
+   "priority": 0
+  },
+  "subscription-valid": {
+   "cache": {
+    "key": {
+     "selector": "((has(auth.metadata) && has(auth.metadata.apiKeyValidation)) ? auth.metadata.apiKeyValidation.userId : (has(auth.identity.preferred_username) ? auth.identity.preferred_username : (has(auth.identity.sub) ? auth.identity.sub : auth.identity.user.username))) + \"|\" + ((has(auth.metadata) && has(auth.metadata.apiKeyValidation)) ? auth.metadata.apiKeyValidation.groups : (has(auth.identity.groups) ? auth.identity.groups : auth.identity.user.groups)).join(\",\") + \"|\" + ((has(auth.metadata) && has(auth.metadata.apiKeyValidation)) ? auth.metadata.apiKeyValidation.subscription : (\"x-maas-subscription\" in request.headers ? request.headers[\"x-maas-subscription\"] : \"\")) + \"|\" + (size(request.path.split(\"/\").filter(x, x != \"\")) >= 2 && request.path.split(\"/\").filter(x, x != \"\")[0] != \"v1\" && request.path.split(\"/\").filter(x, x != \"\")[0] != \"maas-api\" ? request.path.split(\"/\").filter(x, x != \"\")[0] + \"/\" + request.path.split(\"/\").filter(x, x != \"\")[1] : (\"x-gateway-model-name\" in request.headers   ? request.headers[\"x-gateway-model-name\"]   : \"\"))"
+    },
+    "ttl": 60
+   },
+   "metrics": false,
+   "opa": {
+    "allValues": false,
+    "rego": "allow {\n\tobject.get(input.auth.metadata[\"subscription-info\"], \"name\", \"\") != \"\"\n\tobject.get(input.auth.metadata[\"subscription-info\"], \"error\", \"\") == \"\"\n\tphase := object.get(input.auth.metadata[\"subscription-info\"], \"phase\", \"\")\n\tany([phase == \"Active\", phase == \"Degraded\"])\n\tobject.get(input.auth.metadata[\"subscription-info\"], \"deletionTimestamp\", \"\") == \"\"\n}"
+   },
+   "priority": 0,
+   "when": [
+    {
+     "predicate": "(size(request.path.split(\"/\").filter(x, x != \"\")) >= 2 && request.path.split(\"/\").filter(x, x != \"\")[0] != \"v1\" && request.path.split(\"/\").filter(x, x != \"\")[0] != \"maas-api\" || \"x-gateway-model-name\" in request.headers)"
+    }
+   ]
+  },
+  "tenant-gateway-isolation": {
+   "metrics": false,
+   "opa": {
+    "allValues": false,
+    "rego": "# Tenant hostname isolation stub.\n# Replace with a real maas-api call to validate that the API key's tenant\n# matches the gateway hostname (prevents Coke key on Pepsi gateway).\nallow { true }"
+   },
+   "priority": 0
+  }
+ },
+ "hosts": [
+  "1a07c4c259ae5ccbdb664ec4cc466b61fb3b40e501526de43dfef1e068827ab7"
+ ],
+ "metadata": {
+  "apiKeyValidation": {
+   "cache": {
+    "key": {
+     "selector": "request.headers.authorization.replace(\"Bearer \", \"\")"
+    },
+    "ttl": 60
+   },
+   "http": {
+    "body": {
+     "expression": "{\"key\": request.headers.authorization.replace(\"Bearer \", \"\")}"
+    },
+    "contentType": "application/json",
+    "credentials": {},
+    "method": "POST",
+    "url": "https://maas-api-site-a.redhat-ai-gateway-infra.svc.cluster.local:8443/internal/v1/api-keys/validate"
+   },
+   "metrics": false,
+   "priority": 0,
+   "when": [
+    {
+     "predicate": "request.headers.authorization.matches(\"^Bearer sk-oai-.*\")"
+    }
+   ]
+  },
+  "subscription-info": {
+   "cache": {
+    "key": {
+     "selector": "((has(auth.metadata) && has(auth.metadata.apiKeyValidation)) ? auth.metadata.apiKeyValidation.userId : (has(auth.identity.preferred_username) ? auth.identity.preferred_username : (has(auth.identity.sub) ? auth.identity.sub : auth.identity.user.username))) + \"|\" + ((has(auth.metadata) && has(auth.metadata.apiKeyValidation)) ? auth.metadata.apiKeyValidation.groups : (has(auth.identity.groups) ? auth.identity.groups : auth.identity.user.groups)).join(\",\") + \"|\" + ((has(auth.metadata) && has(auth.metadata.apiKeyValidation)) ? auth.metadata.apiKeyValidation.subscription : (\"x-maas-subscription\" in request.headers ? request.headers[\"x-maas-subscription\"] : \"\")) + \"|\" + (size(request.path.split(\"/\").filter(x, x != \"\")) >= 2 && request.path.split(\"/\").filter(x, x != \"\")[0] != \"v1\" && request.path.split(\"/\").filter(x, x != \"\")[0] != \"maas-api\" ? request.path.split(\"/\").filter(x, x != \"\")[0] + \"/\" + request.path.split(\"/\").filter(x, x != \"\")[1] : (\"x-gateway-model-name\" in request.headers   ? request.headers[\"x-gateway-model-name\"]   : \"\"))"
+    },
+    "ttl": 60
+   },
+   "http": {
+    "body": {
+     "expression": "{\n  \"groups\": (has(auth.metadata) && has(auth.metadata.apiKeyValidation)) ? auth.metadata.apiKeyValidation.groups : (has(auth.identity.groups) ? auth.identity.groups : auth.identity.user.groups),\n  \"username\": (has(auth.metadata) && has(auth.metadata.apiKeyValidation)) ? auth.metadata.apiKeyValidation.username : (has(auth.identity.preferred_username) ? auth.identity.preferred_username : (has(auth.identity.sub) ? auth.identity.sub : auth.identity.user.username)),\n  \"requestedSubscription\": (has(auth.metadata) && has(auth.metadata.apiKeyValidation)) ? auth.metadata.apiKeyValidation.subscription : (\"x-maas-subscription\" in request.headers ? request.headers[\"x-maas-subscription\"] : \"\"),\n  \"requestedModel\": (size(request.path.split(\"/\").filter(x, x != \"\")) >= 2 && request.path.split(\"/\").filter(x, x != \"\")[0] != \"v1\" && request.path.split(\"/\").filter(x, x != \"\")[0] != \"maas-api\" ? request.path.split(\"/\").filter(x, x != \"\")[0] + \"/\" + request.path.split(\"/\").filter(x, x != \"\")[1] : (\"x-gateway-model-name\" in request.headers   ? request.headers[\"x-gateway-model-name\"]   : \"\"))\n}"
+    },
+    "contentType": "application/json",
+    "credentials": {},
+    "method": "POST",
+    "url": "https://maas-api-site-a.redhat-ai-gateway-infra.svc.cluster.local:8443/internal/v1/subscriptions/select"
+   },
+   "metrics": false,
+   "priority": 1,
+   "when": [
+    {
+     "predicate": "(size(request.path.split(\"/\").filter(x, x != \"\")) >= 2 && request.path.split(\"/\").filter(x, x != \"\")[0] != \"v1\" && request.path.split(\"/\").filter(x, x != \"\")[0] != \"maas-api\" || \"x-gateway-model-name\" in request.headers)"
+    }
+   ]
+  }
+ },
+ "response": {
+  "success": {
+   "dynamicMetadata": {
+    "identity": {
+     "json": {
+      "properties": {
+       "groups": {
+        "expression": "(has(auth.metadata) && has(auth.metadata.apiKeyValidation)) ? auth.metadata.apiKeyValidation.groups : (has(auth.identity.groups) ? auth.identity.groups : auth.identity.user.groups)"
+       },
+       "groups_str": {
+        "expression": "((has(auth.metadata) && has(auth.metadata.apiKeyValidation)) ? auth.metadata.apiKeyValidation.groups : (has(auth.identity.groups) ? auth.identity.groups : auth.identity.user.groups)).join(\",\")"
+       },
+       "keyId": {
+        "expression": "(has(auth.metadata) && has(auth.metadata.apiKeyValidation)) ? auth.metadata.apiKeyValidation.keyId : \"\""
+       },
+       "keyName": {
+        "expression": "(has(auth.metadata) && has(auth.metadata.apiKeyValidation)) ? auth.metadata.apiKeyValidation.keyName : \"\""
+       },
+       "selected_subscription": {
+        "expression": "has(auth.metadata[\"subscription-info\"].name) ? auth.metadata[\"subscription-info\"].name : \"\""
+       },
+       "selected_subscription_key": {
+        "expression": "(has(auth.metadata[\"subscription-info\"].namespace) && has(auth.metadata[\"subscription-info\"].name)) ? auth.metadata[\"subscription-info\"].namespace + \"/\" + auth.metadata[\"subscription-info\"].name + \"@\" + (has(auth.metadata[\"subscription-info\"].resolvedModel) && auth.metadata[\"subscription-info\"].resolvedModel != \"\" ? auth.metadata[\"subscription-info\"].resolvedModel : (size(request.path.split(\"/\").filter(x, x != \"\")) >= 2 && request.path.split(\"/\").filter(x, x != \"\")[0] != \"v1\" && request.path.split(\"/\").filter(x, x != \"\")[0] != \"maas-api\" ? request.path.split(\"/\").filter(x, x != \"\")[0] + \"/\" + request.path.split(\"/\").filter(x, x != \"\")[1] : (\"x-gateway-model-name\" in request.headers   ? request.headers[\"x-gateway-model-name\"]   : \"\"))) : \"\""
+       },
+       "subscription_error": {
+        "expression": "has(auth.metadata[\"subscription-info\"].error) ? auth.metadata[\"subscription-info\"].error : \"\""
+       },
+       "subscription_error_message": {
+        "expression": "has(auth.metadata[\"subscription-info\"].message) ? auth.metadata[\"subscription-info\"].message : \"\""
+       },
+       "subscription_info": {
+        "expression": "has(auth.metadata[\"subscription-info\"].name) ? auth.metadata[\"subscription-info\"] : {}"
+       },
+       "userid": {
+        "expression": "(has(auth.metadata) && has(auth.metadata.apiKeyValidation)) ? auth.metadata.apiKeyValidation.username : (has(auth.identity.preferred_username) ? auth.identity.preferred_username : (has(auth.identity.sub) ? auth.identity.sub : auth.identity.user.username))"
+       }
+      }
+     },
+     "metrics": true,
+     "priority": 0
+    }
+   },
+   "headers": {
+    "X-MaaS-Group": {
+     "metrics": false,
+     "plain": {
+      "expression": "size(auth.metadata.apiKeyValidation.groups) > 0 ? '[\"' + auth.metadata.apiKeyValidation.groups.join('\",\"') + '\"]' : '[]'"
+     },
+     "priority": 0,
+     "when": [
+      {
+       "predicate": "request.headers.authorization.matches(\"^Bearer sk-oai-.*\")"
+      }
+     ]
+    },
+    "X-MaaS-Group-Token": {
+     "key": "X-MaaS-Group",
+     "metrics": false,
+     "plain": {
+      "expression": "has(auth.identity.groups) ? (size(auth.identity.groups) > 0 && auth.identity.groups.all(g, g.matches('^[A-Za-z0-9:._/-]+$')) ? '[\"system:authenticated\",\"' + auth.identity.groups.join('\",\"') + '\"]' : '[\"system:authenticated\"]') : (has(auth.identity.user.groups) && size(auth.identity.user.groups) > 0 ? '[\"system:authenticated\",\"' + auth.identity.user.groups.join('\",\"') + '\"]' : '[\"system:authenticated\"]')"
+     },
+     "priority": 1,
+     "when": [
+      {
+       "predicate": "!request.headers.authorization.startsWith(\"Bearer sk-oai-\")"
+      }
+     ]
+    },
+    "X-MaaS-Subscription": {
+     "metrics": false,
+     "plain": {
+      "expression": "(has(auth.metadata) && has(auth.metadata.apiKeyValidation)) ? auth.metadata.apiKeyValidation.subscription : (\"x-maas-subscription\" in request.headers ? request.headers[\"x-maas-subscription\"] : \"\")"
+     },
+     "priority": 0,
+     "when": [
+      {
+       "predicate": "(has(auth.metadata) && has(auth.metadata.apiKeyValidation) && auth.metadata.apiKeyValidation.subscription != \"\") || \"x-maas-subscription\" in request.headers"
+      }
+     ]
+    },
+    "X-MaaS-Username": {
+     "metrics": false,
+     "plain": {
+      "selector": "auth.metadata.apiKeyValidation.username"
+     },
+     "priority": 0,
+     "when": [
+      {
+       "predicate": "request.headers.authorization.matches(\"^Bearer sk-oai-.*\")"
+      }
+     ]
+    },
+    "X-MaaS-Username-Token": {
+     "key": "X-MaaS-Username",
+     "metrics": false,
+     "plain": {
+      "expression": "has(auth.identity.preferred_username) ? auth.identity.preferred_username : (has(auth.identity.sub) ? auth.identity.sub : auth.identity.user.username)"
+     },
+     "priority": 1,
+     "when": [
+      {
+       "predicate": "!request.headers.authorization.startsWith(\"Bearer sk-oai-\")"
+      }
+     ]
+    }
+   }
+  },
+  "unauthenticated": {
+   "code": 401,
+   "message": {
+    "value": "Authentication required"
+   }
+  },
+  "unauthorized": {
+   "body": {
+    "expression": "has(auth.metadata[\"subscription-info\"].message) ? auth.metadata[\"subscription-info\"].message : \"Access denied\""
+   },
+   "code": 403,
+   "headers": {
+    "content-type": {
+     "value": "text/plain"
+    },
+    "x-ext-auth-reason": {
+     "expression": "has(auth.metadata[\"subscription-info\"].error) ? auth.metadata[\"subscription-info\"].error : \"unauthorized\""
+    }
+   }
+  }
+ }
+}

--- a/maas-controller/pkg/controller/maas/testdata/oracle-limitador-site-a.json
+++ b/maas-controller/pkg/controller/maas/testdata/oracle-limitador-site-a.json
@@ -1,0 +1,26 @@
+[
+ {
+  "conditions": [
+   "descriptors[0][\"tokenlimit.ai_tenant_site_a_site_a_tier_qwen3_tokens__b42c1f29\"] == \"1\""
+  ],
+  "max_value": 200000,
+  "name": "ai-tenant-site-a-site-a-tier-qwen3-tokens",
+  "namespace": "ai-tenant-site-a/qwen3-kserve-route",
+  "seconds": 3600,
+  "variables": [
+   "descriptors[0][\"auth.identity.userid\"]"
+  ]
+ },
+ {
+  "conditions": [
+   "descriptors[0][\"tokenlimit.deny_all_by_default__d3136ae7\"] == \"1\""
+  ],
+  "max_value": 0,
+  "name": "deny-all-by-default",
+  "namespace": "redhat-ai-gateway-infra/maas-api-route-site-a",
+  "seconds": 60,
+  "variables": [
+   "descriptors[0][\"auth.identity.userid\"]"
+  ]
+ }
+]

--- a/maas-controller/pkg/controller/maas/testdata/oracle-pluginconfig-site-a.json
+++ b/maas-controller/pkg/controller/maas/testdata/oracle-pluginconfig-site-a.json
@@ -1,0 +1,2132 @@
+{
+ "actionSets": [
+  {
+   "actions": [
+    {
+     "predicates": [
+      "request.path != \"/maas-api/health\" || request.method != \"GET\""
+     ],
+     "scope": "410f8ee4ef0bb20b515d4c56db735b69d29d244f2091bfcb8bd32f5c93ef312f",
+     "service": "auth-service",
+     "sources": [
+      "authpolicy.kuadrant.io:openshift-ingress/maas-site-a-gateway-maas-auth"
+     ]
+    },
+    {
+     "conditionalData": [
+      {
+       "data": [
+        {
+         "expression": {
+          "key": "tokenlimit.ai_tenant_site_a_site_a_tier_qwen3_tokens__b42c1f29",
+          "value": "1"
+         }
+        },
+        {
+         "expression": {
+          "key": "auth.identity.userid",
+          "value": "auth.identity.userid"
+         }
+        },
+        {
+         "expression": {
+          "key": "ratelimit.hits_addend",
+          "value": "0"
+         }
+        }
+       ],
+       "predicates": [
+        "auth.identity.selected_subscription_key == \"ai-tenant-site-a/site-a-tier@ai-tenant-site-a/qwen3\" && !request.path.endsWith(\"/v1/models\")"
+       ]
+      }
+     ],
+     "scope": "ai-tenant-site-a/qwen3-kserve-route",
+     "service": "ratelimit-check-service",
+     "sources": [
+      "tokenratelimitpolicy.kuadrant.io:ai-tenant-site-a/maas-trlp-qwen3"
+     ]
+    },
+    {
+     "conditionalData": [
+      {
+       "data": [
+        {
+         "expression": {
+          "key": "tokenlimit.ai_tenant_site_a_site_a_tier_qwen3_tokens__b42c1f29",
+          "value": "1"
+         }
+        },
+        {
+         "expression": {
+          "key": "auth.identity.userid",
+          "value": "auth.identity.userid"
+         }
+        },
+        {
+         "expression": {
+          "key": "ratelimit.hits_addend",
+          "value": "responseBodyJSON(\"/usage/total_tokens\")"
+         }
+        }
+       ],
+       "predicates": [
+        "auth.identity.selected_subscription_key == \"ai-tenant-site-a/site-a-tier@ai-tenant-site-a/qwen3\" && !request.path.endsWith(\"/v1/models\")"
+       ]
+      }
+     ],
+     "scope": "ai-tenant-site-a/qwen3-kserve-route",
+     "service": "ratelimit-report-service",
+     "sources": [
+      "tokenratelimitpolicy.kuadrant.io:ai-tenant-site-a/maas-trlp-qwen3"
+     ]
+    }
+   ],
+   "name": "e00320cf06fef706a33db4c6d166f654826cac7f7a28c6eb1c8f677c13bd472d",
+   "routeRuleConditions": {
+    "hostnames": [
+     "site-a.example.com"
+    ],
+    "predicates": [
+     "request.url_path == '/v1/chat/completions/'",
+     "request.headers.exists(h, h.lowerAscii() == 'x-gateway-model-name' && request.headers[h] == 'publishers/ai-tenant-site-a/models/Qwen/Qwen3-0.6B')"
+    ]
+   }
+  },
+  {
+   "actions": [
+    {
+     "predicates": [
+      "request.path != \"/maas-api/health\" || request.method != \"GET\""
+     ],
+     "scope": "410f8ee4ef0bb20b515d4c56db735b69d29d244f2091bfcb8bd32f5c93ef312f",
+     "service": "auth-service",
+     "sources": [
+      "authpolicy.kuadrant.io:openshift-ingress/maas-site-a-gateway-maas-auth"
+     ]
+    },
+    {
+     "conditionalData": [
+      {
+       "data": [
+        {
+         "expression": {
+          "key": "tokenlimit.ai_tenant_site_a_site_a_tier_qwen3_tokens__b42c1f29",
+          "value": "1"
+         }
+        },
+        {
+         "expression": {
+          "key": "auth.identity.userid",
+          "value": "auth.identity.userid"
+         }
+        },
+        {
+         "expression": {
+          "key": "ratelimit.hits_addend",
+          "value": "0"
+         }
+        }
+       ],
+       "predicates": [
+        "auth.identity.selected_subscription_key == \"ai-tenant-site-a/site-a-tier@ai-tenant-site-a/qwen3\" && !request.path.endsWith(\"/v1/models\")"
+       ]
+      }
+     ],
+     "scope": "ai-tenant-site-a/qwen3-kserve-route",
+     "service": "ratelimit-check-service",
+     "sources": [
+      "tokenratelimitpolicy.kuadrant.io:ai-tenant-site-a/maas-trlp-qwen3"
+     ]
+    },
+    {
+     "conditionalData": [
+      {
+       "data": [
+        {
+         "expression": {
+          "key": "tokenlimit.ai_tenant_site_a_site_a_tier_qwen3_tokens__b42c1f29",
+          "value": "1"
+         }
+        },
+        {
+         "expression": {
+          "key": "auth.identity.userid",
+          "value": "auth.identity.userid"
+         }
+        },
+        {
+         "expression": {
+          "key": "ratelimit.hits_addend",
+          "value": "responseBodyJSON(\"/usage/total_tokens\")"
+         }
+        }
+       ],
+       "predicates": [
+        "auth.identity.selected_subscription_key == \"ai-tenant-site-a/site-a-tier@ai-tenant-site-a/qwen3\" && !request.path.endsWith(\"/v1/models\")"
+       ]
+      }
+     ],
+     "scope": "ai-tenant-site-a/qwen3-kserve-route",
+     "service": "ratelimit-report-service",
+     "sources": [
+      "tokenratelimitpolicy.kuadrant.io:ai-tenant-site-a/maas-trlp-qwen3"
+     ]
+    }
+   ],
+   "name": "468e50f9a4615ade432b54834f37d8ce85e02d98ac321ba0402829c58e8e3848",
+   "routeRuleConditions": {
+    "hostnames": [
+     "site-a.example.com"
+    ],
+    "predicates": [
+     "request.url_path == '/v1/chat/completions'",
+     "request.headers.exists(h, h.lowerAscii() == 'x-gateway-model-name' && request.headers[h] == 'publishers/ai-tenant-site-a/models/Qwen/Qwen3-0.6B')"
+    ]
+   }
+  },
+  {
+   "actions": [
+    {
+     "predicates": [
+      "request.path != \"/maas-api/health\" || request.method != \"GET\""
+     ],
+     "scope": "410f8ee4ef0bb20b515d4c56db735b69d29d244f2091bfcb8bd32f5c93ef312f",
+     "service": "auth-service",
+     "sources": [
+      "authpolicy.kuadrant.io:openshift-ingress/maas-site-a-gateway-maas-auth"
+     ]
+    },
+    {
+     "conditionalData": [
+      {
+       "data": [
+        {
+         "expression": {
+          "key": "tokenlimit.ai_tenant_site_a_site_a_tier_qwen3_tokens__b42c1f29",
+          "value": "1"
+         }
+        },
+        {
+         "expression": {
+          "key": "auth.identity.userid",
+          "value": "auth.identity.userid"
+         }
+        },
+        {
+         "expression": {
+          "key": "ratelimit.hits_addend",
+          "value": "0"
+         }
+        }
+       ],
+       "predicates": [
+        "auth.identity.selected_subscription_key == \"ai-tenant-site-a/site-a-tier@ai-tenant-site-a/qwen3\" && !request.path.endsWith(\"/v1/models\")"
+       ]
+      }
+     ],
+     "scope": "ai-tenant-site-a/qwen3-kserve-route",
+     "service": "ratelimit-check-service",
+     "sources": [
+      "tokenratelimitpolicy.kuadrant.io:ai-tenant-site-a/maas-trlp-qwen3"
+     ]
+    },
+    {
+     "conditionalData": [
+      {
+       "data": [
+        {
+         "expression": {
+          "key": "tokenlimit.ai_tenant_site_a_site_a_tier_qwen3_tokens__b42c1f29",
+          "value": "1"
+         }
+        },
+        {
+         "expression": {
+          "key": "auth.identity.userid",
+          "value": "auth.identity.userid"
+         }
+        },
+        {
+         "expression": {
+          "key": "ratelimit.hits_addend",
+          "value": "responseBodyJSON(\"/usage/total_tokens\")"
+         }
+        }
+       ],
+       "predicates": [
+        "auth.identity.selected_subscription_key == \"ai-tenant-site-a/site-a-tier@ai-tenant-site-a/qwen3\" && !request.path.endsWith(\"/v1/models\")"
+       ]
+      }
+     ],
+     "scope": "ai-tenant-site-a/qwen3-kserve-route",
+     "service": "ratelimit-report-service",
+     "sources": [
+      "tokenratelimitpolicy.kuadrant.io:ai-tenant-site-a/maas-trlp-qwen3"
+     ]
+    }
+   ],
+   "name": "96814282a42fbf9cb9598184a9bbd8a539657004c8c1ace5e39813e0ff9d8476",
+   "routeRuleConditions": {
+    "hostnames": [
+     "site-a.example.com"
+    ],
+    "predicates": [
+     "request.url_path == '/v1/completions/'",
+     "request.headers.exists(h, h.lowerAscii() == 'x-gateway-model-name' && request.headers[h] == 'publishers/ai-tenant-site-a/models/Qwen/Qwen3-0.6B')"
+    ]
+   }
+  },
+  {
+   "actions": [
+    {
+     "predicates": [
+      "request.path != \"/maas-api/health\" || request.method != \"GET\""
+     ],
+     "scope": "410f8ee4ef0bb20b515d4c56db735b69d29d244f2091bfcb8bd32f5c93ef312f",
+     "service": "auth-service",
+     "sources": [
+      "authpolicy.kuadrant.io:openshift-ingress/maas-site-a-gateway-maas-auth"
+     ]
+    },
+    {
+     "conditionalData": [
+      {
+       "data": [
+        {
+         "expression": {
+          "key": "tokenlimit.ai_tenant_site_a_site_a_tier_qwen3_tokens__b42c1f29",
+          "value": "1"
+         }
+        },
+        {
+         "expression": {
+          "key": "auth.identity.userid",
+          "value": "auth.identity.userid"
+         }
+        },
+        {
+         "expression": {
+          "key": "ratelimit.hits_addend",
+          "value": "0"
+         }
+        }
+       ],
+       "predicates": [
+        "auth.identity.selected_subscription_key == \"ai-tenant-site-a/site-a-tier@ai-tenant-site-a/qwen3\" && !request.path.endsWith(\"/v1/models\")"
+       ]
+      }
+     ],
+     "scope": "ai-tenant-site-a/qwen3-kserve-route",
+     "service": "ratelimit-check-service",
+     "sources": [
+      "tokenratelimitpolicy.kuadrant.io:ai-tenant-site-a/maas-trlp-qwen3"
+     ]
+    },
+    {
+     "conditionalData": [
+      {
+       "data": [
+        {
+         "expression": {
+          "key": "tokenlimit.ai_tenant_site_a_site_a_tier_qwen3_tokens__b42c1f29",
+          "value": "1"
+         }
+        },
+        {
+         "expression": {
+          "key": "auth.identity.userid",
+          "value": "auth.identity.userid"
+         }
+        },
+        {
+         "expression": {
+          "key": "ratelimit.hits_addend",
+          "value": "responseBodyJSON(\"/usage/total_tokens\")"
+         }
+        }
+       ],
+       "predicates": [
+        "auth.identity.selected_subscription_key == \"ai-tenant-site-a/site-a-tier@ai-tenant-site-a/qwen3\" && !request.path.endsWith(\"/v1/models\")"
+       ]
+      }
+     ],
+     "scope": "ai-tenant-site-a/qwen3-kserve-route",
+     "service": "ratelimit-report-service",
+     "sources": [
+      "tokenratelimitpolicy.kuadrant.io:ai-tenant-site-a/maas-trlp-qwen3"
+     ]
+    }
+   ],
+   "name": "10334ced6f431f90098e62fd0172640da9b83c99063d0f38aa2261be79bd2fe9",
+   "routeRuleConditions": {
+    "hostnames": [
+     "site-a.example.com"
+    ],
+    "predicates": [
+     "request.url_path == '/v1/completions'",
+     "request.headers.exists(h, h.lowerAscii() == 'x-gateway-model-name' && request.headers[h] == 'publishers/ai-tenant-site-a/models/Qwen/Qwen3-0.6B')"
+    ]
+   }
+  },
+  {
+   "actions": [
+    {
+     "predicates": [
+      "request.path != \"/maas-api/health\" || request.method != \"GET\""
+     ],
+     "scope": "410f8ee4ef0bb20b515d4c56db735b69d29d244f2091bfcb8bd32f5c93ef312f",
+     "service": "auth-service",
+     "sources": [
+      "authpolicy.kuadrant.io:openshift-ingress/maas-site-a-gateway-maas-auth"
+     ]
+    },
+    {
+     "conditionalData": [
+      {
+       "data": [
+        {
+         "expression": {
+          "key": "tokenlimit.ai_tenant_site_a_site_a_tier_qwen3_tokens__b42c1f29",
+          "value": "1"
+         }
+        },
+        {
+         "expression": {
+          "key": "auth.identity.userid",
+          "value": "auth.identity.userid"
+         }
+        },
+        {
+         "expression": {
+          "key": "ratelimit.hits_addend",
+          "value": "0"
+         }
+        }
+       ],
+       "predicates": [
+        "auth.identity.selected_subscription_key == \"ai-tenant-site-a/site-a-tier@ai-tenant-site-a/qwen3\" && !request.path.endsWith(\"/v1/models\")"
+       ]
+      }
+     ],
+     "scope": "ai-tenant-site-a/qwen3-kserve-route",
+     "service": "ratelimit-check-service",
+     "sources": [
+      "tokenratelimitpolicy.kuadrant.io:ai-tenant-site-a/maas-trlp-qwen3"
+     ]
+    },
+    {
+     "conditionalData": [
+      {
+       "data": [
+        {
+         "expression": {
+          "key": "tokenlimit.ai_tenant_site_a_site_a_tier_qwen3_tokens__b42c1f29",
+          "value": "1"
+         }
+        },
+        {
+         "expression": {
+          "key": "auth.identity.userid",
+          "value": "auth.identity.userid"
+         }
+        },
+        {
+         "expression": {
+          "key": "ratelimit.hits_addend",
+          "value": "responseBodyJSON(\"/usage/total_tokens\")"
+         }
+        }
+       ],
+       "predicates": [
+        "auth.identity.selected_subscription_key == \"ai-tenant-site-a/site-a-tier@ai-tenant-site-a/qwen3\" && !request.path.endsWith(\"/v1/models\")"
+       ]
+      }
+     ],
+     "scope": "ai-tenant-site-a/qwen3-kserve-route",
+     "service": "ratelimit-report-service",
+     "sources": [
+      "tokenratelimitpolicy.kuadrant.io:ai-tenant-site-a/maas-trlp-qwen3"
+     ]
+    }
+   ],
+   "name": "f07a772aebc6df3768d1621e6d8c23f2dc25e4ce2425db79231ffa01660e346c",
+   "routeRuleConditions": {
+    "hostnames": [
+     "site-a.example.com"
+    ],
+    "predicates": [
+     "request.url_path == '/v1/responses/'",
+     "request.headers.exists(h, h.lowerAscii() == 'x-gateway-model-name' && request.headers[h] == 'publishers/ai-tenant-site-a/models/Qwen/Qwen3-0.6B')"
+    ]
+   }
+  },
+  {
+   "actions": [
+    {
+     "predicates": [
+      "request.path != \"/maas-api/health\" || request.method != \"GET\""
+     ],
+     "scope": "410f8ee4ef0bb20b515d4c56db735b69d29d244f2091bfcb8bd32f5c93ef312f",
+     "service": "auth-service",
+     "sources": [
+      "authpolicy.kuadrant.io:openshift-ingress/maas-site-a-gateway-maas-auth"
+     ]
+    },
+    {
+     "conditionalData": [
+      {
+       "data": [
+        {
+         "expression": {
+          "key": "tokenlimit.ai_tenant_site_a_site_a_tier_qwen3_tokens__b42c1f29",
+          "value": "1"
+         }
+        },
+        {
+         "expression": {
+          "key": "auth.identity.userid",
+          "value": "auth.identity.userid"
+         }
+        },
+        {
+         "expression": {
+          "key": "ratelimit.hits_addend",
+          "value": "0"
+         }
+        }
+       ],
+       "predicates": [
+        "auth.identity.selected_subscription_key == \"ai-tenant-site-a/site-a-tier@ai-tenant-site-a/qwen3\" && !request.path.endsWith(\"/v1/models\")"
+       ]
+      }
+     ],
+     "scope": "ai-tenant-site-a/qwen3-kserve-route",
+     "service": "ratelimit-check-service",
+     "sources": [
+      "tokenratelimitpolicy.kuadrant.io:ai-tenant-site-a/maas-trlp-qwen3"
+     ]
+    },
+    {
+     "conditionalData": [
+      {
+       "data": [
+        {
+         "expression": {
+          "key": "tokenlimit.ai_tenant_site_a_site_a_tier_qwen3_tokens__b42c1f29",
+          "value": "1"
+         }
+        },
+        {
+         "expression": {
+          "key": "auth.identity.userid",
+          "value": "auth.identity.userid"
+         }
+        },
+        {
+         "expression": {
+          "key": "ratelimit.hits_addend",
+          "value": "responseBodyJSON(\"/usage/total_tokens\")"
+         }
+        }
+       ],
+       "predicates": [
+        "auth.identity.selected_subscription_key == \"ai-tenant-site-a/site-a-tier@ai-tenant-site-a/qwen3\" && !request.path.endsWith(\"/v1/models\")"
+       ]
+      }
+     ],
+     "scope": "ai-tenant-site-a/qwen3-kserve-route",
+     "service": "ratelimit-report-service",
+     "sources": [
+      "tokenratelimitpolicy.kuadrant.io:ai-tenant-site-a/maas-trlp-qwen3"
+     ]
+    }
+   ],
+   "name": "8c796b760975e3612dd49b0ba2048aaacc857808312c798f77835d2e99980243",
+   "routeRuleConditions": {
+    "hostnames": [
+     "site-a.example.com"
+    ],
+    "predicates": [
+     "request.url_path == '/v1/messages/'",
+     "request.headers.exists(h, h.lowerAscii() == 'x-gateway-model-name' && request.headers[h] == 'publishers/ai-tenant-site-a/models/Qwen/Qwen3-0.6B')"
+    ]
+   }
+  },
+  {
+   "actions": [
+    {
+     "predicates": [
+      "request.path != \"/maas-api/health\" || request.method != \"GET\""
+     ],
+     "scope": "410f8ee4ef0bb20b515d4c56db735b69d29d244f2091bfcb8bd32f5c93ef312f",
+     "service": "auth-service",
+     "sources": [
+      "authpolicy.kuadrant.io:openshift-ingress/maas-site-a-gateway-maas-auth"
+     ]
+    },
+    {
+     "conditionalData": [
+      {
+       "data": [
+        {
+         "expression": {
+          "key": "tokenlimit.ai_tenant_site_a_site_a_tier_qwen3_tokens__b42c1f29",
+          "value": "1"
+         }
+        },
+        {
+         "expression": {
+          "key": "auth.identity.userid",
+          "value": "auth.identity.userid"
+         }
+        },
+        {
+         "expression": {
+          "key": "ratelimit.hits_addend",
+          "value": "0"
+         }
+        }
+       ],
+       "predicates": [
+        "auth.identity.selected_subscription_key == \"ai-tenant-site-a/site-a-tier@ai-tenant-site-a/qwen3\" && !request.path.endsWith(\"/v1/models\")"
+       ]
+      }
+     ],
+     "scope": "ai-tenant-site-a/qwen3-kserve-route",
+     "service": "ratelimit-check-service",
+     "sources": [
+      "tokenratelimitpolicy.kuadrant.io:ai-tenant-site-a/maas-trlp-qwen3"
+     ]
+    },
+    {
+     "conditionalData": [
+      {
+       "data": [
+        {
+         "expression": {
+          "key": "tokenlimit.ai_tenant_site_a_site_a_tier_qwen3_tokens__b42c1f29",
+          "value": "1"
+         }
+        },
+        {
+         "expression": {
+          "key": "auth.identity.userid",
+          "value": "auth.identity.userid"
+         }
+        },
+        {
+         "expression": {
+          "key": "ratelimit.hits_addend",
+          "value": "responseBodyJSON(\"/usage/total_tokens\")"
+         }
+        }
+       ],
+       "predicates": [
+        "auth.identity.selected_subscription_key == \"ai-tenant-site-a/site-a-tier@ai-tenant-site-a/qwen3\" && !request.path.endsWith(\"/v1/models\")"
+       ]
+      }
+     ],
+     "scope": "ai-tenant-site-a/qwen3-kserve-route",
+     "service": "ratelimit-report-service",
+     "sources": [
+      "tokenratelimitpolicy.kuadrant.io:ai-tenant-site-a/maas-trlp-qwen3"
+     ]
+    }
+   ],
+   "name": "8f9253af731e56e0dd5809ac4c0eeb3d47aa3252413e8b5d71a2660596d54ad9",
+   "routeRuleConditions": {
+    "hostnames": [
+     "site-a.example.com"
+    ],
+    "predicates": [
+     "request.url_path == '/v1/responses'",
+     "request.headers.exists(h, h.lowerAscii() == 'x-gateway-model-name' && request.headers[h] == 'publishers/ai-tenant-site-a/models/Qwen/Qwen3-0.6B')"
+    ]
+   }
+  },
+  {
+   "actions": [
+    {
+     "predicates": [
+      "request.path != \"/maas-api/health\" || request.method != \"GET\""
+     ],
+     "scope": "410f8ee4ef0bb20b515d4c56db735b69d29d244f2091bfcb8bd32f5c93ef312f",
+     "service": "auth-service",
+     "sources": [
+      "authpolicy.kuadrant.io:openshift-ingress/maas-site-a-gateway-maas-auth"
+     ]
+    },
+    {
+     "conditionalData": [
+      {
+       "data": [
+        {
+         "expression": {
+          "key": "tokenlimit.ai_tenant_site_a_site_a_tier_qwen3_tokens__b42c1f29",
+          "value": "1"
+         }
+        },
+        {
+         "expression": {
+          "key": "auth.identity.userid",
+          "value": "auth.identity.userid"
+         }
+        },
+        {
+         "expression": {
+          "key": "ratelimit.hits_addend",
+          "value": "0"
+         }
+        }
+       ],
+       "predicates": [
+        "auth.identity.selected_subscription_key == \"ai-tenant-site-a/site-a-tier@ai-tenant-site-a/qwen3\" && !request.path.endsWith(\"/v1/models\")"
+       ]
+      }
+     ],
+     "scope": "ai-tenant-site-a/qwen3-kserve-route",
+     "service": "ratelimit-check-service",
+     "sources": [
+      "tokenratelimitpolicy.kuadrant.io:ai-tenant-site-a/maas-trlp-qwen3"
+     ]
+    },
+    {
+     "conditionalData": [
+      {
+       "data": [
+        {
+         "expression": {
+          "key": "tokenlimit.ai_tenant_site_a_site_a_tier_qwen3_tokens__b42c1f29",
+          "value": "1"
+         }
+        },
+        {
+         "expression": {
+          "key": "auth.identity.userid",
+          "value": "auth.identity.userid"
+         }
+        },
+        {
+         "expression": {
+          "key": "ratelimit.hits_addend",
+          "value": "responseBodyJSON(\"/usage/total_tokens\")"
+         }
+        }
+       ],
+       "predicates": [
+        "auth.identity.selected_subscription_key == \"ai-tenant-site-a/site-a-tier@ai-tenant-site-a/qwen3\" && !request.path.endsWith(\"/v1/models\")"
+       ]
+      }
+     ],
+     "scope": "ai-tenant-site-a/qwen3-kserve-route",
+     "service": "ratelimit-report-service",
+     "sources": [
+      "tokenratelimitpolicy.kuadrant.io:ai-tenant-site-a/maas-trlp-qwen3"
+     ]
+    }
+   ],
+   "name": "49bbc0691cefb40aa40ea60b23302f4c5ebce92b7c710ca23f615c3d80be70c7",
+   "routeRuleConditions": {
+    "hostnames": [
+     "site-a.example.com"
+    ],
+    "predicates": [
+     "request.url_path == '/v1/messages'",
+     "request.headers.exists(h, h.lowerAscii() == 'x-gateway-model-name' && request.headers[h] == 'publishers/ai-tenant-site-a/models/Qwen/Qwen3-0.6B')"
+    ]
+   }
+  },
+  {
+   "actions": [
+    {
+     "predicates": [
+      "request.path != \"/maas-api/health\" || request.method != \"GET\""
+     ],
+     "scope": "d394bfba395025cf537ff9cf27f127b1e736003961237be92c44fe6591b3a068",
+     "service": "auth-service",
+     "sources": [
+      "authpolicy.kuadrant.io:openshift-ingress/maas-site-a-gateway-maas-auth"
+     ]
+    },
+    {
+     "conditionalData": [
+      {
+       "data": [
+        {
+         "expression": {
+          "key": "tokenlimit.ai_tenant_site_a_site_a_tier_qwen3_tokens__b42c1f29",
+          "value": "1"
+         }
+        },
+        {
+         "expression": {
+          "key": "auth.identity.userid",
+          "value": "auth.identity.userid"
+         }
+        },
+        {
+         "expression": {
+          "key": "ratelimit.hits_addend",
+          "value": "0"
+         }
+        }
+       ],
+       "predicates": [
+        "auth.identity.selected_subscription_key == \"ai-tenant-site-a/site-a-tier@ai-tenant-site-a/qwen3\" && !request.path.endsWith(\"/v1/models\")"
+       ]
+      }
+     ],
+     "scope": "ai-tenant-site-a/qwen3-kserve-route",
+     "service": "ratelimit-check-service",
+     "sources": [
+      "tokenratelimitpolicy.kuadrant.io:ai-tenant-site-a/maas-trlp-qwen3"
+     ]
+    },
+    {
+     "conditionalData": [
+      {
+       "data": [
+        {
+         "expression": {
+          "key": "tokenlimit.ai_tenant_site_a_site_a_tier_qwen3_tokens__b42c1f29",
+          "value": "1"
+         }
+        },
+        {
+         "expression": {
+          "key": "auth.identity.userid",
+          "value": "auth.identity.userid"
+         }
+        },
+        {
+         "expression": {
+          "key": "ratelimit.hits_addend",
+          "value": "responseBodyJSON(\"/usage/total_tokens\")"
+         }
+        }
+       ],
+       "predicates": [
+        "auth.identity.selected_subscription_key == \"ai-tenant-site-a/site-a-tier@ai-tenant-site-a/qwen3\" && !request.path.endsWith(\"/v1/models\")"
+       ]
+      }
+     ],
+     "scope": "ai-tenant-site-a/qwen3-kserve-route",
+     "service": "ratelimit-report-service",
+     "sources": [
+      "tokenratelimitpolicy.kuadrant.io:ai-tenant-site-a/maas-trlp-qwen3"
+     ]
+    }
+   ],
+   "name": "041229d140685cc3406b9b53001e1a48464c6c38787958e5e0e8f64ebc0a54be",
+   "routeRuleConditions": {
+    "hostnames": [
+     "site-a.example.com"
+    ],
+    "predicates": [
+     "request.url_path.startsWith('/publishers/ai-tenant-site-a/models/Qwen/Qwen3-0.6B/v1/chat/completions')"
+    ]
+   }
+  },
+  {
+   "actions": [
+    {
+     "predicates": [
+      "request.path != \"/maas-api/health\" || request.method != \"GET\""
+     ],
+     "scope": "86badcbd108cb97b7b2c881395e74e8135984b7d1b308593c25812b7da53a020",
+     "service": "auth-service",
+     "sources": [
+      "authpolicy.kuadrant.io:openshift-ingress/maas-site-a-gateway-maas-auth"
+     ]
+    },
+    {
+     "conditionalData": [
+      {
+       "data": [
+        {
+         "expression": {
+          "key": "tokenlimit.ai_tenant_site_a_site_a_tier_qwen3_tokens__b42c1f29",
+          "value": "1"
+         }
+        },
+        {
+         "expression": {
+          "key": "auth.identity.userid",
+          "value": "auth.identity.userid"
+         }
+        },
+        {
+         "expression": {
+          "key": "ratelimit.hits_addend",
+          "value": "0"
+         }
+        }
+       ],
+       "predicates": [
+        "auth.identity.selected_subscription_key == \"ai-tenant-site-a/site-a-tier@ai-tenant-site-a/qwen3\" && !request.path.endsWith(\"/v1/models\")"
+       ]
+      }
+     ],
+     "scope": "ai-tenant-site-a/qwen3-kserve-route",
+     "service": "ratelimit-check-service",
+     "sources": [
+      "tokenratelimitpolicy.kuadrant.io:ai-tenant-site-a/maas-trlp-qwen3"
+     ]
+    },
+    {
+     "conditionalData": [
+      {
+       "data": [
+        {
+         "expression": {
+          "key": "tokenlimit.ai_tenant_site_a_site_a_tier_qwen3_tokens__b42c1f29",
+          "value": "1"
+         }
+        },
+        {
+         "expression": {
+          "key": "auth.identity.userid",
+          "value": "auth.identity.userid"
+         }
+        },
+        {
+         "expression": {
+          "key": "ratelimit.hits_addend",
+          "value": "responseBodyJSON(\"/usage/total_tokens\")"
+         }
+        }
+       ],
+       "predicates": [
+        "auth.identity.selected_subscription_key == \"ai-tenant-site-a/site-a-tier@ai-tenant-site-a/qwen3\" && !request.path.endsWith(\"/v1/models\")"
+       ]
+      }
+     ],
+     "scope": "ai-tenant-site-a/qwen3-kserve-route",
+     "service": "ratelimit-report-service",
+     "sources": [
+      "tokenratelimitpolicy.kuadrant.io:ai-tenant-site-a/maas-trlp-qwen3"
+     ]
+    }
+   ],
+   "name": "186e7455fcaa00b130aa111b8283c43092c2116fdc26cfcd1757ca287855831a",
+   "routeRuleConditions": {
+    "hostnames": [
+     "site-a.example.com"
+    ],
+    "predicates": [
+     "request.url_path.startsWith('/publishers/ai-tenant-site-a/models/Qwen/Qwen3-0.6B/v1/completions')"
+    ]
+   }
+  },
+  {
+   "actions": [
+    {
+     "predicates": [
+      "request.path != \"/maas-api/health\" || request.method != \"GET\""
+     ],
+     "scope": "678ebffd06cc248d2ea677b762f18d3aacd1532d046e04aea69385386f515094",
+     "service": "auth-service",
+     "sources": [
+      "authpolicy.kuadrant.io:openshift-ingress/maas-site-a-gateway-maas-auth"
+     ]
+    },
+    {
+     "conditionalData": [
+      {
+       "data": [
+        {
+         "expression": {
+          "key": "tokenlimit.ai_tenant_site_a_site_a_tier_qwen3_tokens__b42c1f29",
+          "value": "1"
+         }
+        },
+        {
+         "expression": {
+          "key": "auth.identity.userid",
+          "value": "auth.identity.userid"
+         }
+        },
+        {
+         "expression": {
+          "key": "ratelimit.hits_addend",
+          "value": "0"
+         }
+        }
+       ],
+       "predicates": [
+        "auth.identity.selected_subscription_key == \"ai-tenant-site-a/site-a-tier@ai-tenant-site-a/qwen3\" && !request.path.endsWith(\"/v1/models\")"
+       ]
+      }
+     ],
+     "scope": "ai-tenant-site-a/qwen3-kserve-route",
+     "service": "ratelimit-check-service",
+     "sources": [
+      "tokenratelimitpolicy.kuadrant.io:ai-tenant-site-a/maas-trlp-qwen3"
+     ]
+    },
+    {
+     "conditionalData": [
+      {
+       "data": [
+        {
+         "expression": {
+          "key": "tokenlimit.ai_tenant_site_a_site_a_tier_qwen3_tokens__b42c1f29",
+          "value": "1"
+         }
+        },
+        {
+         "expression": {
+          "key": "auth.identity.userid",
+          "value": "auth.identity.userid"
+         }
+        },
+        {
+         "expression": {
+          "key": "ratelimit.hits_addend",
+          "value": "responseBodyJSON(\"/usage/total_tokens\")"
+         }
+        }
+       ],
+       "predicates": [
+        "auth.identity.selected_subscription_key == \"ai-tenant-site-a/site-a-tier@ai-tenant-site-a/qwen3\" && !request.path.endsWith(\"/v1/models\")"
+       ]
+      }
+     ],
+     "scope": "ai-tenant-site-a/qwen3-kserve-route",
+     "service": "ratelimit-report-service",
+     "sources": [
+      "tokenratelimitpolicy.kuadrant.io:ai-tenant-site-a/maas-trlp-qwen3"
+     ]
+    }
+   ],
+   "name": "df70711c5d8f5e6f8cada5ff0c665a81e32533324da0ceeee52edb5de537145f",
+   "routeRuleConditions": {
+    "hostnames": [
+     "site-a.example.com"
+    ],
+    "predicates": [
+     "request.url_path.startsWith('/publishers/ai-tenant-site-a/models/Qwen/Qwen3-0.6B/v1/responses')"
+    ]
+   }
+  },
+  {
+   "actions": [
+    {
+     "predicates": [
+      "request.path != \"/maas-api/health\" || request.method != \"GET\""
+     ],
+     "scope": "bd34e3b0c82105ae352214ffa523bcccef200712c87d67801afd983448f6aaff",
+     "service": "auth-service",
+     "sources": [
+      "authpolicy.kuadrant.io:openshift-ingress/maas-site-a-gateway-maas-auth"
+     ]
+    },
+    {
+     "conditionalData": [
+      {
+       "data": [
+        {
+         "expression": {
+          "key": "tokenlimit.ai_tenant_site_a_site_a_tier_qwen3_tokens__b42c1f29",
+          "value": "1"
+         }
+        },
+        {
+         "expression": {
+          "key": "auth.identity.userid",
+          "value": "auth.identity.userid"
+         }
+        },
+        {
+         "expression": {
+          "key": "ratelimit.hits_addend",
+          "value": "0"
+         }
+        }
+       ],
+       "predicates": [
+        "auth.identity.selected_subscription_key == \"ai-tenant-site-a/site-a-tier@ai-tenant-site-a/qwen3\" && !request.path.endsWith(\"/v1/models\")"
+       ]
+      }
+     ],
+     "scope": "ai-tenant-site-a/qwen3-kserve-route",
+     "service": "ratelimit-check-service",
+     "sources": [
+      "tokenratelimitpolicy.kuadrant.io:ai-tenant-site-a/maas-trlp-qwen3"
+     ]
+    },
+    {
+     "conditionalData": [
+      {
+       "data": [
+        {
+         "expression": {
+          "key": "tokenlimit.ai_tenant_site_a_site_a_tier_qwen3_tokens__b42c1f29",
+          "value": "1"
+         }
+        },
+        {
+         "expression": {
+          "key": "auth.identity.userid",
+          "value": "auth.identity.userid"
+         }
+        },
+        {
+         "expression": {
+          "key": "ratelimit.hits_addend",
+          "value": "responseBodyJSON(\"/usage/total_tokens\")"
+         }
+        }
+       ],
+       "predicates": [
+        "auth.identity.selected_subscription_key == \"ai-tenant-site-a/site-a-tier@ai-tenant-site-a/qwen3\" && !request.path.endsWith(\"/v1/models\")"
+       ]
+      }
+     ],
+     "scope": "ai-tenant-site-a/qwen3-kserve-route",
+     "service": "ratelimit-report-service",
+     "sources": [
+      "tokenratelimitpolicy.kuadrant.io:ai-tenant-site-a/maas-trlp-qwen3"
+     ]
+    }
+   ],
+   "name": "6a1bb720c447e5a0ffa2e2d37729ef69fcbbbf7060a3b2f22db4df72166fdf87",
+   "routeRuleConditions": {
+    "hostnames": [
+     "site-a.example.com"
+    ],
+    "predicates": [
+     "request.url_path.startsWith('/publishers/ai-tenant-site-a/models/Qwen/Qwen3-0.6B/v1/messages')"
+    ]
+   }
+  },
+  {
+   "actions": [
+    {
+     "predicates": [
+      "request.path != \"/maas-api/health\" || request.method != \"GET\""
+     ],
+     "scope": "71610575e35e16b640298d74871d0adad2229486fb98d86003590e77b1933a82",
+     "service": "auth-service",
+     "sources": [
+      "authpolicy.kuadrant.io:openshift-ingress/maas-site-a-gateway-maas-auth"
+     ]
+    },
+    {
+     "conditionalData": [
+      {
+       "data": [
+        {
+         "expression": {
+          "key": "tokenlimit.ai_tenant_site_a_site_a_tier_qwen3_tokens__b42c1f29",
+          "value": "1"
+         }
+        },
+        {
+         "expression": {
+          "key": "auth.identity.userid",
+          "value": "auth.identity.userid"
+         }
+        },
+        {
+         "expression": {
+          "key": "ratelimit.hits_addend",
+          "value": "0"
+         }
+        }
+       ],
+       "predicates": [
+        "auth.identity.selected_subscription_key == \"ai-tenant-site-a/site-a-tier@ai-tenant-site-a/qwen3\" && !request.path.endsWith(\"/v1/models\")"
+       ]
+      }
+     ],
+     "scope": "ai-tenant-site-a/qwen3-kserve-route",
+     "service": "ratelimit-check-service",
+     "sources": [
+      "tokenratelimitpolicy.kuadrant.io:ai-tenant-site-a/maas-trlp-qwen3"
+     ]
+    },
+    {
+     "conditionalData": [
+      {
+       "data": [
+        {
+         "expression": {
+          "key": "tokenlimit.ai_tenant_site_a_site_a_tier_qwen3_tokens__b42c1f29",
+          "value": "1"
+         }
+        },
+        {
+         "expression": {
+          "key": "auth.identity.userid",
+          "value": "auth.identity.userid"
+         }
+        },
+        {
+         "expression": {
+          "key": "ratelimit.hits_addend",
+          "value": "responseBodyJSON(\"/usage/total_tokens\")"
+         }
+        }
+       ],
+       "predicates": [
+        "auth.identity.selected_subscription_key == \"ai-tenant-site-a/site-a-tier@ai-tenant-site-a/qwen3\" && !request.path.endsWith(\"/v1/models\")"
+       ]
+      }
+     ],
+     "scope": "ai-tenant-site-a/qwen3-kserve-route",
+     "service": "ratelimit-report-service",
+     "sources": [
+      "tokenratelimitpolicy.kuadrant.io:ai-tenant-site-a/maas-trlp-qwen3"
+     ]
+    }
+   ],
+   "name": "ff9969f950fff09f056626c3c1184d24fd84e3e717953d7ac43e65bbf7be6868",
+   "routeRuleConditions": {
+    "hostnames": [
+     "site-a.example.com"
+    ],
+    "predicates": [
+     "request.url_path.startsWith('/publishers/ai-tenant-site-a/models/Qwen/Qwen3-0.6B')"
+    ]
+   }
+  },
+  {
+   "actions": [
+    {
+     "predicates": [
+      "request.path != \"/maas-api/health\" || request.method != \"GET\""
+     ],
+     "scope": "c4b9b61bd91369cdc60bd17155d0e5c03a2e39865c461c97ffb123f0f03ba79a",
+     "service": "auth-service",
+     "sources": [
+      "authpolicy.kuadrant.io:openshift-ingress/maas-site-a-gateway-maas-auth"
+     ]
+    },
+    {
+     "conditionalData": [
+      {
+       "data": [
+        {
+         "expression": {
+          "key": "tokenlimit.ai_tenant_site_a_site_a_tier_qwen3_tokens__b42c1f29",
+          "value": "1"
+         }
+        },
+        {
+         "expression": {
+          "key": "auth.identity.userid",
+          "value": "auth.identity.userid"
+         }
+        },
+        {
+         "expression": {
+          "key": "ratelimit.hits_addend",
+          "value": "0"
+         }
+        }
+       ],
+       "predicates": [
+        "auth.identity.selected_subscription_key == \"ai-tenant-site-a/site-a-tier@ai-tenant-site-a/qwen3\" && !request.path.endsWith(\"/v1/models\")"
+       ]
+      }
+     ],
+     "scope": "ai-tenant-site-a/qwen3-kserve-route",
+     "service": "ratelimit-check-service",
+     "sources": [
+      "tokenratelimitpolicy.kuadrant.io:ai-tenant-site-a/maas-trlp-qwen3"
+     ]
+    },
+    {
+     "conditionalData": [
+      {
+       "data": [
+        {
+         "expression": {
+          "key": "tokenlimit.ai_tenant_site_a_site_a_tier_qwen3_tokens__b42c1f29",
+          "value": "1"
+         }
+        },
+        {
+         "expression": {
+          "key": "auth.identity.userid",
+          "value": "auth.identity.userid"
+         }
+        },
+        {
+         "expression": {
+          "key": "ratelimit.hits_addend",
+          "value": "responseBodyJSON(\"/usage/total_tokens\")"
+         }
+        }
+       ],
+       "predicates": [
+        "auth.identity.selected_subscription_key == \"ai-tenant-site-a/site-a-tier@ai-tenant-site-a/qwen3\" && !request.path.endsWith(\"/v1/models\")"
+       ]
+      }
+     ],
+     "scope": "ai-tenant-site-a/qwen3-kserve-route",
+     "service": "ratelimit-report-service",
+     "sources": [
+      "tokenratelimitpolicy.kuadrant.io:ai-tenant-site-a/maas-trlp-qwen3"
+     ]
+    }
+   ],
+   "name": "d72a4ec7b914afb375a9d0da664d8d325378e689f2b9373886640ad2f7c52d66",
+   "routeRuleConditions": {
+    "hostnames": [
+     "site-a.example.com"
+    ],
+    "predicates": [
+     "request.url_path.startsWith('/ai-tenant-site-a/qwen3/v1/chat/completions')"
+    ]
+   }
+  },
+  {
+   "actions": [
+    {
+     "predicates": [
+      "request.path != \"/maas-api/health\" || request.method != \"GET\""
+     ],
+     "scope": "9077fcabfc2dab2c42f92e1a9308bf5ec724533d258b2eb3b44145d5ba4c32ce",
+     "service": "auth-service",
+     "sources": [
+      "authpolicy.kuadrant.io:openshift-ingress/maas-site-a-gateway-maas-auth"
+     ]
+    },
+    {
+     "conditionalData": [
+      {
+       "data": [
+        {
+         "expression": {
+          "key": "tokenlimit.ai_tenant_site_a_site_a_tier_qwen3_tokens__b42c1f29",
+          "value": "1"
+         }
+        },
+        {
+         "expression": {
+          "key": "auth.identity.userid",
+          "value": "auth.identity.userid"
+         }
+        },
+        {
+         "expression": {
+          "key": "ratelimit.hits_addend",
+          "value": "0"
+         }
+        }
+       ],
+       "predicates": [
+        "auth.identity.selected_subscription_key == \"ai-tenant-site-a/site-a-tier@ai-tenant-site-a/qwen3\" && !request.path.endsWith(\"/v1/models\")"
+       ]
+      }
+     ],
+     "scope": "ai-tenant-site-a/qwen3-kserve-route",
+     "service": "ratelimit-check-service",
+     "sources": [
+      "tokenratelimitpolicy.kuadrant.io:ai-tenant-site-a/maas-trlp-qwen3"
+     ]
+    },
+    {
+     "conditionalData": [
+      {
+       "data": [
+        {
+         "expression": {
+          "key": "tokenlimit.ai_tenant_site_a_site_a_tier_qwen3_tokens__b42c1f29",
+          "value": "1"
+         }
+        },
+        {
+         "expression": {
+          "key": "auth.identity.userid",
+          "value": "auth.identity.userid"
+         }
+        },
+        {
+         "expression": {
+          "key": "ratelimit.hits_addend",
+          "value": "responseBodyJSON(\"/usage/total_tokens\")"
+         }
+        }
+       ],
+       "predicates": [
+        "auth.identity.selected_subscription_key == \"ai-tenant-site-a/site-a-tier@ai-tenant-site-a/qwen3\" && !request.path.endsWith(\"/v1/models\")"
+       ]
+      }
+     ],
+     "scope": "ai-tenant-site-a/qwen3-kserve-route",
+     "service": "ratelimit-report-service",
+     "sources": [
+      "tokenratelimitpolicy.kuadrant.io:ai-tenant-site-a/maas-trlp-qwen3"
+     ]
+    }
+   ],
+   "name": "344a7b3e89d21e632c2b99dbe00e07682c4b06a9c3084ca8e2b01eabbb90913f",
+   "routeRuleConditions": {
+    "hostnames": [
+     "site-a.example.com"
+    ],
+    "predicates": [
+     "request.url_path.startsWith('/ai-tenant-site-a/qwen3/v1/completions')"
+    ]
+   }
+  },
+  {
+   "actions": [
+    {
+     "predicates": [
+      "request.path != \"/maas-api/health\" || request.method != \"GET\""
+     ],
+     "scope": "df0a1f9d3026f7ef6a6281176be468467ce2d689eea3815372972f9c872ffed7",
+     "service": "auth-service",
+     "sources": [
+      "authpolicy.kuadrant.io:openshift-ingress/maas-site-a-gateway-maas-auth"
+     ]
+    },
+    {
+     "conditionalData": [
+      {
+       "data": [
+        {
+         "expression": {
+          "key": "tokenlimit.ai_tenant_site_a_site_a_tier_qwen3_tokens__b42c1f29",
+          "value": "1"
+         }
+        },
+        {
+         "expression": {
+          "key": "auth.identity.userid",
+          "value": "auth.identity.userid"
+         }
+        },
+        {
+         "expression": {
+          "key": "ratelimit.hits_addend",
+          "value": "0"
+         }
+        }
+       ],
+       "predicates": [
+        "auth.identity.selected_subscription_key == \"ai-tenant-site-a/site-a-tier@ai-tenant-site-a/qwen3\" && !request.path.endsWith(\"/v1/models\")"
+       ]
+      }
+     ],
+     "scope": "ai-tenant-site-a/qwen3-kserve-route",
+     "service": "ratelimit-check-service",
+     "sources": [
+      "tokenratelimitpolicy.kuadrant.io:ai-tenant-site-a/maas-trlp-qwen3"
+     ]
+    },
+    {
+     "conditionalData": [
+      {
+       "data": [
+        {
+         "expression": {
+          "key": "tokenlimit.ai_tenant_site_a_site_a_tier_qwen3_tokens__b42c1f29",
+          "value": "1"
+         }
+        },
+        {
+         "expression": {
+          "key": "auth.identity.userid",
+          "value": "auth.identity.userid"
+         }
+        },
+        {
+         "expression": {
+          "key": "ratelimit.hits_addend",
+          "value": "responseBodyJSON(\"/usage/total_tokens\")"
+         }
+        }
+       ],
+       "predicates": [
+        "auth.identity.selected_subscription_key == \"ai-tenant-site-a/site-a-tier@ai-tenant-site-a/qwen3\" && !request.path.endsWith(\"/v1/models\")"
+       ]
+      }
+     ],
+     "scope": "ai-tenant-site-a/qwen3-kserve-route",
+     "service": "ratelimit-report-service",
+     "sources": [
+      "tokenratelimitpolicy.kuadrant.io:ai-tenant-site-a/maas-trlp-qwen3"
+     ]
+    }
+   ],
+   "name": "f14f2dd3356fa57cd85ddf660e0e08846f44d01570b72c6ce1824c62db56f89e",
+   "routeRuleConditions": {
+    "hostnames": [
+     "site-a.example.com"
+    ],
+    "predicates": [
+     "request.url_path.startsWith('/ai-tenant-site-a/qwen3/v1/responses')"
+    ]
+   }
+  },
+  {
+   "actions": [
+    {
+     "predicates": [
+      "request.path != \"/maas-api/health\" || request.method != \"GET\""
+     ],
+     "scope": "ff7f844efb9e9377dd88ca6e6ff3f13a992dd55c68f82feb4a3bdd5c54e0f393",
+     "service": "auth-service",
+     "sources": [
+      "authpolicy.kuadrant.io:openshift-ingress/maas-site-a-gateway-maas-auth"
+     ]
+    },
+    {
+     "conditionalData": [
+      {
+       "data": [
+        {
+         "expression": {
+          "key": "tokenlimit.ai_tenant_site_a_site_a_tier_qwen3_tokens__b42c1f29",
+          "value": "1"
+         }
+        },
+        {
+         "expression": {
+          "key": "auth.identity.userid",
+          "value": "auth.identity.userid"
+         }
+        },
+        {
+         "expression": {
+          "key": "ratelimit.hits_addend",
+          "value": "0"
+         }
+        }
+       ],
+       "predicates": [
+        "auth.identity.selected_subscription_key == \"ai-tenant-site-a/site-a-tier@ai-tenant-site-a/qwen3\" && !request.path.endsWith(\"/v1/models\")"
+       ]
+      }
+     ],
+     "scope": "ai-tenant-site-a/qwen3-kserve-route",
+     "service": "ratelimit-check-service",
+     "sources": [
+      "tokenratelimitpolicy.kuadrant.io:ai-tenant-site-a/maas-trlp-qwen3"
+     ]
+    },
+    {
+     "conditionalData": [
+      {
+       "data": [
+        {
+         "expression": {
+          "key": "tokenlimit.ai_tenant_site_a_site_a_tier_qwen3_tokens__b42c1f29",
+          "value": "1"
+         }
+        },
+        {
+         "expression": {
+          "key": "auth.identity.userid",
+          "value": "auth.identity.userid"
+         }
+        },
+        {
+         "expression": {
+          "key": "ratelimit.hits_addend",
+          "value": "responseBodyJSON(\"/usage/total_tokens\")"
+         }
+        }
+       ],
+       "predicates": [
+        "auth.identity.selected_subscription_key == \"ai-tenant-site-a/site-a-tier@ai-tenant-site-a/qwen3\" && !request.path.endsWith(\"/v1/models\")"
+       ]
+      }
+     ],
+     "scope": "ai-tenant-site-a/qwen3-kserve-route",
+     "service": "ratelimit-report-service",
+     "sources": [
+      "tokenratelimitpolicy.kuadrant.io:ai-tenant-site-a/maas-trlp-qwen3"
+     ]
+    }
+   ],
+   "name": "6b71f5e0dc68b6ed3a1419f849bf3a35aebcf2a6c647cfde4dae321b44d1d0a8",
+   "routeRuleConditions": {
+    "hostnames": [
+     "site-a.example.com"
+    ],
+    "predicates": [
+     "request.url_path.startsWith('/ai-tenant-site-a/qwen3/v1/messages')"
+    ]
+   }
+  },
+  {
+   "actions": [
+    {
+     "predicates": [
+      "request.path != \"/maas-api/health\" || request.method != \"GET\""
+     ],
+     "scope": "e419bdfcf283c0971abea66fa777b4886bbd0548a0b2d21c5275f72f93b1bc28",
+     "service": "auth-service",
+     "sources": [
+      "authpolicy.kuadrant.io:openshift-ingress/maas-site-a-gateway-maas-auth"
+     ]
+    },
+    {
+     "conditionalData": [
+      {
+       "data": [
+        {
+         "expression": {
+          "key": "tokenlimit.ai_tenant_site_a_site_a_tier_qwen3_tokens__b42c1f29",
+          "value": "1"
+         }
+        },
+        {
+         "expression": {
+          "key": "auth.identity.userid",
+          "value": "auth.identity.userid"
+         }
+        },
+        {
+         "expression": {
+          "key": "ratelimit.hits_addend",
+          "value": "0"
+         }
+        }
+       ],
+       "predicates": [
+        "auth.identity.selected_subscription_key == \"ai-tenant-site-a/site-a-tier@ai-tenant-site-a/qwen3\" && !request.path.endsWith(\"/v1/models\")"
+       ]
+      }
+     ],
+     "scope": "ai-tenant-site-a/qwen3-kserve-route",
+     "service": "ratelimit-check-service",
+     "sources": [
+      "tokenratelimitpolicy.kuadrant.io:ai-tenant-site-a/maas-trlp-qwen3"
+     ]
+    },
+    {
+     "conditionalData": [
+      {
+       "data": [
+        {
+         "expression": {
+          "key": "tokenlimit.ai_tenant_site_a_site_a_tier_qwen3_tokens__b42c1f29",
+          "value": "1"
+         }
+        },
+        {
+         "expression": {
+          "key": "auth.identity.userid",
+          "value": "auth.identity.userid"
+         }
+        },
+        {
+         "expression": {
+          "key": "ratelimit.hits_addend",
+          "value": "responseBodyJSON(\"/usage/total_tokens\")"
+         }
+        }
+       ],
+       "predicates": [
+        "auth.identity.selected_subscription_key == \"ai-tenant-site-a/site-a-tier@ai-tenant-site-a/qwen3\" && !request.path.endsWith(\"/v1/models\")"
+       ]
+      }
+     ],
+     "scope": "ai-tenant-site-a/qwen3-kserve-route",
+     "service": "ratelimit-report-service",
+     "sources": [
+      "tokenratelimitpolicy.kuadrant.io:ai-tenant-site-a/maas-trlp-qwen3"
+     ]
+    }
+   ],
+   "name": "78efc3942e9454f6c42d4658f48a737c5f8adaf69b981023232822db514b6418",
+   "routeRuleConditions": {
+    "hostnames": [
+     "site-a.example.com"
+    ],
+    "predicates": [
+     "request.url_path.startsWith('/ai-tenant-site-a/qwen3')"
+    ]
+   }
+  },
+  {
+   "actions": [
+    {
+     "predicates": [
+      "request.path != \"/maas-api/health\" || request.method != \"GET\""
+     ],
+     "scope": "c606e92e65e343721096f47e75b7bd35eb373b7881e22a219888e928fbcd52bc",
+     "service": "auth-service",
+     "sources": [
+      "authpolicy.kuadrant.io:openshift-ingress/maas-site-a-gateway-maas-auth"
+     ]
+    },
+    {
+     "conditionalData": [
+      {
+       "data": [
+        {
+         "expression": {
+          "key": "tokenlimit.deny_all_by_default__d3136ae7",
+          "value": "1"
+         }
+        },
+        {
+         "expression": {
+          "key": "auth.identity.userid",
+          "value": "auth.identity.userid"
+         }
+        },
+        {
+         "expression": {
+          "key": "ratelimit.hits_addend",
+          "value": "0"
+         }
+        }
+       ],
+       "predicates": [
+        "!request.path.startsWith(\"/maas-api\") && !request.path.startsWith(\"/v1/models\") && !request.path.startsWith(\"/v1/subscriptions\") && !request.path.startsWith(\"/v1/api-keys\")"
+       ]
+      }
+     ],
+     "scope": "redhat-ai-gateway-infra/maas-api-route-site-a",
+     "service": "ratelimit-check-service",
+     "sources": [
+      "tokenratelimitpolicy.kuadrant.io:openshift-ingress/gateway-default-deny-site-a"
+     ]
+    },
+    {
+     "conditionalData": [
+      {
+       "data": [
+        {
+         "expression": {
+          "key": "tokenlimit.deny_all_by_default__d3136ae7",
+          "value": "1"
+         }
+        },
+        {
+         "expression": {
+          "key": "auth.identity.userid",
+          "value": "auth.identity.userid"
+         }
+        },
+        {
+         "expression": {
+          "key": "ratelimit.hits_addend",
+          "value": "responseBodyJSON(\"/usage/total_tokens\")"
+         }
+        }
+       ],
+       "predicates": [
+        "!request.path.startsWith(\"/maas-api\") && !request.path.startsWith(\"/v1/models\") && !request.path.startsWith(\"/v1/subscriptions\") && !request.path.startsWith(\"/v1/api-keys\")"
+       ]
+      }
+     ],
+     "scope": "redhat-ai-gateway-infra/maas-api-route-site-a",
+     "service": "ratelimit-report-service",
+     "sources": [
+      "tokenratelimitpolicy.kuadrant.io:openshift-ingress/gateway-default-deny-site-a"
+     ]
+    }
+   ],
+   "name": "1f7d132fc8ed475e71177c74637ee867ed48355cf5d50e0ef8dd365ba71b2fa5",
+   "routeRuleConditions": {
+    "hostnames": [
+     "site-a.example.com"
+    ],
+    "predicates": [
+     "request.url_path.startsWith('/v1/subscriptions')"
+    ]
+   }
+  },
+  {
+   "actions": [
+    {
+     "predicates": [
+      "request.path != \"/maas-api/health\" || request.method != \"GET\""
+     ],
+     "scope": "1a07c4c259ae5ccbdb664ec4cc466b61fb3b40e501526de43dfef1e068827ab7",
+     "service": "auth-service",
+     "sources": [
+      "authpolicy.kuadrant.io:openshift-ingress/maas-site-a-gateway-maas-auth"
+     ]
+    },
+    {
+     "conditionalData": [
+      {
+       "data": [
+        {
+         "expression": {
+          "key": "tokenlimit.deny_all_by_default__d3136ae7",
+          "value": "1"
+         }
+        },
+        {
+         "expression": {
+          "key": "auth.identity.userid",
+          "value": "auth.identity.userid"
+         }
+        },
+        {
+         "expression": {
+          "key": "ratelimit.hits_addend",
+          "value": "0"
+         }
+        }
+       ],
+       "predicates": [
+        "!request.path.startsWith(\"/maas-api\") && !request.path.startsWith(\"/v1/models\") && !request.path.startsWith(\"/v1/subscriptions\") && !request.path.startsWith(\"/v1/api-keys\")"
+       ]
+      }
+     ],
+     "scope": "redhat-ai-gateway-infra/maas-api-route-site-a",
+     "service": "ratelimit-check-service",
+     "sources": [
+      "tokenratelimitpolicy.kuadrant.io:openshift-ingress/gateway-default-deny-site-a"
+     ]
+    },
+    {
+     "conditionalData": [
+      {
+       "data": [
+        {
+         "expression": {
+          "key": "tokenlimit.deny_all_by_default__d3136ae7",
+          "value": "1"
+         }
+        },
+        {
+         "expression": {
+          "key": "auth.identity.userid",
+          "value": "auth.identity.userid"
+         }
+        },
+        {
+         "expression": {
+          "key": "ratelimit.hits_addend",
+          "value": "responseBodyJSON(\"/usage/total_tokens\")"
+         }
+        }
+       ],
+       "predicates": [
+        "!request.path.startsWith(\"/maas-api\") && !request.path.startsWith(\"/v1/models\") && !request.path.startsWith(\"/v1/subscriptions\") && !request.path.startsWith(\"/v1/api-keys\")"
+       ]
+      }
+     ],
+     "scope": "redhat-ai-gateway-infra/maas-api-route-site-a",
+     "service": "ratelimit-report-service",
+     "sources": [
+      "tokenratelimitpolicy.kuadrant.io:openshift-ingress/gateway-default-deny-site-a"
+     ]
+    }
+   ],
+   "name": "593016ff49d89d59ce7151304262879eef910bf0989f9a3f86127db2cd365f58",
+   "routeRuleConditions": {
+    "hostnames": [
+     "site-a.example.com"
+    ],
+    "predicates": [
+     "request.url_path.startsWith('/v1/api-keys')"
+    ]
+   }
+  },
+  {
+   "actions": [
+    {
+     "predicates": [
+      "request.path != \"/maas-api/health\" || request.method != \"GET\""
+     ],
+     "scope": "c287ceab29bba4cd6ce10d734ae583a8e7eec74503eee87f3f93fa6f0295f60e",
+     "service": "auth-service",
+     "sources": [
+      "authpolicy.kuadrant.io:openshift-ingress/maas-site-a-gateway-maas-auth"
+     ]
+    },
+    {
+     "conditionalData": [
+      {
+       "data": [
+        {
+         "expression": {
+          "key": "tokenlimit.deny_all_by_default__d3136ae7",
+          "value": "1"
+         }
+        },
+        {
+         "expression": {
+          "key": "auth.identity.userid",
+          "value": "auth.identity.userid"
+         }
+        },
+        {
+         "expression": {
+          "key": "ratelimit.hits_addend",
+          "value": "0"
+         }
+        }
+       ],
+       "predicates": [
+        "!request.path.startsWith(\"/maas-api\") && !request.path.startsWith(\"/v1/models\") && !request.path.startsWith(\"/v1/subscriptions\") && !request.path.startsWith(\"/v1/api-keys\")"
+       ]
+      }
+     ],
+     "scope": "redhat-ai-gateway-infra/maas-api-route-site-a",
+     "service": "ratelimit-check-service",
+     "sources": [
+      "tokenratelimitpolicy.kuadrant.io:openshift-ingress/gateway-default-deny-site-a"
+     ]
+    },
+    {
+     "conditionalData": [
+      {
+       "data": [
+        {
+         "expression": {
+          "key": "tokenlimit.deny_all_by_default__d3136ae7",
+          "value": "1"
+         }
+        },
+        {
+         "expression": {
+          "key": "auth.identity.userid",
+          "value": "auth.identity.userid"
+         }
+        },
+        {
+         "expression": {
+          "key": "ratelimit.hits_addend",
+          "value": "responseBodyJSON(\"/usage/total_tokens\")"
+         }
+        }
+       ],
+       "predicates": [
+        "!request.path.startsWith(\"/maas-api\") && !request.path.startsWith(\"/v1/models\") && !request.path.startsWith(\"/v1/subscriptions\") && !request.path.startsWith(\"/v1/api-keys\")"
+       ]
+      }
+     ],
+     "scope": "redhat-ai-gateway-infra/maas-api-route-site-a",
+     "service": "ratelimit-report-service",
+     "sources": [
+      "tokenratelimitpolicy.kuadrant.io:openshift-ingress/gateway-default-deny-site-a"
+     ]
+    }
+   ],
+   "name": "75d5eae514a62aa7d0735f1d727b83ea27b5cea13f478753214c8e640075ca40",
+   "routeRuleConditions": {
+    "hostnames": [
+     "site-a.example.com"
+    ],
+    "predicates": [
+     "request.url_path.startsWith('/v1/models')"
+    ]
+   }
+  },
+  {
+   "actions": [
+    {
+     "predicates": [
+      "request.path != \"/maas-api/health\" || request.method != \"GET\""
+     ],
+     "scope": "c46ee200e43b3011e96cc5770aae1f79223f03d2b0a91d4bad6b7b8b16f86e57",
+     "service": "auth-service",
+     "sources": [
+      "authpolicy.kuadrant.io:openshift-ingress/maas-site-a-gateway-maas-auth"
+     ]
+    },
+    {
+     "conditionalData": [
+      {
+       "data": [
+        {
+         "expression": {
+          "key": "tokenlimit.deny_all_by_default__d3136ae7",
+          "value": "1"
+         }
+        },
+        {
+         "expression": {
+          "key": "auth.identity.userid",
+          "value": "auth.identity.userid"
+         }
+        },
+        {
+         "expression": {
+          "key": "ratelimit.hits_addend",
+          "value": "0"
+         }
+        }
+       ],
+       "predicates": [
+        "!request.path.startsWith(\"/maas-api\") && !request.path.startsWith(\"/v1/models\") && !request.path.startsWith(\"/v1/subscriptions\") && !request.path.startsWith(\"/v1/api-keys\")"
+       ]
+      }
+     ],
+     "scope": "redhat-ai-gateway-infra/maas-api-route-site-a",
+     "service": "ratelimit-check-service",
+     "sources": [
+      "tokenratelimitpolicy.kuadrant.io:openshift-ingress/gateway-default-deny-site-a"
+     ]
+    },
+    {
+     "conditionalData": [
+      {
+       "data": [
+        {
+         "expression": {
+          "key": "tokenlimit.deny_all_by_default__d3136ae7",
+          "value": "1"
+         }
+        },
+        {
+         "expression": {
+          "key": "auth.identity.userid",
+          "value": "auth.identity.userid"
+         }
+        },
+        {
+         "expression": {
+          "key": "ratelimit.hits_addend",
+          "value": "responseBodyJSON(\"/usage/total_tokens\")"
+         }
+        }
+       ],
+       "predicates": [
+        "!request.path.startsWith(\"/maas-api\") && !request.path.startsWith(\"/v1/models\") && !request.path.startsWith(\"/v1/subscriptions\") && !request.path.startsWith(\"/v1/api-keys\")"
+       ]
+      }
+     ],
+     "scope": "redhat-ai-gateway-infra/maas-api-route-site-a",
+     "service": "ratelimit-report-service",
+     "sources": [
+      "tokenratelimitpolicy.kuadrant.io:openshift-ingress/gateway-default-deny-site-a"
+     ]
+    }
+   ],
+   "name": "2214c49dcf72716de962a80222fb3c51c1c881581bd7ebefc2ba0e019957a8b0",
+   "routeRuleConditions": {
+    "hostnames": [
+     "site-a.example.com"
+    ],
+    "predicates": [
+     "request.url_path.startsWith('/maas-api')"
+    ]
+   }
+  },
+  {
+   "actions": [
+    {
+     "predicates": [
+      "request.path != \"/maas-api/health\" || request.method != \"GET\""
+     ],
+     "scope": "dae973d1cc3575d9566fb78aeac31d838c706462df6058bf56495c046dee5afc",
+     "service": "auth-service",
+     "sources": [
+      "authpolicy.kuadrant.io:openshift-ingress/maas-site-a-gateway-maas-auth"
+     ]
+    },
+    {
+     "conditionalData": [
+      {
+       "data": [
+        {
+         "expression": {
+          "key": "tokenlimit.ai_tenant_site_a_site_a_tier_qwen3_tokens__b42c1f29",
+          "value": "1"
+         }
+        },
+        {
+         "expression": {
+          "key": "auth.identity.userid",
+          "value": "auth.identity.userid"
+         }
+        },
+        {
+         "expression": {
+          "key": "ratelimit.hits_addend",
+          "value": "0"
+         }
+        }
+       ],
+       "predicates": [
+        "auth.identity.selected_subscription_key == \"ai-tenant-site-a/site-a-tier@ai-tenant-site-a/qwen3\" && !request.path.endsWith(\"/v1/models\")"
+       ]
+      }
+     ],
+     "scope": "ai-tenant-site-a/qwen3-kserve-route",
+     "service": "ratelimit-check-service",
+     "sources": [
+      "tokenratelimitpolicy.kuadrant.io:ai-tenant-site-a/maas-trlp-qwen3"
+     ]
+    },
+    {
+     "conditionalData": [
+      {
+       "data": [
+        {
+         "expression": {
+          "key": "tokenlimit.ai_tenant_site_a_site_a_tier_qwen3_tokens__b42c1f29",
+          "value": "1"
+         }
+        },
+        {
+         "expression": {
+          "key": "auth.identity.userid",
+          "value": "auth.identity.userid"
+         }
+        },
+        {
+         "expression": {
+          "key": "ratelimit.hits_addend",
+          "value": "responseBodyJSON(\"/usage/total_tokens\")"
+         }
+        }
+       ],
+       "predicates": [
+        "auth.identity.selected_subscription_key == \"ai-tenant-site-a/site-a-tier@ai-tenant-site-a/qwen3\" && !request.path.endsWith(\"/v1/models\")"
+       ]
+      }
+     ],
+     "scope": "ai-tenant-site-a/qwen3-kserve-route",
+     "service": "ratelimit-report-service",
+     "sources": [
+      "tokenratelimitpolicy.kuadrant.io:ai-tenant-site-a/maas-trlp-qwen3"
+     ]
+    }
+   ],
+   "name": "4ac69625b2ea94c6b09db934722cf3c787760014b94d07a3bd23bf94da0c7966",
+   "routeRuleConditions": {
+    "hostnames": [
+     "site-a.example.com"
+    ],
+    "predicates": [
+     "request.url_path.startsWith('/')",
+     "request.headers.exists(h, h.lowerAscii() == 'x-gateway-model-name' && request.headers[h] == 'publishers/ai-tenant-site-a/models/Qwen/Qwen3-0.6B')"
+    ]
+   }
+  }
+ ],
+ "services": {
+  "auth-service": {
+   "endpoint": "kuadrant-auth-service",
+   "failureMode": "deny",
+   "timeout": "200ms",
+   "type": "auth"
+  },
+  "ratelimit-check-service": {
+   "endpoint": "kuadrant-ratelimit-service",
+   "failureMode": "allow",
+   "timeout": "100ms",
+   "type": "ratelimit-check"
+  },
+  "ratelimit-report-service": {
+   "endpoint": "kuadrant-ratelimit-service",
+   "failureMode": "allow",
+   "timeout": "100ms",
+   "type": "ratelimit-report"
+  },
+  "ratelimit-service": {
+   "endpoint": "kuadrant-ratelimit-service",
+   "failureMode": "allow",
+   "timeout": "100ms",
+   "type": "ratelimit"
+  }
+ }
+}


### PR DESCRIPTION
> [!IMPORTANT]
> **Parent operator RBAC not yet updated.** This PR changes maas-controller RBAC
> (adds authconfigs and limitadors rules). Companion PRs are still needed in:
> - https://github.com/opendatahub-io/ai-gateway-operator/
> - https://github.com/opendatahub-io/opendatahub-operator
>
> Do not merge until those repos reflect the same RBAC changes (link the PRs here when ready).

Part of a proof-of-concept exploring enforcement paths that move off Envoy
ext_proc. The controller change here lets MaaS own enforcement config generation
instead of deriving it from Kuadrant policies, which is the decoupling any
off-ext_proc dataplane needs. Draft, for early review.

## Summary

The Kuadrant wasm-shim is the current enforcement dataplane, an Envoy wasm filter
wrapped by ext_proc stages. It cannot split input and output tokens and it
short-circuits with a local reply. Moving enforcement off that path is blocked by
one coupling: an enforced AuthPolicy or TokenRateLimitPolicy always makes Kuadrant
generate the wasm dataplane.

This change removes that coupling. Instead of creating the Kuadrant policies, the
controller compiles the same three artifacts itself and applies them. Those are the
Authorino AuthConfig, the Limitador limits, and the enforcement pluginConfig
written as a ConfigMap. With no policies, Kuadrant generates no wasm, so the
enforcement config becomes MaaS-owned and free to feed a different dataplane. It is
opt-in behind `--enable-native-enforcement` and changes nothing when the flag is
off.

## What it does

- A pure compiler turns a gateway's routes and subscription intent into the
  pluginConfig action sets, the AuthConfig, and the shared Limitador limits. The
  auth rules reuse the existing AuthPolicy builder, so the auth logic stays single
  sourced.
- A GatewayEnforcement reconciler gathers each gateway's input from the cluster,
  compiles the artifacts, and applies them. It reconciles gateways by tenant
  label and watches HTTPRoutes and subscriptions.
- Model access stays a request-time decision: the generated AuthConfig carries the
  same subscription-info callout the AuthPolicy uses, so access is not baked into
  the config.

## Design notes

- The compiler is pure and the reconciler holds no shared mutable state, so it
  needs no locks. The informer cache is the only shared state.
- Reconciles are request driven and idempotent. A gateway that is not yet ready is
  skipped without requeue, and the reconciler writes the shared Limitador only when
  its limits change, so a redundant reconcile does not churn the shared object.
- Cross-artifact hashes only need to be internally consistent across the three
  artifacts. They do not have to equal Kuadrant's.
- Config such as upstream addresses, TLS trust, and namespaces is flag driven so it
  can be set per environment rather than hardcoded.

## Testing

- Unit tests assert the generated pluginConfig, AuthConfig, and Limitador limits
  against captured Kuadrant output held as testdata oracles, including
  multi-subscription aggregation and the shared-Limitador merge.
- Reconciler tests cover input gathering, the watch mappers, the not-ready skip,
  and subject validation, using the controller-runtime fake client.
- Benchmarks cover the compile path and the shared-limit merge.

## What is outstanding

- Deployment wiring: the flag and its config (upstream addresses, TLS trust,
  namespaces) are not yet surfaced in the manifests. Enabling native enforcement
  today means setting the args on the manager Deployment by hand. A follow-up adds
  the params.env defaults, the manager args, and an overlay that opts in.
- End-to-end coverage: there is no e2e test yet. It needs the ext_proc service
  enforcing in place of the wasm path, so it lands with that cutover.
- Reconciler apply coverage: the unit tests cover input gathering and compilation,
  but the server-side apply of the ConfigMap, AuthConfig, and Limitador is not
  exercised in unit tests. Covering it needs envtest or e2e.


## Manual validation

Validated by hand on a running cluster with the ext_proc dataplane, Authorino, and Limitador:

- With `--enable-native-enforcement`, the MaaSAuthPolicy and MaaSSubscription reconcilers are not started and no TokenRateLimitPolicy is created. The GatewayEnforcement reconciler generates and applies the ext_proc ConfigMap, the Authorino AuthConfig, and the Limitador limits from a MaaSSubscription.
- The enforced subscription is marked Active/Ready by the enforcement reconciler, so key issuance and the authorization policy work without the Kuadrant subscription reconciler running.
- Through the ext_proc auth path: a valid API key is allowed, an invalid or absent key is denied (403 / 401), and a subscription whose token budget is exhausted is rate-limited (429).
- Editing a subscription's token limit re-triggers enforcement and updates the shared Limitador limit.
- A MaaSModelRef whose backing kind has no CRD on the cluster is marked Failed/Unsupported and does not requeue-loop.
