### PR TITLE
fix(RHOAIENG-90216): make the curl image configurable via env var

### DIFF
--- a/test/e2e/tests/test_helper.py
+++ b/test/e2e/tests/test_helper.py
@@ -119,7 +119,7 @@ GATEWAY_NAMESPACE = os.environ.get("GATEWAY_NAMESPACE", "openshift-ingress")
 # Ephemeral curl probes run from the deployment namespace (where the UI runs),
 # matching the real traffic path for internal endpoints like /v1/tenants.
 E2E_CURL_POD_NAMESPACE = os.environ.get("E2E_CURL_POD_NAMESPACE", DEPLOYMENT_NAMESPACE)
-E2E_CURL_IMAGE = os.environ.get("E2E_CURL_IMAGE", "curlimages/curl:latest")
+E2E_CURL_IMAGE = os.environ.get("E2E_CURL_IMAGE", "registry.access.redhat.com/ubi9/ubi-minimal:latest")
 SIMULATOR_SUBSCRIPTION = os.environ.get("E2E_SIMULATOR_SUBSCRIPTION", "simulator-subscription")
 PREMIUM_MODEL_REF = os.environ.get("E2E_PREMIUM_MODEL_REF", "premium-simulated-simulated-premium")
 PREMIUM_MODEL_NAME = os.environ.get("E2E_PREMIUM_MODEL_NAME", "facebook/opt-125m-premium")

--- a/test/e2e/tests/test_helper.py
+++ b/test/e2e/tests/test_helper.py
@@ -119,6 +119,7 @@ GATEWAY_NAMESPACE = os.environ.get("GATEWAY_NAMESPACE", "openshift-ingress")
 # Ephemeral curl probes run from the deployment namespace (where the UI runs),
 # matching the real traffic path for internal endpoints like /v1/tenants.
 E2E_CURL_POD_NAMESPACE = os.environ.get("E2E_CURL_POD_NAMESPACE", DEPLOYMENT_NAMESPACE)
+E2E_CURL_IMAGE = os.environ.get("E2E_CURL_IMAGE", "curlimages/curl:latest")
 SIMULATOR_SUBSCRIPTION = os.environ.get("E2E_SIMULATOR_SUBSCRIPTION", "simulator-subscription")
 PREMIUM_MODEL_REF = os.environ.get("E2E_PREMIUM_MODEL_REF", "premium-simulated-simulated-premium")
 PREMIUM_MODEL_NAME = os.environ.get("E2E_PREMIUM_MODEL_NAME", "facebook/opt-125m-premium")

--- a/test/e2e/tests/test_tenant_discovery.py
+++ b/test/e2e/tests/test_tenant_discovery.py
@@ -18,7 +18,7 @@ import os
 import pytest
 import requests
 from conftest import TLS_VERIFY
-from test_helper import E2E_CURL_POD_NAMESPACE
+from test_helper import E2E_CURL_IMAGE, E2E_CURL_POD_NAMESPACE
 
 log = logging.getLogger(__name__)
 
@@ -50,7 +50,7 @@ def _kubectl_curl(url: str, headers: dict = None, namespace: str = None) -> tupl
     cmd = [
         "kubectl", "run", f"test-curl-{os.getpid()}-{id(url)}",
         "--rm", "-i", "--restart=Never",
-        "--image=curlimages/curl:latest",
+        f"--image={E2E_CURL_IMAGE}",
         "-n", namespace,
         "--",
         "curl"

--- a/test/e2e/tests/test_tenant_discovery_isolation.py
+++ b/test/e2e/tests/test_tenant_discovery_isolation.py
@@ -16,7 +16,7 @@ import json
 import os
 
 from conftest import TLS_VERIFY
-from test_helper import E2E_CURL_POD_NAMESPACE, MAAS_API_DEPLOYMENT_NAMESPACE, _get_cluster_token
+from test_helper import E2E_CURL_IMAGE, E2E_CURL_POD_NAMESPACE, MAAS_API_DEPLOYMENT_NAMESPACE, _get_cluster_token
 
 log = logging.getLogger(__name__)
 
@@ -35,7 +35,7 @@ def _kubectl_curl(url: str, headers: dict = None, namespace: str = None) -> tupl
     cmd = [
         "kubectl", "run", f"test-curl-{os.getpid()}-{id(url)}",
         "--rm", "-i", "--restart=Never",
-        "--image=curlimages/curl:latest",
+        f"--image={E2E_CURL_IMAGE}",
         "-n", namespace,
         "--", "curl"
     ] + curl_args


### PR DESCRIPTION
In disconnected environments the unqualified `curlimages/curl:latest` image resolves to a path which is not reachable in disconnected environments.

<!--- Provide a general summary of your changes in the Title above -->

## Description
Allow the curl image to be configurable via `E2E_CURL_IMAGE` env var. That allows test execution in disconnected environments to point the image to a path which is reachable.

Update the default image to `registry.access.redhat.com/ubi9/ubi-minimal:latest`

## How Has This Been Tested?
Tested against a RHOAI-3.6-EA.1 cluster

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end tenant discovery and isolation tests to use a shared, configurable container image for curl-based scenarios.
  * The default image is now `registry.access.redhat.com/ubi9/ubi-minimal:latest`.
  * The `E2E_CURL_IMAGE` environment-variable override remains available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->