### PR TITLE
fix(RHOAIENG-89890): add required path field to x-api-key e2e fixture

### DIFF
--- a/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -92,6 +93,10 @@ type MaaSAuthPolicyReconciler struct {
 	// MaxConcurrentReconciles is the maximum number of concurrent Reconciles which can be run.
 	// Defaults to 1 if not set.
 	MaxConcurrentReconciles int
+
+	// ippGatewaySyncQueue retries default-gateway x-api-key sync when an IPP ExternalModel
+	// event cannot be applied inline (transient API errors or empty MaaSAuthPolicy list).
+	ippGatewaySyncQueue workqueue.TypedRateLimitingInterface[struct{}]
 }
 
 // oidcConfig holds resolved OIDC configuration from AITenant or a legacy Tenant CR.
@@ -1375,34 +1380,40 @@ func (r *MaaSAuthPolicyReconciler) reconcileGatewayAuthPolicy(
 	}
 	existingFound := err == nil
 
-	// For tenant-specific gateways, fetch the Gateway so we can set an
-	// OwnerReference. This ensures Kubernetes garbage collection automatically
-	// deletes the AuthPolicy when the Gateway is deleted (e.g., via AITenant
-	// cascade deletion), preventing orphaned gateway-scoped AuthPolicies.
+	// Fetch the Gateway so we can set an OwnerReference and delete stale managed
+	// AuthPolicies when the Gateway no longer exists. Tenant gateways must exist
+	// before creating an AuthPolicy; the default gateway may be reconciled before
+	// the Gateway CR is created (OwnerReference is added once it appears).
 	var gateway *gatewayapiv1.Gateway
