### PR TITLE
ci: disable automatic early gate testing on pull requests

### DIFF
--- a/.tekton/odh-maas-api-pull-request.yaml
+++ b/.tekton/odh-maas-api-pull-request.yaml
@@ -38,6 +38,8 @@ spec:
     value: pull-request
   - name: enable-group-testing
     value: "true"
+  - name: enable-early-gate-testing
+    value: "false"
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-maas-controller-pull-request.yaml
+++ b/.tekton/odh-maas-controller-pull-request.yaml
@@ -38,6 +38,8 @@ spec:
     value: pull-request
   - name: enable-group-testing
     value: "true"
+  - name: enable-early-gate-testing
+    value: "false"
   pipelineRef:
     resolver: git
     params:


### PR DESCRIPTION
## Summary

Temporarily disable automatic early gate CI build triggering on MaaS PR builds until the upstream `push-build-metadata` task is fixed.

## Description

The early gate component pipeline (`early-gate-component-pipeline.yaml`) in `odh-konflux-central` has a known bug in the `push-build-metadata` task that causes OOM failures (exit code 137) during concurrent git rebases on the `odh-build-metadata` repository. This has been blocking all MaaS PRs since the `Red Hat Konflux / early-gate-ci-build` check is a required status check.

- Set `enable-early-gate-testing: "false"` in both `odh-maas-api-pull-request.yaml` and `odh-maas-controller-pull-request.yaml` PipelineRuns.
- This overrides the pipeline default (`"true"`) so the early gate build is no longer auto-triggered on every PR.
- Early gate can still be triggered manually via `/early-gate` PR comment when needed.
- This should be reverted once the upstream pipeline fix fully lands. Related upstream fix: https://github.com/opendatahub-io/odh-konflux-central/pull/626

## Risk analysis

- **Risk rating**: 1
- **Why**: This only disables one CI check that is currently broken anyway. No runtime behavior change. The early gate can still be manually triggered. The change is trivially revertible.

## How it was tested

- Verified the diff adds the correct parameter to both PipelineRun files.
- Confirmed the pipeline definition in `odh-konflux-central` accepts this parameter and skips early gate when set to `"false"`.