### PR TITLE
feat(tenantreconcile): clean up IPP resources when SkipIPP is enabled

### DIFF
--- a/maas-controller/pkg/controller/maas/aitenant_controller.go
+++ b/maas-controller/pkg/controller/maas/aitenant_controller.go
@@ -283,7 +283,11 @@ func (r *AITenantReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&maasv1alpha1.AITenant{}, builder.WithPredicates(
-			predicate.Or(predicate.GenerationChangedPredicate{}, predicate.Funcs{UpdateFunc: deletionTimestampSet}),
+			predicate.Or(
+				predicate.GenerationChangedPredicate{},
+				predicate.Funcs{UpdateFunc: deletionTimestampSet},
+				predicate.Funcs{UpdateFunc: payloadProcessingTypeAnnotationChanged},
+			),
 		)).
 		Watches(
 			&maasv1alpha1.MaasTenantConfig{},

--- a/maas-controller/pkg/controller/maas/aitenant_controller_test.go
+++ b/maas-controller/pkg/controller/maas/aitenant_controller_test.go
@@ -77,6 +77,60 @@ func TestApplyAITenantMetadata_PropagatesPayloadProcessingTypeAnnotation(t *test
 	g.Expect(ok).To(BeFalse())
 }
 
+func TestAITenantReconcile_RemovesPayloadProcessingTypeMirrorOnDeannotation(t *testing.T) {
+	g := NewWithT(t)
+	s := aitenantTestScheme(t)
+	ctx := context.Background()
+
+	aitenant := &maasv1alpha1.AITenant{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "praxis-sync",
+			Namespace: tenantreconcile.DefaultAITenantNamespace,
+			Annotations: map[string]string{
+				tenantreconcile.AnnotationPayloadProcessingType: tenantreconcile.PayloadProcessingTypePraxis,
+			},
+		},
+	}
+	cl := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(&maasv1alpha1.AITenant{}).
+		WithObjects(aitenant, existingAITenantGateway("praxis-sync")).
+		Build()
+	r := &AITenantReconciler{
+		Client:           cl,
+		Scheme:           s,
+		APIReader:        cl,
+		AppNamespace:     "opendatahub",
+		TenantNamespace:  "models-as-a-service",
+		GatewayNamespace: "openshift-ingress",
+	}
+
+	key := types.NamespacedName{Name: aitenant.Name, Namespace: aitenant.Namespace}
+	reconcileAITenantToActive(t, r, key)
+
+	configKey := client.ObjectKey{
+		Name:      maasv1alpha1.MaasTenantConfigInstanceName,
+		Namespace: "ai-tenant-praxis-sync",
+	}
+	var config maasv1alpha1.MaasTenantConfig
+	g.Expect(cl.Get(ctx, configKey, &config)).To(Succeed())
+	g.Expect(config.Annotations).To(HaveKeyWithValue(
+		tenantreconcile.AnnotationPayloadProcessingType,
+		tenantreconcile.PayloadProcessingTypePraxis,
+	))
+
+	g.Expect(cl.Get(ctx, key, aitenant)).To(Succeed())
+	delete(aitenant.Annotations, tenantreconcile.AnnotationPayloadProcessingType)
+	g.Expect(cl.Update(ctx, aitenant)).To(Succeed())
+
+	_, _, err := r.ensureTenantConfig(ctx, aitenant)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	g.Expect(cl.Get(ctx, configKey, &config)).To(Succeed())
+	_, ok := config.Annotations[tenantreconcile.AnnotationPayloadProcessingType]
+	g.Expect(ok).To(BeFalse())
+}
+
 func existingAITenantGateway(name string) *gatewayapiv1.Gateway {
 	return &gatewayapiv1.Gateway{
 		TypeMeta: metav1.TypeMeta{

--- a/maas-controller/pkg/controller/maas/helpers.go
+++ b/maas-controller/pkg/controller/maas/helpers.go
@@ -29,6 +29,26 @@ func deletionTimestampSet(e event.UpdateEvent) bool {
 		!e.ObjectNew.GetDeletionTimestamp().IsZero()
 }
 
+// payloadProcessingTypeAnnotationChanged returns true when the mirrored
+// maas.opendatahub.io/payload-processing-type annotation changes on an AITenant.
+// Annotation-only edits do not bump metadata.generation, so this predicate ensures
+// MaasTenantConfig mirrors stay in sync when operators switch praxis ↔ legacy IPP.
+func payloadProcessingTypeAnnotationChanged(e event.UpdateEvent) bool {
+	key := tenantreconcile.AnnotationPayloadProcessingType
+	return objectAnnotation(e.ObjectOld, key) != objectAnnotation(e.ObjectNew, key)
+}
+
+func objectAnnotation(obj client.Object, key string) string {
+	if obj == nil {
+		return ""
+	}
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		return ""
+	}
+	return annotations[key]
+}
+
 // unstructuredConditionsChangedPredicate passes Create/Delete events unconditionally
 // and Update events only when the object's generation changed or its status.conditions
 // actually transitioned (type+status pairs differ). This filters out noise from

--- a/maas-controller/pkg/controller/maas/helpers_test.go
+++ b/maas-controller/pkg/controller/maas/helpers_test.go
@@ -141,8 +141,8 @@ func TestPayloadProcessingTypeAnnotationChanged(t *testing.T) {
 		{
 			name: "ignore unrelated annotation changes",
 			oldObj: aitenant(map[string]string{
-				annotationKey:                  tenantreconcile.PayloadProcessingTypePraxis,
-				"example.com/unrelated":        "old",
+				annotationKey:           tenantreconcile.PayloadProcessingTypePraxis,
+				"example.com/unrelated": "old",
 			}),
 			newObj: aitenant(map[string]string{
 				annotationKey:           tenantreconcile.PayloadProcessingTypePraxis,

--- a/maas-controller/pkg/controller/maas/helpers_test.go
+++ b/maas-controller/pkg/controller/maas/helpers_test.go
@@ -31,6 +31,7 @@ import (
 	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	maasv1alpha1 "github.com/opendatahub-io/models-as-a-service/maas-controller/api/maas/v1alpha1"
+	"github.com/opendatahub-io/models-as-a-service/maas-controller/pkg/platform/tenantreconcile"
 )
 
 func TestDeletionTimestampSet(t *testing.T) {
@@ -90,6 +91,81 @@ func TestDeletionTimestampSet(t *testing.T) {
 			got := deletionTimestampSet(e)
 			if got != tt.expected {
 				t.Errorf("deletionTimestampSet() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestPayloadProcessingTypeAnnotationChanged(t *testing.T) {
+	annotationKey := tenantreconcile.AnnotationPayloadProcessingType
+	aitenant := func(annotations map[string]string) *maasv1alpha1.AITenant {
+		return &maasv1alpha1.AITenant{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "team-a",
+				Namespace:   tenantreconcile.DefaultAITenantNamespace,
+				Annotations: annotations,
+			},
+		}
+	}
+
+	tests := []struct {
+		name     string
+		oldObj   client.Object
+		newObj   client.Object
+		expected bool
+	}{
+		{
+			name:     "add praxis annotation",
+			oldObj:   aitenant(nil),
+			newObj:   aitenant(map[string]string{annotationKey: tenantreconcile.PayloadProcessingTypePraxis}),
+			expected: true,
+		},
+		{
+			name: "remove praxis annotation",
+			oldObj: aitenant(map[string]string{
+				annotationKey: tenantreconcile.PayloadProcessingTypePraxis,
+			}),
+			newObj:   aitenant(nil),
+			expected: true,
+		},
+		{
+			name: "change praxis to unknown value",
+			oldObj: aitenant(map[string]string{
+				annotationKey: tenantreconcile.PayloadProcessingTypePraxis,
+			}),
+			newObj: aitenant(map[string]string{
+				annotationKey: "legacy",
+			}),
+			expected: true,
+		},
+		{
+			name: "ignore unrelated annotation changes",
+			oldObj: aitenant(map[string]string{
+				annotationKey:                  tenantreconcile.PayloadProcessingTypePraxis,
+				"example.com/unrelated":        "old",
+			}),
+			newObj: aitenant(map[string]string{
+				annotationKey:           tenantreconcile.PayloadProcessingTypePraxis,
+				"example.com/unrelated": "new",
+			}),
+			expected: false,
+		},
+		{
+			name:     "ignore spec-only generation bump with stable annotation",
+			oldObj:   aitenant(map[string]string{annotationKey: tenantreconcile.PayloadProcessingTypePraxis}),
+			newObj:   aitenant(map[string]string{annotationKey: tenantreconcile.PayloadProcessingTypePraxis}),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := payloadProcessingTypeAnnotationChanged(event.UpdateEvent{
+				ObjectOld: tt.oldObj,
+				ObjectNew: tt.newObj,
+			})
+			if got != tt.expected {
+				t.Errorf("payloadProcessingTypeAnnotationChanged() = %v, want %v", got, tt.expected)
 			}
 		})
 	}

--- a/maas-controller/pkg/platform/tenantreconcile/pipeline.go
+++ b/maas-controller/pkg/platform/tenantreconcile/pipeline.go
@@ -13,6 +13,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/client-go/util/retry"
@@ -104,14 +105,15 @@ func RunPlatform(
 		return nil, fmt.Errorf("post-render: %w", err)
 	}
 
-	// Clean up orphaned HPA before applying static replicas. When autoscaling is
-	// disabled, the HPA must be deleted first so it cannot reset spec.replicas
-	// between the apply and the next reconciliation. SSA only creates/updates
-	// resources in the rendered set; it does NOT delete absent resources.
-	if !params.SkipIPP {
-		if err := cleanupPayloadProcessingHPA(ctx, c, params, log); err != nil {
-			return nil, fmt.Errorf("cleanup payload-processing HPA: %w", err)
+	// SSA only creates/updates resources in the rendered set; it does NOT delete
+	// absent resources. Explicit cleanup is required when operands drop out of
+	// the rendered set (praxis SkipIPP) or when autoscaling is disabled (HPA).
+	if params.SkipIPP {
+		if err := cleanupIPPResources(ctx, c, params, log); err != nil {
+			return nil, fmt.Errorf("cleanup IPP resources: %w", err)
 		}
+	} else if err := cleanupPayloadProcessingHPA(ctx, c, params, log); err != nil {
+		return nil, fmt.Errorf("cleanup payload-processing HPA: %w", err)
 	}
 
 	if err := ApplyRendered(ctx, c, scheme, tenant, appNs, mcfg, resources); err != nil {
@@ -301,6 +303,74 @@ func PayloadProcessingEnvoyFilterReady(ctx context.Context, c client.Client, gat
 			gatewayNamespace, efName, gatewayNameLabel, got, gatewayName), nil
 	}
 	return true, "", nil
+}
+
+type ippResourceRef struct {
+	gvk       schema.GroupVersionKind
+	namespace string
+	name      string
+}
+
+// ippResourcesForTenant lists IPP operands maas-controller may have created for a tenant.
+// When SkipIPP is true these are omitted from the rendered set; explicit deletion is
+// required because SSA apply does not remove absent resources (see cleanupPayloadProcessingHPA).
+func ippResourcesForTenant(params PlatformParams) []ippResourceRef {
+	tenantID := params.TenantIdentifier
+	gatewayNamespace := params.GatewayNamespace
+	return []ippResourceRef{
+		{gvk: GVKHPA, namespace: gatewayNamespace, name: PayloadProcessingHPAName(tenantID)},
+		{gvk: GVKDeployment, namespace: gatewayNamespace, name: PayloadProcessingDeploymentName(tenantID)},
+		{gvk: GVKDeployment, namespace: gatewayNamespace, name: PayloadPreProcessingDeploymentName(tenantID)},
+		{gvk: GVKService, namespace: gatewayNamespace, name: PayloadProcessingServiceName(tenantID)},
+		{gvk: GVKService, namespace: gatewayNamespace, name: PayloadPreProcessingServiceName(tenantID)},
+		{gvk: GVKEnvoyFilter, namespace: gatewayNamespace, name: PayloadProcessingEnvoyFilterName(tenantID)},
+		{gvk: GVKNetworkPolicy, namespace: gatewayNamespace, name: PayloadProcessingNetworkPolicyName(tenantID)},
+		{gvk: GVKDestinationRule, namespace: gatewayNamespace, name: PayloadProcessingDeploymentName(tenantID)},
+		{gvk: GVKDestinationRule, namespace: gatewayNamespace, name: PayloadPreProcessingDeploymentName(tenantID)},
+		{gvk: GVKServiceAccount, namespace: gatewayNamespace, name: PayloadProcessingServiceAccountName(tenantID)},
+		{gvk: GVKConfigMap, namespace: gatewayNamespace, name: PayloadProcessingPluginsConfigMapForTenant(tenantID)},
+		{gvk: GVKClusterRoleBinding, name: PayloadProcessingReaderClusterRoleBindingNameForTenant(tenantID)},
+	}
+}
+
+// cleanupIPPResources removes tenant IPP operands when the tenant opts into the praxis
+// dataplane. Supports IPP→praxis migration: resources created before SkipIPP was set
+// would otherwise linger because PostRender filters them out of the apply set.
+func cleanupIPPResources(ctx context.Context, c client.Client, params PlatformParams, log logr.Logger) error {
+	for _, ref := range ippResourcesForTenant(params) {
+		if err := deleteIPPResourceIfManaged(ctx, c, ref, log); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func deleteIPPResourceIfManaged(ctx context.Context, c client.Client, ref ippResourceRef, log logr.Logger) error {
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(ref.gvk)
+	obj.SetName(ref.name)
+	obj.SetNamespace(ref.namespace)
+
+	if isLiveResourceUnmanaged(ctx, c, obj) {
+		log.V(1).Info("Skipping IPP cleanup for opendatahub.io/managed=false resource",
+			"kind", ref.gvk.Kind, "name", ref.name, "namespace", ref.namespace)
+		return nil
+	}
+
+	key := client.ObjectKeyFromObject(obj)
+	if err := c.Get(ctx, key, obj); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("get %s %s/%s: %w", ref.gvk.Kind, ref.namespace, ref.name, err)
+	}
+
+	log.Info("Deleting IPP resource for praxis tenant",
+		"kind", ref.gvk.Kind, "name", ref.name, "namespace", ref.namespace)
+	if err := c.Delete(ctx, obj); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("delete %s %s/%s: %w", ref.gvk.Kind, ref.namespace, ref.name, err)
+	}
+	return nil
 }
 
 // cleanupPayloadProcessingHPA deletes the payload-processing HPA when autoscaling

--- a/maas-controller/pkg/platform/tenantreconcile/pipeline_praxis_test.go
+++ b/maas-controller/pkg/platform/tenantreconcile/pipeline_praxis_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -181,6 +182,87 @@ func TestRunPlatform_PraxisSkipsIPPApply(t *testing.T) {
 	assert.True(t, hasMaaSAPIDeployment, "expected maas-api Deployment to be applied")
 }
 
+func TestRunPlatform_PraxisCleansUpLegacyIPPResources(t *testing.T) {
+	const (
+		tenantName = "praxis-team"
+		appNs      = "ai-tenant-praxis-team"
+		gwNS       = "openshift-ingress"
+		gwName     = "praxis-gateway"
+	)
+	scheme := praxisTestScheme(t)
+	tenant := praxisTenantConfig(appNs, tenantName)
+	mcfg := &maasv1alpha1.Config{
+		ObjectMeta: metav1.ObjectMeta{Name: maasv1alpha1.ConfigInstanceName, UID: types.UID("cfg-uid")},
+	}
+	gateway := &gwapiv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: gwName, Namespace: gwNS},
+	}
+	legacyDeployment := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata": map[string]any{
+				"name":      PayloadProcessingDeploymentName(tenantName),
+				"namespace": gwNS,
+			},
+		},
+	}
+	legacyEnvoyFilter := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "networking.istio.io/v1alpha3",
+			"kind":       "EnvoyFilter",
+			"metadata": map[string]any{
+				"name":      PayloadProcessingEnvoyFilterName(tenantName),
+				"namespace": gwNS,
+			},
+		},
+	}
+	platformContext := PlatformContext{
+		GatewayRef: maasv1alpha1.TenantGatewayRef{Namespace: gwNS, Name: gwName},
+		SkipIPP:    true,
+		Source:     "aitenant",
+	}
+
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+		mcfg, gateway, readyMaaSAPIDeployment(appNs, tenantName), legacyDeployment, legacyEnvoyFilter,
+	).Build()
+
+	result, err := RunPlatform(
+		context.Background(),
+		logr.Discard(),
+		cl,
+		scheme,
+		tenant,
+		platformContext,
+		platformOverlayManifestPath(t),
+		appNs,
+		"controller-ns",
+		"https://kubernetes.default.svc",
+		"opendatahub",
+		mcfg,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	depKey := types.NamespacedName{
+		Namespace: gwNS,
+		Name:      PayloadProcessingDeploymentName(tenantName),
+	}
+	dep := &unstructured.Unstructured{}
+	dep.SetGroupVersionKind(GVKDeployment)
+	err = cl.Get(context.Background(), depKey, dep)
+	require.True(t, apierrors.IsNotFound(err))
+
+	efKey := types.NamespacedName{
+		Namespace: gwNS,
+		Name:      PayloadProcessingEnvoyFilterName(tenantName),
+	}
+	ef := &unstructured.Unstructured{}
+	ef.SetGroupVersionKind(GVKEnvoyFilter)
+	err = cl.Get(context.Background(), efKey, ef)
+	require.True(t, apierrors.IsNotFound(err))
+}
+
 func TestRunPlatform_LegacyTenantAppliesIPPResources(t *testing.T) {
 	const (
 		tenantName = "legacy-team"
@@ -281,4 +363,111 @@ func TestRunPlatform_LegacyTenantReadyWithIPPEnvoyFilter(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	assert.False(t, result.DeploymentPending, result.Detail)
+}
+
+func unstructuredIPPObject(gvk schema.GroupVersionKind, namespace, name string, annotations map[string]string) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(gvk)
+	obj.SetName(name)
+	obj.SetNamespace(namespace)
+	if annotations != nil {
+		obj.SetAnnotations(annotations)
+	}
+	return obj
+}
+
+func TestIPPResourcesForTenant_DefaultTenantUsesLegacyNames(t *testing.T) {
+	params := PlatformParams{
+		GatewayNamespace: "openshift-ingress",
+		TenantIdentifier: "",
+	}
+	refs := ippResourcesForTenant(params)
+	names := make([]string, 0, len(refs))
+	for _, ref := range refs {
+		names = append(names, ref.name)
+	}
+	assert.Contains(t, names, PayloadProcessingName)
+	assert.NotContains(t, names, PayloadProcessingDeploymentName("redteam"))
+}
+
+func TestIPPResourcesForTenant_PerTenantSuffix(t *testing.T) {
+	const tenantID = "praxis-team"
+	params := PlatformParams{
+		GatewayNamespace: "openshift-ingress",
+		TenantIdentifier: tenantID,
+	}
+	refs := ippResourcesForTenant(params)
+	names := make([]string, 0, len(refs))
+	for _, ref := range refs {
+		names = append(names, ref.name)
+		if ref.gvk != GVKClusterRoleBinding {
+			assert.Equal(t, "openshift-ingress", ref.namespace, "namespaced IPP ref %s", ref.name)
+		}
+	}
+	assert.Contains(t, names, PayloadProcessingDeploymentName(tenantID))
+	assert.Contains(t, names, PayloadProcessingEnvoyFilterName(tenantID))
+	assert.Contains(t, names, PayloadProcessingReaderClusterRoleBindingNameForTenant(tenantID))
+}
+
+func TestCleanupIPPResources_DeletesManagedResources(t *testing.T) {
+	const (
+		tenantID = "praxis-team"
+		gwNS     = "openshift-ingress"
+	)
+	params := PlatformParams{
+		GatewayNamespace: gwNS,
+		TenantIdentifier: tenantID,
+	}
+	scheme := praxisTestScheme(t)
+
+	seed := []client.Object{
+		unstructuredIPPObject(GVKDeployment, gwNS, PayloadProcessingDeploymentName(tenantID), nil),
+		unstructuredIPPObject(GVKEnvoyFilter, gwNS, PayloadProcessingEnvoyFilterName(tenantID), nil),
+		unstructuredIPPObject(GVKService, gwNS, PayloadProcessingServiceName(tenantID), nil),
+	}
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(seed...).Build()
+
+	err := cleanupIPPResources(context.Background(), cl, params, logr.Discard())
+	require.NoError(t, err)
+
+	for _, ref := range []ippResourceRef{
+		{gvk: GVKDeployment, namespace: gwNS, name: PayloadProcessingDeploymentName(tenantID)},
+		{gvk: GVKEnvoyFilter, namespace: gwNS, name: PayloadProcessingEnvoyFilterName(tenantID)},
+		{gvk: GVKService, namespace: gwNS, name: PayloadProcessingServiceName(tenantID)},
+	} {
+		obj := &unstructured.Unstructured{}
+		obj.SetGroupVersionKind(ref.gvk)
+		obj.SetName(ref.name)
+		obj.SetNamespace(ref.namespace)
+		err := cl.Get(context.Background(), client.ObjectKeyFromObject(obj), obj)
+		assert.True(t, apierrors.IsNotFound(err), "expected %s/%s to be deleted", ref.namespace, ref.name)
+	}
+}
+
+func TestCleanupIPPResources_SkipsUnmanagedResources(t *testing.T) {
+	const (
+		tenantID = "praxis-team"
+		gwNS     = "openshift-ingress"
+	)
+	params := PlatformParams{
+		GatewayNamespace: gwNS,
+		TenantIdentifier: tenantID,
+	}
+	scheme := praxisTestScheme(t)
+
+	deployment := unstructuredIPPObject(
+		GVKDeployment,
+		gwNS,
+		PayloadProcessingDeploymentName(tenantID),
+		map[string]string{AnnotationManaged: "false"},
+	)
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(deployment).Build()
+
+	err := cleanupIPPResources(context.Background(), cl, params, logr.Discard())
+	require.NoError(t, err)
+
+	got := &unstructured.Unstructured{}
+	got.SetGroupVersionKind(GVKDeployment)
+	key := types.NamespacedName{Namespace: gwNS, Name: PayloadProcessingDeploymentName(tenantID)}
+	require.NoError(t, cl.Get(context.Background(), key, got))
 }

--- a/maas-controller/pkg/platform/tenantreconcile/platform_context_test.go
+++ b/maas-controller/pkg/platform/tenantreconcile/platform_context_test.go
@@ -247,9 +247,3 @@ func TestResolvePlatformContext_AITenantNameAnnotationRequired(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), AnnotationAITenantName)
 }
-
-func TestPlatformContext_IsPraxis(t *testing.T) {
-	assert.True(t, (PlatformContext{PayloadProcessingBackend: maasv1alpha1.PayloadProcessingBackendPraxis}).IsPraxis())
-	assert.False(t, (PlatformContext{PayloadProcessingBackend: maasv1alpha1.PayloadProcessingBackendIPP}).IsPraxis())
-	assert.False(t, (PlatformContext{}).IsPraxis())
-}

--- a/maas-controller/pkg/platform/tenantreconcile/platform_context_test.go
+++ b/maas-controller/pkg/platform/tenantreconcile/platform_context_test.go
@@ -247,3 +247,9 @@ func TestResolvePlatformContext_AITenantNameAnnotationRequired(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), AnnotationAITenantName)
 }