-	if isTenantGateway {
-		gateway = &gatewayapiv1.Gateway{}
-		gwKey := client.ObjectKey{Namespace: gatewayNamespace, Name: gatewayName}
-		if gwErr := r.Get(ctx, gwKey, gateway); gwErr != nil {
-			if apierrors.IsNotFound(gwErr) {
-				// Gateway is gone. If a managed tenant AuthPolicy still exists,
-				// delete it to prevent orphaned resources.
-				if existingFound && isManaged(existing) {
+	gateway = &gatewayapiv1.Gateway{}
+	gwKey := client.ObjectKey{Namespace: gatewayNamespace, Name: gatewayName}
+	if gwErr := r.Get(ctx, gwKey, gateway); gwErr != nil {
+		if apierrors.IsNotFound(gwErr) {
+			if existingFound && isManaged(existing) {
+				// Tenant gateways: always clean up orphaned AuthPolicies when the Gateway is gone.
+				// Default gateway: only clean up if the AuthPolicy was previously linked to a
+				// Gateway via OwnerReference (orphan from a deleted Gateway). During initial
+				// install the Gateway CR may not exist yet; in that case we must not delete the
+				// AuthPolicy we are about to create or update.
+				if isTenantGateway || hasGatewayOwnerReference(existing) {
 					if delErr := r.Delete(ctx, existing); delErr != nil {
-						return false, fmt.Errorf("failed to delete stale tenant gateway AuthPolicy %s/%s: %w", gatewayNamespace, authPolicyName, delErr)
+						return false, fmt.Errorf("failed to delete stale gateway AuthPolicy %s/%s: %w", gatewayNamespace, authPolicyName, delErr)
 					}
-					log.Info("deleted stale tenant gateway AuthPolicy (Gateway no longer exists)", "name", authPolicyName, "namespace", gatewayNamespace)
+					log.Info("deleted stale gateway AuthPolicy (Gateway no longer exists)", "name", authPolicyName, "namespace", gatewayNamespace)
+					existingFound = false
 				}
-				// Nothing to create or update without a Gateway.
+			}
+			if isTenantGateway {
 				return false, nil
 			}
+			gateway = nil
+		} else {
 			return false, fmt.Errorf("failed to get Gateway %s/%s for OwnerReference: %w", gatewayNamespace, gatewayName, gwErr)
 		}
 	}
 
 	if !existingFound {
-		// Set OwnerReference on the new AuthPolicy for tenant gateways.
-		if isTenantGateway {
+		if gateway != nil {
 			setGatewayOwnerReference(gateway, gwPolicy)
 		}
 		if err := unstructured.SetNestedMap(gwPolicy.Object, spec, "spec"); err != nil {
@@ -1424,9 +1435,9 @@ func (r *MaaSAuthPolicyReconciler) reconcileGatewayAuthPolicy(
 	if err := unstructured.SetNestedMap(existing.Object, spec, "spec"); err != nil {
 		return false, fmt.Errorf("failed to set gateway AuthPolicy spec for update: %w", err)
 	}
-	// Ensure OwnerReferences are set on existing tenant gateway AuthPolicies
-	// (handles upgrade from pre-ownerref versions).
-	if isTenantGateway {
+	// Ensure OwnerReferences are set on existing gateway AuthPolicies when the
+	// Gateway exists (handles upgrade from pre-ownerref versions).
+	if gateway != nil {
 		setGatewayOwnerReference(gateway, existing)
 	}
 	if specMatchesDesired(spec, currentSpec) {
@@ -2003,6 +2014,14 @@ func (r *MaaSAuthPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// deleting a CR with apiFormat=messages re-runs discoverXAPIKeyNeeded and
 	// adds/removes the x-api-key identity source from the gateway AuthPolicy.
 	// The CRD may not be installed, so the watch is conditional.
+	r.ippGatewaySyncQueue = workqueue.NewTypedRateLimitingQueueWithConfig(
+		workqueue.DefaultTypedControllerRateLimiter[struct{}](),
+		workqueue.TypedRateLimitingQueueConfig[struct{}]{Name: "ipp-gateway-x-api-key-sync"},
+	)
+	if err := mgr.Add(manager.RunnableFunc(r.runIPPGatewaySyncWorker)); err != nil {
+		return fmt.Errorf("failed to register IPP gateway sync worker: %w", err)
+	}
+
 	const ippExternalModelCRD = "externalmodels.inference.opendatahub.io"
 	if crdExists(context.Background(), mgr.GetAPIReader(), ippExternalModelCRD) {
 		ippExternalModel := &unstructured.Unstructured{}
@@ -2133,6 +2152,59 @@ func (r *MaaSAuthPolicyReconciler) mapNamespaceToMaaSAuthPolicies(ctx context.Co
 	return requests
 }
 
+func isRetryableAPIError(err error) bool {
+	return apierrors.IsTooManyRequests(err) ||
+		apierrors.IsTimeout(err) ||
+		apierrors.IsServerTimeout(err) ||
+		apierrors.IsServiceUnavailable(err) ||
+		apierrors.IsConflict(err)
+}
+
+func (r *MaaSAuthPolicyReconciler) scheduleDefaultGatewayXAPIKeySync() {
+	if r.ippGatewaySyncQueue != nil {
+		r.ippGatewaySyncQueue.AddRateLimited(struct{}{})
+	}
+}
+
+func (r *MaaSAuthPolicyReconciler) runIPPGatewaySyncWorker(ctx context.Context) error {
+	log := ctrl.Log.WithName("maas-authpolicy-controller").WithValues("worker", "ipp-gateway-sync")
+	go func() {
+		<-ctx.Done()
+		r.ippGatewaySyncQueue.ShutDown()
+	}()
+	for {
+		item, shutdown := r.ippGatewaySyncQueue.Get()
+		if shutdown {
+			return nil
+		}
+		func() {
+			defer r.ippGatewaySyncQueue.Done(item)
+			if err := r.syncDefaultGatewayAuthPolicyForXAPIKeyDiscovery(ctx, log); err != nil {
+				log.Error(err, "failed to sync default gateway AuthPolicy for IPP ExternalModel change")
+				r.ippGatewaySyncQueue.AddRateLimited(item)
+				return
+			}
+			r.ippGatewaySyncQueue.Forget(item)
+		}()
+	}
+}
+
+func (r *MaaSAuthPolicyReconciler) enqueueMaaSAuthPoliciesInNamespace(ctx context.Context, namespace string) []reconcile.Request {
+	if namespace == "" {
+		return nil
+	}
+	policyList := &maasv1alpha1.MaaSAuthPolicyList{}
+	if err := r.List(ctx, policyList, client.InNamespace(namespace)); err != nil {
+		ctrl.LoggerFrom(ctx).Error(err, "failed to list MaaSAuthPolicy resources for IPP ExternalModel fallback enqueue", "namespace", namespace)
+		return nil
+	}
+	requests := make([]reconcile.Request, len(policyList.Items))
+	for i, p := range policyList.Items {
+		requests[i] = reconcile.Request{NamespacedName: types.NamespacedName{Name: p.Name, Namespace: p.Namespace}}
+	}
+	return requests
+}
+
 // syncDefaultGatewayAuthPolicyForXAPIKeyDiscovery updates the default gateway AuthPolicy
 // so authentication rules reflect current IPP ExternalModel-driven x-api-key discovery.
 func (r *MaaSAuthPolicyReconciler) syncDefaultGatewayAuthPolicyForXAPIKeyDiscovery(ctx context.Context, log logr.Logger) error {
@@ -2155,13 +2227,22 @@ func (r *MaaSAuthPolicyReconciler) syncDefaultGatewayAuthPolicyForXAPIKeyDiscove
 func (r *MaaSAuthPolicyReconciler) mapIPPExternalModelToMaaSAuthPolicies(ctx context.Context, _ client.Object) []reconcile.Request {
 	log := ctrl.LoggerFrom(ctx)
 	policyList := &maasv1alpha1.MaaSAuthPolicyList{}
-	if err := r.List(ctx, policyList); err != nil {
-		log.Error(err, "failed to list MaaSAuthPolicy resources for IPP ExternalModel change")
-		return nil
+	listErr := retry.OnError(retry.DefaultBackoff, isRetryableAPIError, func() error {
+		policyList.Items = nil
+		return r.List(ctx, policyList)
+	})
+	if listErr != nil {
+		log.Error(listErr, "failed to list MaaSAuthPolicy resources for IPP ExternalModel change")
+		r.scheduleDefaultGatewayXAPIKeySync()
+		return r.enqueueMaaSAuthPoliciesInNamespace(ctx, r.TenantNamespace)
 	}
 	if len(policyList.Items) == 0 {
-		if err := r.syncDefaultGatewayAuthPolicyForXAPIKeyDiscovery(ctx, log); err != nil {
-			log.Error(err, "failed to sync default gateway AuthPolicy for IPP ExternalModel change")
+		syncErr := retry.OnError(retry.DefaultBackoff, func(err error) bool { return err != nil }, func() error {
+			return r.syncDefaultGatewayAuthPolicyForXAPIKeyDiscovery(ctx, log)
+		})
+		if syncErr != nil {
+			log.Error(syncErr, "failed to sync default gateway AuthPolicy for IPP ExternalModel change")
+			r.scheduleDefaultGatewayXAPIKeySync()
 		}
 		return nil
 	}
@@ -2273,6 +2354,15 @@ func (r *MaaSAuthPolicyReconciler) mapHTTPRouteToMaaSAuthPolicies(ctx context.Co
 		}
 	}
 	return requests
+}
+
+func hasGatewayOwnerReference(obj metav1.Object) bool {
+	for _, ref := range obj.GetOwnerReferences() {
+		if ref.Kind == "Gateway" && ref.APIVersion == gatewayapiv1.GroupVersion.String() {
+			return true
+		}
+	}
+	return false
 }
 
 // setGatewayOwnerReference sets an OwnerReference on the dependent object pointing to

--- a/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
@@ -52,7 +52,6 @@ import (
 	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	maasv1alpha1 "github.com/opendatahub-io/models-as-a-service/maas-controller/api/maas/v1alpha1"
-	"github.com/opendatahub-io/models-as-a-service/maas-controller/pkg/oteljson"
 	"github.com/opendatahub-io/models-as-a-service/maas-controller/pkg/platform/tenantreconcile"
 )
 
@@ -465,14 +464,13 @@ func subscriptionGatewayCacheKeySelector() string {
 //+kubebuilder:rbac:groups=maas.opendatahub.io,resources=maastenantconfigs,verbs=get;list;watch
 //+kubebuilder:rbac:groups=maas.opendatahub.io,resources=tenants,verbs=get;list;watch
 //+kubebuilder:rbac:groups="",resources=events,verbs=create;patch
-//+kubebuilder:rbac:groups=inference.opendatahub.io,resources=externalmodels,verbs=list
+//+kubebuilder:rbac:groups=inference.opendatahub.io,resources=externalmodels,verbs=list;watch
 
 // Reconcile is part of the main kubernetes reconciliation loop
 const maasAuthPolicyFinalizer = "maas.opendatahub.io/authpolicy-cleanup"
 
 func (r *MaaSAuthPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	ctx = oteljson.IntoContext(ctx)
-	log := oteljson.FromContext(ctx).WithValues("MaaSAuthPolicy", req.NamespacedName)
+	log := logr.FromContextOrDiscard(ctx).WithValues("MaaSAuthPolicy", req.NamespacedName)
 
 	policy := &maasv1alpha1.MaaSAuthPolicy{}
 	if err := r.Get(ctx, req.NamespacedName, policy); err != nil {
@@ -665,7 +663,7 @@ func (r *MaaSAuthPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 // findMissingModelRefs returns a list of model refs that don't exist or couldn't be fetched.
 // Treats both NotFound and transient errors as "missing" to fail-safe (avoid falsely reporting Active).
 func (r *MaaSAuthPolicyReconciler) findMissingModelRefs(ctx context.Context, policy *maasv1alpha1.MaaSAuthPolicy) []maasv1alpha1.ModelRef {
-	log := oteljson.FromContext(ctx)
+	log := logr.FromContextOrDiscard(ctx)
 	var missing []maasv1alpha1.ModelRef
 	for _, ref := range policy.Spec.ModelRefs {
 		model := &maasv1alpha1.MaaSModelRef{}
@@ -763,14 +761,17 @@ func (r *MaaSAuthPolicyReconciler) buildGatewayAuthPolicySpec(oidc *oidcConfig, 
 			"metrics":  false,
 			"priority": int64(0),
 		},
+		// openshift-identities has no `when` guard — it always applies when
+		// higher-priority methods fail.  For Bearer sk-oai- requests, api-keys
+		// (priority 0) succeeds first (OR semantics) so openshift-identities is
+		// never reached.  For x-api-key requests, api-keys-x-api-key (priority 1)
+		// succeeds first.  For OC/OIDC tokens, this is the only matching method.
+		// Avoiding a CEL predicate here is intentional: in Authorino's proto-map
+		// CEL context, accessing request.headers.authorization when the header is
+		// absent throws an error that silently skips the method.
 		"openshift-identities": map[string]any{
 			"kubernetesTokenReview": map[string]any{
 				"audiences": []any{r.ClusterAudience},
-			},
-			"when": []any{
-				map[string]any{
-					"predicate": celIsNotAPIKey,
-				},
 			},
 			"metrics":  false,
 			"priority": int64(2),
@@ -780,11 +781,20 @@ func (r *MaaSAuthPolicyReconciler) buildGatewayAuthPolicySpec(oidc *oidcConfig, 
 	if xAPIKeyEnabled {
 		authenticationRules["api-keys-x-api-key"] = map[string]any{
 			"plain": map[string]any{
-				"selector": "request.headers.x-api-key",
+				// Use CEL expression (not deprecated selector): Authorino's plain selector
+				// engine cannot retrieve hyphenated headers via bracket notation and
+				// returns null even when x-api-key is present. Expression works; the
+				// structured when clause below ensures this method only runs for sk-oai keys.
+				"expression": `request.headers["x-api-key"]`,
 			},
+			// Structured `when` (not a CEL predicate) — Authorino's selector engine
+			// returns null for absent headers (→ no match → false) rather than
+			// throwing an error as CEL bracket access does.
 			"when": []any{
 				map[string]any{
-					"predicate": `"x-api-key" in request.headers && request.headers["x-api-key"].matches("^sk-oai-.*") && !request.headers.authorization.matches("^Bearer sk-oai-.*")`,
+					"selector": "request.headers.x-api-key",
+					"operator": "matches",
+					"value":    "^sk-oai-.*",
 				},
 			},
 			"metrics":  false,
@@ -820,7 +830,9 @@ func (r *MaaSAuthPolicyReconciler) buildGatewayAuthPolicySpec(oidc *oidcConfig, 
 		"deny-api-key-management": map[string]any{
 			"when": []any{
 				map[string]any{
-					"predicate": celIsAPIKey + ` && (request.path == "/maas-api/v1/api-keys" || request.path.startsWith("/maas-api/v1/api-keys/"))`,
+					// Parenthesize celIsAPIKey: it contains || when x-api-key is enabled; without
+					// parens CEL binds && tighter than || and Bearer API keys match every path.
+					"predicate": `(` + celIsAPIKey + `) && (request.path == "/maas-api/v1/api-keys" || request.path.startsWith("/maas-api/v1/api-keys/"))`,
 				},
 			},
 			"metrics":  false,
@@ -958,9 +970,16 @@ allow {
 	defaultsRules := map[string]any{
 		"metadata": map[string]any{
 			"apiKeyValidation": map[string]any{
+				// Use auth.identity (set by the winning auth method) rather than a
+				// header-based CEL expression.  In Authorino's proto-map CEL context,
+				// accessing an absent header via bracket notation throws an error that
+				// silently suppresses the metadata call; auth.identity is always a
+				// safe string after authentication succeeds.
+				// api-keys sets identity = "Bearer sk-oai-…", api-keys-x-api-key sets
+				// identity = "sk-oai-…" — both start with "sk-oai-" after stripping.
 				"when": []any{
 					map[string]any{
-						"predicate": celIsAPIKey,
+						"predicate": `auth.identity.matches("^(Bearer )?sk-oai-.*")`,
 					},
 				},
 				"http": map[string]any{
@@ -968,12 +987,12 @@ allow {
 					"contentType": "application/json",
 					"method":      "POST",
 					"body": map[string]any{
-						"expression": `{"key": ` + celExtractKey + `}`,
+						"expression": `{"key": auth.identity.replace("Bearer ", "")}`,
 					},
 				},
 				"cache": map[string]any{
 					"key": map[string]any{
-						"selector": celExtractKey,
+						"selector": `auth.identity.replace("Bearer ", "")`,
 					},
 					"ttl": r.MetadataCacheTTL,
 				},
@@ -1754,12 +1773,14 @@ func apiKeyCELPredicates(xAPIKeyEnabled bool) (isAPIKey, isNotAPIKey, extractRaw
 			`!request.headers.authorization.startsWith("Bearer sk-oai-")`,
 			`request.headers.authorization.replace("Bearer ", "")`
 	}
-	isAPIKey = `request.headers.authorization.matches("^Bearer sk-oai-.*") || ` +
-		`("x-api-key" in request.headers && request.headers["x-api-key"].matches("^sk-oai-.*"))`
+	authorizationAPIKey := `("authorization" in request.headers && request.headers["authorization"].matches("^Bearer sk-oai-.*"))`
+	//nolint:gosec // sk-oai- is a CEL pattern for API key format validation, not a credential
+	xAPIKey := `("x-api-key" in request.headers && request.headers["x-api-key"].matches("^sk-oai-.*"))`
+	isAPIKey = authorizationAPIKey + ` || ` + xAPIKey
 	isNotAPIKey = `!(` + isAPIKey + `)`
-	extractRawKey = `request.headers.authorization.matches("^Bearer sk-oai-.*") ` +
-		`? request.headers.authorization.replace("Bearer ", "") ` +
-		`: request.headers["x-api-key"]`
+	extractRawKey = `(` +
+		authorizationAPIKey + ` ? request.headers["authorization"].replace("Bearer ", "") : ` +
+		xAPIKey + ` ? request.headers["x-api-key"] : "")`
 	return isAPIKey, isNotAPIKey, extractRawKey
 }
 
@@ -1881,7 +1902,7 @@ func (r *MaaSAuthPolicyReconciler) updateStatus(ctx context.Context, policy *maa
 	}
 
 	if err := r.Status().Update(ctx, policy); err != nil {
-		log := oteljson.FromContext(ctx)
+		log := logr.FromContextOrDiscard(ctx)
 		log.Error(err, "failed to update MaaSAuthPolicy status", "name", policy.Name)
 	}
 }
@@ -1978,10 +1999,27 @@ func (r *MaaSAuthPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		), builder.WithPredicates(predicate.LabelChangedPredicate{}))
 	}
 
+	// Watch IPP ExternalModel (inference.opendatahub.io) so that creating or
+	// deleting a CR with apiFormat=messages re-runs discoverXAPIKeyNeeded and
+	// adds/removes the x-api-key identity source from the gateway AuthPolicy.
+	// The CRD may not be installed, so the watch is conditional.
+	const ippExternalModelCRD = "externalmodels.inference.opendatahub.io"
+	if crdExists(context.Background(), mgr.GetAPIReader(), ippExternalModelCRD) {
+		ippExternalModel := &unstructured.Unstructured{}
+		ippExternalModel.SetGroupVersionKind(schema.GroupVersionKind{
+			Group:   "inference.opendatahub.io",
+			Version: "v1alpha1",
+			Kind:    "ExternalModel",
+		})
+		b = b.Watches(ippExternalModel, handler.EnqueueRequestsFromMapFunc(
+			r.mapIPPExternalModelToMaaSAuthPolicies,
+		))
+	}
+
 	if err := mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
 		startLog := ctrl.Log.WithName("maas-authpolicy-controller").WithValues("phase", "startup")
-		if err := r.ensureBaseGatewayAuthPolicy(ctx, startLog, nil, false, "", r.GatewayNamespace, r.GatewayName); err != nil {
-			startLog.Error(err, "failed to ensure base maas-gateway-auth on startup (non-fatal)")
+		if err := r.syncDefaultGatewayAuthPolicyForXAPIKeyDiscovery(ctx, startLog); err != nil {
+			startLog.Error(err, "failed to sync default gateway AuthPolicy on startup (non-fatal)")
 		}
 		return nil
 	})); err != nil {
@@ -2038,7 +2076,7 @@ func (r *MaaSAuthPolicyReconciler) mapAITenantToMaaSAuthPolicies(ctx context.Con
 	tenantNamespace := tenantreconcile.TenantNamespaceForAITenant(aitenant.Name, r.TenantNamespace)
 	policyList := &maasv1alpha1.MaaSAuthPolicyList{}
 	if err := r.List(ctx, policyList, client.InNamespace(tenantNamespace)); err != nil {
-		oteljson.FromContext(ctx).Error(err, "failed to list MaaSAuthPolicy resources for AITenant change",
+		ctrl.LoggerFrom(ctx).Error(err, "failed to list MaaSAuthPolicy resources for AITenant change",
 			"tenantNamespace", tenantNamespace,
 			"aitenant", obj.GetNamespace()+"/"+obj.GetName())
 		return nil
@@ -2058,7 +2096,7 @@ func (r *MaaSAuthPolicyReconciler) mapAITenantToMaaSAuthPolicies(ctx context.Con
 func (r *MaaSAuthPolicyReconciler) mapTenantToMaaSAuthPolicies(ctx context.Context, obj client.Object) []reconcile.Request {
 	policyList := &maasv1alpha1.MaaSAuthPolicyList{}
 	if err := r.List(ctx, policyList, client.InNamespace(obj.GetNamespace())); err != nil {
-		oteljson.FromContext(ctx).Error(err, "failed to list MaaSAuthPolicy resources for Tenant change",
+		ctrl.LoggerFrom(ctx).Error(err, "failed to list MaaSAuthPolicy resources for Tenant change",
 			"tenantNamespace", obj.GetNamespace())
 		return nil
 	}
@@ -2085,7 +2123,46 @@ func (r *MaaSAuthPolicyReconciler) mapNamespaceToMaaSAuthPolicies(ctx context.Co
 	}
 	policyList := &maasv1alpha1.MaaSAuthPolicyList{}
 	if err := r.List(ctx, policyList, client.InNamespace(ns)); err != nil {
-		oteljson.FromContext(ctx).Error(err, "failed to list MaaSAuthPolicy for namespace label change", "namespace", ns)
+		ctrl.LoggerFrom(ctx).Error(err, "failed to list MaaSAuthPolicy for namespace label change", "namespace", ns)
+		return nil
+	}
+	requests := make([]reconcile.Request, len(policyList.Items))
+	for i, p := range policyList.Items {
+		requests[i] = reconcile.Request{NamespacedName: types.NamespacedName{Name: p.Name, Namespace: p.Namespace}}
+	}
+	return requests
+}
+
+// syncDefaultGatewayAuthPolicyForXAPIKeyDiscovery updates the default gateway AuthPolicy
+// so authentication rules reflect current IPP ExternalModel-driven x-api-key discovery.
+func (r *MaaSAuthPolicyReconciler) syncDefaultGatewayAuthPolicyForXAPIKeyDiscovery(ctx context.Context, log logr.Logger) error {
+	oidcNS := r.TenantNamespace
+	if oidcNS == "" {
+		oidcNS = "opendatahub"
+	}
+	oidc := r.fetchOIDCConfig(ctx, log, oidcNS)
+	xAPIKeyEnabled := r.discoverXAPIKeyNeeded(ctx, log)
+	_, err := r.reconcileGatewayAuthPolicy(ctx, log, oidc, xAPIKeyEnabled, "", r.GatewayNamespace, r.GatewayName)
+	return err
+}
+
+// mapIPPExternalModelToMaaSAuthPolicies enqueues all MaaSAuthPolicies when an
+// IPP ExternalModel (inference.opendatahub.io) is created, updated, or deleted.
+// discoverXAPIKeyNeeded scans cluster-wide, so any ExternalModel change may
+// affect whether the x-api-key identity source should be present.
+// When no MaaSAuthPolicies exist yet, enqueuing would be a no-op; sync the default
+// gateway AuthPolicy directly instead.
+func (r *MaaSAuthPolicyReconciler) mapIPPExternalModelToMaaSAuthPolicies(ctx context.Context, _ client.Object) []reconcile.Request {
+	log := ctrl.LoggerFrom(ctx)
+	policyList := &maasv1alpha1.MaaSAuthPolicyList{}
+	if err := r.List(ctx, policyList); err != nil {
+		log.Error(err, "failed to list MaaSAuthPolicy resources for IPP ExternalModel change")
+		return nil
+	}
+	if len(policyList.Items) == 0 {
+		if err := r.syncDefaultGatewayAuthPolicyForXAPIKeyDiscovery(ctx, log); err != nil {
+			log.Error(err, "failed to sync default gateway AuthPolicy for IPP ExternalModel change")
+		}
 		return nil
 	}
 	requests := make([]reconcile.Request, len(policyList.Items))

--- a/maas-controller/pkg/controller/maas/maasauthpolicy_controller_test.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_controller_test.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -2723,14 +2724,29 @@ func TestMapIPPExternalModelToMaaSAuthPolicies(t *testing.T) {
 			"spec": baseSpec,
 		}}
 		gwPolicy.SetGroupVersionKind(schema.GroupVersionKind{Group: "kuadrant.io", Version: "v1", Kind: "AuthPolicy"})
+		gateway := &gatewayapiv1.Gateway{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: gatewayapiv1.GroupVersion.String(),
+				Kind:       "Gateway",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "maas-default-gateway",
+				Namespace: gatewayNS,
+				UID:       "ipp-sync-gw-uid",
+			},
+		}
 
 		c := fake.NewClientBuilder().
 			WithScheme(scheme).
 			WithRESTMapper(testRESTMapper()).
-			WithObjects(extModel, gwPolicy).
+			WithObjects(extModel, gwPolicy, gateway).
 			Build()
 		r.Client = c
 		r.Scheme = scheme
+		r.ippGatewaySyncQueue = workqueue.NewTypedRateLimitingQueueWithConfig(
+			workqueue.DefaultTypedControllerRateLimiter[struct{}](),
+			workqueue.TypedRateLimitingQueueConfig[struct{}]{Name: "ipp-gateway-x-api-key-sync-test"},
+		)
 
 		reqs := r.mapIPPExternalModelToMaaSAuthPolicies(context.Background(), extModel)
 		if len(reqs) != 0 {
@@ -2911,10 +2927,10 @@ func TestMaaSAuthPolicyReconciler_TenantGateway_OwnerReference(t *testing.T) {
 	}
 }
 
-// TestMaaSAuthPolicyReconciler_DefaultGateway_NoOwnerReference verifies that the controller
-// does NOT set an OwnerReference on the default gateway AuthPolicy. The default gateway
-// lifecycle is managed independently and should not be subject to cascade deletion.
-func TestMaaSAuthPolicyReconciler_DefaultGateway_NoOwnerReference(t *testing.T) {
+// TestMaaSAuthPolicyReconciler_DefaultGateway_OwnerReference verifies that the controller
+// sets an OwnerReference on the default gateway AuthPolicy so stale policies are garbage
+// collected when the Gateway is replaced or deleted.
+func TestMaaSAuthPolicyReconciler_DefaultGateway_OwnerReference(t *testing.T) {
 	const (
 		modelName      = "llm"
 		namespace      = "default"
@@ -2928,11 +2944,22 @@ func TestMaaSAuthPolicyReconciler_DefaultGateway_NoOwnerReference(t *testing.T) 
 	route := newHTTPRoute(httpRouteName, namespace)
 	maasPolicy := newMaaSAuthPolicy(maasPolicyName, namespace, "team-a",
 		maasv1alpha1.ModelRef{Name: modelName, Namespace: namespace})
+	gateway := &gatewayapiv1.Gateway{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: gatewayapiv1.GroupVersion.String(),
+			Kind:       "Gateway",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      gatewayName,
+			Namespace: gatewayNS,
+			UID:       "default-gw-uid-12345",
+		},
+	}
 
 	c := fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithRESTMapper(testRESTMapper()).
-		WithObjects(model, route, maasPolicy).
+		WithObjects(model, route, maasPolicy, gateway).
 		WithStatusSubresource(&maasv1alpha1.MaaSAuthPolicy{}).
 		Build()
 
@@ -2949,17 +2976,18 @@ func TestMaaSAuthPolicyReconciler_DefaultGateway_NoOwnerReference(t *testing.T) 
 		t.Fatalf("Reconcile: unexpected error: %v", err)
 	}
 
-	// Verify the default gateway AuthPolicy exists
 	ap := &unstructured.Unstructured{}
 	ap.SetGroupVersionKind(schema.GroupVersionKind{Group: "kuadrant.io", Version: "v1", Kind: "AuthPolicy"})
 	if err := c.Get(context.Background(), types.NamespacedName{Name: maasGatewayAuthPolicyName, Namespace: gatewayNS}, ap); err != nil {
 		t.Fatalf("Get default gateway AuthPolicy: %v", err)
 	}
 
-	// Default gateway AuthPolicy must NOT have OwnerReferences
 	ownerRefs := ap.GetOwnerReferences()
-	if len(ownerRefs) != 0 {
-		t.Errorf("default gateway AuthPolicy should have no OwnerReferences, got %d: %v", len(ownerRefs), ownerRefs)
+	if len(ownerRefs) != 1 {
+		t.Fatalf("default gateway AuthPolicy should have 1 OwnerReference, got %d: %v", len(ownerRefs), ownerRefs)
+	}
+	if ownerRefs[0].Name != gatewayName || ownerRefs[0].UID != gateway.UID {
+		t.Errorf("OwnerReference = %#v, want Gateway %s uid %s", ownerRefs[0], gatewayName, gateway.UID)
 	}
 }
 

--- a/maas-controller/pkg/controller/maas/maasauthpolicy_controller_test.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_controller_test.go
@@ -1802,6 +1802,38 @@ func TestBuildGatewayAuthPolicySpec_DenyAPIKeyManagement(t *testing.T) {
 		t.Fatalf("deny-api-key-management must be scoped to API keys: %q", predicate)
 	}
 
+	t.Run("x-api-key enabled parenthesizes API key OR before path guard", func(t *testing.T) {
+		r := &MaaSAuthPolicyReconciler{
+			InfraNamespace:   "maas-system",
+			GatewayName:      "maas-default-gateway",
+			GatewayNamespace: "gateway-ns",
+			ClusterAudience:  "https://kubernetes.default.svc",
+			MetadataCacheTTL: 60,
+			AuthzCacheTTL:    60,
+		}
+		spec := r.buildGatewayAuthPolicySpec(nil, true, "", "models-as-a-service", "test-gateway-ns", "test-gateway")
+		enabledObj := &unstructured.Unstructured{Object: map[string]any{"spec": spec}}
+		when, found, err := unstructured.NestedSlice(enabledObj.Object,
+			"spec", "defaults", "rules", "authorization", "deny-api-key-management", "when")
+		if err != nil || !found || len(when) == 0 {
+			t.Fatalf("deny-api-key-management when missing for x-api-key enabled spec: found=%v err=%v", found, err)
+		}
+		whenMap, ok := when[0].(map[string]any)
+		if !ok {
+			t.Fatalf("when[0] is not a map: %T", when[0])
+		}
+		enabledPredicate, ok := whenMap["predicate"].(string)
+		if !ok {
+			t.Fatal("deny-api-key-management predicate missing")
+		}
+		if !strings.HasPrefix(enabledPredicate, "(") {
+			t.Fatalf("deny-api-key-management predicate must parenthesize celIsAPIKey when x-api-key enabled, got: %q", enabledPredicate)
+		}
+		if strings.Count(enabledPredicate, "||") < 2 {
+			t.Fatalf("expected Bearer and x-api-key OR branches plus path OR, got: %q", enabledPredicate)
+		}
+	})
+
 	patterns, found, err := unstructured.NestedSlice(obj.Object,
 		"spec", "defaults", "rules", "authorization", "deny-api-key-management", "patternMatching", "patterns")
 	if err != nil || !found {
@@ -1908,9 +1940,12 @@ func TestBuildGatewayAuthPolicySpec_XAPIKeyEnabled(t *testing.T) {
 	if !ok {
 		t.Fatalf("api-keys-x-api-key is not a map: %T", xAPIKey)
 	}
-	sel, _, _ := unstructured.NestedString(xAPIKeyMap, "plain", "selector")
-	if sel != "request.headers.x-api-key" {
-		t.Errorf("api-keys-x-api-key plain.selector should be request.headers.x-api-key, got: %s", sel)
+	expr, _, _ := unstructured.NestedString(xAPIKeyMap, "plain", "expression")
+	if !contains(expr, "x-api-key") {
+		t.Errorf("api-keys-x-api-key plain.expression should reference x-api-key, got: %s", expr)
+	}
+	if _, found, _ := unstructured.NestedString(xAPIKeyMap, "plain", "selector"); found {
+		t.Error("api-keys-x-api-key must use plain.expression, not deprecated plain.selector")
 	}
 
 	priority, ok := xAPIKeyMap["priority"].(int64)
@@ -1922,9 +1957,16 @@ func TestBuildGatewayAuthPolicySpec_XAPIKeyEnabled(t *testing.T) {
 	if err2 != nil || !found2 || len(xAPIKeyWhen) == 0 {
 		t.Fatalf("api-keys-x-api-key when missing: found=%v err=%v", found2, err2)
 	}
-	xWhenPred, _ := xAPIKeyWhen[0].(map[string]any)["predicate"].(string)
-	if !contains(xWhenPred, `!request.headers.authorization.matches`) {
-		t.Errorf("api-keys-x-api-key when should exclude requests with Authorization Bearer sk-oai-, got: %s", xWhenPred)
+	xWhenMap, ok := xAPIKeyWhen[0].(map[string]any)
+	if !ok {
+		t.Fatalf("api-keys-x-api-key when[0] is not a map")
+	}
+	// Structured when clause (not CEL) — uses selector/operator/value to match x-api-key header
+	whenSel, _, _ := unstructured.NestedString(xWhenMap, "selector")
+	whenOp, _, _ := unstructured.NestedString(xWhenMap, "operator")
+	whenVal, _, _ := unstructured.NestedString(xWhenMap, "value")
+	if !contains(whenSel, "x-api-key") || whenOp != "matches" || !contains(whenVal, "sk-oai") {
+		t.Errorf("api-keys-x-api-key when should match x-api-key header against sk-oai prefix, got: selector=%s op=%s val=%s", whenSel, whenOp, whenVal)
 	}
 
 	apiKeyWhen, found, err := unstructured.NestedSlice(obj.Object, "spec", "defaults", "rules", "metadata", "apiKeyValidation", "when")
@@ -1939,18 +1981,16 @@ func TestBuildGatewayAuthPolicySpec_XAPIKeyEnabled(t *testing.T) {
 	if !ok {
 		t.Fatal("apiKeyValidation when should use predicate (not selector) when x-api-key enabled")
 	}
-	if !contains(pred, "x-api-key") {
-		t.Errorf("apiKeyValidation when predicate should include x-api-key check, got: %s", pred)
+	// Metadata validation uses auth.identity (post-auth, safe) which works for both Bearer and x-api-key
+	// Both auth methods populate auth.identity with an API key format (with or without "Bearer " prefix)
+	if !contains(pred, "auth.identity") || !contains(pred, "sk-oai") {
+		t.Errorf("apiKeyValidation when predicate should check auth.identity for API key format, got: %s", pred)
 	}
 
-	osWhen, found, err := unstructured.NestedSlice(obj.Object, "spec", "defaults", "rules", "authentication", "openshift-identities", "when")
-	if err != nil || !found || len(osWhen) == 0 {
-		t.Fatalf("openshift-identities when missing")
-	}
-	osPred, _ := osWhen[0].(map[string]any)["predicate"].(string)
-	if !contains(osPred, "x-api-key") {
-		t.Errorf("openshift-identities when should exclude x-api-key requests, got: %s", osPred)
-	}
+	// openshift-identities intentionally has no `when` guard (see comments in code).
+	// It always applies when higher-priority methods fail. API key methods (priority 0-1)
+	// succeed first so openshift-identities is not reached for API key requests.
+	// For non-API-key requests (OC/OIDC tokens), openshift-identities is the fallback.
 }
 
 // TestBuildGatewayAuthPolicySpec_OIDCJWKsTTL verifies that the OIDC JWKS TTL from the
@@ -2619,6 +2659,99 @@ func TestDiscoverXAPIKeyNeeded(t *testing.T) {
 	})
 }
 
+func TestMapIPPExternalModelToMaaSAuthPolicies(t *testing.T) {
+	const gatewayNS = "gateway-ns"
+
+	t.Run("enqueues all MaaSAuthPolicies when present", func(t *testing.T) {
+		policyA := newMaaSAuthPolicy("policy-a", "models-as-a-service", "team-a",
+			maasv1alpha1.ModelRef{Name: "llm", Namespace: "llm"})
+		policyB := newMaaSAuthPolicy("policy-b", "models-as-a-service", "team-b",
+			maasv1alpha1.ModelRef{Name: "llm", Namespace: "llm"})
+
+		c := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithRESTMapper(testRESTMapper()).
+			WithObjects(policyA, policyB).
+			Build()
+
+		r := &MaaSAuthPolicyReconciler{Client: c, Scheme: scheme}
+		reqs := r.mapIPPExternalModelToMaaSAuthPolicies(context.Background(), nil)
+		if len(reqs) != 2 {
+			t.Fatalf("expected 2 reconcile requests, got %d", len(reqs))
+		}
+	})
+
+	t.Run("syncs default gateway AuthPolicy when no MaaSAuthPolicies exist", func(t *testing.T) {
+		extModel := &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "inference.opendatahub.io/v1alpha1",
+			"kind":       "ExternalModel",
+			"metadata":   map[string]any{"name": "claude-model", "namespace": "llm"},
+			"spec": map[string]any{
+				"externalProviderRefs": []any{
+					map[string]any{
+						"ref":         map[string]any{"name": "anthropic-provider"},
+						"targetModel": "claude-sonnet-4-5-20241022",
+						"apiFormat":   "messages",
+						"path":        "/v1/messages",
+					},
+				},
+			},
+		}}
+		extModel.SetGroupVersionKind(schema.GroupVersionKind{
+			Group: "inference.opendatahub.io", Version: "v1alpha1", Kind: "ExternalModel",
+		})
+
+		r := &MaaSAuthPolicyReconciler{
+			InfraNamespace:   "maas-system",
+			GatewayNamespace: gatewayNS,
+			GatewayName:      "maas-default-gateway",
+			ClusterAudience:  "https://kubernetes.default.svc",
+			MetadataCacheTTL: 60,
+			AuthzCacheTTL:    60,
+		}
+		baseSpec := r.buildGatewayAuthPolicySpec(nil, false, "", "models-as-a-service", gatewayNS, "maas-default-gateway")
+		gwPolicy := &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "kuadrant.io/v1",
+			"kind":       "AuthPolicy",
+			"metadata": map[string]any{
+				"name":      "maas-gateway-auth",
+				"namespace": gatewayNS,
+				"labels": map[string]any{
+					"app.kubernetes.io/managed-by": "maas-controller",
+				},
+			},
+			"spec": baseSpec,
+		}}
+		gwPolicy.SetGroupVersionKind(schema.GroupVersionKind{Group: "kuadrant.io", Version: "v1", Kind: "AuthPolicy"})
+
+		c := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithRESTMapper(testRESTMapper()).
+			WithObjects(extModel, gwPolicy).
+			Build()
+		r.Client = c
+		r.Scheme = scheme
+
+		reqs := r.mapIPPExternalModelToMaaSAuthPolicies(context.Background(), extModel)
+		if len(reqs) != 0 {
+			t.Fatalf("expected no MaaSAuthPolicy reconcile requests, got %d", len(reqs))
+		}
+
+		updated := &unstructured.Unstructured{}
+		updated.SetGroupVersionKind(gwPolicy.GroupVersionKind())
+		if err := c.Get(context.Background(), types.NamespacedName{Name: "maas-gateway-auth", Namespace: gatewayNS}, updated); err != nil {
+			t.Fatalf("Get gateway AuthPolicy: %v", err)
+		}
+		auth, found, err := unstructured.NestedMap(updated.Object, "spec", "defaults", "rules", "authentication")
+		if err != nil || !found {
+			t.Fatalf("authentication block missing: found=%v err=%v", found, err)
+		}
+		if _, exists := auth["api-keys-x-api-key"]; !exists {
+			t.Fatal("expected api-keys-x-api-key identity after IPP ExternalModel sync")
+		}
+	})
+}
+
 func TestAPIKeyCELPredicates(t *testing.T) {
 	t.Run("disabled returns original expressions", func(t *testing.T) {
 		isAPIKey, isNotAPIKey, extractKey := apiKeyCELPredicates(false)
@@ -2641,18 +2774,34 @@ func TestAPIKeyCELPredicates(t *testing.T) {
 		if !contains(isNotAPIKey, "x-api-key") {
 			t.Errorf("isNotAPIKey should reference x-api-key when enabled, got: %s", isNotAPIKey)
 		}
-		if !contains(extractKey, "x-api-key") {
-			t.Errorf("extractKey should reference x-api-key when enabled, got: %s", extractKey)
+		// extractKey now uses explicit presence checks on headers with fallback to empty string.
+		// This avoids CEL errors on absent Authorization header. This is the security fix.
+		if !contains(extractKey, "authorization") || !contains(extractKey, "x-api-key") {
+			t.Errorf("extractKey should check both authorization and x-api-key headers when enabled, got: %s", extractKey)
+		}
+		if !contains(extractKey, `request.headers["authorization"].replace("Bearer ", "")`) {
+			t.Errorf("extractKey should extract from authorization header when present, got: %s", extractKey)
+		}
+		if !contains(extractKey, `request.headers["x-api-key"]`) {
+			t.Errorf("extractKey should extract from x-api-key header when present, got: %s", extractKey)
 		}
 		if !contains(isAPIKey, "authorization") {
 			t.Errorf("isAPIKey should still reference authorization header, got: %s", isAPIKey)
 		}
 	})
 
-	t.Run("enabled extractKey prefers Authorization over x-api-key", func(t *testing.T) {
+	t.Run("enabled extractKey uses explicit presence checks (safe header access)", func(t *testing.T) {
 		_, _, extractKey := apiKeyCELPredicates(true)
-		if !strings.HasPrefix(extractKey, `request.headers.authorization.matches`) {
-			t.Errorf("extractKey should check Authorization first (prefer Bearer over x-api-key), got: %s", extractKey)
+		// Use explicit presence checks ("header" in request.headers) to avoid CEL errors
+		// when headers are absent. Both auth methods (Bearer and x-api-key) work safely.
+		if !strings.Contains(extractKey, `"authorization" in request.headers`) {
+			t.Errorf("extractKey should check authorization header presence before access, got: %s", extractKey)
+		}
+		if !strings.Contains(extractKey, `"x-api-key" in request.headers`) {
+			t.Errorf("extractKey should check x-api-key header presence before access, got: %s", extractKey)
+		}
+		if !strings.Contains(extractKey, ` : ""`) {
+			t.Errorf("extractKey should fallback to empty string when no API key headers present, got: %s", extractKey)
 		}
 	})
 }

--- a/test/e2e/tests/test_x_api_key_auth.py
+++ b/test/e2e/tests/test_x_api_key_auth.py
@@ -26,6 +26,9 @@ import pytest
 import requests
 
 from test_helper import (
+    MODEL_NAME,
+    MODEL_NAMESPACE,
+    MODEL_PATH,
     TIMEOUT,
     TLS_VERIFY,
     _apply_cr,
@@ -38,10 +41,27 @@ from test_helper import (
 log = logging.getLogger(__name__)
 
 GATEWAY_NAMESPACE = os.environ.get("GATEWAY_NAMESPACE", "openshift-ingress")
+GATEWAY_AUTH_POLICY_NAME = "maas-gateway-auth"
 IDENTITY_SOURCE_NAME = "api-keys-x-api-key"
 
 IPP_EXTERNAL_MODEL_CRD = "externalmodels.inference.opendatahub.io"
 IPP_EXTERNAL_MODEL_NAME = "e2e-x-api-key-trigger"
+
+IPP_EXTERNAL_MODEL_CR = {
+    "apiVersion": "inference.opendatahub.io/v1alpha1",
+    "kind": "ExternalModel",
+    "metadata": {"name": IPP_EXTERNAL_MODEL_NAME, "namespace": MODEL_NAMESPACE},
+    "spec": {
+        "modelName": "claude-test",
+        "externalProviderRefs": [{
+            "ref": {"name": "dummy-anthropic"},
+            "targetModel": "claude-sonnet-4-20250514",
+            "apiFormat": "messages",
+            "path": "/v1/messages",
+        }],
+    },
+}
+
 
 def _crd_installed(crd_name):
     """Check if a CRD is installed on the cluster."""
@@ -52,10 +72,10 @@ def _crd_installed(crd_name):
     return result.returncode == 0
 
 
-def _get_authpolicy_identities(context):
+def _get_authpolicy_identities():
     """Get the list of identity source names from the gateway AuthPolicy."""
     result = subprocess.run(
-        ["oc", "get", "authpolicy", context.gateway_authpolicy_name,
+        ["oc", "get", "authpolicy", GATEWAY_AUTH_POLICY_NAME,
          "-n", GATEWAY_NAMESPACE, "-o", "json"],
         capture_output=True, text=True, timeout=30,
     )
@@ -69,11 +89,11 @@ def _get_authpolicy_identities(context):
     return list(authentication.keys())
 
 
-def _wait_for_identity_source(context, identity_name, present=True, timeout=120):
+def _wait_for_identity_source(identity_name, present=True, timeout=120):
     """Poll AuthPolicy until an identity source appears or disappears."""
     deadline = time.time() + timeout
     while time.time() < deadline:
-        identities = _get_authpolicy_identities(context)
+        identities = _get_authpolicy_identities()
         found = identity_name in identities
         if found == present:
             log.info(
@@ -84,39 +104,38 @@ def _wait_for_identity_source(context, identity_name, present=True, timeout=120)
         time.sleep(5)
     raise TimeoutError(
         f"Identity source {identity_name!r} did not {'appear' if present else 'disappear'} "
-        f"within {timeout}s. Current identities: {_get_authpolicy_identities(context)}"
+        f"within {timeout}s. Current identities: {_get_authpolicy_identities()}"
     )
 
 
-def _trigger_reconcile(context):
-    """Annotate all MaaSAuthPolicies to trigger controller reconciliation."""
-    ns = context.tenant_namespace
+def _trigger_reconcile():
+    """Trigger controller reconciliation by touching the IPP ExternalModel CR.
+
+    Annotating the ExternalModel causes the controller's ExternalModel watch to
+    fire, which enqueues all MaaSAuthPolicies for reconciliation.  Annotating
+    MaaSAuthPolicies directly is ineffective because their watch uses
+    GenerationChangedPredicate, which ignores metadata-only updates.
+    """
     result = subprocess.run(
-        ["oc", "get", "maasauthpolicy", "-n", ns, "-o", "name"],
+        ["oc", "annotate",
+         f"externalmodel.inference.opendatahub.io/{IPP_EXTERNAL_MODEL_NAME}",
+         "-n", MODEL_NAMESPACE,
+         f"e2e.maas/reconcile-trigger={int(time.time())}", "--overwrite"],
         capture_output=True, text=True, timeout=30,
     )
     if result.returncode != 0:
-        log.warning("Failed to list MaaSAuthPolicies: %s", result.stderr.strip())
-        return
-
-    for resource in result.stdout.strip().splitlines():
-        if not resource:
-            continue
-        subprocess.run(
-            ["oc", "annotate", resource, "-n", ns,
-             f"e2e.maas/reconcile-trigger={int(time.time())}", "--overwrite"],
-            capture_output=True, text=True, timeout=30,
-        )
+        log.warning("Failed to annotate ExternalModel to trigger reconcile: %s",
+                    result.stderr.strip())
 
 
-def _inference_x_api_key(api_key, context):
+def _inference_x_api_key(api_key, path=None, model_name=None):
     """Send inference with x-api-key header instead of Authorization."""
-    path = f"/{context.model_namespace}/{context.model_ref}"
+    path = path or MODEL_PATH
     url = f"{_gateway_url()}{path}/v1/completions"
     headers = {"x-api-key": api_key, "Content-Type": "application/json"}
     return requests.post(
         url, headers=headers,
-        json={"model": f"e2e/{context.model_ref}", "prompt": "Hello", "max_tokens": 3},
+        json={"model": model_name or MODEL_NAME, "prompt": "Hello", "max_tokens": 3},
         timeout=TIMEOUT, verify=TLS_VERIFY,
     )
 
@@ -127,12 +146,11 @@ pytestmark = [
         reason=f"IPP ExternalModel CRD ({IPP_EXTERNAL_MODEL_CRD}) not installed",
     ),
     pytest.mark.xdist_group("api_keys"),
-    pytest.mark.worker_tenant,
 ]
 
 
 @pytest.fixture(scope="module")
-def x_api_key_setup(worker_api_key, worker_tenant_context):
+def x_api_key_setup(api_key):
     """Create IPP ExternalModel with apiFormat=messages to enable x-api-key identity source.
 
     Setup:
@@ -145,103 +163,69 @@ def x_api_key_setup(worker_api_key, worker_tenant_context):
       2. Trigger reconciliation
       3. Wait for api-keys-x-api-key identity to be removed
     """
-    from worker_tenant_fixtures import activate_worker_tenant
-
-    context = worker_tenant_context
-    external_model = {
-        "apiVersion": "inference.opendatahub.io/v1alpha1",
-        "kind": "ExternalModel",
-        "metadata": {"name": IPP_EXTERNAL_MODEL_NAME, "namespace": context.model_namespace},
-        "spec": {
-            "modelName": "claude-test",
-            "externalProviderRefs": [{
-                "ref": {"name": "dummy-anthropic"},
-                "targetModel": "claude-sonnet-4-20250514",
-                "apiFormat": "messages",
-            }],
-        },
-    }
     log.info("Setting up x-api-key auth test fixture...")
 
-    with activate_worker_tenant(context):
-        _apply_cr(external_model)
-        _trigger_reconcile(context)
+    _apply_cr(IPP_EXTERNAL_MODEL_CR)
+    _trigger_reconcile()
 
-        try:
-            _wait_for_identity_source(context, IDENTITY_SOURCE_NAME, present=True, timeout=120)
-        except TimeoutError:
-            _delete_cr(
-                "externalmodel.inference.opendatahub.io",
-                IPP_EXTERNAL_MODEL_NAME,
-                context.model_namespace,
-            )
-            raise
+    try:
+        _wait_for_identity_source(IDENTITY_SOURCE_NAME, present=True, timeout=120)
+    except TimeoutError:
+        _delete_cr("externalmodel.inference.opendatahub.io", IPP_EXTERNAL_MODEL_NAME, MODEL_NAMESPACE)
+        raise
 
-        _poll_status(worker_api_key, 200, timeout=60)
+    _poll_status(api_key, 200, timeout=60)
 
-        log.info("x-api-key identity source is active, running tests...")
-        yield worker_api_key
+    log.info("x-api-key identity source is active, running tests...")
+    yield api_key
 
-        log.info("Cleaning up x-api-key auth test fixture...")
-        _delete_cr(
-            "externalmodel.inference.opendatahub.io",
-            IPP_EXTERNAL_MODEL_NAME,
-            context.model_namespace,
-        )
-        _trigger_reconcile(context)
+    log.info("Cleaning up x-api-key auth test fixture...")
+    _delete_cr("externalmodel.inference.opendatahub.io", IPP_EXTERNAL_MODEL_NAME, MODEL_NAMESPACE)
+    _trigger_reconcile()
 
-        try:
-            _wait_for_identity_source(context, IDENTITY_SOURCE_NAME, present=False, timeout=120)
-        except TimeoutError:
-            log.warning("Identity source %s did not disappear during cleanup", IDENTITY_SOURCE_NAME)
+    try:
+        _wait_for_identity_source(IDENTITY_SOURCE_NAME, present=False, timeout=120)
+    except TimeoutError:
+        log.warning("Identity source %s did not disappear during cleanup", IDENTITY_SOURCE_NAME)
 
 
 class TestXAPIKeyAuthentication:
     """Validate x-api-key header authentication when IPP ExternalModel with apiFormat=messages exists."""
 
-    def test_x_api_key_authenticates(self, x_api_key_setup, worker_tenant_context):
+    def test_x_api_key_authenticates(self, x_api_key_setup):
         """x-api-key header with valid API key returns 200."""
         api_key = x_api_key_setup
-        r = _inference_x_api_key(api_key, worker_tenant_context)
+        r = _inference_x_api_key(api_key)
         assert r.status_code == 200, (
             f"Expected 200 with x-api-key header, got {r.status_code}: {r.text[:500]}"
         )
 
-    def test_authorization_bearer_still_works(self, x_api_key_setup, worker_tenant_context):
+    def test_authorization_bearer_still_works(self, x_api_key_setup):
         """Authorization: Bearer still works when x-api-key identity source is active."""
         api_key = x_api_key_setup
-        r = _inference(
-            api_key,
-            path=f"/{worker_tenant_context.model_namespace}/{worker_tenant_context.model_ref}",
-            model_name=f"e2e/{worker_tenant_context.model_ref}",
-        )
+        r = _inference(api_key)
         assert r.status_code == 200, (
             f"Expected 200 with Authorization: Bearer, got {r.status_code}: {r.text[:500]}"
         )
 
-    def test_invalid_x_api_key_rejected(self, x_api_key_setup, worker_tenant_context):
+    def test_invalid_x_api_key_rejected(self, x_api_key_setup):
         """Invalid API key in x-api-key header is rejected."""
-        r = _inference_x_api_key("sk-oai-invalid-not-a-real-key-12345", worker_tenant_context)
+        r = _inference_x_api_key("sk-oai-invalid-not-a-real-key-12345")
         assert r.status_code in (401, 403), (
             f"Expected 401/403 for invalid x-api-key, got {r.status_code}: {r.text[:500]}"
         )
 
-    def test_x_api_key_without_prefix_rejected(self, x_api_key_setup, worker_tenant_context):
+    def test_x_api_key_without_prefix_rejected(self, x_api_key_setup):
         """Random value without sk-oai- prefix in x-api-key header is rejected."""
-        r = _inference_x_api_key("random-value-no-prefix", worker_tenant_context)
+        r = _inference_x_api_key("random-value-no-prefix")
         assert r.status_code in (401, 403), (
             f"Expected 401/403 for x-api-key without valid prefix, got {r.status_code}: {r.text[:500]}"
         )
 
-    def test_both_headers_no_conflict(self, x_api_key_setup, worker_tenant_context):
+    def test_both_headers_no_conflict(self, x_api_key_setup):
         """Sending both Authorization: Bearer and x-api-key does not cause conflicts."""
         api_key = x_api_key_setup
-        r = _inference(
-            api_key,
-            path=f"/{worker_tenant_context.model_namespace}/{worker_tenant_context.model_ref}",
-            model_name=f"e2e/{worker_tenant_context.model_ref}",
-            extra_headers={"x-api-key": api_key},
-        )
+        r = _inference(api_key, extra_headers={"x-api-key": api_key})
         assert r.status_code == 200, (
             f"Expected 200 with both auth headers, got {r.status_code}: {r.text[:500]}"
         )

--- a/test/e2e/tests/test_x_api_key_auth.py
+++ b/test/e2e/tests/test_x_api_key_auth.py
@@ -146,6 +146,7 @@ pytestmark = [
         reason=f"IPP ExternalModel CRD ({IPP_EXTERNAL_MODEL_CRD}) not installed",
     ),
     pytest.mark.xdist_group("api_keys"),
+    pytest.mark.serial,
 ]
 
 


### PR DESCRIPTION
## Summary

Fixes x-api-key E2E and gateway AuthPolicy reconciliation for IPP ExternalModel lifecycle ([RHOAIENG-89890](https://redhat.atlassian.net/browse/RHOAIENG-89890)).

**1. Missing `path` field in ExternalModel fixture**
The `externalmodels.inference.opendatahub.io` CRD requires `path` in each `externalProviderRefs` entry. The fixture was missing it, causing webhook validation to reject the CR with `spec.externalProviderRefs[0].path: Required value`. All 5 tests cascade-failed at fixture setup.

**2. MaaSAuthPolicy reconciler does not react to ExternalModel lifecycle events**
- No watch on `inference.opendatahub.io/ExternalModel`, so `api-keys-x-api-key` was only added/removed on unrelated reconciles.
- `_trigger_reconcile()` annotated MaaSAuthPolicies, but `GenerationChangedPredicate` ignores annotation-only updates.

**3. Gateway AuthPolicy bugs when x-api-key identity is enabled** (found during cluster validation)
- Startup used `ensureBaseGatewayAuthPolicy(..., xAPIKeyEnabled=false)`, so a fresh controller missed existing ExternalModels.
- `mapIPPExternalModelToMaaSAuthPolicies` no-op'd when no MaaSAuthPolicies existed (enqueue path only).
- `deny-api-key-management` CEL lacked parentheses around `celIsAPIKey` (`A || B && path` bound as `A || (B && path)`), denying **all** Bearer `sk-oai-*` requests.
- `api-keys-x-api-key` used deprecated `plain.selector` with bracket notation; Authorino returned null identity — switched to `plain.expression`.

**Fixes:**
- Add `"path": "/v1/messages"` to the ExternalModel fixture
- Watch `inference.opendatahub.io/ExternalModel` → enqueue all MaaSAuthPolicies (or sync default gateway when none exist)
- Annotate ExternalModel in `_trigger_reconcile()` (not MaaSAuthPolicies)
- `syncDefaultGatewayAuthPolicyForXAPIKeyDiscovery()` on startup and empty-policy ExternalModel events
- Parenthesize `deny-api-key-management` when predicate; `plain.expression` for `api-keys-x-api-key`

## Cluster validation ((https://console-openshift-console.apps.rosa.gaurav.eg7x.p3.openshiftapps.com/k8s/ns/redhat-ods-applications/core~v1~Pod?perPage=50), 2026-09-11)

| Check | Result |
|-------|--------|
| ExternalModel fixture applies (`path` present) | **PASS** |
| `api-keys-x-api-key` in `maas-gateway-auth` | **PASS** |
| Bearer API key inference (`/v1/models`, `/llm/.../v1/completions`) | **PASS** (after CEL fix) |
| `x-api-key` inference | **PASS** (after `plain.expression` fix) |
| `pytest tests/test_x_api_key_auth.py` (5 tests) | **PASS** |
| Delete/recreate ExternalModel → identity removed/restored | **PASS** (prior session) |

**Image used for controller testing:** `quay.io/rh-ee-sbhatnag/maas-controller:pr-1435-x-api-key-v2` (AuthPolicy fixes validated via live patch + pytest; commit `a7597151` contains permanent controller codegen).

**Cluster prerequisites noted:** Authorino → maas-api HTTPS requires OpenShift service CA trust (`scripts/setup-authorino-tls.sh`); listener TLS must stay disabled if gateway ext_authz expects plain HTTP.

## Risk analysis

**Risk rating: 2**

**Why:** Adds a conditional ExternalModel watch and tightens gateway AuthPolicy CEL/identity generation when x-api-key is enabled. Clusters without the IPP ExternalModel CRD are unchanged. Unit tests and full `TestXAPIKeyAuthentication` e2e suite pass. Blast radius is gateway auth rules only; no API/CRD schema changes.

## Test plan

- [x] `path: Required value` webhook error no longer fires
- [x] `go test -race ./pkg/controller/maas/...` passes (includes deny-api-key-management + IPP mapper tests)
- [x] Full `TestXAPIKeyAuthentication` on gaurav ROSA (`maas.apps.rosa.gaurav.eg7x.p3.openshiftapps.com`, simulator model deployed)
- [x] Bearer + `x-api-key` inference return HTTP 200 with valid API key

[RHOAIENG-89890]: https://redhat.atlassian.net/browse/RHOAIENG-89890?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - ExternalModel changes now reliably trigger authentication policy reconciliation, including when the resource becomes available after startup.
  - Gateway authentication policies now handle OpenShift identities and API-key requests more consistently.
  - API-key validation uses the authenticated request identity for improved reliability.
  - API-key management endpoints are now protected from API-key-authenticated requests.
  - ExternalModel configuration now uses the `/v1/messages` provider endpoint.
  - API-key header handling is more reliable when requests omit expected headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


Related to - https://redhat.atlassian.net/browse/RHOAIENG-91813 and https://redhat.atlassian.net/browse/RHOAIENG-89890