### PR TITLE
test: revert "docs: improve docs to track usage"

### DIFF
--- a/docs/content/configuration-and-management/quota-and-access-configuration.md
+++ b/docs/content/configuration-and-management/quota-and-access-configuration.md
@@ -182,22 +182,6 @@ TRLP=$(kubectl get tokenratelimitpolicy -n ${MODEL_NS} -l maas.opendatahub.io/mo
     
     Authentication, subscription validation, and model access controls still apply to all endpoints — only token-based rate limiting enforcement is affected.
 
-### Model server must include usage data
-
-Token rate limiting requires the model server to return `usage` information in every response. By default, vLLM and llm-d only include usage in non-streaming responses. For streaming (SSE) responses — the default for many chat completion clients — usage data is omitted unless explicitly enabled.
-
-**Start the model server with `--enable-force-include-usage`** to ensure usage data is always returned regardless of whether the client requests it. Without this flag, token rate limits will not be enforced for streaming chat completion requests (the gateway sees 0 tokens consumed).
-
-Embedding endpoints are unaffected because they always return non-streaming JSON with `usage.total_tokens`.
-
-How to enable, depending on your deployment:
-
-- **llm-d-inference-sim / vLLM CLI args:** add `--enable-force-include-usage` to the container `args`
-- **vLLM via `VLLM_ADDITIONAL_ARGS`:** add `--enable-force-include-usage` to the env var value
-- **vLLM via shell script:** append `--enable-force-include-usage` to the `vllm serve` command
-
-See [vLLM documentation](https://docs.vllm.ai/en/stable/cli/serve/#-enable-force-include-usage-no-enable-force-include-usage) for details.
-
 !!! note "Namespace requirements"
     Both **MaaSAuthPolicy** and **MaaSSubscription** must be installed in the `models-as-a-service` namespace. Each `modelRefs` entry must specify the `namespace` where the MaaSModelRef lives (e.g. `llm`).
 
@@ -289,12 +273,6 @@ When a user belongs to multiple groups that each have a subscription, the access
 - Verify MaaSModelRef exists in the model namespace (e.g. `llm`) and has `status.phase: Ready`
 - Check MaaSAuthPolicy in `models-as-a-service` includes the user's groups and references the MaaSModelRef with correct `name` (e.g. `${MODEL_NAME}-ref`) and `namespace`
 - Ensure MaaSSubscription in `models-as-a-service` exists for the model and user's groups
-
-### Token rate limits not enforced (no 429 errors)
-
-**Cause:** The model server is not returning `usage.total_tokens` in responses. The gateway sees 0 tokens consumed and never triggers the rate limit. This commonly affects streaming chat completion requests.
-
-**Fix:** Start the model server with `--enable-force-include-usage`. See the warning box above for details on how to enable this for different deployment patterns.
 
 ### Policies not enforced
 

--- a/docs/content/install/model-setup.md
+++ b/docs/content/install/model-setup.md
@@ -62,8 +62,6 @@ kubectl get maasmodelref -n llm facebook-opt-125m-simulated -o jsonpath='{.statu
 
 **Expected output:** `status.phase` should be `Ready` and `status.endpoint` should be a non-empty URL. If either is missing, wait briefly and retry—the controller may still be reconciling (see [Verify Model Deployment](#verify-model-deployment) below).
 
-If your model uses token rate limits (via MaaSSubscription), the model server must be started with `--enable-force-include-usage` so that usage data is returned in every response. Without this, the gateway cannot count tokens and rate limits will not be enforced for streaming chat completion requests. See [Model server must include usage data](../configuration-and-management/quota-and-access-configuration.md#model-server-must-include-usage-data) for details.
-
 ### Step 3: Deploy the MaaSSubscription
 
 The MaaSSubscription defines token rate limits (quotas) for groups. It references the MaaSModelRef by name and namespace. This controls how many tokens each group can consume per model.

--- a/docs/samples/models/e2e-distinct-2-simulated/model.yaml
+++ b/docs/samples/models/e2e-distinct-2-simulated/model.yaml
@@ -32,8 +32,6 @@ spec:
         - --mode
         - random
         - --no-mm-encoder-only
-        # Required for token rate limiting: https://docs.vllm.ai/en/stable/cli/serve/#-enable-force-include-usage-no-enable-force-include-usage
-        - --enable-force-include-usage
         - --ssl-certfile
         - /var/run/kserve/tls/tls.crt
         - --ssl-keyfile

--- a/docs/samples/models/e2e-distinct-simulated/model.yaml
+++ b/docs/samples/models/e2e-distinct-simulated/model.yaml
@@ -32,8 +32,6 @@ spec:
         - --mode
         - random
         - --no-mm-encoder-only
-        # Required for token rate limiting: https://docs.vllm.ai/en/stable/cli/serve/#-enable-force-include-usage-no-enable-force-include-usage
-        - --enable-force-include-usage
         - --ssl-certfile
         - /var/run/kserve/tls/tls.crt
         - --ssl-keyfile

--- a/docs/samples/models/embedding-simulator/model.yaml
+++ b/docs/samples/models/embedding-simulator/model.yaml
@@ -35,8 +35,6 @@ spec:
         - --mode
         - random
         - --no-mm-encoder-only
-        # Required for token rate limiting: https://docs.vllm.ai/en/stable/cli/serve/#-enable-force-include-usage-no-enable-force-include-usage
-        - --enable-force-include-usage
         - --ssl-certfile
         - /var/run/kserve/tls/tls.crt
         - --ssl-keyfile

--- a/docs/samples/models/facebook-opt-125m-cpu/model.yaml
+++ b/docs/samples/models/facebook-opt-125m-cpu/model.yaml
@@ -19,9 +19,6 @@ spec:
       - name: main
         image: quay.io/pierdipi/vllm-cpu:latest
         env:
-          # --enable-force-include-usage required for token rate limiting: https://docs.vllm.ai/en/stable/cli/serve/#-enable-force-include-usage-no-enable-force-include-usage
-          - name: VLLM_ADDITIONAL_ARGS
-            value: "--enable-force-include-usage"
           - name: VLLM_LOGGING_LEVEL
             value: INFO
         resources:

--- a/docs/samples/models/granite-3-1-8b-rhelai-modelcar/model.yaml
+++ b/docs/samples/models/granite-3-1-8b-rhelai-modelcar/model.yaml
@@ -45,8 +45,7 @@ spec:
             value: "3"
           # Omit --trust-remote-code: vLLM warns it only applies to HF AutoModel paths; no effect for mounted/OCI weights.
           - name: VLLM_ADDITIONAL_ARGS
-            # --enable-force-include-usage required for token rate limiting: https://docs.vllm.ai/en/stable/cli/serve/#-enable-force-include-usage-no-enable-force-include-usage
-            value: "--max-model-len 4096 --enable-force-include-usage"
+            value: "--max-model-len 4096"
         resources:
           requests:
             cpu: "3"

--- a/docs/samples/models/ibm-granite-2b-gpu/model.yaml
+++ b/docs/samples/models/ibm-granite-2b-gpu/model.yaml
@@ -28,8 +28,7 @@ spec:
         env:
           # Granite-specific configuration via environment variables
           - name: VLLM_ADDITIONAL_ARGS
-            # --enable-force-include-usage required for token rate limiting: https://docs.vllm.ai/en/stable/cli/serve/#-enable-force-include-usage-no-enable-force-include-usage
-            value: "--max-model-len 4096 --trust-remote-code --dtype float16 --enable-force-include-usage"
+            value: "--max-model-len 4096 --trust-remote-code --dtype float16"
           - name: VLLM_ATTENTION_BACKEND
             value: XFORMERS
           - name: VLLM_USE_V1

--- a/docs/samples/models/qwen3/model.yaml
+++ b/docs/samples/models/qwen3/model.yaml
@@ -44,8 +44,7 @@ spec:
               --ssl-certfile /var/run/kserve/tls/tls.crt \
               --ssl-keyfile /var/run/kserve/tls/tls.key \
               --enforce-eager \
-              --max-model-len 8192 \
-              --enable-force-include-usage  # Required for token rate limiting: https://docs.vllm.ai/en/stable/cli/serve/#-enable-force-include-usage-no-enable-force-include-usage
+              --max-model-len 8192
         env:
           # Avoid Triton completely
           - name: VLLM_ATTENTION_BACKEND

--- a/docs/samples/models/simulator-premium/model.yaml
+++ b/docs/samples/models/simulator-premium/model.yaml
@@ -33,8 +33,6 @@ spec:
         - --mode
         - random
         - --no-mm-encoder-only
-        # Required for token rate limiting: https://docs.vllm.ai/en/stable/cli/serve/#-enable-force-include-usage-no-enable-force-include-usage
-        - --enable-force-include-usage
         - --ssl-certfile
         - /var/run/kserve/tls/tls.crt
         - --ssl-keyfile

--- a/docs/samples/models/simulator/model.yaml
+++ b/docs/samples/models/simulator/model.yaml
@@ -37,8 +37,6 @@ spec:
         - random
         # Keep full OpenAI surface (e.g. /v1/embeddings); do not use encoder-only mode.
         - --no-mm-encoder-only
-        # Required for token rate limiting: https://docs.vllm.ai/en/stable/cli/serve/#-enable-force-include-usage-no-enable-force-include-usage
-        - --enable-force-include-usage
         - --ssl-certfile
         - /var/run/kserve/tls/tls.crt
         - --ssl-keyfile


### PR DESCRIPTION
Reverts opendatahub-io/models-as-a-service#1464

Simulator models are failing to come up in e2e tests.  

https://github.com/opendatahub-io/models-as-a-service/pull/1464#discussion_r3972684662