+
+func TestPlatformContext_IsPraxis(t *testing.T) {
+	assert.True(t, (PlatformContext{PayloadProcessingBackend: maasv1alpha1.PayloadProcessingBackendPraxis}).IsPraxis())
+	assert.False(t, (PlatformContext{PayloadProcessingBackend: maasv1alpha1.PayloadProcessingBackendIPP}).IsPraxis())
+	assert.False(t, (PlatformContext{}).IsPraxis())
+}


### PR DESCRIPTION
## Summary

When a tenant opts into the praxis dataplane (`maas.opendatahub.io/payload-processing-type: praxis`), maas-controller must remove legacy IPP operands that SSA no longer renders — but **must not** repeatedly delete payload-processing resources by name once ai-gateway-controller owns them at the same names.

This PR replaces continuous SkipIPP cleanup with:

1. **One-shot migration cleanup** — run legacy IPP delete only when `maas.opendatahub.io/ipp-migration-cleanup-complete` is absent, then set the marker.
2. **Ownership-gated delete** — delete only maas-owned legacy IPP (Config controller ownerRef, `maas-controller` SSA field manager, or tenant tracking labels). Skip `opendatahub.io/managed=false` and resources with SSA field manager `ai-gateway-controller`.
3. **Marker lifecycle** — clear the marker when returning to legacy (`SkipIPP=false`) so a future praxis switch can migrate again.

