### PR TITLE
fix: block api keys from key management endpoints

### DIFF
--- a/deployment/base/maas-api/policies/auth-policy.yaml
+++ b/deployment/base/maas-api/policies/auth-policy.yaml
@@ -48,6 +48,15 @@ spec:
             expression: '{"key": request.headers.authorization.replace("Bearer ", "")}'
         priority: 0
     authorization:
+      # API keys are inference credentials and must not be used to mint more API keys.
+      # AuthPolicy evaluates the external path before the HTTPRoute URLRewrite.
+      deny-api-key-management:
+        when:
+          - predicate: 'request.headers.authorization.startsWith("Bearer sk-oai-") && (request.path == "/maas-api/v1/api-keys" || request.path.startsWith("/maas-api/v1/api-keys/"))'
+        patternMatching:
+          patterns:
+            - predicate: "false"
+        priority: 0
       # Reject client-supplied identity headers; Authorino injects these after auth.
       deny-client-identity-headers:
         metrics: false

--- a/maas-api/internal/api_keys/handler.go
+++ b/maas-api/internal/api_keys/handler.go
@@ -29,6 +29,7 @@ const (
 // Regular expressions to match invalid control characters in key name and label values.
 var invalidKeyNameCharsPattern = regexp.MustCompile(`[\x00-\x1F\x7F]`)
 var invalidLabelCharsPattern = regexp.MustCompile(`[\x00-\x1F\x7F]`)
+
 // Kubernetes-style label keys: optional DNS prefix + name
 // https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
 // Prefix: DNS subdomain (alphanumeric, dots, hyphens) ending with /
@@ -202,6 +203,16 @@ type CreateAPIKeyRequest struct {
 // Per "Keys Shown Only Once": key is returned ONCE at creation and never again.
 // Users can only create keys for themselves - the key inherits the user's groups.
 func (h *Handler) CreateAPIKey(c *gin.Context) {
+	// API keys are inference credentials, not credentials for minting more API keys.
+	// Reject them here, even if the gateway has already authenticated the key, so a
+	// subscription-scoped key cannot recover the broader permissions of the user and
+	// groups stored in its metadata or extend its own lifetime through a child key.
+	if isAPIKeyBearer(c.GetHeader("Authorization")) {
+		h.recordTokenMint(h.service.GetTenantName(), "rejected")
+		c.JSON(http.StatusForbidden, gin.H{"error": "API keys cannot create API keys"})
+		return
+	}
+
 	var req CreateAPIKeyRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
@@ -321,48 +332,53 @@ func (h *Handler) CreateAPIKey(c *gin.Context) {
 	c.JSON(http.StatusCreated, result)
 }
 
+func isAPIKeyBearer(authorization string) bool {
+	scheme, credential, found := strings.Cut(strings.TrimSpace(authorization), " ")
+	return found && strings.EqualFold(scheme, "Bearer") && strings.HasPrefix(credential, KeyPrefix)
+}
+
 // validateLabels validates the labels map for security and size constraints.
 // Labels are user-defined key-value pairs for organizing and filtering API keys.
 func validateLabels(labels map[string]string) error {
-    if labels == nil {
-        return nil
-    }
-    
-    // Limit number of label entries (prevent abuse)
-    if len(labels) > constant.MaxLabelsEntries {
-        return fmt.Errorf("labels cannot exceed %d key-value pairs", constant.MaxLabelsEntries)
-    }
-    
-    // Validate each key-value pair
-    for key, value := range labels {
-        // Key validation
-        if len(key) == 0 {
-            return errors.New("label keys cannot be empty")
-        }
-        if len(key) > constant.MaxLabelKeyLength {
-            return fmt.Errorf("label key '%s' exceeds %d characters", key, constant.MaxLabelKeyLength)
-        }
-        // Only allow alphanumerics, underscores, hyphens, dots (similar to K8s labels). 
+	if labels == nil {
+		return nil
+	}
+
+	// Limit number of label entries (prevent abuse)
+	if len(labels) > constant.MaxLabelsEntries {
+		return fmt.Errorf("labels cannot exceed %d key-value pairs", constant.MaxLabelsEntries)
+	}
+
+	// Validate each key-value pair
+	for key, value := range labels {
+		// Key validation
+		if len(key) == 0 {
+			return errors.New("label keys cannot be empty")
+		}
+		if len(key) > constant.MaxLabelKeyLength {
+			return fmt.Errorf("label key '%s' exceeds %d characters", key, constant.MaxLabelKeyLength)
+		}
+		// Only allow alphanumerics, underscores, hyphens, dots (similar to K8s labels).
 		// Use a package-level variable for comparison to avoid recomputing the regex every iteration of the loop.
-        if !validLabelKeyPattern.MatchString(key) {
-            return fmt.Errorf("label key '%s' contains invalid characters (only alphanumerics, dots, underscores, hyphens allowed)", key)
-        }
-        
-        // Value validation
+		if !validLabelKeyPattern.MatchString(key) {
+			return fmt.Errorf("label key '%s' contains invalid characters (only alphanumerics, dots, underscores, hyphens allowed)", key)
+		}
+
+		// Value validation
 		if len(value) == 0 {
 			return fmt.Errorf("label value for key '%s' cannot be empty", key)
 		}
-        if len(value) > constant.MaxLabelValueLength {
-            return fmt.Errorf("label value for key '%s' exceeds %d characters", key, constant.MaxLabelValueLength)
-        }
+		if len(value) > constant.MaxLabelValueLength {
+			return fmt.Errorf("label value for key '%s' exceeds %d characters", key, constant.MaxLabelValueLength)
+		}
 
-        // Reject control characters in values
+		// Reject control characters in values
 		if invalidLabelCharsPattern.MatchString(value) {
-            return fmt.Errorf("label value for key '%s' contains invalid control characters", key)
-        }
-    }
-    
-    return nil
+			return fmt.Errorf("label value for key '%s' contains invalid control characters", key)
+		}
+	}
+
+	return nil
 }
 
 // ValidateAPIKeyRequest is the request body for validating an API key.

--- a/maas-api/internal/api_keys/handler_test.go
+++ b/maas-api/internal/api_keys/handler_test.go
@@ -17,9 +17,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-
-	"github.com/opendatahub-io/models-as-a-service/maas-api/internal/constant"
 	"github.com/opendatahub-io/models-as-a-service/maas-api/internal/config"
+	"github.com/opendatahub-io/models-as-a-service/maas-api/internal/constant"
 	"github.com/opendatahub-io/models-as-a-service/maas-api/internal/logger"
 	"github.com/opendatahub-io/models-as-a-service/maas-api/internal/subscription"
 	"github.com/opendatahub-io/models-as-a-service/maas-api/internal/token"
@@ -181,6 +180,34 @@ func TestCreateAPIKey_TokenMintMetrics(t *testing.T) {
 			assert.Equal(t, tt.expectedResult, spy.tokenMints[0].result)
 		})
 	}
