### PR TITLE
fix: reject API key authentication on key mint

### DIFF
--- a/maas-api/internal/api_keys/handler.go
+++ b/maas-api/internal/api_keys/handler.go
@@ -196,12 +196,39 @@ type CreateAPIKeyRequest struct {
 	Labels       map[string]string `json:"labels,omitempty"`       // Structured key-value pairs for API key metadata
 }
 
+// rejectAPIKeyMintAuth blocks key minting when the caller authenticated with an existing
+// API key. Minting requires a live OpenShift or OIDC identity token.
+func (h *Handler) rejectAPIKeyMintAuth(c *gin.Context) bool {
+	if !CredentialUsesAPIKey(c.GetHeader("Authorization"), c.GetHeader("X-Api-Key")) {
+		return false
+	}
+
+	tenant := ""
+	if userCtx, exists := c.Get("user"); exists {
+		if user, ok := userCtx.(*token.UserContext); ok {
+			tenant = user.Tenant
+		}
+	}
+	h.recordTokenMint(tenant, "rejected")
+	if h.metrics != nil {
+		h.metrics.RecordRejection(constant.RejectionUnauthorized)
+	}
+	c.JSON(http.StatusForbidden, gin.H{
+		"error": "API keys cannot be used to create new API keys; authenticate with your OpenShift or OIDC token",
+	})
+	return true
+}
+
 // CreateAPIKey handles POST /v1/api-keys
 // Creates a new API key (sk-oai-* format) per Feature Refinement.
 // If expiresIn is not provided, defaults to API_KEY_MAX_EXPIRATION_DAYS (1hr for ephemeral).
 // Per "Keys Shown Only Once": key is returned ONCE at creation and never again.
 // Users can only create keys for themselves - the key inherits the user's groups.
 func (h *Handler) CreateAPIKey(c *gin.Context) {
+	if h.rejectAPIKeyMintAuth(c) {
+		return
+	}
+
 	var req CreateAPIKeyRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})

--- a/maas-api/internal/api_keys/handler_test.go
+++ b/maas-api/internal/api_keys/handler_test.go
@@ -183,6 +183,36 @@ func TestCreateAPIKey_TokenMintMetrics(t *testing.T) {
 	}
 }
 
