### PR TITLE
fix(tenantreconcile): one-shot ownership-gated IPP cleanup on praxis migration

### DIFF
--- a/maas-controller/pkg/platform/tenantreconcile/constants.go
+++ b/maas-controller/pkg/platform/tenantreconcile/constants.go
@@ -32,6 +32,10 @@ const (
 	// Deprecated: prefer spec.payloadProcessing.replicas on MaasTenantConfig/Tenant.
 	AnnotationPayloadProcessingReplicas = "maas.opendatahub.io/payload-processing-replicas"
 
+	// AnnotationIPPMigrationCleanupComplete marks that the one-shot legacy IPP cleanup
+	// for an IPP→praxis migration has finished on this tenant config.
+	AnnotationIPPMigrationCleanupComplete = "maas.opendatahub.io/ipp-migration-cleanup-complete"
+
 	// ComponentName is the ODH component label key suffix (app.opendatahub.io/<name>).
 	// This is the DSC component identifier, not a standalone CR kind.
 	ComponentName = "modelsasservice"

--- a/maas-controller/pkg/platform/tenantreconcile/ipp_cleanup_test.go
+++ b/maas-controller/pkg/platform/tenantreconcile/ipp_cleanup_test.go
@@ -1,0 +1,63 @@
+package tenantreconcile
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+
+	maasv1alpha1 "github.com/opendatahub-io/models-as-a-service/maas-controller/api/maas/v1alpha1"
+)
+
+func TestIsMaaSOwnedIPPResource(t *testing.T) {
+	const configUID = types.UID("cfg-uid")
+
+	legacyWithOwner := &unstructured.Unstructured{}
+	legacyWithOwner.SetGroupVersionKind(GVKDeployment)
+	setConfigControllerOwnerRef(legacyWithOwner, configUID)
+
+	praxisOwned := &unstructured.Unstructured{Object: map[string]any{
+		"metadata": map[string]any{
+			"managedFields": []any{
+				map[string]any{"manager": aiGatewayControllerFieldOwner},
+			},
+		},
+	}}
+	praxisOwned.SetGroupVersionKind(GVKDeployment)
+
+	legacyWithManager := &unstructured.Unstructured{Object: map[string]any{
+		"metadata": map[string]any{
+			"managedFields": []any{
+				map[string]any{"manager": ssaFieldOwner},
+			},
+		},
+	}}
+	legacyWithManager.SetGroupVersionKind(GVKDeployment)
+
+	unmanaged := &unstructured.Unstructured{}
+	unmanaged.SetGroupVersionKind(GVKDeployment)
+	unmanaged.SetAnnotations(map[string]string{AnnotationManaged: "false"})
+
+	legacyWithTenantLabel := &unstructured.Unstructured{}
+	legacyWithTenantLabel.SetGroupVersionKind(GVKDeployment)
+	legacyWithTenantLabel.SetLabels(map[string]string{LabelTenantName: "team-a"})
+
+	assert.True(t, isMaaSOwnedIPPResource(legacyWithOwner, configUID))
+	assert.False(t, isMaaSOwnedIPPResource(praxisOwned, configUID))
+	assert.True(t, isMaaSOwnedIPPResource(legacyWithManager, configUID))
+	assert.False(t, isMaaSOwnedIPPResource(unmanaged, configUID))
+	assert.True(t, isMaaSOwnedIPPResource(legacyWithTenantLabel, configUID))
+}
+
+func TestIPPMigrationCleanupMarker(t *testing.T) {
+	tenant := &maasv1alpha1.MaasTenantConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{AnnotationIPPMigrationCleanupComplete: "true"},
+		},
+	}
+	assert.True(t, isIPPMigrationCleanupComplete(tenant))
+	tenant.SetAnnotations(nil)
+	assert.False(t, isIPPMigrationCleanupComplete(tenant))
+}

