### PR TITLE
fix(cache): scope informer caches

### DIFF
--- a/maas-controller/cmd/manager/main.go
+++ b/maas-controller/cmd/manager/main.go
@@ -1006,6 +1006,7 @@ func buildCacheOptions(
 	standardByObject := map[client.Object]cache.ByObject{
 		&appsv1.Deployment{}:         {Namespaces: deploymentNsCfg},
 		&corev1.ConfigMap{}:          {Namespaces: configMapNsCfg},
+		&gatewayapiv1.Gateway{}:      {Namespaces: map[string]cache.Config{gatewayNamespace: {}}},
 		&rbacv1.ClusterRoleBinding{}: {Label: maasResourceSelector},
 		&netwv1.NetworkPolicy{}:      {Namespaces: networkPolicyNsCfg, Label: maasResourceSelector},
 	}
@@ -1225,6 +1226,7 @@ func main() {
 
 	if err := (&maas.MaaSModelRefReconciler{
 		Client:                          mgr.GetClient(),
+		APIReader:                       mgr.GetAPIReader(),
 		Scheme:                          mgr.GetScheme(),
 		GatewayName:                     gatewayName,
 		GatewayNamespace:                gatewayNamespace,
@@ -1237,6 +1239,7 @@ func main() {
 	}
 	if err := (&maas.MaaSAuthPolicyReconciler{
 		Client:                          mgr.GetClient(),
+		APIReader:                       mgr.GetAPIReader(),
 		Scheme:                          mgr.GetScheme(),
 		InfraNamespace:                  infraNamespace,
 		TenantNamespace:                 maasSubscriptionNamespace,

--- a/maas-controller/cmd/manager/main.go
+++ b/maas-controller/cmd/manager/main.go
@@ -33,11 +33,14 @@ import (
 	utiltls "github.com/openshift/controller-runtime-common/pkg/tls"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	netwv1 "k8s.io/api/networking/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -960,6 +963,80 @@ func setupWebhooks(mgr ctrl.Manager, aitenantNamespace, gatewayNamespace string)
 	return nil
 }
 
+func buildCacheOptions(
+	maasSubscriptionNamespace, infraNamespace, controllerNamespace,
+	aitenantNamespace, gatewayNamespace, monitoringNamespace string,
+	enableTenantNamespaceDiscovery, defaultSubscriptionNamespaceExists bool,
+) cache.Options {
+	nsCfg := map[string]cache.Config{maasSubscriptionNamespace: {}}
+	infraNsCfg := map[string]cache.Config{infraNamespace: {}}
+
+	// Scope standard Kubernetes resources to the namespaces where MaaS renders or
+	// observes them. Predicates only filter reconciliation events; they do not
+	// reduce the objects loaded by an informer.
+	deploymentNsCfg := map[string]cache.Config{controllerNamespace: {}}
+	if infraNamespace != controllerNamespace {
+		deploymentNsCfg[infraNamespace] = cache.Config{}
+	}
+	if gatewayNamespace != controllerNamespace && gatewayNamespace != infraNamespace {
+		deploymentNsCfg[gatewayNamespace] = cache.Config{}
+	}
+
+	configMapNsCfg := map[string]cache.Config{infraNamespace: {}}
+	for _, namespace := range []string{aitenantNamespace, gatewayNamespace, monitoringNamespace} {
+		if namespace != "" {
+			configMapNsCfg[namespace] = cache.Config{}
+		}
+	}
+
+	networkPolicyNsCfg := map[string]cache.Config{controllerNamespace: {}}
+	for _, namespace := range []string{infraNamespace, gatewayNamespace, monitoringNamespace} {
+		if namespace != "" {
+			networkPolicyNsCfg[namespace] = cache.Config{}
+		}
+	}
+
+	// postBuildTransform applies this label to every rendered MaaS resource,
+	// including ClusterRoleBindings and NetworkPolicies. It is stable across
+	// namespace remapping and matches resources from existing installations.
+	maasResourceSelector := labels.SelectorFromSet(labels.Set{
+		tenantreconcile.LabelODHAppPrefix + "/" + tenantreconcile.ComponentName: "true",
+	})
+
+	standardByObject := map[client.Object]cache.ByObject{
+		&appsv1.Deployment{}:         {Namespaces: deploymentNsCfg},
+		&corev1.ConfigMap{}:          {Namespaces: configMapNsCfg},
+		&rbacv1.ClusterRoleBinding{}: {Label: maasResourceSelector},
+		&netwv1.NetworkPolicy{}:      {Namespaces: networkPolicyNsCfg, Label: maasResourceSelector},
+	}
+
+	cacheOpts := cache.Options{
+		ByObject: map[client.Object]cache.ByObject{
+			// These CRs are intentionally cluster-wide when tenant discovery is
+			// disabled because AITenant can create them outside the default namespace.
+			&maasv1alpha1.MaasTenantConfig{}: {},
+			&maasv1alpha1.Tenant{}:           {},
+			&maasv1alpha1.MaaSAuthPolicy{}:   {Namespaces: nsCfg},
+			&maasv1alpha1.MaaSSubscription{}: {Namespaces: nsCfg},
+			&corev1.Secret{}:                 {Namespaces: infraNsCfg},
+		},
+	}
+	if enableTenantNamespaceDiscovery || !defaultSubscriptionNamespaceExists {
+		allNamespacesCfg := map[string]cache.Config{cache.AllNamespaces: {}}
+		cacheOpts.ByObject = map[client.Object]cache.ByObject{
+			&maasv1alpha1.MaasTenantConfig{}: {Namespaces: allNamespacesCfg},
+			&maasv1alpha1.Tenant{}:           {Namespaces: allNamespacesCfg},
+			&maasv1alpha1.MaaSAuthPolicy{}:   {Namespaces: allNamespacesCfg},
+			&maasv1alpha1.MaaSSubscription{}: {Namespaces: allNamespacesCfg},
+			&corev1.Secret{}:                 {Namespaces: infraNsCfg},
+		}
+	}
+	for object, byObject := range standardByObject {
+		cacheOpts.ByObject[object] = byObject
+	}
+	return cacheOpts
+}
+
 func main() {
 	var metricsAddr string
 	var secureMetrics bool
@@ -1097,36 +1174,13 @@ func main() {
 		setupLog.Error(err, "unable to inspect subscription namespace", "namespace", maasSubscriptionNamespace)
 		os.Exit(1)
 	}
-	nsCfg := map[string]cache.Config{maasSubscriptionNamespace: {}}
-	// maas-db-config lives in the infrastructure namespace (where maas-api runs).
-	infraNsCfg := map[string]cache.Config{infraNamespace: {}}
-	cacheOpts := cache.Options{
-		ByObject: map[client.Object]cache.ByObject{
-			// MaasTenantConfig CRs are watched cluster-wide to support AITenant-created tenants in any namespace.
-			// TODO: Replace with proper namespace discovery from S1 when merged.
-			&maasv1alpha1.MaasTenantConfig{}: {},
-			&maasv1alpha1.Tenant{}:           {},
-			&maasv1alpha1.MaaSAuthPolicy{}:   {Namespaces: nsCfg},
-			&maasv1alpha1.MaaSSubscription{}: {Namespaces: nsCfg},
-			// Restrict the Secret informer to the infrastructure namespace (where maas-db-config lives)
-			// to avoid caching cluster-wide Secrets.
-			&corev1.Secret{}: {Namespaces: infraNsCfg},
-		},
-	}
+	cacheOpts := buildCacheOptions(
+		maasSubscriptionNamespace, infraNamespace, controllerNamespace,
+		aitenantNamespace, gatewayNamespace, monitoringNamespace,
+		enableTenantNamespaceDiscovery, defaultSubscriptionNamespaceExists,
+	)
 	setupLog.Info("watching namespace for MaaS CRs", "namespace", maasSubscriptionNamespace)
 	if enableTenantNamespaceDiscovery || !defaultSubscriptionNamespaceExists {
-		allNamespacesCfg := map[string]cache.Config{cache.AllNamespaces: {}}
-		cacheOpts = cache.Options{
-			ByObject: map[client.Object]cache.ByObject{
-				&maasv1alpha1.MaasTenantConfig{}: {Namespaces: allNamespacesCfg},
-				&maasv1alpha1.Tenant{}:           {Namespaces: allNamespacesCfg},
-				&maasv1alpha1.MaaSAuthPolicy{}:   {Namespaces: allNamespacesCfg},
-				&maasv1alpha1.MaaSSubscription{}: {Namespaces: allNamespacesCfg},
-				// Keep Secret informer scoped to the infra namespace even in multi-tenant mode —
-				// maas-db-config always lives in the infra namespace regardless of tenant count.
-				&corev1.Secret{}: {Namespaces: infraNsCfg},
-			},
-		}
 		setupLog.Info("watching MaaS CRs across all namespaces",
 			"defaultNamespace", maasSubscriptionNamespace,
 			"defaultNamespaceExists", defaultSubscriptionNamespaceExists,
@@ -1273,6 +1327,7 @@ func main() {
 
 	if err := (&maas.TenantReconciler{
 		Client:                          mgr.GetClient(),
+		APIReader:                       mgr.GetAPIReader(),
 		Scheme:                          mgr.GetScheme(),
 		ManifestPath:                    manifestPath,
 		AppNamespace:                    infraNamespace,

--- a/maas-controller/cmd/manager/main_test.go
+++ b/maas-controller/cmd/manager/main_test.go
@@ -9,10 +9,14 @@ import (
 	"time"
 
 	confv1 "github.com/openshift/api/config/v1"
+	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	netwv1 "k8s.io/api/networking/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -20,6 +24,7 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	controllerfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
@@ -29,6 +34,73 @@ import (
 	"github.com/opendatahub-io/models-as-a-service/maas-controller/pkg/controller/maas"
 	"github.com/opendatahub-io/models-as-a-service/maas-controller/pkg/platform/tenantreconcile"
 )
+
+func cacheByObjectFor[T client.Object](t *testing.T, options cache.Options) cache.ByObject {
+	t.Helper()
+	for object, byObject := range options.ByObject {
+		if _, ok := object.(T); ok {
+			return byObject
+		}
+	}
+	t.Fatalf("cache configuration for %T not found", *new(T))
+	return cache.ByObject{}
+}
+
+func TestBuildCacheOptionsScopesRenderedMaaSResources(t *testing.T) {
+	t.Parallel()
+
+	options := buildCacheOptions(
+		"models-as-a-service", "odh-ai-gateway-infra", "opendatahub",
+		"ai-tenants", "openshift-ingress", "opendatahub",
+		false, true,
+	)
+
+	deployment := cacheByObjectFor[*appsv1.Deployment](t, options)
+	require.Contains(t, deployment.Namespaces, "opendatahub")
+	require.Contains(t, deployment.Namespaces, "odh-ai-gateway-infra")
+	require.Contains(t, deployment.Namespaces, "openshift-ingress")
+
+	configMap := cacheByObjectFor[*corev1.ConfigMap](t, options)
+	for _, namespace := range []string{"odh-ai-gateway-infra", "ai-tenants", "openshift-ingress", "opendatahub"} {
+		require.Contains(t, configMap.Namespaces, namespace)
+	}
+
+	selectorLabels := labels.Set{
+		tenantreconcile.LabelODHAppPrefix + "/" + tenantreconcile.ComponentName: "true",
+	}
+	clusterRoleBinding := cacheByObjectFor[*rbacv1.ClusterRoleBinding](t, options)
+	require.True(t, clusterRoleBinding.Label.Matches(selectorLabels))
+	require.False(t, clusterRoleBinding.Label.Matches(labels.Set{}))
+
+	networkPolicy := cacheByObjectFor[*netwv1.NetworkPolicy](t, options)
+	for _, namespace := range []string{"opendatahub", "odh-ai-gateway-infra", "openshift-ingress"} {
+		require.Contains(t, networkPolicy.Namespaces, namespace)
+	}
+	require.True(t, networkPolicy.Label.Matches(selectorLabels))
+
+	secret := cacheByObjectFor[*corev1.Secret](t, options)
+	require.Equal(t, map[string]cache.Config{"odh-ai-gateway-infra": {}}, secret.Namespaces)
+}
+
+func TestBuildCacheOptionsKeepsStandardScopesWhenTenantDiscoveryIsEnabled(t *testing.T) {
+	t.Parallel()
+
+	options := buildCacheOptions(
+		"models-as-a-service", "odh-ai-gateway-infra", "opendatahub",
+		"ai-tenants", "openshift-ingress", "opendatahub",
+		true, true,
+	)
+
+	tenant := cacheByObjectFor[*maasv1alpha1.Tenant](t, options)
+	require.Contains(t, tenant.Namespaces, cache.AllNamespaces)
+
+	deployment := cacheByObjectFor[*appsv1.Deployment](t, options)
+	require.Contains(t, deployment.Namespaces, "openshift-ingress")
+	configMap := cacheByObjectFor[*corev1.ConfigMap](t, options)
+	require.Contains(t, configMap.Namespaces, "openshift-ingress")
+	networkPolicy := cacheByObjectFor[*netwv1.NetworkPolicy](t, options)
+	require.Contains(t, networkPolicy.Namespaces, "openshift-ingress")
+}
 
 func TestEnsureAITenantNamespaceWithClientCreatesNamespace(t *testing.T) {
 	clientset := clientsetfake.NewSimpleClientset()

--- a/maas-controller/cmd/manager/main_test.go
+++ b/maas-controller/cmd/manager/main_test.go
@@ -29,6 +29,7 @@ import (
 	controllerfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	maasv1alpha1 "github.com/opendatahub-io/models-as-a-service/maas-controller/api/maas/v1alpha1"
 	"github.com/opendatahub-io/models-as-a-service/maas-controller/pkg/controller/maas"
@@ -65,6 +66,9 @@ func TestBuildCacheOptionsScopesRenderedMaaSResources(t *testing.T) {
 		require.Contains(t, configMap.Namespaces, namespace)
 	}
 
+	gateway := cacheByObjectFor[*gatewayapiv1.Gateway](t, options)
+	require.Equal(t, map[string]cache.Config{"openshift-ingress": {}}, gateway.Namespaces)
+
 	selectorLabels := labels.Set{
 		tenantreconcile.LabelODHAppPrefix + "/" + tenantreconcile.ComponentName: "true",
 	}
@@ -98,6 +102,8 @@ func TestBuildCacheOptionsKeepsStandardScopesWhenTenantDiscoveryIsEnabled(t *tes
 	require.Contains(t, deployment.Namespaces, "openshift-ingress")
 	configMap := cacheByObjectFor[*corev1.ConfigMap](t, options)
 	require.Contains(t, configMap.Namespaces, "openshift-ingress")
+	gateway := cacheByObjectFor[*gatewayapiv1.Gateway](t, options)
+	require.Equal(t, map[string]cache.Config{"openshift-ingress": {}}, gateway.Namespaces)
 	networkPolicy := cacheByObjectFor[*netwv1.NetworkPolicy](t, options)
 	require.Contains(t, networkPolicy.Namespaces, "openshift-ingress")
 }

--- a/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
@@ -58,7 +58,9 @@ import (
 // MaaSAuthPolicyReconciler reconciles a MaaSAuthPolicy object
 type MaaSAuthPolicyReconciler struct {
 	client.Client
-	Scheme *runtime.Scheme
+	// APIReader bypasses the scoped cache for Gateway owner-reference lookups.
+	APIReader client.Reader
+	Scheme    *runtime.Scheme
 	// InfraNamespace is the infrastructure namespace where maas-api service is deployed.
 	// Used to construct the subscription selector endpoint URL.
 	InfraNamespace string
@@ -1346,7 +1348,11 @@ func (r *MaaSAuthPolicyReconciler) reconcileGatewayAuthPolicy(
 	if isTenantGateway {
 		gateway = &gatewayapiv1.Gateway{}
 		gwKey := client.ObjectKey{Namespace: gatewayNamespace, Name: gatewayName}
-		if gwErr := r.Get(ctx, gwKey, gateway); gwErr != nil {
+		gatewayReader := client.Reader(r.Client)
+		if r.APIReader != nil {
+			gatewayReader = r.APIReader
+		}
+		if gwErr := gatewayReader.Get(ctx, gwKey, gateway); gwErr != nil {
 			if apierrors.IsNotFound(gwErr) {
 				// Gateway is gone. If a managed tenant AuthPolicy still exists,
 				// delete it to prevent orphaned resources.

--- a/maas-controller/pkg/controller/maas/maasmodelref_controller.go
+++ b/maas-controller/pkg/controller/maas/maasmodelref_controller.go
@@ -476,8 +476,16 @@ func crdExists(ctx context.Context, reader client.Reader, crdName string) bool {
 	return false
 }
 
+func crdPartialMetadata() *metav1.PartialObjectMetadata {
+	// CRD specs contain large OpenAPI schemas; all current CRD predicates only
+	// inspect metadata, so the informer does not need to cache the full object.
+	metadata := &metav1.PartialObjectMetadata{}
+	metadata.SetGroupVersionKind(apiextensionsv1.SchemeGroupVersion.WithKind("CustomResourceDefinition"))
+	return metadata
+}
+
 // registerWatchWhenCRDAppears dynamically registers a resource watch the first time
-// the target CRD becomes available. It watches CRD objects (always available) and
+// the target CRD becomes available. It watches CRD metadata (always available) and
 // calls makeSource() exactly once via sync.Once when the named CRD is detected —
 // so multiple CRD update events never produce duplicate watchers. No pod restart needed.
 func registerWatchWhenCRDAppears(
@@ -491,9 +499,9 @@ func registerWatchWhenCRDAppears(
 	var once sync.Once
 	return c.Watch(source.Kind(
 		mgr.GetCache(),
-		&apiextensionsv1.CustomResourceDefinition{},
-		handler.TypedEnqueueRequestsFromMapFunc[*apiextensionsv1.CustomResourceDefinition](
-			func(ctx context.Context, crd *apiextensionsv1.CustomResourceDefinition) []reconcile.Request {
+		crdPartialMetadata(),
+		handler.TypedEnqueueRequestsFromMapFunc[*metav1.PartialObjectMetadata](
+			func(ctx context.Context, crd *metav1.PartialObjectMetadata) []reconcile.Request {
 				if crd.Name != crdName {
 					return nil
 				}

--- a/maas-controller/pkg/controller/maas/maasmodelref_controller.go
+++ b/maas-controller/pkg/controller/maas/maasmodelref_controller.go
@@ -55,7 +55,9 @@ import (
 // MaaSModelRefReconciler reconciles a MaaSModelRef object
 type MaaSModelRefReconciler struct {
 	client.Client
-	Scheme *runtime.Scheme
+	// APIReader bypasses the scoped cache for Gateway lookups that may use a legacy/custom namespace.
+	APIReader client.Reader
+	Scheme    *runtime.Scheme
 
 	// GatewayName and GatewayNamespace identify the Gateway used for model HTTPRoutes (configurable via flags).
 	GatewayName      string

--- a/maas-controller/pkg/controller/maas/providers.go
+++ b/maas-controller/pkg/controller/maas/providers.go
@@ -155,3 +155,11 @@ func getHTTPRoute(ctx context.Context, c client.Reader, name, ns string) (*gatew
 	}
 	return route, nil
 }
+
+func (r *MaaSModelRefReconciler) getGateway(ctx context.Context, key client.ObjectKey, gateway *gatewayapiv1.Gateway) error {
+	reader := client.Reader(r.Client)
+	if r.APIReader != nil {
+		reader = r.APIReader
+	}
+	return reader.Get(ctx, key, gateway)
+}

--- a/maas-controller/pkg/controller/maas/providers_external.go
+++ b/maas-controller/pkg/controller/maas/providers_external.go
@@ -251,7 +251,7 @@ func (h *externalModelHandler) GetModelEndpoint(ctx context.Context, log logr.Lo
 	gatewayNS := h.r.gatewayNamespace()
 	gateway := &gatewayapiv1.Gateway{}
 	key := client.ObjectKey{Name: gatewayName, Namespace: gatewayNS}
-	if err := h.r.Get(ctx, key, gateway); err != nil {
+	if err := h.r.getGateway(ctx, key, gateway); err != nil {
 		return "", fmt.Errorf("failed to get gateway %s/%s: %w", gatewayNS, gatewayName, err)
 	}
 

--- a/maas-controller/pkg/controller/maas/providers_llmisvc.go
+++ b/maas-controller/pkg/controller/maas/providers_llmisvc.go
@@ -163,7 +163,7 @@ func (h *llmisvcHandler) GetModelEndpoint(ctx context.Context, log logr.Logger, 
 
 	gateway := &gatewayapiv1.Gateway{}
 	key := client.ObjectKey{Name: gatewayName, Namespace: gatewayNS}
-	if err := h.r.Get(ctx, key, gateway); err != nil {
+	if err := h.r.getGateway(ctx, key, gateway); err != nil {
 		return "", fmt.Errorf("failed to get gateway %s/%s: %w", gatewayNS, gatewayName, err)
 	}
 	if len(gateway.Spec.Listeners) > 0 {

--- a/maas-controller/pkg/controller/maas/self_deployment_controller.go
+++ b/maas-controller/pkg/controller/maas/self_deployment_controller.go
@@ -31,7 +31,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	netwv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -1060,8 +1059,8 @@ func (r *LifecycleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		).
 		// Re-reconcile when optional operator CRDs (e.g. Perses from COO) are installed
 		// so that resources previously skipped due to missing CRDs are applied immediately.
-		Watches(
-			&extv1.CustomResourceDefinition{},
+		WatchesMetadata(
+			crdPartialMetadata(),
 			handler.EnqueueRequestsFromMapFunc(func(_ context.Context, _ client.Object) []reconcile.Request {
 				return []reconcile.Request{{NamespacedName: types.NamespacedName{
 					Namespace: r.DeploymentNS,

--- a/maas-controller/pkg/controller/maas/tenant_controller.go
+++ b/maas-controller/pkg/controller/maas/tenant_controller.go
@@ -23,7 +23,6 @@ import (
 	"sync"
 
 	corev1 "k8s.io/api/core/v1"
-	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -47,7 +46,9 @@ import (
 // The MaasTenantConfig CR is the runtime object; DSC.modelsAsService controls only enablement.
 type TenantReconciler struct {
 	client.Client
-	Scheme *runtime.Scheme
+	// APIReader bypasses the manager cache for live ownership and managed annotation checks.
+	APIReader client.Reader
+	Scheme    *runtime.Scheme
 	// OperatorNamespace overrides POD_NAMESPACE / WATCH_NAMESPACE when discovering namespaced platform workloads (tests).
 	OperatorNamespace string
 	// ManifestPath is the directory containing kustomization.yaml for the ODH maas-api overlay (e.g. maas-api/deploy/overlays/odh).
@@ -241,8 +242,8 @@ func (r *TenantReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			&maasv1alpha1.AITenant{},
 			handler.EnqueueRequestsFromMapFunc(r.enqueueTenantForAITenant),
 		).
-		Watches(
-			&extv1.CustomResourceDefinition{},
+		WatchesMetadata(
+			crdPartialMetadata(),
 			handler.EnqueueRequestsFromMapFunc(r.enqueueDefaultTenant),
 			builder.WithPredicates(crdLabeledForMaaSComponent()),
 		).

--- a/maas-controller/pkg/controller/maas/tenant_reconcile.go
+++ b/maas-controller/pkg/controller/maas/tenant_reconcile.go
@@ -324,7 +324,7 @@ func (r *TenantReconciler) reconcilePlatform(
 	mcfg *maasv1alpha1.Config,
 ) (*tenantreconcile.RunResult, *ctrl.Result, error) {
 	appNs := r.appNamespaceForTenant()
-	runRes, err := tenantreconcile.RunPlatform(ctx, log, r.Client, r.Scheme, tenant, platformContext, r.ManifestPath, appNs, r.ControllerNamespace, r.ClusterAudience, r.MonitoringNamespace, mcfg)
+	runRes, err := tenantreconcile.RunPlatform(ctx, log, r.Client, r.APIReader, r.Scheme, tenant, platformContext, r.ManifestPath, appNs, r.ControllerNamespace, r.ClusterAudience, r.MonitoringNamespace, mcfg)
 	if err != nil {
 		log.Error(err, "Tenant platform reconcile failed")
 		setDeploymentsAvailableCondition(tenant, false, "PlatformReconcileFailed", err.Error())

--- a/maas-controller/pkg/platform/tenantreconcile/apply.go
+++ b/maas-controller/pkg/platform/tenantreconcile/apply.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -27,9 +28,12 @@ const ssaFieldOwner = "maas-controller"
 // Objects matched by skipConfigControllerOwnerRef (see configOwnerRefSkips) do not receive a
 // Config controller ownerReference; they still receive tenant tracking labels. Add predicates
 // there for future exceptions (e.g. shared config that must outlive Config GC).
-func ApplyRendered(ctx context.Context, c client.Client, scheme *runtime.Scheme, tenant client.Object, appNs string, mcfg *maasv1alpha1.Config, objs []unstructured.Unstructured) error {
+func ApplyRendered(ctx context.Context, c client.Client, reader client.Reader, scheme *runtime.Scheme, tenant client.Object, appNs string, mcfg *maasv1alpha1.Config, objs []unstructured.Unstructured) error {
 	if mcfg == nil || mcfg.UID == "" {
 		return errors.New("config with UID is required for platform apply")
+	}
+	if reader == nil {
+		reader = c
 	}
 
 	for i := range objs {
@@ -41,7 +45,11 @@ func ApplyRendered(ctx context.Context, c client.Client, scheme *runtime.Scheme,
 		// bootstrap/migrate (see preparePayloadProcessingPluginsConfigMapApply) so
 		// subsequent reconciles leave user plugin edits alone unless they set
 		// opendatahub.io/managed=true to opt back into continuous management.
-		if isLiveResourceUnmanaged(ctx, c, u) {
+		unmanaged, err := isLiveResourceUnmanaged(ctx, reader, u)
+		if err != nil {
+			return fmt.Errorf("check managed annotation on %s %s/%s: %w", u.GetKind(), u.GetNamespace(), u.GetName(), err)
+		}
+		if unmanaged {
 			ctrl.LoggerFrom(ctx).V(1).Info("Skipping SSA for resource with opendatahub.io/managed=false on cluster",
 				"kind", u.GetKind(), "name", u.GetName(), "namespace", u.GetNamespace())
 			continue
@@ -51,7 +59,11 @@ func ApplyRendered(ctx context.Context, c client.Client, scheme *runtime.Scheme,
 		// controller (e.g. ODH operator's ModelsAsService component). SSA-applying
 		// over them would fail on immutable fields like spec.selector and produce
 		// conflicting controller:true ownerReferences.
-		if isOwnedByExternalController(ctx, c, u, mcfg.UID) {
+		externallyOwned, err := isOwnedByExternalController(ctx, reader, u, mcfg.UID)
+		if err != nil {
+			return fmt.Errorf("check owner references on %s %s/%s: %w", u.GetKind(), u.GetNamespace(), u.GetName(), err)
+		}
+		if externallyOwned {
 			ctrl.LoggerFrom(ctx).Info("Skipping SSA: resource owned by external controller",
 				"kind", u.GetKind(), "namespace", u.GetNamespace(), "name", u.GetName())
 			continue
@@ -72,7 +84,9 @@ func ApplyRendered(ctx context.Context, c client.Client, scheme *runtime.Scheme,
 			}
 			setTenantTrackingLabels(u, tenant)
 		}
-		preparePayloadProcessingPluginsConfigMapApply(ctx, c, u)
+		if err := preparePayloadProcessingPluginsConfigMapApply(ctx, reader, u); err != nil {
+			return fmt.Errorf("prepare %s %s/%s: %w", u.GetKind(), u.GetNamespace(), u.GetName(), err)
+		}
 		unstructured.RemoveNestedField(u.Object, "metadata", "managedFields")
 		unstructured.RemoveNestedField(u.Object, "metadata", "resourceVersion")
 		unstructured.RemoveNestedField(u.Object, "status")
@@ -110,18 +124,21 @@ func isMaaSControllerDeployment(u *unstructured.Unstructured, appNs string) bool
 	return strings.EqualFold(u.GetKind(), "Deployment") && u.GetName() == MaaSControllerDeploymentName
 }
 
-func isLiveResourceUnmanaged(ctx context.Context, c client.Client, rendered *unstructured.Unstructured) bool {
+func isLiveResourceUnmanaged(ctx context.Context, reader client.Reader, rendered *unstructured.Unstructured) (bool, error) {
 	live := &unstructured.Unstructured{}
 	live.SetGroupVersionKind(rendered.GroupVersionKind())
 	key := client.ObjectKeyFromObject(rendered)
 	if key.Name == "" {
-		return false
+		return false, nil
 	}
-	if err := c.Get(ctx, key, live); err != nil {
-		return false
+	if err := reader.Get(ctx, key, live); err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
 	}
 	ann := live.GetAnnotations()
-	return ann != nil && ann[AnnotationManaged] == "false"
+	return ann != nil && ann[AnnotationManaged] == "false", nil
 }
 
 // isPayloadProcessingPluginsConfigMap reports whether u is the IPP plugins ConfigMap
@@ -147,19 +164,21 @@ func isPayloadProcessingPluginsConfigMap(u *unstructured.Unstructured) bool {
 //
 // Do not put managed=false in the source YAML: PostRender drops resources that
 // already carry that annotation, which would prevent first-time creation.
-func preparePayloadProcessingPluginsConfigMapApply(ctx context.Context, c client.Client, u *unstructured.Unstructured) {
+func preparePayloadProcessingPluginsConfigMapApply(ctx context.Context, reader client.Reader, u *unstructured.Unstructured) error {
 	if !isPayloadProcessingPluginsConfigMap(u) {
-		return
+		return nil
 	}
 	managedValue := "false"
 	live := &unstructured.Unstructured{}
 	live.SetGroupVersionKind(u.GroupVersionKind())
 	key := client.ObjectKeyFromObject(u)
 	if key.Name != "" {
-		if err := c.Get(ctx, key, live); err == nil {
+		if err := reader.Get(ctx, key, live); err == nil {
 			if ann := live.GetAnnotations(); ann != nil && ann[AnnotationManaged] == "true" {
 				managedValue = "true"
 			}
+		} else if !apierrors.IsNotFound(err) {
+			return err
 		}
 	}
 	ann := u.GetAnnotations()
@@ -168,6 +187,7 @@ func preparePayloadProcessingPluginsConfigMapApply(ctx context.Context, c client
 	}
 	ann[AnnotationManaged] = managedValue
 	u.SetAnnotations(ann)
+	return nil
 }
 
 // isOwnedByExternalController returns true when the live cluster copy of the
@@ -176,22 +196,25 @@ func preparePayloadProcessingPluginsConfigMapApply(ctx context.Context, c client
 // over resources the ODH operator's ModelsAsService component already owns,
 // which would fail on immutable fields (spec.selector) and produce conflicting
 // controller ownerReferences.
-func isOwnedByExternalController(ctx context.Context, c client.Client, rendered *unstructured.Unstructured, configUID types.UID) bool {
+func isOwnedByExternalController(ctx context.Context, reader client.Reader, rendered *unstructured.Unstructured, configUID types.UID) (bool, error) {
 	live := &unstructured.Unstructured{}
 	live.SetGroupVersionKind(rendered.GroupVersionKind())
 	key := client.ObjectKeyFromObject(rendered)
 	if key.Name == "" {
-		return false
+		return false, nil
 	}
-	if err := c.Get(ctx, key, live); err != nil {
-		return false
+	if err := reader.Get(ctx, key, live); err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
 	}
 	for _, ref := range live.GetOwnerReferences() {
 		if ref.Controller != nil && *ref.Controller && ref.UID != configUID {
-			return true
+			return true, nil
 		}
 	}
-	return false
+	return false, nil
 }
 
 func setTenantTrackingLabels(obj *unstructured.Unstructured, tenant client.Object) {

--- a/maas-controller/pkg/platform/tenantreconcile/apply_plugins_configmap_test.go
+++ b/maas-controller/pkg/platform/tenantreconcile/apply_plugins_configmap_test.go
@@ -51,7 +51,7 @@ func TestPreparePayloadProcessingPluginsConfigMapApply(t *testing.T) {
 		t.Parallel()
 		c := fake.NewClientBuilder().WithScheme(scheme).Build()
 		u := newRendered()
-		preparePayloadProcessingPluginsConfigMapApply(context.Background(), c, u)
+		require.NoError(t, preparePayloadProcessingPluginsConfigMapApply(context.Background(), c, u))
 		assert.Equal(t, "false", u.GetAnnotations()[AnnotationManaged])
 	})
 
@@ -65,7 +65,7 @@ func TestPreparePayloadProcessingPluginsConfigMapApply(t *testing.T) {
 		}
 		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(live).Build()
 		u := newRendered()
-		preparePayloadProcessingPluginsConfigMapApply(context.Background(), c, u)
+		require.NoError(t, preparePayloadProcessingPluginsConfigMapApply(context.Background(), c, u))
 		assert.Equal(t, "false", u.GetAnnotations()[AnnotationManaged])
 	})
 
@@ -82,7 +82,7 @@ func TestPreparePayloadProcessingPluginsConfigMapApply(t *testing.T) {
 		}
 		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(live).Build()
 		u := newRendered()
-		preparePayloadProcessingPluginsConfigMapApply(context.Background(), c, u)
+		require.NoError(t, preparePayloadProcessingPluginsConfigMapApply(context.Background(), c, u))
 		assert.Equal(t, "true", u.GetAnnotations()[AnnotationManaged])
 	})
 
@@ -92,7 +92,7 @@ func TestPreparePayloadProcessingPluginsConfigMapApply(t *testing.T) {
 		u := &unstructured.Unstructured{}
 		u.SetGroupVersionKind(GVKConfigMap)
 		u.SetName("unrelated")
-		preparePayloadProcessingPluginsConfigMapApply(context.Background(), c, u)
+		require.NoError(t, preparePayloadProcessingPluginsConfigMapApply(context.Background(), c, u))
 		assert.Nil(t, u.GetAnnotations())
 	})
 }

--- a/maas-controller/pkg/platform/tenantreconcile/pipeline.go
+++ b/maas-controller/pkg/platform/tenantreconcile/pipeline.go
@@ -47,6 +47,7 @@ func RunPlatform(
 	ctx context.Context,
 	log logr.Logger,
 	c client.Client,
+	reader client.Reader,
 	scheme *runtime.Scheme,
 	tenant client.Object,
 	platformContext PlatformContext,
@@ -110,7 +111,10 @@ func RunPlatform(
 		return nil, fmt.Errorf("cleanup payload-processing HPA: %w", err)
 	}
 
-	if err := ApplyRendered(ctx, c, scheme, tenant, appNs, mcfg, resources); err != nil {
+	if reader == nil {
+		reader = c
+	}
+	if err := ApplyRendered(ctx, c, reader, scheme, tenant, appNs, mcfg, resources); err != nil {
 		return nil, fmt.Errorf("apply: %w", err)
 	}
 
@@ -177,7 +181,7 @@ func Run(
 		return nil, err
 	}
 
-	return RunPlatform(ctx, log, c, scheme, tenant, platformContext, manifestPath, appNs, controllerNs, clusterAudience, monitoringNamespace, mcfg)
+	return RunPlatform(ctx, log, c, c, scheme, tenant, platformContext, manifestPath, appNs, controllerNs, clusterAudience, monitoringNamespace, mcfg)
 }
 
 const maasParametersConfigMapName = "maas-parameters"

--- a/maas-controller/pkg/platform/tenantreconcile/pipeline.go
+++ b/maas-controller/pkg/platform/tenantreconcile/pipeline.go
@@ -70,8 +70,11 @@ func RunPlatform(
 	if platformContext.GatewayRef.Namespace == "" || platformContext.GatewayRef.Name == "" {
 		return nil, errors.New("gateway ref must be set before calling RunPlatform")
 	}
+	if reader == nil {
+		reader = c
+	}
 	gw := &gwapiv1.Gateway{}
-	if err := c.Get(ctx, types.NamespacedName{Namespace: platformContext.GatewayRef.Namespace, Name: platformContext.GatewayRef.Name}, gw); err != nil {
+	if err := reader.Get(ctx, types.NamespacedName{Namespace: platformContext.GatewayRef.Namespace, Name: platformContext.GatewayRef.Name}, gw); err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil, fmt.Errorf("gateway %s/%s not found", platformContext.GatewayRef.Namespace, platformContext.GatewayRef.Name)
 		}
@@ -111,9 +114,6 @@ func RunPlatform(
 		return nil, fmt.Errorf("cleanup payload-processing HPA: %w", err)
 	}
 
-	if reader == nil {
-		reader = c
-	}
 	if err := ApplyRendered(ctx, c, reader, scheme, tenant, appNs, mcfg, resources); err != nil {
 		return nil, fmt.Errorf("apply: %w", err)
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Scopes MaaS informer caches and CRD watches to reduce memory usage on large clusters. Uses uncached API reads for live ownership checks and adds gateway namespace coverage without breaking tenant discovery.

This PR should replace autogenerated https://github.com/opendatahub-io/models-as-a-service/pull/1433

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of live-resource checks and payload preparation, with clearer error reporting for unexpected Kubernetes API failures.
  - Improved tenant reconciliation and endpoint resolution by separating live reads from cached resource operations.

- **Performance**
  - Reduced controller memory and API usage by limiting selected resources to relevant namespaces and labels.
  - CRD monitoring now retrieves metadata only instead of full resource definitions.

- **Reliability**
  - Expanded test coverage for cache scoping, tenant discovery, and payload processing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->