### PR TITLE
chore: add migration status update to legacy ExternalModels

### DIFF
--- a/deployment/base/maas-controller/crd/bases/maas.opendatahub.io_externalmodels.yaml
+++ b/deployment/base/maas-controller/crd/bases/maas.opendatahub.io_externalmodels.yaml
@@ -161,12 +161,19 @@ spec:
                   - type
                   type: object
                 type: array
+              message:
+                description: Message provides details about the current phase.
+                type: string
               phase:
-                description: Phase represents the current phase of the external model
+                description: |-
+                  Phase represents the current phase of the external model
+                  Migrated means networking is managed by the corresponding
+                  inference.opendatahub.io ExternalModel.
                 enum:
                 - Pending
                 - Ready
                 - Failed
+                - Migrated
                 type: string
             type: object
         required:

--- a/deployment/base/maas-controller/rbac/clusterrole.yaml
+++ b/deployment/base/maas-controller/rbac/clusterrole.yaml
@@ -289,6 +289,7 @@ rules:
   - maas.opendatahub.io
   resources:
   - aitenants/status
+  - externalmodels/status
   - maasauthpolicies/status
   - maasmodelrefs/status
   - maassubscriptions/status

--- a/maas-controller/api/maas/v1alpha1/externalmodel_types.go
+++ b/maas-controller/api/maas/v1alpha1/externalmodel_types.go
@@ -83,8 +83,14 @@ type CredentialReference struct {
 // ExternalModelStatus defines the observed state of ExternalModel
 type ExternalModelStatus struct {
 	// Phase represents the current phase of the external model
-	// +kubebuilder:validation:Enum=Pending;Ready;Failed
+	// Migrated means networking is managed by the corresponding
+	// inference.opendatahub.io ExternalModel.
+	// +kubebuilder:validation:Enum=Pending;Ready;Failed;Migrated
 	Phase string `json:"phase,omitempty"`
+
+	// Message provides details about the current phase.
+	// +optional
+	Message string `json:"message,omitempty"`
 
 	// Conditions represent the latest available observations of the external model's state
 	// +optional

--- a/maas-controller/pkg/reconciler/externalmodel/reconciler.go
+++ b/maas-controller/pkg/reconciler/externalmodel/reconciler.go
@@ -108,6 +108,7 @@ func getTLSInfo(extModel *maasv1alpha1.ExternalModel) (tls bool, port int32, err
 //+kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=httproutes,verbs=get;list;watch;create;update
 //+kubebuilder:rbac:groups=maas.opendatahub.io,resources=externalmodels,verbs=get;list;watch
 //+kubebuilder:rbac:groups=maas.opendatahub.io,resources=externalmodels/finalizers,verbs=update
+//+kubebuilder:rbac:groups=maas.opendatahub.io,resources=externalmodels/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;delete
 //+kubebuilder:rbac:groups=networking.istio.io,resources=serviceentries,verbs=get;list;watch;create;update
 //+kubebuilder:rbac:groups=networking.istio.io,resources=destinationrules,verbs=get;list;watch;create;update;delete
@@ -136,7 +137,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	} else if superseded {
 		log.FromContext(ctx).Info("inference ExternalModel exists, tearing down legacy networking",
 			"name", req.Name, "namespace", req.Namespace)
-		return r.teardownLegacyChildren(ctx, extModel)
+		if _, err := r.teardownLegacyChildren(ctx, extModel); err != nil {
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{}, r.markMigrated(ctx, extModel)
 	}
 
 	tls, port, err := getTLSInfo(extModel)
@@ -398,6 +402,23 @@ func (r *Reconciler) teardownLegacyChildren(ctx context.Context, extModel *maasv
 	}
 
 	return ctrl.Result{}, nil
+}
+
+// markMigrated records that the inference API now owns networking for this
+// legacy ExternalModel. The legacy object remains as the owner of the migrated
+// inference resources, so the status gives users a durable migration signal.
+func (r *Reconciler) markMigrated(ctx context.Context, extModel *maasv1alpha1.ExternalModel) error {
+	desiredMessage := fmt.Sprintf("Model migrated to inference.opendatahub.io ExternalModel: %s", extModel.Name)
+	if extModel.Status.Phase == "Migrated" && extModel.Status.Message == desiredMessage {
+		return nil
+	}
+
+	extModel.Status.Phase = "Migrated"
+	extModel.Status.Message = desiredMessage
+	if err := r.Status().Update(ctx, extModel); err != nil {
+		return fmt.Errorf("failed to mark legacy ExternalModel %s/%s as migrated: %w", extModel.Namespace, extModel.Name, err)
+	}
+	return nil
 }
 
 // SetupWithManager registers the reconciler to watch ExternalModel CRs.

--- a/maas-controller/pkg/reconciler/externalmodel/reconciler_test.go
+++ b/maas-controller/pkg/reconciler/externalmodel/reconciler_test.go
@@ -371,6 +371,7 @@ func TestReconcile_SupersededByInference(t *testing.T) {
 	inferenceEM := newInferenceExternalModel(name, ns, resourceName)
 
 	c := fake.NewClientBuilder().WithScheme(testScheme).
+		WithStatusSubresource(&maasv1alpha1.ExternalModel{}).
 		WithObjects(em, legacySvc, legacyHR).
 		WithObjects(inferenceEM).
 		Build()
@@ -392,6 +393,13 @@ func TestReconcile_SupersededByInference(t *testing.T) {
 	assert.True(t, apierrors.IsNotFound(
 		c.Get(context.Background(), types.NamespacedName{Name: resourceName, Namespace: ns}, gotHR)),
 		"expected legacy HTTPRoute to be deleted")
+
+	// Legacy ExternalModel remains as owner of the inference resources and
+	// exposes a durable signal that migration completed.
+	gotEM := &maasv1alpha1.ExternalModel{}
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: name, Namespace: ns}, gotEM))
+	assert.Equal(t, "Migrated", gotEM.Status.Phase)
+	assert.Equal(t, "Model migrated to inference.opendatahub.io ExternalModel: gpt-4o", gotEM.Status.Message)
 }
 
 // TestReconcile_NoInferenceModel_ProceedsNormally verifies that without an