--- a/maas-controller/pkg/platform/tenantreconcile/pipeline.go
+++ b/maas-controller/pkg/platform/tenantreconcile/pipeline.go
@@ -342,11 +342,17 @@ func clearIPPMigrationCleanupComplete(ctx context.Context, c client.Client, tena
 func patchTenantAnnotations(ctx context.Context, c client.Client, tenant client.Object, mutate func(map[string]string)) error {
 	key := client.ObjectKeyFromObject(tenant)
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		latest := tenant.DeepCopyObject().(client.Object)
+		latest, ok := tenant.DeepCopyObject().(client.Object)
+		if !ok {
+			return fmt.Errorf("expected client.Object copy, got %T", tenant.DeepCopyObject())
+		}
 		if err := c.Get(ctx, key, latest); err != nil {
 			return err
 		}
-		base := latest.DeepCopyObject().(client.Object)
+		base, ok := latest.DeepCopyObject().(client.Object)
+		if !ok {
+			return fmt.Errorf("expected client.Object copy, got %T", latest.DeepCopyObject())
+		}
 		annotations := latest.GetAnnotations()
 		if annotations == nil {
 			annotations = make(map[string]string)

--- a/maas-controller/pkg/platform/tenantreconcile/pipeline.go
+++ b/maas-controller/pkg/platform/tenantreconcile/pipeline.go
@@ -11,6 +11,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -106,14 +107,25 @@ func RunPlatform(
 	}
 
 	// SSA only creates/updates resources in the rendered set; it does NOT delete
-	// absent resources. Explicit cleanup is required when operands drop out of
-	// the rendered set (praxis SkipIPP) or when autoscaling is disabled (HPA).
+	// absent resources. When SkipIPP is true (praxis), run a one-shot, ownership-
+	// gated cleanup of legacy maas-controller IPP operands, then stop touching
+	// payload-processing names — ai-gateway-controller owns them for praxis tenants.
 	if params.SkipIPP {
-		if err := cleanupIPPResources(ctx, c, params, log); err != nil {
-			return nil, fmt.Errorf("cleanup IPP resources: %w", err)
+		if !isIPPMigrationCleanupComplete(tenant) {
+			if err := cleanupIPPResources(ctx, c, params, mcfg.UID, log); err != nil {
+				return nil, fmt.Errorf("cleanup IPP resources: %w", err)
+			}
+			if err := markIPPMigrationCleanupComplete(ctx, c, tenant); err != nil {
+				return nil, fmt.Errorf("mark IPP migration cleanup complete: %w", err)
+			}
 		}
-	} else if err := cleanupPayloadProcessingHPA(ctx, c, params, log); err != nil {
-		return nil, fmt.Errorf("cleanup payload-processing HPA: %w", err)
+	} else {
+		if err := clearIPPMigrationCleanupComplete(ctx, c, tenant); err != nil {
+			return nil, fmt.Errorf("clear IPP migration cleanup marker: %w", err)
+		}
+		if err := cleanupPayloadProcessingHPA(ctx, c, params, log); err != nil {
+			return nil, fmt.Errorf("cleanup payload-processing HPA: %w", err)
+		}
 	}
 
 	if err := ApplyRendered(ctx, c, scheme, tenant, appNs, mcfg, resources); err != nil {
@@ -305,6 +317,115 @@ func PayloadProcessingEnvoyFilterReady(ctx context.Context, c client.Client, gat
 	return true, "", nil
 }
 
+const aiGatewayControllerFieldOwner = "ai-gateway-controller"
+
+func isIPPMigrationCleanupComplete(tenant client.Object) bool {
+	annotations := tenant.GetAnnotations()
+	return annotations != nil && annotations[AnnotationIPPMigrationCleanupComplete] == "true"
+}
+
+func markIPPMigrationCleanupComplete(ctx context.Context, c client.Client, tenant client.Object) error {
+	return patchTenantAnnotations(ctx, c, tenant, func(annotations map[string]string) {
+		annotations[AnnotationIPPMigrationCleanupComplete] = "true"
+	})
+}
+
+func clearIPPMigrationCleanupComplete(ctx context.Context, c client.Client, tenant client.Object) error {
+	if !isIPPMigrationCleanupComplete(tenant) {
+		return nil
+	}
+	return patchTenantAnnotations(ctx, c, tenant, func(annotations map[string]string) {
+		delete(annotations, AnnotationIPPMigrationCleanupComplete)
+	})
+}
+
+func patchTenantAnnotations(ctx context.Context, c client.Client, tenant client.Object, mutate func(map[string]string)) error {
+	key := client.ObjectKeyFromObject(tenant)
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		latest := tenant.DeepCopyObject().(client.Object)
+		if err := c.Get(ctx, key, latest); err != nil {
+			return err
+		}
+		base := latest.DeepCopyObject().(client.Object)
+		annotations := latest.GetAnnotations()
+		if annotations == nil {
+			annotations = make(map[string]string)
+		}
+		mutate(annotations)
+		latest.SetAnnotations(annotations)
+		return c.Patch(ctx, latest, client.MergeFrom(base))
+	})
+}
+
+func hasSSAFieldManager(obj *unstructured.Unstructured, manager string) bool {
+	managedFields, found, err := unstructured.NestedSlice(obj.Object, "metadata", "managedFields")
+	if err != nil || !found {
+		return false
+	}
+	for _, entry := range managedFields {
+		field, ok := entry.(map[string]any)
+		if !ok {
+			continue
+		}
+		if mgr, _ := field["manager"].(string); mgr == manager {
+			return true
+		}
+	}
+	return false
+}
+
+func hasConfigControllerOwner(obj *unstructured.Unstructured, configUID types.UID) bool {
+	if configUID == "" {
+		return false
+	}
+	for _, ref := range obj.GetOwnerReferences() {
+		if ref.Kind != "Config" || ref.UID != configUID {
+			continue
+		}
+		if ref.Controller != nil && *ref.Controller {
+			return true
+		}
+	}
+	return false
+}
+
+// isMaaSOwnedIPPResource reports whether obj is legacy IPP applied by maas-controller
+// and safe to delete during the one-shot IPP→praxis migration cleanup. Resources owned
+// by ai-gateway-controller (praxis) or with opendatahub.io/managed=false are excluded.
+func isMaaSOwnedIPPResource(obj *unstructured.Unstructured, configUID types.UID) bool {
+	if ann := obj.GetAnnotations(); ann != nil && ann[AnnotationManaged] == "false" {
+		return false
+	}
+	if hasSSAFieldManager(obj, aiGatewayControllerFieldOwner) {
+		return false
+	}
+	if hasConfigControllerOwner(obj, configUID) {
+		return true
+	}
+	if hasSSAFieldManager(obj, ssaFieldOwner) {
+		return true
+	}
+	labels := obj.GetLabels()
+	if labels != nil && labels[LabelTenantName] != "" {
+		return true
+	}
+	return false
+}
+
+func setConfigControllerOwnerRef(obj *unstructured.Unstructured, configUID types.UID) {
+	if configUID == "" {
+		return
+	}
+	controller := true
+	obj.SetOwnerReferences([]metav1.OwnerReference{{
+		APIVersion: "maas.opendatahub.io/v1alpha1",
+		Kind:       "Config",
+		Name:       maasv1alpha1.ConfigInstanceName,
+		UID:        configUID,
+		Controller: &controller,
+	}})
+}
+
 type ippResourceRef struct {
 	gvk       schema.GroupVersionKind
 	namespace string
@@ -333,29 +454,23 @@ func ippResourcesForTenant(params PlatformParams) []ippResourceRef {
 	}
 }
 
-// cleanupIPPResources removes tenant IPP operands when the tenant opts into the praxis
-// dataplane. Supports IPP→praxis migration: resources created before SkipIPP was set
-// would otherwise linger because PostRender filters them out of the apply set.
-func cleanupIPPResources(ctx context.Context, c client.Client, params PlatformParams, log logr.Logger) error {
+// cleanupIPPResources removes legacy maas-controller IPP operands during the one-shot
+// IPP→praxis migration. Only maas-owned resources are deleted; praxis operands applied
+// by ai-gateway-controller at the same names are left intact.
+func cleanupIPPResources(ctx context.Context, c client.Client, params PlatformParams, configUID types.UID, log logr.Logger) error {
 	for _, ref := range ippResourcesForTenant(params) {
-		if err := deleteIPPResourceIfManaged(ctx, c, ref, log); err != nil {
+		if err := deleteIPPResourceIfManaged(ctx, c, ref, configUID, log); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func deleteIPPResourceIfManaged(ctx context.Context, c client.Client, ref ippResourceRef, log logr.Logger) error {
+func deleteIPPResourceIfManaged(ctx context.Context, c client.Client, ref ippResourceRef, configUID types.UID, log logr.Logger) error {
 	obj := &unstructured.Unstructured{}
 	obj.SetGroupVersionKind(ref.gvk)
 	obj.SetName(ref.name)
 	obj.SetNamespace(ref.namespace)
-
-	if isLiveResourceUnmanaged(ctx, c, obj) {
-		log.V(1).Info("Skipping IPP cleanup for opendatahub.io/managed=false resource",
-			"kind", ref.gvk.Kind, "name", ref.name, "namespace", ref.namespace)
-		return nil
-	}
 
 	key := client.ObjectKeyFromObject(obj)
 	if err := c.Get(ctx, key, obj); err != nil {
@@ -365,7 +480,13 @@ func deleteIPPResourceIfManaged(ctx context.Context, c client.Client, ref ippRes
 		return fmt.Errorf("get %s %s/%s: %w", ref.gvk.Kind, ref.namespace, ref.name, err)
 	}
 
-	log.Info("Deleting IPP resource for praxis tenant",
+	if !isMaaSOwnedIPPResource(obj, configUID) {
+		log.V(1).Info("Skipping IPP cleanup for resource not owned by maas-controller",
+			"kind", ref.gvk.Kind, "name", ref.name, "namespace", ref.namespace)
+		return nil
+	}
+
+	log.Info("Deleting legacy IPP resource during praxis migration",
 		"kind", ref.gvk.Kind, "name", ref.name, "namespace", ref.namespace)
 	if err := c.Delete(ctx, obj); err != nil && !apierrors.IsNotFound(err) {
 		return fmt.Errorf("delete %s %s/%s: %w", ref.gvk.Kind, ref.namespace, ref.name, err)

--- a/maas-controller/pkg/platform/tenantreconcile/pipeline_praxis_test.go
+++ b/maas-controller/pkg/platform/tenantreconcile/pipeline_praxis_test.go
@@ -2,6 +2,7 @@ package tenantreconcile
 
 import (
 	"context"
+	"encoding/json"
 	"path/filepath"
 	goruntime "runtime"
 	"strings"
@@ -149,7 +150,7 @@ func TestRunPlatform_PraxisSkipsIPPApply(t *testing.T) {
 
 	var applied []appliedResource
 	cl := runPlatformTestClient(t, scheme, []client.Object{
-		mcfg, gateway, readyMaaSAPIDeployment(appNs, tenantName),
+		mcfg, gateway, tenant, readyMaaSAPIDeployment(appNs, tenantName),
 	}, &applied)
 
 	result, err := RunPlatform(
@@ -197,26 +198,10 @@ func TestRunPlatform_PraxisCleansUpLegacyIPPResources(t *testing.T) {
 	gateway := &gwapiv1.Gateway{
 		ObjectMeta: metav1.ObjectMeta{Name: gwName, Namespace: gwNS},
 	}
-	legacyDeployment := &unstructured.Unstructured{
-		Object: map[string]any{
-			"apiVersion": "apps/v1",
-			"kind":       "Deployment",
-			"metadata": map[string]any{
-				"name":      PayloadProcessingDeploymentName(tenantName),
-				"namespace": gwNS,
-			},
-		},
-	}
-	legacyEnvoyFilter := &unstructured.Unstructured{
-		Object: map[string]any{
-			"apiVersion": "networking.istio.io/v1alpha3",
-			"kind":       "EnvoyFilter",
-			"metadata": map[string]any{
-				"name":      PayloadProcessingEnvoyFilterName(tenantName),
-				"namespace": gwNS,
-			},
-		},
-	}
+	legacyDeployment := unstructuredIPPObject(GVKDeployment, gwNS, PayloadProcessingDeploymentName(tenantName), nil)
+	setConfigControllerOwnerRef(legacyDeployment, mcfg.UID)
+	legacyEnvoyFilter := unstructuredIPPObject(GVKEnvoyFilter, gwNS, PayloadProcessingEnvoyFilterName(tenantName), nil)
+	setConfigControllerOwnerRef(legacyEnvoyFilter, mcfg.UID)
 	platformContext := PlatformContext{
 		GatewayRef: maasv1alpha1.TenantGatewayRef{Namespace: gwNS, Name: gwName},
 		SkipIPP:    true,
@@ -224,7 +209,7 @@ func TestRunPlatform_PraxisCleansUpLegacyIPPResources(t *testing.T) {
 	}
 
 	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
-		mcfg, gateway, readyMaaSAPIDeployment(appNs, tenantName), legacyDeployment, legacyEnvoyFilter,
+		mcfg, gateway, tenant, readyMaaSAPIDeployment(appNs, tenantName), legacyDeployment, legacyEnvoyFilter,
 	).Build()
 
 	result, err := RunPlatform(
@@ -261,6 +246,107 @@ func TestRunPlatform_PraxisCleansUpLegacyIPPResources(t *testing.T) {
 	ef.SetGroupVersionKind(GVKEnvoyFilter)
 	err = cl.Get(context.Background(), efKey, ef)
 	require.True(t, apierrors.IsNotFound(err))
+
+	gotTenant := &maasv1alpha1.MaasTenantConfig{}
+	require.NoError(t, cl.Get(context.Background(), types.NamespacedName{Namespace: appNs, Name: maasv1alpha1.MaasTenantConfigInstanceName}, gotTenant))
+	assert.Equal(t, "true", gotTenant.Annotations[AnnotationIPPMigrationCleanupComplete])
+}
+
+func TestRunPlatform_PraxisMigrationCleanupSkipsPraxisOwnedResources(t *testing.T) {
+	const (
+		tenantName = "praxis-team"
+		appNs      = "ai-tenant-praxis-team"
+		gwNS       = "openshift-ingress"
+		gwName     = "praxis-gateway"
+	)
+	scheme := praxisTestScheme(t)
+	tenant := praxisTenantConfig(appNs, tenantName)
+	mcfg := &maasv1alpha1.Config{
+		ObjectMeta: metav1.ObjectMeta{Name: maasv1alpha1.ConfigInstanceName, UID: types.UID("cfg-uid")},
+	}
+	gateway := &gwapiv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: gwName, Namespace: gwNS},
+	}
+	praxisDeployment := praxisOwnedDeployment(gwNS, PayloadProcessingDeploymentName(tenantName))
+	platformContext := PlatformContext{
+		GatewayRef: maasv1alpha1.TenantGatewayRef{Namespace: gwNS, Name: gwName},
+		SkipIPP:    true,
+		Source:     "aitenant",
+	}
+
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+		mcfg, gateway, tenant, readyMaaSAPIDeployment(appNs, tenantName), praxisDeployment,
+	).Build()
+
+	_, err := RunPlatform(
+		context.Background(),
+		logr.Discard(),
+		cl,
+		scheme,
+		tenant,
+		platformContext,
+		platformOverlayManifestPath(t),
+		appNs,
+		"controller-ns",
+		"https://kubernetes.default.svc",
+		"opendatahub",
+		mcfg,
+	)
+	require.NoError(t, err)
+
+	depKey := types.NamespacedName{Namespace: gwNS, Name: PayloadProcessingDeploymentName(tenantName)}
+	got := &appsv1.Deployment{}
+	require.NoError(t, cl.Get(context.Background(), depKey, got), "praxis-owned deployment should survive migration cleanup")
+}
+
+func TestRunPlatform_PraxisSkipsCleanupAfterMigrationComplete(t *testing.T) {
+	const (
+		tenantName = "praxis-team"
+		appNs      = "ai-tenant-praxis-team"
+		gwNS       = "openshift-ingress"
+		gwName     = "praxis-gateway"
+	)
+	scheme := praxisTestScheme(t)
+	tenant := praxisTenantConfig(appNs, tenantName)
+	tenant.Annotations[AnnotationIPPMigrationCleanupComplete] = "true"
+	mcfg := &maasv1alpha1.Config{
+		ObjectMeta: metav1.ObjectMeta{Name: maasv1alpha1.ConfigInstanceName, UID: types.UID("cfg-uid")},
+	}
+	gateway := &gwapiv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: gwName, Namespace: gwNS},
+	}
+	legacyDeployment := unstructuredIPPObject(GVKDeployment, gwNS, PayloadProcessingDeploymentName(tenantName), nil)
+	setConfigControllerOwnerRef(legacyDeployment, mcfg.UID)
+	platformContext := PlatformContext{
+		GatewayRef: maasv1alpha1.TenantGatewayRef{Namespace: gwNS, Name: gwName},
+		SkipIPP:    true,
+		Source:     "aitenant",
+	}
+
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+		mcfg, gateway, tenant, readyMaaSAPIDeployment(appNs, tenantName), legacyDeployment,
+	).Build()
+
+	_, err := RunPlatform(
+		context.Background(),
+		logr.Discard(),
+		cl,
+		scheme,
+		tenant,
+		platformContext,
+		platformOverlayManifestPath(t),
+		appNs,
+		"controller-ns",
+		"https://kubernetes.default.svc",
+		"opendatahub",
+		mcfg,
+	)
+	require.NoError(t, err)
+
+	depKey := types.NamespacedName{Namespace: gwNS, Name: PayloadProcessingDeploymentName(tenantName)}
+	dep := &unstructured.Unstructured{}
+	dep.SetGroupVersionKind(GVKDeployment)
+	require.NoError(t, cl.Get(context.Background(), depKey, dep))
 }
 
 func TestRunPlatform_LegacyTenantAppliesIPPResources(t *testing.T) {
@@ -376,6 +462,30 @@ func unstructuredIPPObject(gvk schema.GroupVersionKind, namespace, name string, 
 	return obj
 }
 
+func praxisOwnedDeployment(namespace, name string) *appsv1.Deployment {
+	fieldV1, err := json.Marshal(map[string]any{
+		"f:metadata": map[string]any{
+			"f:name": map[string]any{},
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			ManagedFields: []metav1.ManagedFieldsEntry{{
+				Manager:    aiGatewayControllerFieldOwner,
+				Operation:  metav1.ManagedFieldsOperationApply,
+				APIVersion: "apps/v1",
+				FieldsType: "FieldsV1",
+				FieldsV1:   &metav1.FieldsV1{Raw: fieldV1},
+			}},
+		},
+	}
+}
+
 func TestIPPResourcesForTenant_DefaultTenantUsesLegacyNames(t *testing.T) {
 	params := PlatformParams{
 		GatewayNamespace: "openshift-ingress",
@@ -425,9 +535,14 @@ func TestCleanupIPPResources_DeletesManagedResources(t *testing.T) {
 		unstructuredIPPObject(GVKEnvoyFilter, gwNS, PayloadProcessingEnvoyFilterName(tenantID), nil),
 		unstructuredIPPObject(GVKService, gwNS, PayloadProcessingServiceName(tenantID), nil),
 	}
+	for i := range seed {
+		if obj, ok := seed[i].(*unstructured.Unstructured); ok {
+			setConfigControllerOwnerRef(obj, types.UID("cfg-uid"))
+		}
+	}
 	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(seed...).Build()
 
-	err := cleanupIPPResources(context.Background(), cl, params, logr.Discard())
+	err := cleanupIPPResources(context.Background(), cl, params, types.UID("cfg-uid"), logr.Discard())
 	require.NoError(t, err)
 
 	for _, ref := range []ippResourceRef{
@@ -463,7 +578,30 @@ func TestCleanupIPPResources_SkipsUnmanagedResources(t *testing.T) {
 	)
 	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(deployment).Build()
 
-	err := cleanupIPPResources(context.Background(), cl, params, logr.Discard())
+	err := cleanupIPPResources(context.Background(), cl, params, types.UID("cfg-uid"), logr.Discard())
+	require.NoError(t, err)
+
+	got := &unstructured.Unstructured{}
+	got.SetGroupVersionKind(GVKDeployment)
+	key := types.NamespacedName{Namespace: gwNS, Name: PayloadProcessingDeploymentName(tenantID)}
+	require.NoError(t, cl.Get(context.Background(), key, got))
+}
+
+func TestCleanupIPPResources_SkipsPraxisOwnedResources(t *testing.T) {
+	const (
+		tenantID = "praxis-team"
+		gwNS     = "openshift-ingress"
+	)
+	params := PlatformParams{
+		GatewayNamespace: gwNS,
+		TenantIdentifier: tenantID,
+	}
+	scheme := praxisTestScheme(t)
+
+	deployment := praxisOwnedDeployment(gwNS, PayloadProcessingDeploymentName(tenantID))
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(deployment).Build()
+
+	err := cleanupIPPResources(context.Background(), cl, params, types.UID("cfg-uid"), logr.Discard())
 	require.NoError(t, err)
 
 	got := &unstructured.Unstructured{}


### PR DESCRIPTION
## Summary

Follow-up to #1484 (merged). The initial merge deleted legacy IPP resources on every reconcile when `SkipIPP=true`, which fights ai-gateway-controller (AIGC) praxis installs at shared resource names (`payload-processing-{tenant}`, etc.).

This PR refines the approach to:

- **One-shot migration cleanup** — run legacy IPP deletion only once when migrating to praxis, then set `maas.opendatahub.io/ipp-migration-cleanup-complete=true` on `MaasTenantConfig`
- **Ownership-gated deletes** — skip resources managed by AIGC (SSA manager) or marked `managed=false`; delete only MaaS-owned legacy IPP
- **Marker lifecycle** — clear the migration marker when `SkipIPP=false` so tenants can revert cleanly

Cluster-tested on `yqin.2rkm` with image `quay.io/isequeir/maas-controller:ipp-cleanup-local`: 7 one-shot deletes, marker set, no repeated deletes over 10+ minutes, praxis deployments eventually 1/1 Running.

**AIGC dependency:** symmetric ownership-gated cleanup and apply ordering on the AIGC side (see opendatahub-io/ai-gateway-controller#9) is recommended but not required for this MaaS merge.

## Known races (migration window)

This approach removes the **steady-state** delete/recreate loop from #1484, but there is no distributed lock between maas-controller and AIGC. Remaining races are bounded to the **migration window**:

| Scenario | Severity | Handled by this PR? |
|----------|----------|---------------------|
| Continuous delete/recreate loop | High | **Yes** (one-shot + stop) |
| MaaS cleanup vs AIGC apply overlap | Medium | **Mostly** (ownership gate) |
| Get-then-delete TOCTOU | Low–Medium | **Partially** (could re-fetch before delete) |
| Both apply during annotation flip | Medium | **Partially** (live AITenant in `resolveSkipIPP`) |
| Praxis → legacy switch | **High** | **No** — needs AIGC ownership gate |
| Stale `MaasTenantConfig` annotation | Low–Medium | Partially (AITenant fallback in `resolveSkipIPP`) |
| Double one-shot cleanup | Low | **Yes** (idempotent deletes + marker retry) |

### Cluster finding: cross-controller handoff race (`praxistest`)

During IPP → praxis migration on `yqin.2rkm`, maas one-shot cleanup behaved correctly, but the praxis handoff hit a **transition-timing race**:

1. MaaS deleted legacy resources in one shot, including the **ServiceAccount**
2. AIGC tried to SSA-apply the praxis Deployment while legacy objects still existed → brief error: duplicate port name `"metrics"`
3. Pods stuck in `ContainerCreating` (`serviceaccounts "payload-processing-praxistest" not found`)

After AIGC re-reconciled (SA recreated) and pods were restarted, both praxis deployments reached **1/1 Running**. This confirms maas cleanup works as designed; the handoff gap is on the AIGC side:

- **Apply ordering** — create ServiceAccount (and other deps) before Deployments, or re-reconcile when SA appears after maas cleanup
- **SSA overlap retry** — first praxis apply can fail if it races with the last legacy Deployment; retry fixed it in testing

Full bidirectional switching (praxis → legacy) also requires AIGC ownership-gated cleanup (AIGC PR #9).

## Test plan

- [x] `go test ./maas-controller/pkg/platform/tenantreconcile/... -count=1`
- [x] Cluster E2E on `yqin.2rkm`: create IPP tenant → annotate `payload-processing-type=praxis` → verify one-shot cleanup + marker + praxis handoff
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved migration cleanup for legacy IPP resources during the transition to Praxis.
  - Cleanup now targets only resources owned by the platform, preserving Praxis-managed and unrelated resources.
  - Migration cleanup runs once per tenant and records completion to prevent repeated cleanup.
  - Reconciliation clears the completion marker when legacy IPP handling is active again.
  - Added coverage for ownership detection, migration markers, and cleanup behavior across managed, unmanaged, and Praxis-owned resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->