### PR TITLE
fix: allow group names to include spaces

### DIFF
--- a/maas-api/internal/api_keys/service.go
+++ b/maas-api/internal/api_keys/service.go
@@ -18,10 +18,10 @@ import (
 )
 
 // validGroupNamePattern matches Kubernetes/OpenShift group names.
-// Allows alphanumerics, colons (for system: prefixes), dots, underscores, and hyphens.
+// Allows alphanumerics, colons (for system: prefixes), dots, underscores, hyphens, and spaces.
 // Rejects control characters, quotes, backslashes, and other unsafe characters
 // that could break JSON encoding in AuthPolicy CEL expressions (CWE-116/CWE-74 mitigation).
-var validGroupNamePattern = regexp.MustCompile(`^[a-zA-Z0-9:._-]+$`)
+var validGroupNamePattern = regexp.MustCompile(`^[a-zA-Z0-9:._ -]+$`)
 
 var (
 	ErrTenantRequired = errors.New("tenant is required")
@@ -116,7 +116,7 @@ func (s *Service) CreateAPIKey(
 	// functions, so we reject any characters outside the safe allowlist on write.
 	for _, group := range userGroups {
 		if !validGroupNamePattern.MatchString(group) {
-			return nil, fmt.Errorf("group name %q contains invalid characters (only alphanumerics, colons, dots, underscores, and hyphens are allowed)", group)
+			return nil, fmt.Errorf("group name %q contains invalid characters (only alphanumerics, colons, dots, underscores, hyphens, and spaces are allowed)", group)
 		}
 	}
 

--- a/maas-api/internal/api_keys/service_test.go
+++ b/maas-api/internal/api_keys/service_test.go
@@ -1279,6 +1279,7 @@ func TestCreateAPIKey_GroupNameValidation(t *testing.T) {
 	validGroups := [][]string{
 		{"system:authenticated"},
 		{"my-group"},
+		{"group with spaces"},
 		{"group.with.dots"},
 		{"group_with_underscores"},
 		{"GROUP123"},
@@ -1299,7 +1300,6 @@ func TestCreateAPIKey_GroupNameValidation(t *testing.T) {
 	}{
 		{`group"with"quotes`, "double quotes"},
 		{`group\with\backslash`, "backslashes"},
-		{`group with spaces`, "spaces"},
 		{"group\nwith\nnewline", "newlines"},
 		{"group\twith\ttab", "tabs"},
 		{"group;with;semicolon", "semicolons"},

--- a/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
+++ b/maas-controller/pkg/controller/maas/maasauthpolicy_controller.go
@@ -386,7 +386,7 @@ const (
 		`? auth.metadata.apiKeyValidation.groups ` +
 		`: (has(auth.identity.groups) ? auth.identity.groups : auth.identity.user.groups)`
 
-	safeGroupNamePattern = `^[A-Za-z0-9:._/-]+$`
+	safeGroupNamePattern = `^[A-Za-z0-9:._/ -]+$`
 	celOIDCGroupsSafe    = `auth.identity.groups.all(g, g.matches('` + safeGroupNamePattern + `'))`
 
 	// celTokenGroupsHeaderJSON renders the X-MaaS-Group header for non-API-key

--- a/maas-controller/pkg/platform/tenantreconcile/postrender.go
+++ b/maas-controller/pkg/platform/tenantreconcile/postrender.go
@@ -234,7 +234,7 @@ func patchAuthPolicyWithOIDC(log logr.Logger, resource *unstructured.Unstructure
 		return fmt.Errorf("failed to set X-MaaS-Username-OC: %w", err)
 	}
 	groupsExpr := `has(auth.identity.groups) ? ` +
-		`(size(auth.identity.groups) > 0 && auth.identity.groups.all(g, g.matches('^[A-Za-z0-9:._/-]+$')) ? ` +
+		`(size(auth.identity.groups) > 0 && auth.identity.groups.all(g, g.matches('^[A-Za-z0-9:._/ -]+$')) ? ` +
 		`'["system:authenticated","' + auth.identity.groups.join('","') + '"]' : ` +
 		`'["system:authenticated"]') : ` +
 		`(has(auth.identity.user.groups) && size(auth.identity.user.groups) > 0 ? ` +


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Allow spaces to address https://redhat.atlassian.net/browse/RHOAIENG-94549

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested creating APIKEYs for subscriptions with groups with spaces.  Tested both OIDC and Openshift token. 

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Group names containing spaces are now supported when creating API keys.
  - Authentication policies and group-based response handling now accept group names with spaces.
  - Existing restrictions on other unsupported characters remain in place.
- **Bug Fixes**
  - Validation messages now accurately indicate that spaces are permitted in group names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->