@@ -484,6 +492,7 @@ func TestReconcile_SupersededDoesNotTeardownOptedOut(t *testing.T) {
 	inferenceEM := newInferenceExternalModel(name, ns, resourceName)
 
 	c := fake.NewClientBuilder().WithScheme(testScheme).
+		WithStatusSubresource(&maasv1alpha1.ExternalModel{}).
 		WithObjects(em, legacySvc).
 		WithObjects(inferenceEM).
 		Build()

--- a/test/e2e/tests/test_external_models.py
+++ b/test/e2e/tests/test_external_models.py
@@ -24,6 +24,7 @@ import logging
 import os
 import subprocess
 import time
+import uuid
 
 import pytest
 import requests
@@ -426,6 +427,88 @@ requires_ipp = pytest.mark.skipif(
     not _check_ipp_pods_deployed(),
     reason="Payload-processing (IPP) pods not deployed; body routing tests require IPP",
 )
+
+
+@requires_ipp
+class TestLegacyExternalModelMigration:
+    """Verify IPP migration is reflected on the retained legacy CR."""
+
+    def test_migration_sets_legacy_status_and_removes_networking(self):
+        name = f"e2e-legacy-migration-{uuid.uuid4().hex[:8]}"
+        secret_name = f"{name}-api-key"
+        legacy_kind = "externalmodels.maas.opendatahub.io"
+        legacy_resource_name = f"maas-{name}"
+        expected_message = f"Model migrated to inference.opendatahub.io ExternalModel: {name}"
+        deadline = time.monotonic() + 180
+
+        try:
+            _apply_cr({
+                "apiVersion": "v1",
+                "kind": "Secret",
+                "metadata": {"name": secret_name, "namespace": MODEL_NAMESPACE},
+                "type": "Opaque",
+                "stringData": {"api-key": "e2e-test-key"},
+            })
+            # Seed one legacy networking child so this test proves teardown ran,
+            # even if IPP migrates the model before the legacy reconciler has
+            # time to create the full networking set.
+            _apply_cr({
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {"name": legacy_resource_name, "namespace": MODEL_NAMESPACE},
+                "spec": {
+                    "type": "ExternalName",
+                    "externalName": EXTERNAL_ENDPOINT,
+                    "ports": [{"name": "https", "port": 443}],
+                },
+            })
+            _apply_cr({
+                "apiVersion": "maas.opendatahub.io/v1alpha1",
+                "kind": "ExternalModel",
+                "metadata": {"name": name, "namespace": MODEL_NAMESPACE},
+                "spec": {
+                    "provider": "openai",
+                    "targetModel": TARGET_MODEL,
+                    "endpoint": EXTERNAL_ENDPOINT,
+                    "credentialRef": {"name": secret_name},
+                },
+            })
+
+            legacy = None
+            inference = None
+            while time.monotonic() < deadline:
+                legacy = _get_cr(legacy_kind, name, MODEL_NAMESPACE)
+                inference = _get_cr(EXTERNAL_MODEL_KIND, name, MODEL_NAMESPACE)
+                if (
+                    legacy
+                    and legacy.get("status", {}).get("phase") == "Migrated"
+                    and inference
+                    and inference.get("status", {}).get("httpRouteName")
+                ):
+                    break
+                time.sleep(2)
+
+            assert inference is not None, "IPP did not create the inference ExternalModel"
+            assert inference.get("status", {}).get("httpRouteName"), (
+                "Migrated inference ExternalModel did not publish status.httpRouteName"
+            )
+            assert legacy is not None, "Legacy ExternalModel was unexpectedly removed"
+            assert legacy.get("status", {}).get("phase") == "Migrated"
+            assert legacy.get("status", {}).get("message") == expected_message
+
+            assert _get_cr("httproute", legacy_resource_name, MODEL_NAMESPACE) is None, (
+                f"Legacy HTTPRoute {legacy_resource_name} was not removed"
+            )
+            assert _get_cr("service", legacy_resource_name, MODEL_NAMESPACE) is None, (
+                f"Legacy Service {legacy_resource_name} was not removed"
+            )
+        finally:
+            # The legacy CR owns the inference resources created by the migration
+            # controller, so deleting it should garbage-collect those children.
+            _delete_cr(legacy_kind, name, MODEL_NAMESPACE)
+            _delete_cr(EXTERNAL_MODEL_KIND, name, MODEL_NAMESPACE)
+            _delete_cr("service", legacy_resource_name, MODEL_NAMESPACE)
+            _delete_cr("secret", secret_name, MODEL_NAMESPACE)
 
 
 @requires_ipp


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Addressing the request of adding migration status update to legacy ExternalModels. https://github.com/opendatahub-io/models-as-a-service/pull/1417#issuecomment-5499551816

## How Has This Been Tested?
* Local cluster testing
* E2E test added for simulating the behavior

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a **Migrated** status for legacy external models that have been replaced by inference-managed models.
  - Added a status message explaining the migration and identifying the corresponding model.

- **Bug Fixes**
  - Legacy networking resources are now removed when migration completes.
  - Migrated models now reliably report their final status instead of remaining in an earlier phase.

- **Tests**
  - Added end-to-end coverage verifying migration status updates, networking cleanup, and published route availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->