### PR TITLE
build: add semgrep TLS exclusion for maas-discovery service

### DIFF
--- a/.github/semgrep-tls-excludes
+++ b/.github/semgrep-tls-excludes
@@ -7,6 +7,10 @@
 go-http-server-tls-override:maas-api/cmd/server.go
 go-http-server-tls-override:maas-api/internal/metrics/server.go
 #
+# discovery main.go: TLS listener requires explicit tls.Config for certificate loading
+# (cert/key files or self-signed). Cluster TLS profile integration tracked in RHOAIENG-90729.
+go-http-server-tls-override:maas-discovery/cmd/discovery/main.go
+#
 # discovery.go: Cluster-internal HTTP client uses cluster CA bundle plus profile
 # MinVersion/CipherSuites plumbed from setupTLSProfile; required assignment for probes.
 go-http-client-tls-override:maas-api/internal/models/discovery.go


### PR DESCRIPTION
## Summary

- Add `maas-discovery/cmd/discovery/main.go` to `.github/semgrep-tls-excludes` for the `go-http-server-tls-override` rule
- The discovery service ([RHOAIENG-90728](https://redhat.atlassian.net/browse/RHOAIENG-90728)) requires explicit `tls.Config` for certificate loading — same justification as `maas-api/cmd/server.go`
- Cluster TLS security profile integration is tracked in [RHOAIENG-90729](https://redhat.atlassian.net/browse/RHOAIENG-90729)

## Test plan

- [ ] Semgrep TLS CI passes on [#1462](https://github.com/opendatahub-io/models-as-a-service/pull/1462) after this merges

## Risk analysis

- **Risk rating**: 0
- **Why**: Only modifies a CI suppression file. No runtime impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RHOAIENG-90729]: https://redhat.atlassian.net/browse/RHOAIENG-90729?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[RHOAIENG-90728]: https://redhat.atlassian.net/browse/RHOAIENG-90728?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