## Cross-controller coordination

- **Shared names stay** by design (`payload-processing-{tenant}`, etc.).
- **MaaS scope (this PR):** one-shot + ownership-gated cleanup + migration marker.
- **AIGC dependency ([ai-gateway-controller#9](https://github.com/opendatahub-io/ai-gateway-controller/pull/9)):** symmetric ownership-gated cleanup when switching praxis → legacy. Full bidirectional switching also needs AIGC apply-order hardening (ServiceAccount before Deployments during migration).

## Known races (migration window)

| Scenario | Severity | Handled by this PR? |
|----------|----------|---------------------|
| Continuous delete/recreate loop | High | **Yes** (one-shot + stop) |
| MaaS cleanup vs AIGC apply overlap | Medium | **Mostly** (ownership gate) |
| Praxis → legacy switch | High | **No** — needs AIGC ownership gate |
| Stale MaasTenantConfig annotation | Low–Medium | Partially (AITenant fallback in `resolveSkipIPP`) |

## Test plan

- [x] `go test ./pkg/platform/tenantreconcile/... -count=1`
- [x] `go test ./pkg/controller/maas/... -run 'PayloadProcessingType|PropagatesPayloadProcessing' -count=1`
- [x] Cluster migration test (IPP → praxis) on ROSA `yqin.2rkm`

## How this was tested

### Automated

```bash
cd maas-controller
go test ./pkg/platform/tenantreconcile/... -count=1
```

Key coverage:

| Area | Tests |
|------|--------|
| Ownership gate | `TestIsMaaSOwnedIPPResource`, `TestCleanupIPPResources_SkipsPraxisOwnedResources` |
| One-shot cleanup + marker | `TestRunPlatform_PraxisCleansUpLegacyIPPResources`, `TestRunPlatform_PraxisSkipsCleanupAfterMigrationComplete` |
| Skip apply for praxis | `TestRunPlatform_PraxisSkipsIPPApply` |
| Legacy IPP still applies | `TestRunPlatform_LegacyTenantAppliesIPPResources` |
| Annotation resolution | `platform_context_test.go` |
| AITenant propagation | `TestApplyAITenantMetadata_PropagatesPayloadProcessingTypeAnnotation` |

### Manual (ROSA cluster `yqin.2rkm`)

**Controller image:** `quay.io/isequeir/maas-controller:ipp-cleanup-local` (amd64 dev build from this branch)

**Deploy note:** pin via `opendatahub-operator-controller-manager` env `RELATED_IMAGE_ODH_MAAS_CONTROLLER_IMAGE` (Platform reconciles downstream; patching `ai-gateway-operator` alone is reverted).

**Tenant `praxistest` (AITenant on `data-science-gateway`):**

1. Created AITenant without praxis annotation → legacy IPP appeared (`payload-processing-praxistest`, pre-processing, Services, EnvoyFilter, NetworkPolicy, etc.).
2. Patched `maas.opendatahub.io/payload-processing-type=praxis`.
3. maas-controller logs showed **one-shot** `Deleting legacy IPP resource during praxis migration` for 7 resource kinds (single reconcile batch).
4. `MaasTenantConfig` annotated with `maas.opendatahub.io/ipp-migration-cleanup-complete=true` and `payload-processing-type=praxis`.
5. `payload-processing-plugins-praxistest` ConfigMap **preserved** (`opendatahub.io/managed=false`).
6. No further maas delete logs after marker set (7 total over 10+ minutes).
7. ai-gateway-controller applied praxis; after SA re-reconcile + pod restart, `payload-processing-praxistest` and `payload-pre-processing-praxistest` reached **1/1 Running**.

**Migration handoff issue (AIGC, not maas cleanup):** initial race deleted ServiceAccount before AIGC recreated it; pods stuck until AIGC re-reconciled. Tracked for AIGC PR #9 follow-up.

### Prior manual test (`cleanuptest` on `syfef-mb87h-hb5`, PR catalog)

Documented in earlier PR pushes: legacy IPP cleanup on annotation flip; plugins ConfigMap intentionally retained.