### PR TITLE
fix: remove path separator from docs latest checkout

### DIFF
--- a/.github/workflows/update-docs-latest.yml
+++ b/.github/workflows/update-docs-latest.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Checkout tag
         env:
           TAG: ${{ inputs.tag }}
-        run: git checkout --detach -- "$TAG"
+        run: git checkout --detach "$TAG"
 
       - name: Setup Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0


### PR DESCRIPTION
## Summary

Fixes the **Update Docs Latest** workflow failing at the "Checkout tag" step with exit code 128.

`git checkout --detach -- "$TAG"` makes Git treat the tag as a **path** argument to `--detach`, not a ref. Drop the `--` so the tag resolves correctly.

## Test plan

- [x] Reproduced failure locally: `git checkout --detach -- v0.2.1` exits 128
- [x] Verified fix: `git checkout --detach v0.2.1` succeeds when tag exists
- [ ] Merge and re-run **Update Docs Latest** for `v0.2.1`

## Risk analysis

- **Risk rating**: 0
- **Why**: One-line workflow fix; no runtime product behavior change.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the documentation workflow’s tag checkout command to improve compatibility with tag-based updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->