+}
+
+func TestCreateAPIKey_RejectsAPIKeyAuthentication(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	store := NewMockStore()
+	cfg := &config.Config{TenantName: "redteam"}
+	service := NewServiceWithLogger(store, cfg, fixedSubSelector{}, logger.Development())
+	spy := &spyMetricsRecorder{}
+	handler := NewHandler(logger.Development(), service, newMockAdminChecker(), spy)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/api-keys", strings.NewReader(`{"name":"escalation-attempt","subscription":"other-sub"}`))
+	c.Request.Header.Set("Authorization", "Bearer "+KeyPrefix+"caller_secret")
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Set("user", &token.UserContext{
+		Username: "alice",
+		Groups:   []string{"system:authenticated"},
+		Tenant:   "redteam",
+	})
+
+	handler.CreateAPIKey(c)
+
+	require.Equal(t, http.StatusForbidden, w.Code)
+	assert.JSONEq(t, `{"error":"API keys cannot create API keys"}`, w.Body.String())
+	assert.Empty(t, store.keys, "rejected requests must not persist a child key")
+	require.Len(t, spy.tokenMints, 1)
+	assert.Equal(t, metricsCall{tenant: "redteam", result: "rejected"}, spy.tokenMints[0])
 }
 
 func TestValidateAPIKey_RecordsValidationMetric(t *testing.T) {
@@ -449,7 +476,7 @@ func TestSearchAPIKeys_StatusFilter(t *testing.T) {
 	// Create active and revoked keys
 	err := store.AddKey(ctx, testUser.Username, "active-key", "active-hash", "Active Key", "", []string{"system:authenticated"}, testSubscriptionName, "test-tenant", nil, false, nil)
 	require.NoError(t, err)
-	err = store.AddKey(ctx, testUser.Username, "revoked-key", "revoked-hash", "Revoked Key", "", []string{"system:authenticated"}, testSubscriptionName, 
+	err = store.AddKey(ctx, testUser.Username, "revoked-key", "revoked-hash", "Revoked Key", "", []string{"system:authenticated"}, testSubscriptionName,
 		"test-tenant", nil, false, nil)
 	require.NoError(t, err)
 	err = store.Revoke(ctx, "revoked-key")
@@ -1698,7 +1725,7 @@ func TestCleanupExpiredEphemeralKeys(t *testing.T) {
 
 	// Create expired ephemeral key within 30-minute grace period (should NOT be deleted)
 	recentExpiry := time.Now().Add(-10 * time.Minute)
-	err = store.AddKey(ctx, "alice", "recently-expired-ephemeral", "hash-5", "Recently Expired Ephemeral", "", []string{"users"}, testSubscriptionName, 
+	err = store.AddKey(ctx, "alice", "recently-expired-ephemeral", "hash-5", "Recently Expired Ephemeral", "", []string{"users"}, testSubscriptionName,
 		"test-tenant", &recentExpiry, true, nil)
 	require.NoError(t, err)
 
@@ -1849,10 +1876,10 @@ func TestSearchExcludesEphemeralByDefault(t *testing.T) {
 
 	// Create ephemeral keys
 	futureExpiry := time.Now().Add(1 * time.Hour)
-	err = store.AddKey(ctx, testUser.Username, "ephemeral-key-1", "hash-3", "Ephemeral Key 1", "", []string{"system:authenticated"}, testSubscriptionName, 
+	err = store.AddKey(ctx, testUser.Username, "ephemeral-key-1", "hash-3", "Ephemeral Key 1", "", []string{"system:authenticated"}, testSubscriptionName,
 		"test-tenant", &futureExpiry, true, nil)
 	require.NoError(t, err)
-	err = store.AddKey(ctx, testUser.Username, "ephemeral-key-2", "hash-4", "Ephemeral Key 2", "", []string{"system:authenticated"}, testSubscriptionName, 
+	err = store.AddKey(ctx, testUser.Username, "ephemeral-key-2", "hash-4", "Ephemeral Key 2", "", []string{"system:authenticated"}, testSubscriptionName,
 		"test-tenant", &futureExpiry, true, nil)
 	require.NoError(t, err)
 
@@ -1900,18 +1927,18 @@ func TestSearchAPIKeys_ExpiredStatusComputation(t *testing.T) {
 
 	// Create a key that expired yesterday (stored as active, but past expiration)
 	pastExpiry := time.Now().Add(-24 * time.Hour)
-	err := store.AddKey(ctx, testUser.Username, "expired-key", "expired-hash", "Expired Key", "", []string{"system:authenticated"}, testSubscriptionName, 
+	err := store.AddKey(ctx, testUser.Username, "expired-key", "expired-hash", "Expired Key", "", []string{"system:authenticated"}, testSubscriptionName,
 		"test-tenant", &pastExpiry, false, nil)
 	require.NoError(t, err)
 
 	// Create an active key with future expiration
 	futureExpiry := time.Now().Add(24 * time.Hour)
-	err = store.AddKey(ctx, testUser.Username, "active-key", "active-hash", "Active Key","", []string{"system:authenticated"}, testSubscriptionName, 
+	err = store.AddKey(ctx, testUser.Username, "active-key", "active-hash", "Active Key", "", []string{"system:authenticated"}, testSubscriptionName,
 		"test-tenant", &futureExpiry, false, nil)
 	require.NoError(t, err)
 
 	// Create an active key with no expiration
-	err = store.AddKey(ctx, testUser.Username, "permanent-key", "permanent-hash", "Permanent Key", "", []string{"system:authenticated"}, testSubscriptionName, 
+	err = store.AddKey(ctx, testUser.Username, "permanent-key", "permanent-hash", "Permanent Key", "", []string{"system:authenticated"}, testSubscriptionName,
 		"test-tenant", nil, false, nil)
 	require.NoError(t, err)
 
@@ -1965,13 +1992,13 @@ func TestGetAPIKey_ExpiredStatusComputation(t *testing.T) {
 
 	// Create a key that expired yesterday
 	pastExpiry := time.Now().Add(-24 * time.Hour)
-	err := store.AddKey(ctx, testUser.Username, "expired-key", "expired-hash", "Expired Key", "", []string{"system:authenticated"}, testSubscriptionName, 
+	err := store.AddKey(ctx, testUser.Username, "expired-key", "expired-hash", "Expired Key", "", []string{"system:authenticated"}, testSubscriptionName,
 		"test-tenant", &pastExpiry, false, nil)
 	require.NoError(t, err)
 
 	// Create an active key with future expiration
 	futureExpiry := time.Now().Add(24 * time.Hour)
-	err = store.AddKey(ctx, testUser.Username, "active-key", "active-hash", "Active Key", "", []string{"system:authenticated"}, testSubscriptionName, 
+	err = store.AddKey(ctx, testUser.Username, "active-key", "active-hash", "Active Key", "", []string{"system:authenticated"}, testSubscriptionName,
 		"test-tenant", &futureExpiry, false, nil)
 	require.NoError(t, err)
 
@@ -2712,7 +2739,7 @@ func TestValidateLabels_Success(t *testing.T) {
 			},
 		},
 		{
-			name: "max entries (50)",
+			name:   "max entries (50)",
 			labels: makeLargeLabels(constant.MaxLabelsEntries),
 		},
 	}
@@ -2983,7 +3010,7 @@ func TestCreateAPIKey_InvalidLabels(t *testing.T) {
 			handler.CreateAPIKey(c)
 
 			assert.Equal(t, tt.wantStatus, w.Code)
-			
+
 			var errResp map[string]any
 			err := json.Unmarshal(w.Body.Bytes(), &errResp)
 			require.NoError(t, err)

--- a/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
@@ -813,6 +813,22 @@ func (r *MaaSAuthPolicyReconciler) buildGatewayAuthPolicySpec(oidc *oidcConfig, 
 }`
 
 	authorizationRules := map[string]any{
+		// API keys are inference credentials, not management credentials. Block the
+		// MaaS API key-management surface at the gateway before proxying the request.
+		"deny-api-key-management": map[string]any{
+			"when": []any{
+				map[string]any{
+					"predicate": celIsAPIKey + ` && (request.path == "/maas-api/v1/api-keys" || request.path.startsWith("/maas-api/v1/api-keys/"))`,
+				},
+			},
+			"metrics":  false,
+			"priority": int64(0),
+			"patternMatching": map[string]any{
+				"patterns": []any{
+					map[string]any{"predicate": "false"},
+				},
+			},
+		},
 		// Reject client-supplied identity headers; Authorino injects these after auth.
 		"deny-client-identity-headers": map[string]any{
 			"metrics":  false,

--- a/maas-controller/pkg/controller/maas/maasauthpolicy_controller_test.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_controller_test.go
@@ -1780,6 +1780,42 @@ func TestBuildGatewayAuthPolicySpec_DenyClientIdentityHeaders(t *testing.T) {
 	}
 }
 
+func TestBuildGatewayAuthPolicySpec_DenyAPIKeyManagement(t *testing.T) {
+	obj := gatewayAuthPolicySpecTestObject(t, nil)
+
+	rule := nestedMapRequired(t, obj,
+		"spec", "defaults", "rules", "authorization", "deny-api-key-management")
+	when, ok := rule["when"].([]any)
+	if !ok || len(when) != 1 {
+		t.Fatalf("deny-api-key-management when missing or invalid: %#v", rule["when"])
+	}
+	condition, ok := when[0].(map[string]any)
+	if !ok {
+		t.Fatalf("deny-api-key-management when[0] is not a map: %T", when[0])
+	}
+	predicate, ok := condition["predicate"].(string)
+	if !ok || !strings.Contains(predicate, `request.path == "/maas-api/v1/api-keys"`) ||
+		!strings.Contains(predicate, `request.path.startsWith("/maas-api/v1/api-keys/")`) {
+		t.Fatalf("deny-api-key-management path predicate is incomplete: %q", predicate)
+	}
+	if !strings.Contains(predicate, "sk-oai-") {
+		t.Fatalf("deny-api-key-management must be scoped to API keys: %q", predicate)
+	}
+
+	patterns, found, err := unstructured.NestedSlice(obj.Object,
+		"spec", "defaults", "rules", "authorization", "deny-api-key-management", "patternMatching", "patterns")
+	if err != nil || !found {
+		t.Fatalf("deny-api-key-management patterns missing: found=%v err=%v", found, err)
+	}
+	if len(patterns) != 1 {
+		t.Fatalf("deny-api-key-management patterns length = %d, want 1", len(patterns))
+	}
+	deny, ok := patterns[0].(map[string]any)
+	if !ok || deny["predicate"] != "false" {
+		t.Fatalf("deny-api-key-management must fail authorization: %#v", patterns[0])
+	}
+}
+
 func TestBuildGatewayAuthPolicySpec_OIDCAuth(t *testing.T) {
 	oidc := &oidcConfig{
 		IssuerURL: "https://keycloak.example.com/realms/test",

--- a/test/e2e/tests/test_negative_security.py
+++ b/test/e2e/tests/test_negative_security.py
@@ -3,6 +3,7 @@ Negative-path and security-oriented E2E tests for MaaS.
 
 Validates that the platform correctly rejects abuse scenarios:
 - Header spoofing: client-supplied X-MaaS identity headers are rejected at the gateway
+- API key delegation: API keys cannot access the API-key management surface
 - Expired API keys: rejected at gateway level
 - Cross-model access: subscription-model binding enforced
 - AuthPolicy removal: access revoked when policy deleted
@@ -63,6 +64,72 @@ from test_helper import (
 log = logging.getLogger(__name__)
 
 pytestmark = pytest.mark.xdist_group("security")
+
+
+# ============================================================================
+# P0: API Key Management Isolation
+# ============================================================================
+
+class TestAPIKeyManagementIsolation:
+    """Verify that inference API keys cannot act as management credentials."""
+
+    def test_api_key_cannot_mint_another_api_key(self):
+        """A valid subscription-bound API key must be denied on POST /v1/api-keys.
+
+        The initial key is minted with a cluster token as a control. The test then
+        presents that valid key to the management endpoint and verifies that the
+        gateway or MaaS API rejects it without returning new key material.
+        """
+        _wait_for_gateway_auth_enforced()
+        oc_token = _get_cluster_token()
+        parent_key_id = None
+
+        try:
+            parent = _create_api_key_raw(
+                oc_token,
+                name=f"e2e-delegation-parent-{uuid.uuid4().hex[:8]}",
+                subscription=SIMULATOR_SUBSCRIPTION,
+            )
+            assert parent.status_code in (200, 201), (
+                f"Control API key mint failed: {parent.status_code} "
+                f"body_bytes={len(parent.content)}"
+            )
+            parent_body = parent.json()
+            parent_key_id = parent_body.get("id")
+            parent_key = parent_body.get("key", "")
+            assert parent_key.startswith("sk-oai-"), "Control mint did not return an API key"
+
+            # Use the API key, not the cluster token, to attempt delegation.
+            # Do not log the response body: a regression could return a live key.
+            delegated = requests.post(
+                f"{_maas_api_url()}/v1/api-keys",
+                headers={
+                    "Authorization": f"Bearer {parent_key}",
+                    "Content-Type": "application/json",
+                },
+                json={
+                    "name": f"e2e-delegation-child-{uuid.uuid4().hex[:8]}",
+                    "subscription": SIMULATOR_SUBSCRIPTION,
+                },
+                timeout=TIMEOUT,
+                verify=TLS_VERIFY,
+            )
+
+            log.info(
+                "API-key-authenticated key mint -> %s body_bytes=%d",
+                delegated.status_code,
+                len(delegated.content),
+            )
+            assert delegated.status_code in (401, 403), (
+                f"Expected API-key-authenticated mint to be denied, got "
+                f"{delegated.status_code} body_bytes={len(delegated.content)}"
+            )
+            assert "sk-oai-" not in delegated.text, (
+                "Denied delegation response must not contain API key material"
+            )
+        finally:
+            if parent_key_id:
+                _revoke_api_key(oc_token, parent_key_id)
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary
Prevent MaaS API keys from being used as management credentials.
- Deny API-key access to `/maas-api/v1/api-keys` and its subpaths in gateway AuthPolicies.
- Reject API-key-authenticated key creation in MaaS API as defense-in-depth.
- Preserve API-key access to inference endpoints.
- Add unit and E2E regression coverage for recursive API-key minting.

## Security impact
Previously, a subscription-bound API key could reuse its stored username and groups to mint another key, potentially for a different subscription accessible to the original identity. It could also extend access by creating a longer-lived key.

API keys are now treated as inference-only credentials for the API-key management surface.

## Testing
- `go test ./...` in `maas-api`
- Focused `maas-controller` gateway AuthPolicy tests
- `./scripts/ci/validate-manifests.sh`
- E2E test added to validate the behavior

## Risk analysis
**Risk rating: 4**
**Why:** This changes gateway authorization behavior and is tightly coupled to Authorino/Kuadrant policy evaluation. Incorrect path matching or policy composition could affect API-key authentication across MaaS management or inference routes.

Unit tests, manifest validation, and an E2E regression reduce the risk; inference routes remain outside the blocked path.

Addresses https://redhat.atlassian.net/browse/RHOAIENG-93058

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * API keys can no longer be used to create or manage additional API keys.
  * Attempts to perform API key management with an API key are rejected with a 403 Forbidden response.
  * API key credentials cannot be used to gain broader user or group permissions through key delegation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->