+func TestCreateAPIKey_RejectsAPIKeyAuth(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	spy := &spyMetricsRecorder{}
+	store := NewMockStore()
+	svc := NewServiceWithLogger(store, &config.Config{}, fixedSubSelector{}, logger.Development())
+	h := NewHandler(logger.Development(), svc, newMockAdminChecker(), spy)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/api-keys", nil)
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Request.Header.Set("Authorization", "Bearer sk-oai-testKeyID123_testSecretValue456")
+	c.Request.Body = io.NopCloser(strings.NewReader(`{"name": "nested-mint-key"}`))
+	c.Set("user", &token.UserContext{
+		Username: "alice",
+		Groups:   []string{"system:authenticated"},
+		Tenant:   "redteam",
+	})
+
+	h.CreateAPIKey(c)
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
+	assert.Contains(t, w.Body.String(), "API keys cannot be used to create new API keys")
+	require.Len(t, spy.tokenMints, 1)
+	assert.Equal(t, "redteam", spy.tokenMints[0].tenant)
+	assert.Equal(t, "rejected", spy.tokenMints[0].result)
+	require.Len(t, spy.rejections, 1)
+	assert.Equal(t, "unauthorized", spy.rejections[0])
+}
+
 func TestValidateAPIKey_RecordsValidationMetric(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	store := NewMockStore()

--- a/maas-api/internal/api_keys/keygen.go
+++ b/maas-api/internal/api_keys/keygen.go
@@ -130,6 +130,16 @@ func HashAPIKey(key string) string {
 	return hashWithSalt(keyID, secret)
 }
 
+// CredentialUsesAPIKey reports whether the caller authenticated with an sk-oai-* API key
+// via Authorization Bearer or the X-Api-Key header (Anthropic SDK path).
+func CredentialUsesAPIKey(authHeader, xAPIKeyHeader string) bool {
+	if strings.HasPrefix(authHeader, "Bearer "+KeyPrefix) {
+		return true
+	}
+	xKey := strings.TrimSpace(xAPIKeyHeader)
+	return strings.HasPrefix(xKey, KeyPrefix)
+}
+
 // IsValidKeyFormat checks if a key has the correct format: sk-oai-{key_id}_{secret}
 // Both key_id and secret must be non-empty base62 strings.
 func IsValidKeyFormat(key string) bool {

--- a/maas-api/internal/api_keys/keygen_test.go
+++ b/maas-api/internal/api_keys/keygen_test.go
@@ -8,6 +8,28 @@ import (
 	"github.com/opendatahub-io/models-as-a-service/maas-api/internal/api_keys"
 )
 
+func TestCredentialUsesAPIKey(t *testing.T) {
+	tests := []struct {
+		name       string
+		authHeader string
+		xAPIKey    string
+		want       bool
+	}{
+		{"bearer api key", "Bearer sk-oai-keyid_secret", "", true},
+		{"openshift token", "Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9", "", false},
+		{"x-api-key header", "", "sk-oai-keyid_secret", true},
+		{"empty", "", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := api_keys.CredentialUsesAPIKey(tt.authHeader, tt.xAPIKey); got != tt.want {
+				t.Errorf("CredentialUsesAPIKey() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestGenerateAPIKey(t *testing.T) {
 	plaintext, hash, prefix, err := api_keys.GenerateAPIKey()
 

--- a/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
@@ -813,6 +813,23 @@ func (r *MaaSAuthPolicyReconciler) buildGatewayAuthPolicySpec(oidc *oidcConfig, 
 }`
 
 	authorizationRules := map[string]any{
+		// API keys are for inference and discovery; minting requires a live identity token.
+		"deny-api-key-mint": map[string]any{
+			"when": []any{
+				map[string]any{
+					"predicate": `request.method == "POST" && request.path.endsWith("/v1/api-keys")`,
+				},
+			},
+			"patternMatching": map[string]any{
+				"patterns": []any{
+					map[string]any{
+						"predicate": `!(has(auth.metadata) && has(auth.metadata.apiKeyValidation))`,
+					},
+				},
+			},
+			"metrics":  false,
+			"priority": int64(0),
+		},
 		// Reject client-supplied identity headers; Authorino injects these after auth.
 		"deny-client-identity-headers": map[string]any{
 			"metrics":  false,

--- a/maas-controller/pkg/controller/maas/maasauthpolicy_controller_test.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_controller_test.go
@@ -1780,6 +1780,40 @@ func TestBuildGatewayAuthPolicySpec_DenyClientIdentityHeaders(t *testing.T) {
 	}
 }
 
+func TestBuildGatewayAuthPolicySpec_DenyAPIKeyMint(t *testing.T) {
+	obj := gatewayAuthPolicySpecTestObject(t, nil)
+
+	authz := nestedMapRequired(t, obj, "spec", "defaults", "rules", "authorization")
+	if _, exists := authz["deny-api-key-mint"]; !exists {
+		t.Fatal("deny-api-key-mint must be present to block API-key-authenticated minting")
+	}
+
+	whenPred := nestedWhenPredicateRequired(t, obj, "spec", "defaults", "rules", "authorization", "deny-api-key-mint", "when")
+	if !contains(whenPred, `request.method == "POST"`) || !contains(whenPred, `request.path.endsWith("/v1/api-keys")`) {
+		t.Errorf("deny-api-key-mint when should scope to POST /v1/api-keys, got: %s", whenPred)
+	}
+
+	patterns, found, err := unstructured.NestedSlice(
+		obj.Object,
+		"spec", "defaults", "rules", "authorization", "deny-api-key-mint", "patternMatching", "patterns",
+	)
+	if err != nil || !found || len(patterns) != 1 {
+		t.Fatalf("deny-api-key-mint patterns missing: found=%v len=%d err=%v", found, len(patterns), err)
+	}
+	pattern, ok := patterns[0].(map[string]any)
+	if !ok {
+		t.Fatalf("deny-api-key-mint patterns[0] is not a map: %T", patterns[0])
+	}
+	pred, ok := pattern["predicate"].(string)
+	if !ok {
+		t.Fatal("deny-api-key-mint patterns[0] missing predicate string")
+	}
+	wantPred := `!(has(auth.metadata) && has(auth.metadata.apiKeyValidation))`
+	if pred != wantPred {
+		t.Fatalf("deny-api-key-mint predicate = %q, want %q", pred, wantPred)
+	}
+}
+
 func TestBuildGatewayAuthPolicySpec_OIDCAuth(t *testing.T) {
 	oidc := &oidcConfig{
 		IssuerURL: "https://keycloak.example.com/realms/test",

--- a/test/e2e/tests/test_negative_security.py
+++ b/test/e2e/tests/test_negative_security.py
@@ -166,6 +166,42 @@ class TestHeaderSpoofing:
             if control_key_id:
                 _revoke_api_key(oc_token, control_key_id)
 
+    def test_api_key_cannot_mint_new_api_key(self):
+        """POST /v1/api-keys with an existing API key must be denied.
+
+        Minting requires a live OpenShift/OIDC identity token. An existing
+        sk-oai-* credential must not be able to create additional keys.
+        """
+        _wait_for_gateway_auth_enforced()
+        oc_token = _get_cluster_token()
+        parent_key = _create_api_key(oc_token, subscription=SIMULATOR_SUBSCRIPTION)
+
+        url = f"{_maas_api_url()}/v1/api-keys"
+        body = {
+            "name": f"e2e-nested-mint-{uuid.uuid4().hex[:8]}",
+            "subscription": SIMULATOR_SUBSCRIPTION,
+        }
+
+        r = requests.post(
+            url,
+            headers={
+                "Authorization": f"Bearer {parent_key}",
+                "Content-Type": "application/json",
+            },
+            json=body,
+            timeout=TIMEOUT,
+            verify=TLS_VERIFY,
+        )
+
+        log.info("API key mint-with-key -> %s body_bytes=%d", r.status_code, len(r.content))
+        assert r.status_code in (401, 403), (
+            f"Expected 401/403 denying API-key-authenticated mint, "
+            f"got {r.status_code} body_bytes={len(r.content)}"
+        )
+        assert "sk-oai-" not in r.text, (
+            "Denied mint response must not contain API key material"
+        )
+
     def test_injected_identity_headers_rejected_on_inference(self):
         """Client injects X-MaaS-Username/Group — gateway rejects the request.
 


### PR DESCRIPTION
## Summary

- Add gateway `deny-api-key-mint` AuthPolicy rule so `POST /v1/api-keys` rejects callers authenticated with an existing `sk-oai-*` credential
- Reject the same path in `maas-api` `CreateAPIKey` (covers direct-to-pod bypass) with HTTP 403
- Add unit and e2e coverage for nested mint denial

## Test plan

- [x] `go test ./internal/api_keys/... -run TestCreateAPIKey_RejectsAPIKeyAuth`
- [x] `go test ./pkg/controller/maas/... -run TestBuildGatewayAuthPolicySpec_DenyAPIKeyMint`
- [ ] E2E: `test_negative_security.py::TestHeaderSpoofing::test_api_key_cannot_mint_new_api_key`

## Risk analysis

**Risk rating**: 2

**Why**: Behavior change is narrowly scoped to `POST /v1/api-keys` when the caller presents an API key. Legitimate minting with OpenShift/OIDC tokens is unchanged. Gateway and maas-api both enforce the rule; unit tests cover both layers. E2E validates the gateway path in CI when security tests run.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - API keys can no longer be used to create additional API keys.
  - Attempts to mint keys with an existing API key are rejected with a 403 Forbidden response and do not expose key material.
  - The restriction applies to API keys supplied through supported authentication headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->